### PR TITLE
feat(search): decay worker for adaptive importance (issue #90)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/claude"
 	"github.com/petersimmons1972/engram/internal/db"
@@ -44,6 +45,7 @@ func run() error {
 	host := fs.String("host", envOr("ENGRAM_HOST", "0.0.0.0"), "Bind address")
 	apiKey := fs.String("api-key", envOr("ENGRAM_API_KEY", ""), "Bearer token for auth (required; set ENGRAM_API_KEY)")
 	dataDir := fs.String("data-dir", envOr("ENGRAM_DATA_DIR", ""), "Base directory for file operations (required when using export/ingest tools)")
+	decayInterval := fs.Duration("decay-interval", envDuration("ENGRAM_DECAY_INTERVAL", 0), "How often the importance decay worker runs (0 = default 8h)")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return err
@@ -121,7 +123,7 @@ func run() error {
 		if err != nil {
 			return nil, fmt.Errorf("postgres backend for project %q: %w", project, err)
 		}
-		engine := search.New(ctx, backend, embedClient, project, ollamaURLVal, sumModel, sumEnabled, claudeCompleter)
+		engine := search.New(ctx, backend, embedClient, project, ollamaURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval)
 		return &internalmcp.EngineHandle{Engine: engine}, nil
 	}
 
@@ -216,4 +218,13 @@ func envBool(key string, def bool) bool {
 	default:
 		return def
 	}
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
 }

--- a/internal/search/adaptive_test.go
+++ b/internal/search/adaptive_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/assert"
@@ -162,6 +163,50 @@ func TestAdaptiveImportance_DecayStale(t *testing.T) {
 	require.NoError(t, err)
 	assert.Less(t, *after.DynamicImportance, initialDI,
 		"dynamic_importance must decrease after stale decay pass")
+}
+
+// TestDecayWorker_RunsOnTick verifies that the background DecayWorker actually
+// fires and reduces dynamic_importance on stale memories without any explicit
+// caller — the worker must tick autonomously and call DecayStaleImportance.
+func TestDecayWorker_RunsOnTick(t *testing.T) {
+	dsn := testDSN(t)
+	ctx := context.Background()
+	project := uniqueProject("test-decay-worker")
+
+	backend, err := db.NewPostgresBackend(ctx, project, dsn)
+	require.NoError(t, err)
+
+	// 50ms tick so the test completes quickly.
+	engine := search.New(ctx, backend, &fakeClient{dims: 768}, project,
+		"http://ollama:11434", "llama3.2", false, nil, 50*time.Millisecond)
+	t.Cleanup(func() { engine.Close() })
+
+	m := &types.Memory{
+		Content:     "Stale memory for decay worker tick test",
+		MemoryType:  types.MemoryTypeContext,
+		Project:     project,
+		Importance:  3,
+		StorageMode: "focused",
+	}
+	require.NoError(t, engine.Store(ctx, m))
+
+	// Force next_review_at into the past so the worker will pick it up.
+	pastReview := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, backend.SetNextReviewAt(ctx, m.ID, pastReview))
+
+	before, err := backend.GetMemory(ctx, m.ID)
+	require.NoError(t, err)
+	require.NotNil(t, before.DynamicImportance)
+	initialDI := *before.DynamicImportance
+
+	// Wait long enough for at least two ticks.
+	time.Sleep(200 * time.Millisecond)
+
+	after, err := backend.GetMemory(ctx, m.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after.DynamicImportance)
+	assert.Less(t, *after.DynamicImportance, initialDI,
+		"decay worker must have fired and reduced dynamic_importance on the stale memory")
 }
 
 // TestAdaptiveImportance_UsedInRecall verifies that a memory with higher

