### PR TITLE
fix: integration test bugs + code reviewer findings (post-expansion)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ restart: build
 
 ## Build the engram-go Docker image
 build:
-	docker build -t engram-go:latest -t engram-go:2.1.0 .
+	docker build -t engram-go:latest -t engram-go:2.2.0 .
 
 ## Tail container logs
 logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
 
   engram-go:
     container_name: engram-go-app
-    image: engram-go:2.1.0
+    image: engram-go:2.2.0
     ports:
       - "127.0.0.1:${ENGRAM_PORT:-8788}:8788"
     env_file:
@@ -96,7 +96,7 @@ services:
   # ── Test database (CI only) ───────────────────────────────────────────────
   test-postgres:
     container_name: engram-test-postgres
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     profiles: ["test"]
     environment:
       - POSTGRES_DB=engram_test

--- a/internal/db/migrations/002_indexes.sql
+++ b/internal/db/migrations/002_indexes.sql
@@ -8,8 +8,8 @@ CREATE INDEX IF NOT EXISTS idx_memories_project
 CREATE INDEX IF NOT EXISTS idx_chunks_memory_id
     ON chunks (memory_id);
 
-CREATE INDEX IF NOT EXISTS idx_chunks_last_accessed
-    ON chunks (last_accessed DESC);
+CREATE INDEX IF NOT EXISTS idx_chunks_last_matched
+    ON chunks (last_matched DESC);
 
 CREATE INDEX IF NOT EXISTS idx_chunks_project
     ON chunks (project);

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -428,7 +428,7 @@ func (b *PostgresBackend) UpdateMemory(
 
 	// Lock the row for the duration of the read-modify-write to prevent races.
 	row, err := tx.Query(ctx,
-		"SELECT * FROM memories WHERE id=$1 AND project=$2 FOR UPDATE",
+		"SELECT * FROM memories WHERE id=$1 AND project=$2 AND valid_to IS NULL FOR UPDATE",
 		id, b.project)
 	if err != nil {
 		return nil, err
@@ -1280,7 +1280,7 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 }
 
 func (b *PostgresBackend) ListAllProjects(ctx context.Context) ([]string, error) {
-	rows, err := b.pool.Query(ctx, "SELECT DISTINCT project FROM memories ORDER BY project")
+	rows, err := b.pool.Query(ctx, "SELECT DISTINCT project FROM memories WHERE valid_to IS NULL ORDER BY project")
 	if err != nil {
 		return nil, err
 	}
@@ -1645,13 +1645,21 @@ func (b *PostgresBackend) versionMemoryTx(ctx context.Context, tx pgx.Tx, m *typ
 	if changeReason != "" {
 		reason = &changeReason
 	}
+	now := time.Now().UTC()
+	// Close the system_to window on all prior open versions for this memory.
+	if _, err = tx.Exec(ctx,
+		"UPDATE memory_versions SET system_to=$1 WHERE memory_id=$2 AND system_to IS NULL",
+		now, m.ID,
+	); err != nil {
+		return fmt.Errorf("versionMemoryTx: close prior system_to: %w", err)
+	}
 	_, err = tx.Exec(ctx, `
 		INSERT INTO memory_versions
 			(id, memory_id, content, memory_type, tags, importance,
 			 system_from, valid_from, valid_to, change_type, change_reason, project)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		types.NewMemoryID(), m.ID, m.Content, m.MemoryType, tagsJSON, m.Importance,
-		time.Now().UTC(), m.ValidFrom, m.ValidTo, changeType, reason, m.Project,
+		now, m.ValidFrom, m.ValidTo, changeType, reason, m.Project,
 	)
 	return err
 }

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -345,22 +345,30 @@ func (b *PostgresBackend) storeMemoryExec(ctx context.Context, ex execer, m *typ
 		episodeArg = episodeID
 	}
 
+	// Seed dynamic_importance from static importance using Feature 2 formula.
+	if m.DynamicImportance == nil {
+		di := math.Max(0.1, (5.0-float64(m.Importance))/3.0)
+		m.DynamicImportance = &di
+	}
+
 	_, err = ex.Exec(ctx, `
 		INSERT INTO memories
 		  (id, content, memory_type, project, tags,
 		   importance, access_count, last_accessed, created_at, updated_at,
-		   immutable, expires_at, content_hash, storage_mode, episode_id)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		   immutable, expires_at, content_hash, storage_mode, episode_id,
+		   dynamic_importance)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
 		m.ID, m.Content, m.MemoryType, m.Project, tagsJSON,
 		m.Importance, m.AccessCount, now, now, now,
 		m.Immutable, m.ExpiresAt, hash, m.StorageMode, episodeArg,
+		m.DynamicImportance,
 	)
 	return err
 }
 
 func (b *PostgresBackend) GetMemory(ctx context.Context, id string) (*types.Memory, error) {
 	row, err := b.pool.Query(ctx,
-		"SELECT * FROM memories WHERE id=$1 AND project=$2", id, b.project)
+		"SELECT * FROM memories WHERE id=$1 AND project=$2 AND valid_to IS NULL", id, b.project)
 	if err != nil {
 		return nil, err
 	}
@@ -614,9 +622,14 @@ func (b *PostgresBackend) storeChunksExec(ctx context.Context, ex execer, chunks
 	return nil
 }
 
+// chunkCols is an explicit column list for chunks SELECTs. Using SELECT c.*
+// breaks positional scanning when migrations reorder columns (e.g. after
+// 003_pgvector.sql drops the old BYTEA embedding and adds vector(768)).
+const chunkCols = "c.id, c.memory_id, c.project, c.chunk_text, c.chunk_index, c.chunk_hash, c.embedding, c.section_heading, c.chunk_type, c.last_matched"
+
 func (b *PostgresBackend) GetChunksForMemory(ctx context.Context, memoryID string) ([]*types.Chunk, error) {
 	rows, err := b.pool.Query(ctx,
-		"SELECT * FROM chunks WHERE memory_id=$1 ORDER BY chunk_index", memoryID,
+		"SELECT "+chunkCols+" FROM chunks c WHERE c.memory_id=$1 ORDER BY c.chunk_index", memoryID,
 	)
 	if err != nil {
 		return nil, err
@@ -626,7 +639,7 @@ func (b *PostgresBackend) GetChunksForMemory(ctx context.Context, memoryID strin
 
 func (b *PostgresBackend) GetAllChunksWithEmbeddings(ctx context.Context, project string, limit int) ([]*types.Chunk, error) {
 	rows, err := b.pool.Query(ctx, `
-		SELECT c.* FROM chunks c
+		SELECT `+chunkCols+` FROM chunks c
 		JOIN memories m ON m.id = c.memory_id
 		WHERE c.embedding IS NOT NULL AND m.project=$1 AND m.valid_to IS NULL
 		ORDER BY m.last_accessed DESC
@@ -664,7 +677,7 @@ func (b *PostgresBackend) GetChunksForMemories(ctx context.Context, memoryIDs []
 		return nil, nil
 	}
 	rows, err := b.pool.Query(ctx, `
-		SELECT c.* FROM chunks c
+		SELECT `+chunkCols+` FROM chunks c
 		WHERE c.memory_id = ANY($1) AND c.embedding IS NOT NULL
 		ORDER BY c.chunk_index`, memoryIDs,
 	)
@@ -674,13 +687,14 @@ func (b *PostgresBackend) GetChunksForMemories(ctx context.Context, memoryIDs []
 	return pgx.CollectRows(rows, rowToChunk)
 }
 
-func (b *PostgresBackend) ChunkHashExists(ctx context.Context, chunkHash, memoryID string) (bool, error) {
+func (b *PostgresBackend) ChunkHashExists(ctx context.Context, chunkHash, _ string) (bool, error) {
 	var exists bool
 	err := b.pool.QueryRow(ctx, `
 		SELECT EXISTS(
-			SELECT 1 FROM chunks
-			WHERE chunk_hash=$1 AND memory_id=$2
-		)`, chunkHash, memoryID,
+			SELECT 1 FROM chunks c
+			JOIN memories m ON m.id = c.memory_id
+			WHERE c.chunk_hash=$1 AND m.project=$2
+		)`, chunkHash, b.project,
 	).Scan(&exists)
 	return exists, err
 }
@@ -717,7 +731,7 @@ func (b *PostgresBackend) NullAllEmbeddings(ctx context.Context, project string)
 
 func (b *PostgresBackend) GetChunksPendingEmbedding(ctx context.Context, project string, limit int) ([]*types.Chunk, error) {
 	rows, err := b.pool.Query(ctx, `
-		SELECT c.* FROM chunks c
+		SELECT `+chunkCols+` FROM chunks c
 		JOIN memories m ON m.id = c.memory_id
 		WHERE m.project=$1 AND c.embedding IS NULL
 		ORDER BY m.last_accessed DESC

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -525,6 +525,9 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 	if err != nil {
 		return nil, err
 	}
+	if updated == nil {
+		return nil, fmt.Errorf("memory %q not found or has been soft-deleted", id)
+	}
 	return toolResult(updated)
 }
 

--- a/internal/search/federation.go
+++ b/internal/search/federation.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 
 	"github.com/petersimmons1972/engram/internal/types"
@@ -40,6 +41,7 @@ func RecallAcrossEngines(ctx context.Context, engines []*SearchEngine, query str
 		fan := <-ch
 		if fan.err != nil {
 			// Best-effort: log and skip failing engines rather than aborting the whole call.
+			slog.Warn("federation: engine recall failed", "err", fan.err)
 			continue
 		}
 		for _, r := range fan.results {

--- a/internal/search/temporal_test.go
+++ b/internal/search/temporal_test.go
@@ -40,13 +40,18 @@ func TestTemporalVersioning_SoftDelete(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, deleted)
 
-	// GetMemory by ID should still return the memory (admin/history path is not filtered by valid_to).
+	// GetMemory must return nil — active-filter excludes soft-deleted records.
 	afterDelete, err := engine.Backend().GetMemory(ctx, m.ID)
 	require.NoError(t, err)
-	require.NotNil(t, afterDelete)
-	assert.NotNil(t, afterDelete.ValidTo, "valid_to must be set after soft-delete")
-	assert.NotNil(t, afterDelete.InvalidationReason)
-	assert.Equal(t, "superseded by new auth design", *afterDelete.InvalidationReason)
+	assert.Nil(t, afterDelete, "GetMemory must exclude soft-deleted memories from active results")
+
+	// GetMemoryHistory must contain the invalidation snapshot with the correct reason.
+	history, err := engine.MemoryHistory(ctx, m.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, history, "GetMemoryHistory must return at least one version entry")
+	assert.Equal(t, types.VersionChangeInvalidate, history[0].ChangeType)
+	require.NotNil(t, history[0].ChangeReason)
+	assert.Equal(t, "superseded by new auth design", *history[0].ChangeReason)
 
 	// Second forget on the same ID should return false (already invalidated).
 	deleted2, err := engine.Forget(ctx, m.ID, "duplicate")


### PR DESCRIPTION
## Summary

- Fixes 6 bugs exposed when integration tests ran against a fresh Postgres (pgvector migration shifts column order, NULL dynamic_importance at INSERT, per-memory instead of project-wide chunk dedup, GetMemory returning soft-deleted records)
- Addresses 4 critical/important findings from superpowers:code-reviewer audit of the Features 1–7 expansion PR (#89)

## Changes

**Commit 1 — Integration bugs (ba8210a)**
- `002_indexes.sql`: `idx_chunks_last_accessed` → `idx_chunks_last_matched` (column didn't exist)
- `postgres.go`: add `chunkCols` explicit column list — prevents positional scan skew on fresh DBs after pgvector migration reorders chunks columns
- `postgres.go`: seed `dynamic_importance` at INSERT time using `GREATEST(0.1, (5.0−importance)/3.0)` — prevents nil dereference in adaptive importance tests
- `postgres.go`: `ChunkHashExists` now project-wide dedup (was per-memory)
- `postgres.go`: `GetMemory` filters `AND valid_to IS NULL` — active-only semantics
- `temporal_test.go`: update `SoftDelete` test to verify via `GetMemoryHistory` (consistent with active-filter fix)

**Commit 2 — Code reviewer findings (54ca467)**
- `postgres.go UpdateMemory`: add `AND valid_to IS NULL` to FOR UPDATE lock — prevents `memory_correct` ghost-writing to soft-deleted memories
- `postgres.go ListAllProjects`: add `WHERE valid_to IS NULL` — ghost projects no longer appear in federation wildcard / `memory_projects`
- `postgres.go versionMemoryTx`: close prior open `system_to` rows before inserting new snapshot — preserves bi-temporal validity windows
- `federation.go`: `slog.Warn` on engine recall failure — silent failures now produce diagnostic output
- `tools.go handleMemoryCorrect`: explicit error when memory is nil/soft-deleted

## Test plan

- [x] `go test -race -count=1 ./...` — 14/14 packages pass
- [x] `go build ./cmd/engram/` — clean
- [x] `go vet ./...` — clean
- [ ] Deploy to production and verify migrations auto-apply on startup

## Related issues

Filed: #90 #91 #92 #93 #94 #95 #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)