### PR TITLE
fix: Get Well Phase 5 — security hardening, input validation, feature gaps, data correctness (16 issues)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -57,7 +58,15 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	slog.Info("connecting to Ollama", "url", *ollamaURL, "model", *embedModel)
+	// Validate and sanitize ollamaURL (#4 SSRF, #27 credential logging)
+	parsedOllamaURL, err := url.ParseRequestURI(*ollamaURL)
+	if err != nil || (parsedOllamaURL.Scheme != "http" && parsedOllamaURL.Scheme != "https") {
+		return fmt.Errorf("invalid --ollama-url %q: must be an http:// or https:// URL", *ollamaURL)
+	}
+	safeOllamaURL := *parsedOllamaURL
+	safeOllamaURL.User = nil
+	slog.Info("connecting to Ollama", "url", safeOllamaURL.String(), "model", *embedModel)
+
 	embedder, err := embed.NewOllamaClient(ctx, *ollamaURL, *embedModel)
 	if err != nil {
 		return fmt.Errorf("ollama: %w", err)

--- a/internal/chunk/chunker.go
+++ b/internal/chunk/chunker.go
@@ -242,8 +242,8 @@ func ChunkDocument(text string, targetChunkChars int) []ChunkCandidate {
 
 		results = append(results, sectionChunks...)
 
-		if len(results) > 0 {
-			prevLastSentence = lastSentence(results[len(results)-1].Text)
+		if len(sectionChunks) > 0 {
+			prevLastSentence = lastSentence(sectionChunks[len(sectionChunks)-1].Text)
 		}
 	}
 

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -103,6 +103,9 @@ type Backend interface {
 	DecayAllEdges(ctx context.Context, project string, decayFactor, minStrength float64) (int, int, error)
 	// DeleteRelationshipsForMemory deletes all edges touching memoryID.
 	DeleteRelationshipsForMemory(ctx context.Context, memoryID string) error
+	// GetRelationships returns all relationship edges where memoryID is either
+	// the source or the target, scoped to project.
+	GetRelationships(ctx context.Context, project, memoryID string) ([]types.Relationship, error)
 
 	// ── Pruning ─────────────────────────────────────────────────────────────
 

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -973,7 +973,7 @@ func (b *PostgresBackend) FTSSearch(ctx context.Context, project, query string, 
 
 	rows, err := b.pool.Query(ctx, q, args...)
 	if err != nil {
-		slog.Debug("FTS query failed", "query", query, "err", err)
+		slog.Debug("FTS query failed", "query_len", len(query), "err", err)
 		return nil, nil
 	}
 	defer rows.Close()

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -913,6 +913,28 @@ func (b *PostgresBackend) DeleteRelationshipsForMemory(ctx context.Context, memo
 	return err
 }
 
+func (b *PostgresBackend) GetRelationships(ctx context.Context, project, memoryID string) ([]types.Relationship, error) {
+	rows, err := b.pool.Query(ctx, `
+		SELECT id, source_id, target_id, rel_type, strength, project, created_at
+		FROM relationships
+		WHERE project = $1 AND (source_id = $2 OR target_id = $2)`,
+		project, memoryID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var rels []types.Relationship
+	for rows.Next() {
+		var r types.Relationship
+		if err := rows.Scan(&r.ID, &r.SourceID, &r.TargetID, &r.RelType, &r.Strength, &r.Project, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		rels = append(rels, r)
+	}
+	return rels, rows.Err()
+}
+
 // ── Pruning ───────────────────────────────────────────────────────────────────
 
 func (b *PostgresBackend) PruneStaleMemories(ctx context.Context, project string, maxAgeHours float64, maxImportance int) (int, error) {
@@ -1119,6 +1141,18 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 		"SELECT COUNT(*) FROM memories WHERE project=$1 AND summary IS NULL", project,
 	).Scan(&stats.PendingSummarization); err != nil {
 		return nil, err
+	}
+
+	var summarized int
+	err = b.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM memories WHERE project = $1 AND summary IS NOT NULL`,
+		project).Scan(&summarized)
+	if err != nil {
+		summarized = 0
+	}
+	stats.Summarization = map[string]any{
+		"pending":   stats.PendingSummarization,
+		"completed": summarized,
 	}
 
 	if err := b.pool.QueryRow(ctx, "SELECT pg_database_size(current_database())").Scan(&stats.DBSizeBytes); err != nil {

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -24,6 +24,8 @@ type Client interface {
 	Dimensions() int
 }
 
+const maxEmbedResponseBytes = 10 * 1024 * 1024 // 10 MiB (#16)
+
 // OllamaClient calls the local Ollama /api/embed endpoint.
 type OllamaClient struct {
 	baseURL string
@@ -85,7 +87,7 @@ func (c *OllamaClient) Embed(ctx context.Context, text string) ([]float32, error
 	var result struct {
 		Embeddings [][]float32 `json:"embeddings"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxEmbedResponseBytes)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("ollama embed decode: %w", err)
 	}
 	if len(result.Embeddings) == 0 || len(result.Embeddings[0]) == 0 {

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -34,7 +34,7 @@ type engineEntry struct {
 // It enforces a maximum pool size by evicting the least-recently-used engine
 // when the cap is reached. Safe for concurrent use.
 type EnginePool struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	engines map[string]*engineEntry
 	factory EngineFactory
 }
@@ -49,26 +49,44 @@ func NewEnginePool(factory EngineFactory) *EnginePool {
 
 // Get returns the cached engine for project, creating one via factory if needed.
 // If the pool is at capacity, the least-recently-used engine is evicted first.
+//
+// Uses double-checked locking so the slow factory path (PostgreSQL connection +
+// migrations) runs outside the mutex, preventing contention across projects (#31).
 func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, error) {
 	if len(project) > 128 {
 		return nil, fmt.Errorf("project name too long (%d chars, max 128)", len(project))
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
+	// Fast path: read lock is sufficient when the engine already exists.
+	p.mu.RLock()
 	if e, ok := p.engines[project]; ok {
 		e.lastAccess = time.Now()
+		p.mu.RUnlock()
 		return e.handle, nil
 	}
+	p.mu.RUnlock()
 
-	// Evict LRU entry if at capacity.
-	if len(p.engines) >= maxPoolSize {
-		p.evictLRULocked()
-	}
-
+	// Slow path: create engine OUTSIDE the lock so other projects are not blocked
+	// during the PostgreSQL connection + migration phase.
 	h, err := p.factory(ctx, project)
 	if err != nil {
 		return nil, err
+	}
+
+	// Write lock only to insert. Check again in case a concurrent caller already
+	// created this project's engine while we were in factory.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.engines[project]; ok {
+		// Race: another goroutine won — discard the engine we just created.
+		if h != nil && h.Engine != nil {
+			h.Engine.Close()
+		}
+		e.lastAccess = time.Now()
+		return e.handle, nil
+	}
+	if len(p.engines) >= maxPoolSize {
+		p.evictLRULocked()
 	}
 	p.engines[project] = &engineEntry{handle: h, lastAccess: time.Now()}
 	return h, nil

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/search"
@@ -25,9 +26,11 @@ type EngineHandle struct {
 type EngineFactory func(ctx context.Context, project string) (*EngineHandle, error)
 
 // engineEntry holds a handle plus its last-access timestamp for LRU eviction.
+// lastAccess stores UnixNano as an atomic int64 so the fast path (RLock) can
+// update it without a data race.
 type engineEntry struct {
 	handle     *EngineHandle
-	lastAccess time.Time
+	lastAccess atomic.Int64 // UnixNano; use Load/Store only
 }
 
 // EnginePool lazily creates and caches one SearchEngine per project.
@@ -58,9 +61,11 @@ func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, er
 	}
 
 	// Fast path: read lock is sufficient when the engine already exists.
+	// lastAccess is updated atomically so multiple goroutines can safely
+	// record their access time while holding only RLock.
 	p.mu.RLock()
 	if e, ok := p.engines[project]; ok {
-		e.lastAccess = time.Now()
+		e.lastAccess.Store(time.Now().UnixNano())
 		p.mu.RUnlock()
 		return e.handle, nil
 	}
@@ -82,13 +87,15 @@ func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, er
 		if h != nil && h.Engine != nil {
 			h.Engine.Close()
 		}
-		e.lastAccess = time.Now()
+		e.lastAccess.Store(time.Now().UnixNano())
 		return e.handle, nil
 	}
 	if len(p.engines) >= maxPoolSize {
 		p.evictLRULocked()
 	}
-	p.engines[project] = &engineEntry{handle: h, lastAccess: time.Now()}
+	entry := &engineEntry{handle: h}
+	entry.lastAccess.Store(time.Now().UnixNano())
+	p.engines[project] = entry
 	return h, nil
 }
 
@@ -96,12 +103,13 @@ func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, er
 // Caller must hold p.mu.
 func (p *EnginePool) evictLRULocked() {
 	var lruKey string
-	var lruTime time.Time
+	var lruNano int64
 	first := true
 	for k, e := range p.engines {
-		if first || e.lastAccess.Before(lruTime) {
+		nano := e.lastAccess.Load()
+		if first || nano < lruNano {
 			lruKey = k
-			lruTime = e.lastAccess
+			lruNano = nano
 			first = false
 		}
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -52,7 +52,6 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 		Handler:           http.MaxBytesHandler(s.applyMiddleware(sse, apiKey), maxRequestBodyBytes),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       60 * time.Second,
-		WriteTimeout:      120 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -45,10 +45,15 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	slog.Info("engram MCP server starting", "addr", addr)
 
 	sse := server.NewSSEServer(s.mcp, server.WithBaseURL(fmt.Sprintf("http://%s", addr)))
+
+	const maxRequestBodyBytes = 2 * 1024 * 1024 // 2 MiB (#6)
 	httpServer := &http.Server{
 		Addr:              addr,
-		Handler:           s.applyMiddleware(sse, apiKey),
+		Handler:           http.MaxBytesHandler(s.applyMiddleware(sse, apiKey), maxRequestBodyBytes),
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -245,21 +245,32 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 		if !ok {
 			continue
 		}
-		m := &types.Memory{
-			ID:          types.NewMemoryID(),
-			Content:     getString(mmap, "content", ""),
-			MemoryType:  getString(mmap, "memory_type", types.MemoryTypeContext),
-			Project:     project,
-			Importance:  getInt(mmap, "importance", 2),
-			Tags:        toStringSlice(mmap["tags"]),
-			StorageMode: "focused",
-		}
-		if m.Content == "" {
+		content := getString(mmap, "content", "")
+		if content == "" {
 			continue
 		}
-		if len(m.Content) > types.MaxContentLength {
+		if len(content) > types.MaxContentLength {
 			storeErrs = append(storeErrs, fmt.Sprintf("item %d: content exceeds max length %d bytes", idx, types.MaxContentLength))
 			continue
+		}
+		memType := getString(mmap, "memory_type", types.MemoryTypeContext)
+		if !types.ValidateMemoryType(memType) {
+			storeErrs = append(storeErrs, fmt.Sprintf("item %d: invalid memory_type %q", idx, memType))
+			continue
+		}
+		importance := getInt(mmap, "importance", 2)
+		if importance < 0 || importance > 4 {
+			storeErrs = append(storeErrs, fmt.Sprintf("item %d: importance must be 0–4, got %d", idx, importance))
+			continue
+		}
+		m := &types.Memory{
+			ID:          types.NewMemoryID(),
+			Content:     content,
+			MemoryType:  memType,
+			Project:     project,
+			Importance:  importance,
+			Tags:        toStringSlice(mmap["tags"]),
+			StorageMode: "focused",
 		}
 		if err := h.Engine.Store(ctx, m); err != nil {
 			storeErrs = append(storeErrs, fmt.Sprintf("item %d: %s", idx, err))

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -239,7 +239,8 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 		return toolResult(map[string]any{"ids": []string{}, "count": 0, "warning": "no memories provided"})
 	}
 	var ids []string
-	for _, item := range items {
+	var storeErrs []string
+	for idx, item := range items {
 		mmap, ok := item.(map[string]any)
 		if !ok {
 			continue
@@ -257,14 +258,20 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 			continue
 		}
 		if len(m.Content) > types.MaxContentLength {
-			return nil, fmt.Errorf("content exceeds max length %d bytes", types.MaxContentLength)
+			storeErrs = append(storeErrs, fmt.Sprintf("item %d: content exceeds max length %d bytes", idx, types.MaxContentLength))
+			continue
 		}
 		if err := h.Engine.Store(ctx, m); err != nil {
-			return nil, err
+			storeErrs = append(storeErrs, fmt.Sprintf("item %d: %s", idx, err))
+			continue
 		}
 		ids = append(ids, m.ID)
 	}
-	return toolResult(map[string]any{"ids": ids, "count": len(ids)})
+	response := map[string]any{"ids": ids, "count": len(ids)}
+	if len(storeErrs) > 0 {
+		response["errors"] = storeErrs
+	}
+	return toolResult(response)
 }
 
 // handleMemoryRecall performs semantic recall against a project's memories.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -161,12 +161,23 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 	if content == "" {
 		return nil, fmt.Errorf("content is required")
 	}
+	if len(content) > types.MaxContentLength {
+		return nil, fmt.Errorf("content exceeds max length %d bytes", types.MaxContentLength)
+	}
+	memType := getString(args, "memory_type", types.MemoryTypeContext)
+	if !types.ValidateMemoryType(memType) {
+		return nil, fmt.Errorf("invalid memory_type %q; valid values: decision, pattern, error, context, architecture, preference", memType)
+	}
+	importance := getInt(args, "importance", 2)
+	if importance < 0 || importance > 4 {
+		return nil, fmt.Errorf("importance must be 0–4, got %d", importance)
+	}
 	m := &types.Memory{
 		ID:          types.NewMemoryID(),
 		Content:     content,
-		MemoryType:  getString(args, "memory_type", types.MemoryTypeContext),
+		MemoryType:  memType,
 		Project:     project,
-		Importance:  getInt(args, "importance", 2),
+		Importance:  importance,
 		Tags:        toStringSlice(args["tags"]),
 		Immutable:   getBool(args, "immutable", false),
 		StorageMode: "focused",
@@ -189,12 +200,23 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 	if content == "" {
 		return nil, fmt.Errorf("content is required")
 	}
+	if len(content) > types.MaxContentLength {
+		return nil, fmt.Errorf("content exceeds max length %d bytes", types.MaxContentLength)
+	}
+	memType := getString(args, "memory_type", types.MemoryTypeContext)
+	if !types.ValidateMemoryType(memType) {
+		return nil, fmt.Errorf("invalid memory_type %q; valid values: decision, pattern, error, context, architecture, preference", memType)
+	}
+	importance := getInt(args, "importance", 2)
+	if importance < 0 || importance > 4 {
+		return nil, fmt.Errorf("importance must be 0–4, got %d", importance)
+	}
 	m := &types.Memory{
 		ID:          types.NewMemoryID(),
 		Content:     content,
-		MemoryType:  getString(args, "memory_type", types.MemoryTypeContext),
+		MemoryType:  memType,
 		Project:     project,
-		Importance:  getInt(args, "importance", 2),
+		Importance:  importance,
 		Tags:        toStringSlice(args["tags"]),
 		StorageMode: "document",
 	}
@@ -234,6 +256,9 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 		if m.Content == "" {
 			continue
 		}
+		if len(m.Content) > types.MaxContentLength {
+			return nil, fmt.Errorf("content exceeds max length %d bytes", types.MaxContentLength)
+		}
 		if err := h.Engine.Store(ctx, m); err != nil {
 			return nil, err
 		}
@@ -256,6 +281,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		return nil, fmt.Errorf("query is required")
 	}
 	topK := getInt(args, "top_k", 10)
+	if topK < 1 || topK > 100 {
+		topK = 10
+	}
 	detail := getString(args, "detail", "summary")
 	rerank := getBool(args, "rerank", false)
 
@@ -279,6 +307,9 @@ func handleMemoryList(ctx context.Context, pool *EnginePool, req mcpgo.CallToolR
 		return nil, err
 	}
 	limit := getInt(args, "limit", 50)
+	if limit < 1 || limit > 500 {
+		limit = 50
+	}
 	offset := getInt(args, "offset", 0)
 	var memType *string
 	if s := getString(args, "memory_type", ""); s != "" {

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -325,9 +325,6 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			MatchedChunkIndex:   bestChunkIndex[id],
 			MatchedChunkSection: bestChunkSection[id],
 		}
-		if rels, err := e.backend.GetRelationships(ctx, e.project, m.ID); err == nil {
-			result.Connected = toConnectedMemories(rels, m.ID)
-		}
 		switch detail {
 		case "id_only":
 			result.Memory = &types.Memory{ID: m.ID}
@@ -383,6 +380,14 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 
 	if len(results) > topK {
 		results = results[:topK]
+	}
+
+	// Fetch relationships only for the final topK results, not for every
+	// candidate. This reduces DB round-trips from up to topK*6 to exactly topK.
+	for i := range results {
+		if rels, err := e.backend.GetRelationships(ctx, e.project, results[i].Memory.ID); err == nil {
+			results[i].Connected = toConnectedMemories(rels, results[i].Memory.ID)
+		}
 	}
 
 	// Update access timestamps.

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strconv"
 	"time"
@@ -386,7 +387,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 
 	// Update access timestamps.
 	for _, r := range results {
-		_ = e.backend.TouchMemory(ctx, r.Memory.ID)
+		if err := e.backend.TouchMemory(ctx, r.Memory.ID); err != nil {
+			slog.Warn("touch memory failed", "id", r.Memory.ID, "err", err)
+		}
 		if chunkID, ok := bestChunkID[r.Memory.ID]; ok {
 			_ = e.backend.UpdateChunkLastMatched(ctx, chunkID)
 		}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -324,6 +324,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			MatchedChunkIndex:   bestChunkIndex[id],
 			MatchedChunkSection: bestChunkSection[id],
 		}
+		if rels, err := e.backend.GetRelationships(ctx, e.project, m.ID); err == nil {
+			result.Connected = toConnectedMemories(rels, m.ID)
+		}
 		switch detail {
 		case "id_only":
 			result.Memory = &types.Memory{ID: m.ID}
@@ -436,6 +439,25 @@ func (e *SearchEngine) checkEmbedderMeta(ctx context.Context) error {
 
 func hoursSince(t time.Time) float64 {
 	return time.Since(t).Hours()
+}
+
+// toConnectedMemories converts raw relationship rows into ConnectedMemory values
+// relative to the given memory ID. ConnectedMemory.Memory is intentionally left
+// nil to avoid a second DB round-trip per relationship.
+func toConnectedMemories(rels []types.Relationship, memID string) []types.ConnectedMemory {
+	out := make([]types.ConnectedMemory, 0, len(rels))
+	for _, r := range rels {
+		dir := "outgoing"
+		if r.TargetID == memID {
+			dir = "incoming"
+		}
+		out = append(out, types.ConnectedMemory{
+			RelType:   r.RelType,
+			Direction: dir,
+			Strength:  r.Strength,
+		})
+	}
+	return out
 }
 
 // sortResults sorts descending by composite score.


### PR DESCRIPTION
## Summary

Phase 5 of the Get Well campaign closes the 16 remaining open issues across five implementation batches. All fixes are surgical — no structural changes, no new external dependencies.

**Issues closed:** #4 #6 #7 #8 #9 #12 #15 #16 #19 #24 #27 #31 #40 #43 #44 #49

## Commits

| SHA | Batch | Issues |
|-----|-------|--------|
| `12873fb` | Input validation | #7 #8 #9 #12 #15 |
| `bdc5acf` | Security hardening | #4 #6 #16 #19 #27 |
| `ff4b878` | EnginePool mutex | #31 |
| `a1b6b67` | Feature gaps | #40 #43 |
| `8dba139` | Data correctness | #24 #44 #49 |
| `550e36b` | Post-review fixes | WriteTimeout regression, batch validation gap, lastAccess race, GetRelationships N+1 |

## What changed

**Input validation** (`internal/mcp/tools.go`)
- Content length enforced at `MaxContentLength` in Store, StoreDocument, and StoreBatch
- `memory_type` validated against enum in Store, StoreDocument, and StoreBatch
- `importance` range-checked (0–4) in Store, StoreDocument, and StoreBatch
- `top_k` clamped to [1, 100]; `limit` clamped to [1, 500]

**Security hardening**
- `--ollama-url` validated as `http://` or `https://` at startup; credentials stripped from log (#4 #27)
- `http.MaxBytesHandler(2 MiB)` added; `ReadTimeout`/`IdleTimeout` set on server (#6)
- Ollama response body wrapped with `io.LimitReader(10 MiB)` before JSON decode (#16)
- FTS debug log now records `query_len` instead of raw query string (#19)

**EnginePool concurrency** (`internal/mcp/pool.go`)
- `Get()` uses double-checked locking: fast path with `RLock`, factory runs outside any lock, write lock only for insertion (#31)
- `mu` upgraded from `sync.Mutex` to `sync.RWMutex`
- `lastAccess` changed to `atomic.Int64` to eliminate data race under concurrent reads

**Feature gaps**
- `SearchResult.Connected` now populated via `GetRelationships` (called after topK slice, not in scoring loop) (#43)
- `GetStats.Summarization` map populated with `pending` and `completed` counts (#40)

**Data correctness**
- `prevLastSentence` in `ChunkDocument` now captured from current section's chunks, not accumulated results (#44)
- `TouchMemory` errors logged via `slog.Warn` instead of silently discarded (#24)
- `store_batch` continues on per-item failures, returns both `stored` items and `errors` list (#49)

## Test plan
- [ ] `go build ./...` — passes
- [ ] `go test ./...` — all 12 packages pass (including `internal/mcp`, `internal/chunk`, `internal/search`)
- [ ] Send `memory_store` with `memory_type="bogus"` → expect error
- [ ] Send `--ollama-url=file:///etc/passwd` → server refuses to start
- [ ] Send 3 MiB request body → expect 413
- [ ] Send `memory_recall` → verify `connected` field populated in response
- [ ] `memory_status` → verify `summarization` map has `pending` and `completed` keys
- [ ] `store_batch` with one invalid item → confirm valid items stored and errors returned

## Deferred (filed as issues)
- #53 — store_batch: silent skip for non-map items should accumulate into errors
- #54 — EnginePool: add concurrent test for race-detector coverage
- #55 — SSRF: validate ollamaURL host range (RFC-1918, link-local) if URL becomes runtime-configurable

🤖 Generated with [Claude Code](https://claude.com/claude-code)