--- a/internal/search/decay.go
+++ b/internal/search/decay.go
@@ -1,0 +1,94 @@
+package search
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+)
+
+const (
+	decayFactor          = 0.95
+	defaultDecayInterval = 8 * time.Hour
+)
+
+// DecayWorker is a background goroutine that applies spaced-repetition decay to
+// memories whose next_review_at timestamp has passed. It multiplies
+// dynamic_importance by decayFactor (0.95) on each qualifying row and advances
+// next_review_at by retrieval_interval_hrs. This implements the "background decay"
+// half of Feature 2 (Adaptive Importance via Spaced Repetition).
+type DecayWorker struct {
+	backend  db.Backend
+	project  string
+	interval time.Duration
+	cancel   context.CancelFunc
+	done     chan struct{}
+}
+
+// NewDecayWorker creates a DecayWorker. interval is how often the decay pass runs;
+// pass 0 to use the default (8 hours). The worker does not start until Start() is called.
+func NewDecayWorker(backend db.Backend, project string, interval time.Duration) *DecayWorker {
+	if interval <= 0 {
+		interval = defaultDecayInterval
+	}
+	return &DecayWorker{
+		backend:  backend,
+		project:  project,
+		interval: interval,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start launches the background decay goroutine.
+func (w *DecayWorker) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+	go w.run(ctx)
+}
+
+// Stop signals the worker to stop and waits for it to exit (max 10s).
+func (w *DecayWorker) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	select {
+	case <-w.done:
+	case <-time.After(10 * time.Second):
+		slog.Warn("decay worker did not stop within 10s", "project", w.project)
+	}
+}
+
+func (w *DecayWorker) run(ctx context.Context) {
+	defer close(w.done)
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("decay worker panic", "project", w.project, "panic", r)
+		}
+	}()
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.runOnce(ctx)
+		}
+	}
+}
+
+func (w *DecayWorker) runOnce(ctx context.Context) {
+	n, err := w.backend.DecayStaleImportance(ctx, w.project, decayFactor)
+	if err != nil {
+		slog.Warn("decay worker: DecayStaleImportance failed",
+			"project", w.project, "err", err)
+		return
+	}
+	if n > 0 {
+		slog.Info("decay worker: applied importance decay",
+			"project", w.project, "rows", n)
+	}
+}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -74,6 +74,7 @@ type SearchEngine struct {
 	ollamaURL  string
 	summarizer *summarize.Worker
 	reembedder *reembed.Worker
+	decayer    *DecayWorker
 }
 
 // getEmbedder safely reads the current embedder. Use this instead of e.embedder
@@ -84,17 +85,22 @@ func (e *SearchEngine) getEmbedder() embed.Client {
 	return e.embedder
 }
 
-// New constructs a SearchEngine and starts background summarize and reembed workers.
-// claudeClient may be nil, in which case summarization falls back to Ollama.
+// New constructs a SearchEngine and starts background workers (summarize, reembed,
+// and spaced-repetition importance decay). claudeClient may be nil, in which case
+// summarization falls back to Ollama. decayInterval controls how often the decay
+// pass runs; pass 0 to use the default (8 hours).
 func New(ctx context.Context, backend db.Backend, embedder embed.Client, project string,
 	ollamaURL, summarizeModel string, summarizeEnabled bool,
-	claudeClient summarize.ClaudeCompleter) *SearchEngine {
+	claudeClient summarize.ClaudeCompleter, decayInterval time.Duration) *SearchEngine {
 
 	sum := summarize.NewWorkerWithClaude(backend, project, ollamaURL, summarizeModel, summarizeEnabled, claudeClient)
 	sum.Start()
 
 	reb := reembed.NewWorkerFromMeta(ctx, backend, embedder, project)
 	reb.Start()
+
+	dec := NewDecayWorker(backend, project, decayInterval)
+	dec.Start()
 
 	return &SearchEngine{
 		backend:    backend,
@@ -103,12 +109,14 @@ func New(ctx context.Context, backend db.Backend, embedder embed.Client, project
 		ollamaURL:  ollamaURL,
 		summarizer: sum,
 		reembedder: reb,
+		decayer:    dec,
 	}
 }
 
 // Close shuts down the engine, stops all background workers, and releases
 // the database connection pool. Must be called exactly once per engine.
 func (e *SearchEngine) Close() {
+	e.decayer.Stop()
 	e.summarizer.Stop()
 	e.reembedder.Stop()
 	e.backend.Close()

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -51,7 +51,7 @@ func newTestEngine(t *testing.T, project string) *search.SearchEngine {
 	require.NoError(t, err)
 	t.Cleanup(func() { backend.Close() })
 	return search.New(ctx, backend, &fakeClient{dims: 768}, project,
-		"http://ollama:11434", "llama3.2", false, nil)
+		"http://ollama:11434", "llama3.2", false, nil, 0)
 }
 
 func TestSearchEngine_Store(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `DecayWorker` background goroutine (`internal/search/decay.go`) that ticks every `ENGRAM_DECAY_INTERVAL` (default 8h) and calls `DecayStaleImportance(0.95)` on memories past their `next_review_at`
- Wires `DecayWorker` into `SearchEngine.New()` with a `decayInterval time.Duration` parameter; stops cleanly in `Close()`
- Adds `--decay-interval` / `ENGRAM_DECAY_INTERVAL` env-var flag in `cmd/engram/main.go`
- Integration test `TestDecayWorker_RunsOnTick` verifies the worker fires autonomously (50ms tick, asserts `dynamic_importance` decreases on a stale memory)

Closes #90

## Test plan

- [x] `go test -race -count=1 ./...` — all 14 packages pass
- [x] `TestDecayWorker_RunsOnTick` verifies autonomous tick behavior
- [x] `TestAdaptiveImportance_DecayStale` verifies `DecayStaleImportance` correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)