### PR TITLE
[codex] Add safety verification wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The server starts on port 8788. Cold start: under 200ms. Memory at idle: 18 MB.
 
 <p align="center"><img src="docs/architecture.svg" alt="Engram Architecture" width="900"></p>
 
-Your AI client speaks MCP over SSE. Engram exposes 28 tools — store, recall, connect, correct, diagnose, episode management, cross-project federation, and more. PostgreSQL with pgvector stores everything. Ollama (local) runs the embeddings. When Ollama is unavailable, search falls back to BM25 and recency. All tools stay functional.
+Your AI client speaks MCP over SSE. Engram exposes 31 tools — store, recall, connect, correct, diagnose, episode management, cross-project federation, and lightweight safety verification wrappers for constraint checks before acting. PostgreSQL with pgvector stores everything. Ollama (local) runs the embeddings. When Ollama is unavailable, search falls back to BM25 and recency. All tools stay functional.
 
 ---
 
@@ -57,7 +57,7 @@ Your AI client speaks MCP over SSE. Engram exposes 28 tools — store, recall, c
 | [How It Works](docs/how-it-works.md) | Four-signal search, knowledge graph, context efficiency |
 | [Getting Started](docs/getting-started.md) | Install and connect in 5 minutes |
 | [Connecting Your IDE](docs/connecting.md) | Claude Code, Cursor, VS Code, Windsurf, Claude Desktop |
-| [All 28 Tools](docs/tools.md) | MCP tool reference with usage examples |
+| [All 31 Tools](docs/tools.md) | MCP tool reference with usage examples |
 | [Claude Advisor](docs/claude-advisor.md) | AI-powered summarization, consolidation, re-ranking |
 | [Operations](docs/operations.md) | Backup, security, data portability |
 
@@ -65,7 +65,7 @@ Your AI client speaks MCP over SSE. Engram exposes 28 tools — store, recall, c
 
 ## v3.0 vs v2 vs v1
 
-v1 was Python. v2 rewrote in Go. v3.0 adds required authentication, auto-episode starts on every SSE connection, and 28 tools.
+v1 was Python. v2 rewrote in Go. v3.0 adds required authentication, auto-episode starts on every SSE connection, and 31 tools.
 
 | | v1 (Python) | v2 (Go) | v3.0 (Go) |
 |---|---|---|---|

--- a/docs/assets/VISUAL-IDENTITY.md
+++ b/docs/assets/VISUAL-IDENTITY.md
@@ -104,8 +104,8 @@ For architecture diagrams: component boxes should align on a 40px or 60px grid. 
 docs/hero.svg             — hero banner (needs v3.0 update: aria-label, tagline, badge count)
 docs/scoring.svg          — four-signal scoring (needs v3.0 footer update)
 docs/architecture.svg     — system architecture (needs v3.0 footer update)
-docs/ide-ecosystem.svg    — IDE connection diagram (needs v3.0 + 28 tools update)
-docs/quick-start-flow.svg — getting started flow (needs 28 tools update)
+docs/ide-ecosystem.svg    — IDE connection diagram (needs v3.0 footer update)
+docs/quick-start-flow.svg — getting started flow
 docs/session-workflow.svg — three-moment session pattern
 docs/knowledge-graph.svg  — graph traversal visualization
 docs/db-schema.svg        — five-table schema

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -2,7 +2,7 @@
 
 Engram speaks MCP over Server-Sent Events. Any MCP-compatible client that supports SSE transport works.
 
-The SSE endpoint is `http://localhost:8788/sse`. When Engram is running, that endpoint holds a persistent connection open and sends tool definitions and responses over it. You point your IDE at the URL, it discovers the 28 tools, and they appear in your model context.
+The SSE endpoint is `http://localhost:8788/sse`. When Engram is running, that endpoint holds a persistent connection open and sends tool definitions and responses over it. You point your IDE at the URL, it discovers the available tools, and they appear in your model context.
 
 ---
 
@@ -35,7 +35,7 @@ Verify the tools loaded:
 /mcp
 ```
 
-You should see `engram` listed with 27 tools (28 if `ANTHROPIC_API_KEY` is set). If the count is wrong, restart Claude Code — it reads MCP configs at startup, not on demand.
+You should see `engram` listed with 30 tools (31 if `ANTHROPIC_API_KEY` is set). If the count is wrong, restart Claude Code — it reads MCP configs at startup, not on demand.
 
 ---
 
@@ -175,8 +175,8 @@ The SSE transport is a long-lived HTTP connection. Some reverse proxies and fire
 **"Authorization required" error.**
 You have `ENGRAM_API_KEY` set but the IDE is not sending the header. Check the IDE config and confirm the header key is `Authorization` and the value starts with `Bearer `.
 
-**Wrong number of tools (expect 27 or 28).**
-`memory_reason` is only registered when `ANTHROPIC_API_KEY` is set in `.env`. Without it, you see 27 tools. With it, you see 28. Set the key and restart `engram-go`:
+**Wrong number of tools (expect 30 or 31).**
+`memory_reason` is only registered when `ANTHROPIC_API_KEY` is set in `.env`. Without it, you see 30 tools. With it, you see 31. Set the key and restart `engram-go`:
 
 ```bash
 docker compose restart engram-go
