### PR TITLE
fix: deferred issues #53 #54 #55 — store_batch type assertions, EnginePool race test, SSRF IP block

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"os/signal"
@@ -63,6 +64,13 @@ func run() error {
 	if err != nil || (parsedOllamaURL.Scheme != "http" && parsedOllamaURL.Scheme != "https") {
 		return fmt.Errorf("invalid --ollama-url %q: must be an http:// or https:// URL", *ollamaURL)
 	}
+	// Block literal private-IP Ollama URLs to prevent SSRF (#55).
+	// Hostnames (e.g. "ollama" in Docker Compose) are intentionally excluded:
+	// they resolve to private container IPs by design and are not attacker-controlled.
+	if ollamaHost := parsedOllamaURL.Hostname(); net.ParseIP(ollamaHost) != nil && isPrivateIP(ollamaHost) {
+		return fmt.Errorf("invalid --ollama-url: IP %q is in a private/reserved range (SSRF protection)", ollamaHost)
+	}
+
 	safeOllamaURL := *parsedOllamaURL
 	safeOllamaURL.User = nil
 	slog.Info("connecting to Ollama", "url", safeOllamaURL.String(), "model", *embedModel)
@@ -141,6 +149,34 @@ func run() error {
 	slog.Info("engram ready", "host", *host, "port", *port,
 		"embed_model", *embedModel, "summarize_model", sumModel)
 	return srv.Start(ctx, *host, *port, *apiKey)
+}
+
+// isPrivateIP reports whether ipStr is an IP address that falls within a
+// private, loopback, or link-local range. Only literal IP addresses are
+// checked; hostnames must be resolved before calling this function.
+// Used to block SSRF via the Ollama URL flag (#55).
+func isPrivateIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	privateRanges := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"169.254.0.0/16", // link-local / AWS metadata endpoint
+		"127.0.0.0/8",    // loopback
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 ULA
+		"fe80::/10",      // IPv6 link-local
+	}
+	for _, cidr := range privateRanges {
+		_, n, _ := net.ParseCIDR(cidr)
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 func envOr(key, def string) string {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		private bool
+	}{
+		// Private / reserved ranges that must be blocked
+		{"169.254.169.254", true},  // AWS metadata
+		{"10.0.0.1", true},         // RFC-1918
+		{"10.255.255.255", true},   // RFC-1918
+		{"172.16.0.1", true},       // RFC-1918
+		{"172.31.255.255", true},   // RFC-1918
+		{"192.168.1.1", true},      // RFC-1918
+		{"127.0.0.1", true},        // loopback
+		{"127.255.0.1", true},      // loopback range
+		{"::1", true},              // IPv6 loopback
+		{"fc00::1", true},          // IPv6 ULA
+		{"fe80::1", true},          // IPv6 link-local
+
+		// Public addresses that must pass
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"208.67.222.222", false},
+		{"2001:4860:4860::8888", false}, // Google public DNS IPv6
+
+		// Not an IP at all — must return false (not a private IP)
+		{"", false},
+		{"not-an-ip", false},
+	}
+
+	for _, tc := range cases {
+		got := isPrivateIP(tc.ip)
+		if got != tc.private {
+			t.Errorf("isPrivateIP(%q) = %v, want %v", tc.ip, got, tc.private)
+		}
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -243,6 +243,7 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 	for idx, item := range items {
 		mmap, ok := item.(map[string]any)
 		if !ok {
+			storeErrs = append(storeErrs, fmt.Sprintf("item %d: expected object, got %T", idx, item))
 			continue
 		}
 		content := getString(mmap, "content", "")

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2,11 +2,57 @@ package mcp_test
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
 	"github.com/stretchr/testify/require"
 )
+
+// TestEnginePool_ConcurrentFastPath exercises the fast path (RLock) of
+// EnginePool.Get under high concurrency. Twenty goroutines hit the same
+// pre-warmed project key simultaneously. The race detector validates that
+// the atomic lastAccess update inside the fast path is data-race-free.
+func TestEnginePool_ConcurrentFastPath(t *testing.T) {
+	var factoryCalls atomic.Int64
+
+	pool := internalmcp.NewEnginePool(func(ctx context.Context, project string) (*internalmcp.EngineHandle, error) {
+		factoryCalls.Add(1)
+		return &internalmcp.EngineHandle{}, nil
+	})
+
+	ctx := context.Background()
+
+	// Pre-warm: populate the cache so all goroutines below take the fast path.
+	primed, err := pool.Get(ctx, "test-project")
+	require.NoError(t, err)
+	require.NotNil(t, primed)
+
+	const goroutines = 20
+	results := make([]*internalmcp.EngineHandle, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			results[i], errs[i] = pool.Get(ctx, "test-project")
+		}()
+	}
+	wg.Wait()
+
+	// All 20 calls must succeed and return the same pointer as the primed handle.
+	for i := 0; i < goroutines; i++ {
+		require.NoError(t, errs[i], "goroutine %d returned an error", i)
+		require.Same(t, primed, results[i], "goroutine %d returned a different handle", i)
+	}
+
+	// Factory must have been called exactly once — during the pre-warm step.
+	require.Equal(t, int64(1), factoryCalls.Load())
+}
 
 func TestEnginePool_GetOrCreate_SameProject_SameInstance(t *testing.T) {
 	calls := 0


### PR DESCRIPTION
## Summary

- **#53** `store_batch` now accumulates type-assertion failures into the errors array (same path as other per-item errors) instead of silently dropping them
- **#54** Added `TestEnginePool_ConcurrentFastPath` — 20 goroutines on a pre-warmed project, validates same handle returned and atomic `lastAccess` under `-race`
- **#55** `isPrivateIP` blocks literal private-IP Ollama URLs at startup (RFC-1918, loopback, link-local, AWS metadata endpoint, IPv6 ULA/link-local); Docker hostnames like `"ollama"` pass through unchanged

Closes #53, #54, #55

## Test plan
- [ ] `go build ./...` — clean
- [ ] `go test -race ./...` — all pass
- [ ] `TestEnginePool_ConcurrentFastPath` — pass with `-race`
- [ ] `TestIsPrivateIP` — 18 cases across all CIDR blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)