### PR TITLE
get-well: Phase 4 — correctness and hardening (20 issues)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/petersimmons1972/engram/internal/claude"
@@ -151,8 +152,13 @@ func envInt(key string, def int) int {
 }
 
 func envBool(key string, def bool) bool {
-	if v := os.Getenv(key); v != "" {
-		return v == "1" || v == "true" || v == "yes"
+	v := strings.ToLower(os.Getenv(key))
+	switch v {
+	case "1", "true", "yes":
+		return true
+	case "0", "false", "no":
+		return false
+	default:
+		return def
 	}
-	return def
 }

--- a/internal/chunk/chunker.go
+++ b/internal/chunk/chunker.go
@@ -16,6 +16,10 @@ import (
 // Mirrors Python LAZY_CHUNK_THRESHOLD = 8000.
 const LazyChunkThreshold = 8000
 
+// DefaultTargetChunkChars is the default chunk size used by ChunkDocument
+// when the caller passes targetChunkChars <= 0.
+const DefaultTargetChunkChars = 2000
+
 // headingRE matches level-1 and level-2 Markdown headings at the start of a line.
 var headingRE = regexp.MustCompile(`(?m)^#{1,2}\s+(.+)$`)
 
@@ -165,6 +169,9 @@ func ChunkText(text string, maxTokens, overlapTokens int) []string {
 func ChunkDocument(text string, targetChunkChars int) []ChunkCandidate {
 	if strings.TrimSpace(text) == "" {
 		return nil
+	}
+	if targetChunkChars <= 0 {
+		targetChunkChars = DefaultTargetChunkChars
 	}
 
 	type headingPos struct {

--- a/internal/chunk/chunker.go
+++ b/internal/chunk/chunker.go
@@ -446,7 +446,9 @@ func wordSet(text string) map[string]bool {
 func defaultDedupThreshold() float64 {
 	if v := os.Getenv("ENGRAM_DEDUP_THRESHOLD"); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
-			return f
+			if f >= 0 && f <= 1.0 {
+				return f
+			}
 		}
 	}
 	return 0.75

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -61,8 +61,8 @@ type Backend interface {
 	GetAllChunkTexts(ctx context.Context, project string, limit int) ([]string, error)
 	// GetChunksForMemories returns embedded chunks for specific memory IDs.
 	GetChunksForMemories(ctx context.Context, memoryIDs []string) ([]*types.Chunk, error)
-	// ChunkHashExists returns true if a chunk with this hash exists in the project.
-	ChunkHashExists(ctx context.Context, chunkHash, project string) (bool, error)
+	// ChunkHashExists returns true if a chunk with this hash exists for this memory.
+	ChunkHashExists(ctx context.Context, chunkHash, memoryID string) (bool, error)
 	// DeleteChunksForMemory deletes all chunks for a memory.
 	DeleteChunksForMemory(ctx context.Context, memoryID string) error
 	// DeleteChunksByIDs deletes specific chunks by ID. Returns count deleted.

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -728,11 +728,17 @@ func (b *PostgresBackend) GetPendingEmbeddingCount(ctx context.Context, project 
 func (b *PostgresBackend) StoreRelationship(ctx context.Context, rel *types.Relationship) error {
 	// Verify both memories exist.
 	var dummy int
-	if err := b.pool.QueryRow(ctx, "SELECT 1 FROM memories WHERE id=$1", rel.SourceID).Scan(&dummy); err == pgx.ErrNoRows {
-		return fmt.Errorf("source memory %q does not exist", rel.SourceID)
+	if err := b.pool.QueryRow(ctx, "SELECT 1 FROM memories WHERE id=$1", rel.SourceID).Scan(&dummy); err != nil {
+		if err == pgx.ErrNoRows {
+			return fmt.Errorf("source memory %q does not exist", rel.SourceID)
+		}
+		return fmt.Errorf("check source memory: %w", err)
 	}
-	if err := b.pool.QueryRow(ctx, "SELECT 1 FROM memories WHERE id=$1", rel.TargetID).Scan(&dummy); err == pgx.ErrNoRows {
-		return fmt.Errorf("target memory %q does not exist", rel.TargetID)
+	if err := b.pool.QueryRow(ctx, "SELECT 1 FROM memories WHERE id=$1", rel.TargetID).Scan(&dummy); err != nil {
+		if err == pgx.ErrNoRows {
+			return fmt.Errorf("target memory %q does not exist", rel.TargetID)
+		}
+		return fmt.Errorf("check target memory: %w", err)
 	}
 
 	rel.Project = b.project
@@ -858,7 +864,7 @@ func (b *PostgresBackend) GetConnected(ctx context.Context, memoryID string, max
 
 func (b *PostgresBackend) BoostEdgesForMemory(ctx context.Context, memoryID string, factor float64) (int, error) {
 	tag, err := b.pool.Exec(ctx, `
-		UPDATE relationships SET strength=LEAST(1.0, strength+$1)
+		UPDATE relationships SET strength=LEAST(1.0, strength*$1)
 		WHERE source_id=$2 OR target_id=$2`, factor, memoryID,
 	)
 	return int(tag.RowsAffected()), err
@@ -1118,6 +1124,10 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 	if err := b.pool.QueryRow(ctx,
 		"SELECT COUNT(*) FROM memories WHERE project=$1 AND summary IS NULL", project,
 	).Scan(&stats.PendingSummarization); err != nil {
+		return nil, err
+	}
+
+	if err := b.pool.QueryRow(ctx, "SELECT pg_database_size(current_database())").Scan(&stats.DBSizeBytes); err != nil {
 		return nil, err
 	}
 

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -453,14 +453,15 @@ func (b *PostgresBackend) DeleteMemoryAtomic(ctx context.Context, project, id st
 	if _, err := tx.Exec(ctx, "DELETE FROM relationships WHERE source_id=$1 OR target_id=$1", id); err != nil {
 		return false, err
 	}
-	tag, err := tx.Exec(ctx,
-		"WITH d AS (DELETE FROM memories WHERE id=$1 RETURNING id) SELECT count(*) FROM d", id,
-	)
+	tag, err := tx.Exec(ctx, "DELETE FROM memories WHERE id=$1", id)
 	if err != nil {
 		return false, err
 	}
 
-	return tag.RowsAffected() > 0, tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 func (b *PostgresBackend) ListMemories(ctx context.Context, project string, opts ListOptions) ([]*types.Memory, error) {
@@ -624,10 +625,7 @@ func (b *PostgresBackend) DeleteChunksByIDs(ctx context.Context, chunkIDs []stri
 	if len(chunkIDs) == 0 {
 		return 0, nil
 	}
-	tag, err := b.pool.Exec(ctx,
-		"WITH d AS (DELETE FROM chunks WHERE id=ANY($1) RETURNING id) SELECT count(*) FROM d",
-		chunkIDs,
-	)
+	tag, err := b.pool.Exec(ctx, "DELETE FROM chunks WHERE id=ANY($1)", chunkIDs)
 	return int(tag.RowsAffected()), err
 }
 
@@ -921,13 +919,11 @@ func (b *PostgresBackend) DeleteRelationshipsForMemory(ctx context.Context, memo
 func (b *PostgresBackend) PruneStaleMemories(ctx context.Context, project string, maxAgeHours float64, maxImportance int) (int, error) {
 	cutoff := time.Now().UTC().Add(-time.Duration(maxAgeHours * float64(time.Hour)))
 	tag, err := b.pool.Exec(ctx, `
-		WITH d AS (
-			DELETE FROM memories
-			WHERE project=$1 AND NOT immutable AND (
-				(importance>=$2 AND last_accessed<$3 AND access_count=0)
-				OR (expires_at IS NOT NULL AND expires_at<NOW())
-			) RETURNING id
-		) SELECT count(*) FROM d`, project, maxImportance, cutoff,
+		DELETE FROM memories
+		WHERE project=$1 AND NOT immutable AND (
+			(importance>=$2 AND last_accessed<$3 AND access_count=0)
+			OR (expires_at IS NOT NULL AND expires_at<NOW())
+		)`, project, maxImportance, cutoff,
 	)
 	return int(tag.RowsAffected()), err
 }
@@ -935,7 +931,7 @@ func (b *PostgresBackend) PruneStaleMemories(ctx context.Context, project string
 func (b *PostgresBackend) PruneColdDocuments(ctx context.Context, project string, maxAgeHours float64, maxImportance int) (int, error) {
 	cutoff := time.Now().UTC().Add(-time.Duration(maxAgeHours * float64(time.Hour)))
 	tag, err := b.pool.Exec(ctx, `
-		WITH cold AS (
+		DELETE FROM memories WHERE id IN (
 			SELECT m.id FROM memories m
 			WHERE m.project=$1 AND m.storage_mode='document'
 			  AND NOT m.immutable AND m.importance>=$2 AND m.created_at<$3
@@ -943,8 +939,7 @@ func (b *PostgresBackend) PruneColdDocuments(ctx context.Context, project string
 				SELECT 1 FROM chunks c
 				WHERE c.memory_id=m.id AND c.last_matched IS NOT NULL
 			  )
-		), d AS (DELETE FROM memories WHERE id IN (SELECT id FROM cold) RETURNING id)
-		SELECT count(*) FROM d`, project, maxImportance, cutoff,
+		)`, project, maxImportance, cutoff,
 	)
 	return int(tag.RowsAffected()), err
 }

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -604,14 +604,13 @@ func (b *PostgresBackend) GetChunksForMemories(ctx context.Context, memoryIDs []
 	return pgx.CollectRows(rows, rowToChunk)
 }
 
-func (b *PostgresBackend) ChunkHashExists(ctx context.Context, chunkHash, project string) (bool, error) {
+func (b *PostgresBackend) ChunkHashExists(ctx context.Context, chunkHash, memoryID string) (bool, error) {
 	var exists bool
 	err := b.pool.QueryRow(ctx, `
 		SELECT EXISTS(
 			SELECT 1 FROM chunks
-			WHERE chunk_hash=$1
-			AND memory_id IN (SELECT id FROM memories WHERE project=$2)
-		)`, chunkHash, project,
+			WHERE chunk_hash=$1 AND memory_id=$2
+		)`, chunkHash, memoryID,
 	).Scan(&exists)
 	return exists, err
 }

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -124,7 +125,7 @@ func (c *OllamaClient) modelPresent(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	for _, m := range result.Models {
-		if strings.HasPrefix(m.Name, c.model) {
+		if m.Name == c.model || m.Name == c.model+":latest" {
 			return true, nil
 		}
 	}
@@ -147,6 +148,11 @@ func (c *OllamaClient) pullModel(ctx context.Context) error {
 		return fmt.Errorf("ollama pull: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("ollama pull: HTTP %d: %s", resp.StatusCode, string(body))
+	}
 
 	// Drain streaming NDJSON lines until "success" or end of body.
 	scanner := bufio.NewScanner(resp.Body)

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -3,6 +3,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -49,6 +50,9 @@ func NewEnginePool(factory EngineFactory) *EnginePool {
 // Get returns the cached engine for project, creating one via factory if needed.
 // If the pool is at capacity, the least-recently-used engine is evicted first.
 func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, error) {
+	if len(project) > 128 {
+		return nil, fmt.Errorf("project name too long (%d chars, max 128)", len(project))
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/claude"
@@ -115,7 +116,7 @@ func getInt(args map[string]any, key string, def int) int {
 	if v, ok := args[key]; ok {
 		switch n := v.(type) {
 		case float64:
-			return int(n)
+			return int(math.Round(n))
 		case int:
 			return n
 		}
@@ -310,6 +311,9 @@ func handleMemoryConnect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 	strength := 1.0
 	if v, ok := args["strength"].(float64); ok {
 		strength = v
+	}
+	if math.IsNaN(strength) || math.IsInf(strength, 0) || strength < 0 || strength > 1.0 {
+		return nil, fmt.Errorf("strength must be between 0 and 1, got %v", strength)
 	}
 	if err := h.Engine.Connect(ctx, src, dst, relType, strength); err != nil {
 		return nil, err

--- a/internal/reembed/worker.go
+++ b/internal/reembed/worker.go
@@ -57,15 +57,15 @@ func (w *Worker) Start() {
 	go w.run(ctx)
 }
 
-// Stop signals the worker and waits up to 35s.
+// Stop signals the worker and waits up to 8s.
 func (w *Worker) Stop() {
 	if w.cancel != nil {
 		w.cancel()
 	}
 	select {
 	case <-w.done:
-	case <-time.After(35 * time.Second):
-		slog.Warn("reembed worker did not stop within 35s", "project", w.project)
+	case <-time.After(8 * time.Second):
+		slog.Warn("reembed worker did not stop within 8s", "project", w.project)
 	}
 }
 

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -148,7 +148,7 @@ func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
 	for i, c := range candidates {
 		hash := chunk.ChunkHash(c.Text)
 
-		exists, err := e.backend.ChunkHashExists(ctx, hash, e.project)
+		exists, err := e.backend.ChunkHashExists(ctx, hash, m.ID)
 		if err != nil {
 			return fmt.Errorf("check chunk hash: %w", err)
 		}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -68,6 +68,7 @@ type SearchEngine struct {
 	backend    db.Backend
 	embedder   embed.Client
 	project    string
+	ollamaURL  string
 	summarizer *summarize.Worker
 	reembedder *reembed.Worker
 }
@@ -88,6 +89,7 @@ func New(ctx context.Context, backend db.Backend, embedder embed.Client, project
 		backend:    backend,
 		embedder:   embedder,
 		project:    project,
+		ollamaURL:  ollamaURL,
 		summarizer: sum,
 		reembedder: reb,
 	}
@@ -608,10 +610,25 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 	if err := e.backend.SetMeta(ctx, e.project, "embedder_name", newModel); err != nil {
 		return nil, err
 	}
+
+	// Stop old reembed worker and create a new one with the new model.
+	// Without this, the worker holds a stale reference to the original embedder
+	// and never runs because its done channel was already closed at construction.
+	e.reembedder.Stop()
+
+	newEmbedder, err := embed.NewOllamaClient(ctx, e.ollamaURL, newModel)
+	if err != nil {
+		return nil, fmt.Errorf("create embedder for new model %q: %w", newModel, err)
+	}
+	e.embedder = newEmbedder
+
+	e.reembedder = reembed.NewWorker(e.backend, newEmbedder, e.project, true)
+	e.reembedder.Start()
+
 	return map[string]any{
 		"chunks_nulled": nulled,
 		"new_model":     newModel,
-		"status":        "migration started — reembed worker will complete in background",
+		"status":        "migration started — reembed worker running with new model",
 	}, nil
 }
 

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -482,6 +482,9 @@ func (e *SearchEngine) Status(ctx context.Context) (*types.MemoryStats, error) {
 // immediately and subsequent IDs in the slice are not processed. Callers that need
 // all-or-nothing semantics should call this method once per ID and handle errors individually.
 func (e *SearchEngine) Feedback(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return fmt.Errorf("feedback: no memory IDs provided")
+	}
 	for _, id := range ids {
 		if _, err := e.backend.BoostEdgesForMemory(ctx, id, 1.05); err != nil {
 			return err

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -103,26 +103,12 @@ func (e *SearchEngine) Close() {
 // (e.g. EnginePool, MCP tool handlers).
 func (e *SearchEngine) Backend() db.Backend { return e.backend }
 
-// Store persists a memory: sets defaults, chunks content, deduplicates by hash,
-// embeds new chunks, and writes everything inside a single transaction.
-func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
-	if m.ID == "" {
-		m.ID = types.NewMemoryID()
-	}
-	m.Project = e.project
-
-	if m.StorageMode == "" {
-		if len(m.Content) > 10_000 {
-			m.StorageMode = "document"
-		} else {
-			m.StorageMode = "focused"
-		}
-	}
-
-	if err := e.checkEmbedderMeta(ctx); err != nil {
-		return err
-	}
-
+// storeChunksForMemory chunks content, embeds each chunk, and returns the new
+// chunk records ready for storage. It is used by both Store (new memories) and
+// Correct (re-chunking after a content change). Embedding is done outside any
+// transaction because it is slow; callers are responsible for writing the
+// returned chunks inside a transaction.
+func (e *SearchEngine) storeChunksForMemory(ctx context.Context, m *types.Memory) ([]*types.Chunk, error) {
 	// Produce chunk candidates. ChunkDocument returns []ChunkCandidate (with heading
 	// metadata). ChunkText returns plain []string which we wrap into candidates.
 	var candidates []chunk.ChunkCandidate
@@ -150,7 +136,7 @@ func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
 
 		exists, err := e.backend.ChunkHashExists(ctx, hash, m.ID)
 		if err != nil {
-			return fmt.Errorf("check chunk hash: %w", err)
+			return nil, fmt.Errorf("check chunk hash: %w", err)
 		}
 		if exists {
 			continue
@@ -158,7 +144,7 @@ func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
 
 		embedding, err := e.embedder.Embed(ctx, c.Text)
 		if err != nil {
-			return fmt.Errorf("embed chunk %d: %w", i, err)
+			return nil, fmt.Errorf("embed chunk %d: %w", i, err)
 		}
 
 		ch := &types.Chunk{
@@ -176,6 +162,33 @@ func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
 			ch.SectionHeading = &heading
 		}
 		chunks = append(chunks, ch)
+	}
+	return chunks, nil
+}
+
+// Store persists a memory: sets defaults, chunks content, deduplicates by hash,
+// embeds new chunks, and writes everything inside a single transaction.
+func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
+	if m.ID == "" {
+		m.ID = types.NewMemoryID()
+	}
+	m.Project = e.project
+
+	if m.StorageMode == "" {
+		if len(m.Content) > 10_000 {
+			m.StorageMode = "document"
+		} else {
+			m.StorageMode = "focused"
+		}
+	}
+
+	if err := e.checkEmbedderMeta(ctx); err != nil {
+		return err
+	}
+
+	chunks, err := e.storeChunksForMemory(ctx, m)
+	if err != nil {
+		return err
 	}
 
 	tx, err := e.backend.Begin(ctx)
@@ -463,8 +476,41 @@ func (e *SearchEngine) Connect(ctx context.Context, srcID, dstID, relType string
 }
 
 // Correct updates mutable fields on an existing memory and returns the updated record.
+// When content is non-nil, the old chunks are deleted and new chunks are created so
+// the search index reflects the corrected text.
 func (e *SearchEngine) Correct(ctx context.Context, id string, content *string, tags []string, importance *int) (*types.Memory, error) {
-	return e.backend.UpdateMemory(ctx, id, content, tags, importance)
+	mem, err := e.backend.UpdateMemory(ctx, id, content, tags, importance)
+	if err != nil {
+		return nil, err
+	}
+
+	// If content changed, delete stale chunks and re-chunk + re-embed the new content.
+	if content != nil {
+		if err := e.backend.DeleteChunksForMemory(ctx, mem.ID); err != nil {
+			return nil, fmt.Errorf("delete old chunks: %w", err)
+		}
+
+		chunks, err := e.storeChunksForMemory(ctx, mem)
+		if err != nil {
+			return nil, fmt.Errorf("re-chunk after correct: %w", err)
+		}
+
+		if len(chunks) > 0 {
+			tx, err := e.backend.Begin(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if err := e.backend.StoreChunksTx(ctx, tx, chunks); err != nil {
+				_ = tx.Rollback(ctx)
+				return nil, err
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return mem, nil
 }
 
 // Forget deletes a memory by ID. Returns true if deleted, false if not found.

--- a/internal/search/score.go
+++ b/internal/search/score.go
@@ -30,7 +30,7 @@ func RecencyDecay(hoursSince float64) float64 {
 //	importance=2 → 3/3 = 1.00 (neutral)
 //	importance=4 → 1/3 ≈ 0.33 (trivial)
 func ImportanceBoost(importance int) float64 {
-	return float64(5-importance) / 3.0
+	return math.Max(0, float64(5-importance)) / 3.0
 }
 
 // CompositeScore combines vector, BM25, and recency signals into a single rank score.

--- a/internal/summarize/worker.go
+++ b/internal/summarize/worker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -64,6 +65,11 @@ func SummarizeContent(ctx context.Context, content, ollamaURL, model string) (st
 		return "", fmt.Errorf("ollama generate: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("ollama generate: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
 
 	var result struct {
 		Response string `json:"response"`


### PR DESCRIPTION
## Summary

Phase 4 of the Get Well campaign: fixes 20 open issues (2 blockers, 5 high, 13 medium/low) targeting data correctness and input validation.

### Commits
- **10 quick-win fixes**: ChunkDocument default (#34), StoreRelationship error handling (#33), feedback boost multiplicative (#38), GetStats DBSizeBytes (#39), model name exact match (#46), pullModel HTTP check (#42), SummarizeContent HTTP check (#41), ImportanceBoost clamp (#25), empty feedback error (#28), Worker.Stop timeout (#50)
- **CTE count fix**: Drop CTE wrappers so RowsAffected returns real delete counts (#29); fix return-before-commit (#37)
- **Chunk dedup scoped to per-memory**: Prevents silent chunk dropping across memories (#36)
- **memory_correct re-chunks/re-embeds**: Correct() now deletes old chunks and re-creates them when content changes (#30)
- **MigrateEmbedder lifecycle**: Stops old worker, creates new OllamaClient, starts fresh reembed worker (#32)
- **Input validation sweep**: strength bounds (#21), project name length (#26), getInt rounding (#22), dedup threshold bounds (#23), envBool false/0/no (#48)

### Issues Closed
Closes #29, #30, #34, #36, #33, #32, #37, #38, #39, #46, #42, #41, #25, #28, #50, #21, #26, #22, #23, #48

### Already closed (fixed in Phase 0-3)
#35, #45, #47

## Test plan
- [ ] `go build ./... && go test ./...` — all pass
- [ ] Verify `memory_correct` with content change → recall matches new content
- [ ] Verify chunk dedup allows same text in different memories
- [ ] Verify delete/prune operations return accurate counts
- [ ] Verify MigrateEmbedder starts new worker (check logs)
- [ ] Verify strength=NaN rejected, project name >128 chars rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)