@@ -185,4 +185,4 @@ docker compose restart engram-go
 ---
 
 **Previous:** [Getting Started](getting-started.md) — prerequisites, startup, and configuration reference.  
-**Next:** [Tools Reference](tools.md) — all 28 tools with parameters and examples.
+**Next:** [Tools Reference](tools.md) — all 31 tools with parameters and examples.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,7 +101,7 @@ In Claude Code, confirm the tools loaded:
 /mcp
 ```
 
-You should see `engram` listed with 27 tools (28 if `ANTHROPIC_API_KEY` is set). If it shows fewer, restart Claude Code — IDE MCP clients cache the tool list at startup.
+You should see `engram` listed with 30 tools (31 if `ANTHROPIC_API_KEY` is set). If it shows fewer, restart Claude Code — IDE MCP clients cache the tool list at startup.
 
 ---
 

--- a/docs/ide-ecosystem.svg
+++ b/docs/ide-ecosystem.svg
@@ -151,7 +151,7 @@
         font-size="11" fill="#8b949e" text-anchor="middle">port 8788</text>
   <text x="710" y="172"
         font-size="12" font-weight="600"
-        fill="#3fb950" text-anchor="middle">28 tools</text>
+        fill="#3fb950" text-anchor="middle">31 tools</text>
 
   <!-- Right annotation stack — backend dependencies -->
   <text x="838" y="125"

--- a/docs/quick-start-flow.svg
+++ b/docs/quick-start-flow.svg
@@ -74,7 +74,7 @@
   <!-- Code lines -->
   <text x="638" y="158" font-family="'Courier New', monospace" font-size="13" fill="#3fb950">make setup</text>
   <!-- Annotation two lines -->
-  <text x="630" y="206" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8b949e">28 tools now available</text>
+  <text x="630" y="206" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8b949e">31 tools now available</text>
   <text x="630" y="220" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#8b949e">in every Claude Code session</text>
 
   <!-- Bottom strip text: ASCII only, no Unicode -->

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,4 +1,4 @@
-# All 28 Tools
+# All 31 Tools
 
 You open a session. The codebase is the same as yesterday but you have no memory of it. Before writing a line, you need to know: what decisions did we make about auth? Are there any known bugs in this module? What was the next thing we planned to do?
 
@@ -435,6 +435,51 @@ Run this periodically on active projects — monthly or after a major work sessi
 
 ---
 
+## Safety Compatibility Wrappers
+
+Engram now exposes three lightweight safety wrappers that sit on top of the existing memory store. They are intentionally narrow: they do not add a second policy database, and they do not replace `memory_recall`. Instead, they read high-signal memories — typically `importance=0` or `importance=1` items with tags like `constraint`, `policy`, `env:production`, `action:ddl`, or `requires_approval` — and turn them into a pre-action safety check.
+
+### get_constraints
+
+Returns the most relevant policy and constraint memories for a query, or the highest-signal constraint-like memories in a project when no query is provided.
+
+```python
+get_constraints(
+    query="Create index on the production users table",
+    project="my-app"
+)
+```
+
+Use this when you want the raw boundary records before deciding what to do next.
+
+### check_constraints
+
+Checks a proposed action against Engram memories that look like constraints or policy records and returns a lightweight decision (`proceed`, `warn`, `require_approval`, `block`) plus the matched memories.
+
+```python
+check_constraints(
+    proposed_action="Create index on the production users table",
+    project="my-app"
+)
+```
+
+This is the fast path for "does anything in memory say this action is dangerous or approval-gated?"
+
+### verify_before_acting
+
+Runs the same constraint lookup as `check_constraints`, then layers on risk baselines and freshness checks. If the action is inherently dangerous — force-push to main, destructive SQL on production, direct schema change on production — the tool escalates the decision even when memory coverage is thin.
+
+```python
+verify_before_acting(
+    proposed_action="DELETE FROM events on the production database",
+    project="my-app"
+)
+```
+
+This is the best default when an agent is about to take an action rather than answer a question.
+
+---
+
 ## Memory Types Reference
 
 | Type | Use it for | Example |
@@ -454,4 +499,4 @@ Filtering by type is a hard filter — `memory_types=["error"]` returns only err
 
 ---
 
-*28 tools total: 27 registered unconditionally + `memory_reason` when `ANTHROPIC_API_KEY` is set.*
+*31 tools total: 30 registered unconditionally + `memory_reason` when `ANTHROPIC_API_KEY` is set.*

--- a/internal/mcp/safety.go
+++ b/internal/mcp/safety.go
@@ -1,0 +1,697 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+const (
+	defaultConstraintLimit  = 10
+	defaultConstraintWindow = 64
+	defaultStaleAfterDays   = 180
+)
+
+var (
+	constraintTagMarkers = []string{
+		"constraint", "policy", "guardrail", "safety", "protected", "approval_required", "requires_approval",
+	}
+	policyCuePhrases = []string{
+		"never ", "do not", "must not", "should not", "forbidden", "requires approval", "require approval",
+		"approval required", "review required", "deployment pipeline", "migration review", "without approval",
+	}
+	productionHints = []string{"production", "prod", "primary", "main branch", "main"}
+	deleteHints     = []string{"delete from", "delete ", "truncate", "drop ", "destroy", "recreate"}
+	ddlHints        = []string{"create index", "alter table", "ddl", "schema", "migration", "index "}
+	forcePushHints  = []string{"git push --force", "push --force", "force push"}
+	approvalHints   = []string{"approval", "review", "migration", "rollout", "pipeline"}
+)
+
+type actionProfile struct {
+	Text        string   `json:"text"`
+	Signals     []string `json:"signals"`
+	Production  bool     `json:"production"`
+	MainBranch  bool     `json:"main_branch"`
+	Destructive bool     `json:"destructive"`
+	DDL         bool     `json:"ddl"`
+	DML         bool     `json:"dml"`
+	ForcePush   bool     `json:"force_push"`
+}
+
+type constraintMatch struct {
+	MemoryID          string    `json:"memory_id"`
+	Content           string    `json:"content"`
+	Tags              []string  `json:"tags,omitempty"`
+	Importance        int       `json:"importance"`
+	Severity          string    `json:"severity"`
+	RequiresApproval  bool      `json:"requires_approval"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	CreatedAt         time.Time `json:"created_at"`
+	MatchScore        float64   `json:"match_score"`
+	MatchReasons      []string  `json:"match_reasons,omitempty"`
+	ConstraintSignals []string  `json:"constraint_signals,omitempty"`
+	Stale             bool      `json:"stale"`
+	StaleReason       string    `json:"stale_reason,omitempty"`
+}
+
+type verificationResult struct {
+	Decision             string            `json:"decision"`
+	ProposedAction       string            `json:"proposed_action"`
+	ActionProfile        actionProfile     `json:"action_profile"`
+	ChecksRun            []string          `json:"checks_run"`
+	Reasons              []string          `json:"reasons,omitempty"`
+	MatchedConstraints   []constraintMatch `json:"matched_constraints"`
+	SuggestedSafeActions []string          `json:"suggested_safe_actions,omitempty"`
+}
+
+func handleGetConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	project := getString(args, "project", "default")
+	query := getString(args, "query", "")
+	limit := getInt(args, "limit", defaultConstraintLimit)
+	if limit < 1 || limit > 50 {
+		limit = defaultConstraintLimit
+	}
+	staleAfterDays := getInt(args, "stale_after_days", defaultStaleAfterDays)
+	if staleAfterDays < 1 || staleAfterDays > 3650 {
+		staleAfterDays = defaultStaleAfterDays
+	}
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := classifyAction(query)
+	matches, err := findConstraintMatches(ctx, h, query, profile, limit, staleAfterDays)
+	if err != nil {
+		return nil, err
+	}
+
+	return toolResult(map[string]any{
+		"query":       query,
+		"constraints": matches,
+		"count":       len(matches),
+	})
+}
+
+func handleCheckConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	project := getString(args, "project", "default")
+	proposedAction := getString(args, "proposed_action", "")
+	if proposedAction == "" {
+		return nil, fmt.Errorf("proposed_action is required")
+	}
+	limit := getInt(args, "limit", defaultConstraintLimit)
+	if limit < 1 || limit > 50 {
+		limit = defaultConstraintLimit
+	}
+	staleAfterDays := getInt(args, "stale_after_days", defaultStaleAfterDays)
+	if staleAfterDays < 1 || staleAfterDays > 3650 {
+		staleAfterDays = defaultStaleAfterDays
+	}
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := classifyAction(proposedAction)
+	matches, err := findConstraintMatches(ctx, h, proposedAction, profile, limit, staleAfterDays)
+	if err != nil {
+		return nil, err
+	}
+
+	result := evaluateVerification(proposedAction, profile, matches)
+	result.ChecksRun = []string{"constraint_lookup", "constraint_match"}
+	return toolResult(result)
+}
+
+func handleVerifyBeforeActing(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	project := getString(args, "project", "default")
+	proposedAction := getString(args, "proposed_action", "")
+	if proposedAction == "" {
+		return nil, fmt.Errorf("proposed_action is required")
+	}
+	limit := getInt(args, "limit", defaultConstraintLimit)
+	if limit < 1 || limit > 50 {
+		limit = defaultConstraintLimit
+	}
+	staleAfterDays := getInt(args, "stale_after_days", defaultStaleAfterDays)
+	if staleAfterDays < 1 || staleAfterDays > 3650 {
+		staleAfterDays = defaultStaleAfterDays
+	}
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := classifyAction(proposedAction)
+	matches, err := findConstraintMatches(ctx, h, proposedAction, profile, limit, staleAfterDays)
+	if err != nil {
+		return nil, err
+	}
+
+	result := evaluateVerification(proposedAction, profile, matches)
+	result.ChecksRun = []string{"constraint_lookup", "constraint_match", "freshness_scan", "risk_baseline"}
+	return toolResult(result)
+}
+
+func classifyAction(action string) actionProfile {
+	lower := strings.ToLower(strings.TrimSpace(action))
+	p := actionProfile{Text: action}
+	if lower == "" {
+		return p
+	}
+	if containsAny(lower, productionHints) {
+		p.Production = true
+		p.Signals = append(p.Signals, "production_scope")
+	}
+	if containsAny(lower, []string{" main", "main branch", " origin/main", " master"}) {
+		p.MainBranch = true
+		p.Signals = append(p.Signals, "protected_branch")
+	}
+	if containsAny(lower, deleteHints) {
+		p.Destructive = true
+		p.DML = true
+		p.Signals = append(p.Signals, "destructive_mutation")
+	}
+	if containsAny(lower, ddlHints) {
+		p.DDL = true
+		p.Signals = append(p.Signals, "schema_change")
+	}
+	if containsAny(lower, forcePushHints) {
+		p.ForcePush = true
+		p.Destructive = true
+		p.MainBranch = true
+		p.Signals = append(p.Signals, "force_push")
+	}
+	return p
+}
+
+func findConstraintMatches(ctx context.Context, h *EngineHandle, query string, profile actionProfile, limit int, staleAfterDays int) ([]constraintMatch, error) {
+	ceiling := 1
+	window := limit * 4
+	if window < defaultConstraintWindow {
+		window = defaultConstraintWindow
+	}
+
+	seeded, err := h.Engine.List(ctx, nil, nil, &ceiling, window, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make(map[string]*types.Memory, len(seeded))
+	for _, m := range seeded {
+		if isConstraintMemory(m) {
+			candidates[m.ID] = m
+		}
+	}
+
+	if query != "" {
+		results, err := h.Engine.Recall(ctx, buildConstraintQuery(query), window, "full")
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range results {
+			if r.Memory == nil {
+				continue
+			}
+			if isConstraintMemory(r.Memory) {
+				candidates[r.Memory.ID] = r.Memory
+			}
+		}
+	}
+
+	matches := make([]constraintMatch, 0, len(candidates))
+	for _, m := range candidates {
+		match, ok := assessConstraintMatch(m, query, profile, staleAfterDays)
+		if !ok && query != "" {
+			continue
+		}
+		matches = append(matches, match)
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].MatchScore != matches[j].MatchScore {
+			return matches[i].MatchScore > matches[j].MatchScore
+		}
+		if severityRank(matches[i].Severity) != severityRank(matches[j].Severity) {
+			return severityRank(matches[i].Severity) < severityRank(matches[j].Severity)
+		}
+		return matches[i].UpdatedAt.After(matches[j].UpdatedAt)
+	})
+
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return matches, nil
+}
+
+func buildConstraintQuery(query string) string {
+	if strings.TrimSpace(query) == "" {
+		return "constraint policy safety approval"
+	}
+	return "constraint policy safety approval " + query
+}
+
+func isConstraintMemory(m *types.Memory) bool {
+	if m == nil {
+		return false
+	}
+	if hasAnyTag(m.Tags, constraintTagMarkers) {
+		return true
+	}
+	if m.Importance <= 1 && hasScopedConstraintTag(m.Tags) {
+		return true
+	}
+	content := strings.ToLower(m.Content)
+	for _, cue := range policyCuePhrases {
+		if strings.Contains(content, cue) {
+			return true
+		}
+	}
+	return false
+}
+
+func assessConstraintMatch(m *types.Memory, query string, profile actionProfile, staleAfterDays int) (constraintMatch, bool) {
+	match := constraintMatch{
+		MemoryID:         m.ID,
+		Content:          truncateText(m.Content, 500),
+		Tags:             m.Tags,
+		Importance:       m.Importance,
+		Severity:         inferSeverity(m),
+		RequiresApproval: requiresApproval(m),
+		UpdatedAt:        m.UpdatedAt,
+		CreatedAt:        m.CreatedAt,
+	}
+
+	stale, reason := classifyFreshness(m, staleAfterDays)
+	match.Stale = stale
+	match.StaleReason = reason
+
+	if query == "" {
+		match.MatchScore = float64(4-m.Importance) / 4
+		match.ConstraintSignals = inferConstraintSignals(m)
+		return match, true
+	}
+
+	actionLower := strings.ToLower(query)
+	contentLower := strings.ToLower(m.Content)
+	reasons := make([]string, 0, 4)
+	score := 0.0
+
+	if hasAnyTag(m.Tags, constraintTagMarkers) {
+		reasons = append(reasons, "constraint_tag")
+		score += 1.2
+	}
+	if match.RequiresApproval {
+		reasons = append(reasons, "approval_gate")
+		score += 0.8
+	}
+
+	if profile.Production && textContainsAny(contentLower, []string{"production", "prod", "primary"}) {
+		reasons = append(reasons, "production_boundary")
+		score += 1.5
+	}
+	if profile.ForcePush && textContainsAny(contentLower, []string{"force push", "push --force", "rewrite history"}) {
+		reasons = append(reasons, "force_push_policy")
+		score += 2.0
+	}
+	if profile.DDL && textContainsAny(contentLower, []string{"create index", "ddl", "schema", "migration", "deployment pipeline"}) {
+		reasons = append(reasons, "schema_change_policy")
+		score += 1.5
+	}
+	if profile.DML && textContainsAny(contentLower, []string{"delete", "truncate", "drop", "destructive"}) {
+		reasons = append(reasons, "destructive_mutation_policy")
+		score += 1.8
+	}
+
+	for _, tag := range m.Tags {
+		tagLower := strings.ToLower(tag)
+		switch {
+		case strings.HasPrefix(tagLower, "resource:"):
+			if needle := strings.TrimSpace(strings.TrimPrefix(tagLower, "resource:")); needle != "" && strings.Contains(actionLower, needle) {
+				reasons = append(reasons, "resource_scope_match")
+				score += 2.0
+			}
+		case strings.HasPrefix(tagLower, "env:"):
+			if needle := strings.TrimSpace(strings.TrimPrefix(tagLower, "env:")); needle != "" && strings.Contains(actionLower, needle) {
+				reasons = append(reasons, "environment_scope_match")
+				score += 1.5
+			}
+		case strings.HasPrefix(tagLower, "action:"):
+			if needle := strings.TrimSpace(strings.TrimPrefix(tagLower, "action:")); needle != "" && actionTagMatchesProfile(needle, profile, actionLower) {
+				reasons = append(reasons, "action_scope_match")
+				score += 1.7
+			}
+		}
+	}
+
+	if tokenOverlapScore(actionLower, contentLower) >= 2 {
+		reasons = append(reasons, "text_overlap")
+		score += 0.9
+	}
+	if textContainsAny(contentLower, policyCuePhrases) {
+		reasons = append(reasons, "policy_language")
+		score += 0.5
+	}
+	if m.Importance <= 1 {
+		score += 0.5
+	}
+	if stale {
+		score -= 0.25
+	}
+
+	match.MatchScore = score
+	match.MatchReasons = dedupeStrings(reasons)
+	match.ConstraintSignals = inferConstraintSignals(m)
+	return match, score > 0
+}
+
+func evaluateVerification(proposedAction string, profile actionProfile, matches []constraintMatch) verificationResult {
+	result := verificationResult{
+		Decision:           "proceed",
+		ProposedAction:     proposedAction,
+		ActionProfile:      profile,
+		MatchedConstraints: matches,
+	}
+
+	if len(matches) == 0 {
+		result.Reasons = append(result.Reasons, "no_matching_constraints_found")
+	}
+
+	if profile.ForcePush {
+		result.Decision = elevateDecision(result.Decision, "block")
+		result.Reasons = append(result.Reasons, "force_push_is_high_risk")
+	}
+	if profile.Production && profile.DML {
+		result.Decision = elevateDecision(result.Decision, "block")
+		result.Reasons = append(result.Reasons, "destructive_production_mutation")
+	}
+	if profile.Production && profile.DDL {
+		result.Decision = elevateDecision(result.Decision, "require_approval")
+		result.Reasons = append(result.Reasons, "production_schema_change_requires_review")
+	}
+	if profile.Production && !profile.DDL && !profile.DML && !profile.ForcePush {
+		result.Decision = elevateDecision(result.Decision, "warn")
+		result.Reasons = append(result.Reasons, "production_scope_detected")
+	}
+
+	for _, match := range matches {
+		switch match.Severity {
+		case "critical":
+			result.Decision = elevateDecision(result.Decision, "block")
+			result.Reasons = append(result.Reasons, "critical_constraint_match")
+		case "high":
+			result.Decision = elevateDecision(result.Decision, "require_approval")
+			result.Reasons = append(result.Reasons, "high_severity_constraint_match")
+		default:
+			result.Decision = elevateDecision(result.Decision, "warn")
+			result.Reasons = append(result.Reasons, "constraint_match")
+		}
+		if match.RequiresApproval {
+			result.Decision = elevateDecision(result.Decision, "require_approval")
+			result.Reasons = append(result.Reasons, "approval_required_constraint")
+		}
+		if match.Stale {
+			result.Decision = elevateDecision(result.Decision, "warn")
+			result.Reasons = append(result.Reasons, "stale_constraint_evidence")
+		}
+	}
+
+	if len(matches) == 0 && (profile.DML || profile.ForcePush) {
+		result.Decision = elevateDecision(result.Decision, "block")
+		result.Reasons = append(result.Reasons, "high_risk_action_without_matching_policy")
+	}
+	if len(matches) == 0 && profile.DDL {
+		result.Decision = elevateDecision(result.Decision, "require_approval")
+		result.Reasons = append(result.Reasons, "schema_change_without_matching_policy")
+	}
+
+	result.Reasons = dedupeStrings(result.Reasons)
+	result.SuggestedSafeActions = suggestSafeActions(profile)
+	return result
+}
+
+func inferSeverity(m *types.Memory) string {
+	for _, tag := range m.Tags {
+		tagLower := strings.ToLower(tag)
+		if strings.HasPrefix(tagLower, "severity:") {
+			switch strings.TrimSpace(strings.TrimPrefix(tagLower, "severity:")) {
+			case "critical":
+				return "critical"
+			case "high":
+				return "high"
+			case "medium":
+				return "medium"
+			case "low":
+				return "low"
+			}
+		}
+	}
+	switch m.Importance {
+	case 0:
+		return "critical"
+	case 1:
+		return "high"
+	case 2:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func requiresApproval(m *types.Memory) bool {
+	for _, tag := range m.Tags {
+		tagLower := strings.ToLower(tag)
+		if tagLower == "requires_approval" || tagLower == "approval_required" {
+			return true
+		}
+	}
+	return textContainsAny(strings.ToLower(m.Content), []string{"requires approval", "require approval", "review required", "migration review", "deployment pipeline"})
+}
+
+func classifyFreshness(m *types.Memory, staleAfterDays int) (bool, string) {
+	now := time.Now().UTC()
+	if m.ExpiresAt != nil && m.ExpiresAt.Before(now) {
+		return true, "expired"
+	}
+	if m.NextReviewAt != nil && m.NextReviewAt.Before(now) {
+		return true, "review_due"
+	}
+	ref := m.UpdatedAt
+	if ref.IsZero() {
+		ref = m.CreatedAt
+	}
+	if ref.IsZero() {
+		return false, ""
+	}
+	threshold := time.Duration(staleAfterDays) * 24 * time.Hour
+	age := now.Sub(ref)
+	if age > threshold {
+		return true, fmt.Sprintf("older_than_%d_days", staleAfterDays)
+	}
+	return false, ""
+}
+
+func inferConstraintSignals(m *types.Memory) []string {
+	signals := make([]string, 0, 4)
+	if m.Importance <= 1 {
+		signals = append(signals, "high_importance")
+	}
+	if hasAnyTag(m.Tags, constraintTagMarkers) {
+		signals = append(signals, "explicit_constraint_tag")
+	}
+	if requiresApproval(m) {
+		signals = append(signals, "approval_language")
+	}
+	if textContainsAny(strings.ToLower(m.Content), []string{"production", "main", "primary"}) {
+		signals = append(signals, "protected_target")
+	}
+	return dedupeStrings(signals)
+}
+
+func hasAnyTag(tags []string, markers []string) bool {
+	for _, tag := range tags {
+		tagLower := strings.ToLower(tag)
+		for _, marker := range markers {
+			if tagLower == marker || strings.HasPrefix(tagLower, marker+":") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasScopedConstraintTag(tags []string) bool {
+	for _, tag := range tags {
+		tagLower := strings.ToLower(tag)
+		if strings.HasPrefix(tagLower, "env:") ||
+			strings.HasPrefix(tagLower, "action:") ||
+			strings.HasPrefix(tagLower, "resource:") ||
+			strings.HasPrefix(tagLower, "severity:") {
+			return true
+		}
+	}
+	return false
+}
+
+func actionTagMatchesProfile(tag string, profile actionProfile, actionLower string) bool {
+	switch tag {
+	case "production", "prod":
+		return profile.Production
+	case "ddl", "schema":
+		return profile.DDL
+	case "dml", "delete", "destructive":
+		return profile.DML || profile.Destructive
+	case "force-push", "force_push":
+		return profile.ForcePush
+	case "main":
+		return profile.MainBranch
+	default:
+		return strings.Contains(actionLower, tag)
+	}
+}
+
+func tokenOverlapScore(a, b string) int {
+	ta := importantTokens(a)
+	tb := importantTokens(b)
+	if len(ta) == 0 || len(tb) == 0 {
+		return 0
+	}
+	set := make(map[string]struct{}, len(tb))
+	for _, token := range tb {
+		set[token] = struct{}{}
+	}
+	score := 0
+	for _, token := range ta {
+		if _, ok := set[token]; ok {
+			score++
+		}
+	}
+	return score
+}
+
+func importantTokens(s string) []string {
+	replacer := strings.NewReplacer(
+		",", " ", ".", " ", ":", " ", ";", " ", "(", " ", ")", " ",
+		"[", " ", "]", " ", "{", " ", "}", " ", "/", " ", "\\", " ",
+		"-", " ", "_", " ", "'", " ", "\"", " ",
+	)
+	clean := replacer.Replace(strings.ToLower(s))
+	fields := strings.Fields(clean)
+	out := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if len(field) < 4 {
+			continue
+		}
+		if isStopword(field) {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		out = append(out, field)
+	}
+	return out
+}
+
+func isStopword(token string) bool {
+	switch token {
+	case "this", "that", "with", "from", "into", "what", "when", "where", "then", "than", "will", "would", "should", "could", "have", "has", "been", "using":
+		return true
+	default:
+		return false
+	}
+}
+
+func textContainsAny(s string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(s string, needles []string) bool {
+	return textContainsAny(s, needles)
+}
+
+func severityRank(severity string) int {
+	switch severity {
+	case "critical":
+		return 0
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func elevateDecision(current, next string) string {
+	rank := map[string]int{
+		"proceed":          0,
+		"warn":             1,
+		"require_approval": 2,
+		"block":            3,
+	}
+	if rank[next] > rank[current] {
+		return next
+	}
+	return current
+}
+
+func suggestSafeActions(profile actionProfile) []string {
+	switch {
+	case profile.ForcePush:
+		return []string{"create a new branch", "use revert instead of rewriting shared history", "open a pull request for the corrective change"}
+	case profile.Production && profile.DML:
+		return []string{"review the data-retention or cleanup policy first", "archive or back up the data before any change", "use a controlled migration or approved maintenance runbook"}
+	case profile.Production && profile.DDL:
+		return []string{"create a migration file instead of changing production directly", "run the migration through the deployment pipeline", "get schema review or operator approval before execution"}
+	case profile.Production:
+		return []string{"verify current production state before acting", "prefer a reviewed change path over direct mutation"}
+	default:
+		return nil
+	}
+}
+
+func truncateText(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/mcp/safety_test.go
+++ b/internal/mcp/safety_test.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyAction_DeleteOnProduction(t *testing.T) {
+	profile := classifyAction("DELETE FROM events on the production database")
+
+	assert.True(t, profile.Production)
+	assert.True(t, profile.Destructive)
+	assert.True(t, profile.DML)
+	assert.False(t, profile.DDL)
+	assert.Contains(t, profile.Signals, "production_scope")
+	assert.Contains(t, profile.Signals, "destructive_mutation")
+}
+
+func TestClassifyAction_CreateIndexOnProduction(t *testing.T) {
+	profile := classifyAction("Create index on the production users table")
+
+	assert.True(t, profile.Production)
+	assert.True(t, profile.DDL)
+	assert.False(t, profile.DML)
+	assert.Contains(t, profile.Signals, "schema_change")
+}
+
+func TestAssessConstraintMatch_UsesTagsAndFreshness(t *testing.T) {
+	memory := &types.Memory{
+		ID:         "mem-1",
+		Content:    "Production database changes require migration review and operator approval.",
+		Tags:       []string{"constraint", "env:production", "action:ddl", "requires_approval"},
+		Importance: 1,
+		CreatedAt:  time.Now().UTC().Add(-24 * time.Hour),
+		UpdatedAt:  time.Now().UTC().Add(-24 * time.Hour),
+	}
+
+	profile := classifyAction("Create index on the production users table")
+	match, ok := assessConstraintMatch(memory, profile.Text, profile, 180)
+
+	require.True(t, ok)
+	assert.Equal(t, "high", match.Severity)
+	assert.True(t, match.RequiresApproval)
+	assert.False(t, match.Stale)
+	assert.Contains(t, match.MatchReasons, "constraint_tag")
+	assert.Contains(t, match.MatchReasons, "production_boundary")
+	assert.Contains(t, match.MatchReasons, "schema_change_policy")
+	assert.Contains(t, match.MatchReasons, "action_scope_match")
+	assert.Greater(t, match.MatchScore, 0.0)
+}
+
+func TestAssessConstraintMatch_FlagsStaleEvidence(t *testing.T) {
+	old := time.Now().UTC().Add(-365 * 24 * time.Hour)
+	memory := &types.Memory{
+		ID:         "mem-2",
+		Content:    "Deployment notes from January 2025 say the connection limit is 200.",
+		Tags:       []string{"constraint", "env:production"},
+		Importance: 1,
+		CreatedAt:  old,
+		UpdatedAt:  old,
+	}
+
+	profile := classifyAction("Check current production database connection settings")
+	match, ok := assessConstraintMatch(memory, profile.Text, profile, 90)
+
+	require.True(t, ok)
+	assert.True(t, match.Stale)
+	assert.Equal(t, "older_than_90_days", match.StaleReason)
+}
+
+func TestIsConstraintMemory_HighImportanceNeedsConstraintSignal(t *testing.T) {
+	memory := &types.Memory{
+		ID:         "mem-plain",
+		Content:    "We renamed the package layout during the last refactor.",
+		Importance: 1,
+	}
+
+	assert.False(t, isConstraintMemory(memory))
+}
+
+func TestIsConstraintMemory_HighImportanceScopedTagQualifies(t *testing.T) {
+	memory := &types.Memory{
+		ID:         "mem-scope",
+		Content:    "Users table changes on production require review.",
+		Tags:       []string{"env:production", "action:ddl"},
+		Importance: 1,
+	}
+
+	assert.True(t, isConstraintMemory(memory))
+}
+
+func TestEvaluateVerification_CriticalConstraintBlocks(t *testing.T) {
+	profile := classifyAction("DELETE FROM events on production")
+	result := evaluateVerification(profile.Text, profile, []constraintMatch{
+		{
+			Severity:         "critical",
+			RequiresApproval: true,
+			MatchScore:       4.2,
+			MatchReasons:     []string{"constraint_tag", "destructive_mutation_policy"},
+		},
+	})
+
+	assert.Equal(t, "block", result.Decision)
+	assert.Contains(t, result.Reasons, "critical_constraint_match")
+	assert.Contains(t, result.Reasons, "approval_required_constraint")
+	assert.NotEmpty(t, result.SuggestedSafeActions)
+}
+
+func TestEvaluateVerification_DDLRequiresApprovalWithoutConstraint(t *testing.T) {
+	profile := classifyAction("Create index on the production users table")
+	result := evaluateVerification(profile.Text, profile, nil)
+
+	assert.Equal(t, "require_approval", result.Decision)
+	assert.Contains(t, result.Reasons, "production_schema_change_requires_review")
+	assert.Contains(t, result.Reasons, "schema_change_without_matching_policy")
+}
+
+func TestEvaluateVerification_ForcePushBlocksWithoutConstraint(t *testing.T) {
+	profile := classifyAction("git push --force origin main")
+	result := evaluateVerification(profile.Text, profile, nil)
+
+	assert.Equal(t, "block", result.Decision)
+	assert.Contains(t, result.Reasons, "force_push_is_high_risk")
+	assert.Contains(t, result.Reasons, "high_risk_action_without_matching_policy")
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -287,6 +287,18 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryRecall(ctx, pool, req, cfg)
 			}},
+		{"get_constraints", "List high-signal policy and constraint memories relevant to a query or project",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleGetConstraints(ctx, pool, req)
+			}},
+		{"check_constraints", "Check a proposed action against recalled constraints and policy memories",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleCheckConstraints(ctx, pool, req)
+			}},
+		{"verify_before_acting", "Run a lightweight pre-action verification gate over constraints, freshness, and risk",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleVerifyBeforeActing(ctx, pool, req)
+			}},
 		{"memory_list", "List memories with optional filters",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryList(ctx, pool, req)


### PR DESCRIPTION
## What changed

- added lightweight get_constraints, check_constraints, and verify_before_acting MCP wrappers on top of Engram
- reused the existing memory store and recall path instead of adding a second policy database
- added targeted unit coverage for action classification, stale evidence detection, and verification decisions
- updated docs and SVG callouts to reflect the new tool count and wrapper behavior

## Why

ScoreCrux safety scenarios explicitly reward agents that call constraint-check and verify-before-acting tools before risky operations. This adds the smallest compatible surface to Engram without trying to port the full MemoryCrux design.

## Validation

- dockerized go test ./internal/mcp -run Test(ClassifyAction|AssessConstraintMatch|IsConstraintMemory|EvaluateVerification|EnginePool)
- dockerized go test ./cmd/engram

## Notes

- go test ./cmd/engram ./internal/mcp still hits pre-existing handleMemoryRecall scan failures in conflicts_test.go and resummarize_test.go that are unrelated to this diff.