### PR TITLE
fix: resolve nice-to-have findings #170 #171 #172 #173

### DIFF
--- a/internal/consolidate/consolidate_test.go
+++ b/internal/consolidate/consolidate_test.go
@@ -437,7 +437,10 @@ func TestIsContradiction_TemporalSupersession(t *testing.T) {
 		want bool
 	}{
 		{"was vs is", "the security team was responsible for auth middleware validation checks", "the platform team is responsible for auth middleware validation checks", true},
-		{"previously vs currently", "the authentication service previously used Redis for session caching storage", "the authentication service currently uses Redis for session caching storage", true},
+		// Cross-service temporal conflict: Redis → Memcached. Shares 5 significant
+		// words (authentication, service, session, caching, storage) which meets
+		// the >=5 threshold while the service names differ.
+		{"previously vs currently", "the authentication service previously used Redis for session caching storage", "the authentication service currently uses Memcached for session caching storage", true},
 		{"used to vs now", "the platform team used to deploy services with Ansible automation", "the platform team now deploys services with Terraform automation", true},
 		{"both past tense — not contradictory", "the service was built with Java", "the service was tested with JUnit", false},
 		{"both present tense — not contradictory", "the service is built with Go", "the service is tested with Go", false},

--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -14,7 +14,10 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
-func contentHash(content string) string {
+// ContentHash returns the canonical SHA-256 hex digest for a memory's content.
+// Used by both the storage layer and the ingest dedup path to guarantee
+// identical hash values from the same input string.
+func ContentHash(content string) string {
 	h := sha256.Sum256([]byte(content))
 	return fmt.Sprintf("%x", h)
 }
@@ -37,7 +40,7 @@ func (b *PostgresBackend) storeMemoryExec(ctx context.Context, ex execer, m *typ
 	m.UpdatedAt = now
 	m.LastAccessed = now
 	m.Project = b.project
-	hash := contentHash(m.Content)
+	hash := ContentHash(m.Content)
 	m.ContentHash = &hash
 
 	tagsJSON, err := json.Marshal(m.Tags)
@@ -89,7 +92,7 @@ func (b *PostgresBackend) GetMemory(ctx context.Context, id string) (*types.Memo
 	}
 	// Integrity check
 	if m.ContentHash != nil {
-		expected := contentHash(m.Content)
+		expected := ContentHash(m.Content)
 		if *m.ContentHash != expected {
 			slog.Warn("INTEGRITY: content_hash mismatch",
 				"id", m.ID,
@@ -174,7 +177,7 @@ func (b *PostgresBackend) UpdateMemory(
 	}
 
 	if content != nil {
-		hash := contentHash(m.Content)
+		hash := ContentHash(m.Content)
 		m.ContentHash = &hash
 		// Clear the summary so the background worker regenerates it with the new content.
 		_, err = tx.Exec(ctx,
@@ -259,7 +262,7 @@ func (b *PostgresBackend) MergeMemoriesAtomic(ctx context.Context, project, winn
 
 	if newContent != "" {
 		now := time.Now().UTC()
-		hash := contentHash(newContent)
+		hash := ContentHash(newContent)
 		if _, err := tx.Exec(ctx,
 			"UPDATE memories SET content=$1, content_hash=$2, updated_at=$3 WHERE id=$4 AND project=$5",
 			newContent, hash, now, winnerID, project,

--- a/internal/mcp/ingest_dedup_test.go
+++ b/internal/mcp/ingest_dedup_test.go
@@ -1,13 +1,5 @@
 package mcp_test
 
-// TestMemoryIngest_SkipsDuplicates verifies that ingesting the same markdown
-// directory twice stores each memory only once. The second call must return
-// skipped=N, ingested=0 and the project must still contain exactly the same
-// number of memories as after the first call.
-//
-// This is an integration test — it requires a real PostgreSQL instance.
-// Skip with: (no TEST_DATABASE_URL set)
-
 import (
 	"context"
 	"fmt"
@@ -30,6 +22,12 @@ func testIngestDSN(t *testing.T) string {
 	return dsn
 }
 
+// TestMemoryIngest_SkipsDuplicates verifies that ingesting the same markdown
+// directory twice stores each memory only once. The second call must return
+// skipped=N, ingested=0 and the project must still contain exactly the same
+// number of memories as after the first call.
+//
+// This is an integration test — it requires a real PostgreSQL instance.
 func TestMemoryIngest_SkipsDuplicates(t *testing.T) {
 	dsn := testIngestDSN(t)
 	ctx := context.Background()
@@ -64,4 +62,48 @@ func TestMemoryIngest_SkipsDuplicates(t *testing.T) {
 	ids, err := h.Engine.Backend().GetAllMemoryIDs(ctx, proj)
 	require.NoError(t, err)
 	assert.Len(t, ids, 2, "project must contain exactly 2 memories after two ingests")
+}
+
+// TestMemoryIngest_PartialOverlap verifies that when a second ingest contains a
+// mix of already-stored and new memories, only the new ones are stored.
+// Boundary condition: ingested>0 AND skipped>0 in a single call.
+//
+// This is an integration test — it requires a real PostgreSQL instance.
+func TestMemoryIngest_PartialOverlap(t *testing.T) {
+	dsn := testIngestDSN(t)
+	ctx := context.Background()
+	proj := fmt.Sprintf("test-ingest-partial-%d", time.Now().UnixNano())
+
+	dataDir1 := t.TempDir()
+	dataDir2 := t.TempDir()
+
+	content1 := "# Memory Alpha\n\nThis is the first memory for partial overlap testing.\n"
+	content2 := "# Memory Beta\n\nThis is the second memory for partial overlap testing.\n"
+	content3 := "# Memory Gamma\n\nThis is a brand new memory only in the second ingest.\n"
+
+	// First ingest: Alpha + Beta
+	require.NoError(t, os.WriteFile(dataDir1+"/alpha.md", []byte(content1), 0o644))
+	require.NoError(t, os.WriteFile(dataDir1+"/beta.md", []byte(content2), 0o644))
+
+	pool := internalmcp.NewTestPoolWithDSN(t, ctx, dsn, proj)
+
+	first := internalmcp.CallHandleMemoryIngest(ctx, t, pool, proj, dataDir1, dataDir1)
+	assert.Equal(t, 2, first.Ingested, "first ingest: expected 2 new memories")
+	assert.Equal(t, 0, first.Skipped, "first ingest: expected 0 skipped")
+
+	// Second ingest: Beta (duplicate) + Gamma (new) — should store exactly 1, skip exactly 1.
+	require.NoError(t, os.WriteFile(dataDir2+"/beta.md", []byte(content2), 0o644))
+	require.NoError(t, os.WriteFile(dataDir2+"/gamma.md", []byte(content3), 0o644))
+
+	second := internalmcp.CallHandleMemoryIngest(ctx, t, pool, proj, dataDir2, dataDir2)
+	assert.Equal(t, 1, second.Ingested, "second ingest: expected 1 new memory (Gamma)")
+	assert.Equal(t, 1, second.Skipped, "second ingest: expected 1 skipped (Beta duplicate)")
+	assert.Len(t, second.IDs, 1, "second ingest: expected exactly 1 new ID")
+
+	// Confirm exactly 3 memories in project: Alpha, Beta, Gamma
+	h, err := pool.Get(ctx, proj)
+	require.NoError(t, err)
+	ids, err := h.Engine.Backend().GetAllMemoryIDs(ctx, proj)
+	require.NoError(t, err)
+	assert.Len(t, ids, 3, "project must contain exactly 3 memories after partial-overlap ingests")
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2,8 +2,6 @@ package mcp
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -13,6 +11,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/claude"
 	consolidatepkg "github.com/petersimmons1972/engram/internal/consolidate"
+	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/markdown"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/summarize"
@@ -461,6 +460,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if includeConflicts {
 		conflicts := EnrichWithConflicts(ctx, h.Engine.Backend(), project, results)
 		out["conflicting_results"] = conflicts
+		out["conflict_count"] = len(conflicts)
 	}
 	return toolResult(out)
 }
@@ -943,16 +943,14 @@ func handleMemoryIngest(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	var ingested, skipped int
 	for _, m := range memories {
 		m.Project = project
-		// Compute content hash using the same algorithm as StoreMemory (SHA-256 hex).
-		hashBytes := sha256.Sum256([]byte(m.Content))
-		hash := hex.EncodeToString(hashBytes[:])
-		exists, err := h.Engine.Backend().ExistsWithContentHash(ctx, project, hash)
+		contentHash := db.ContentHash(m.Content)
+		exists, err := h.Engine.Backend().ExistsWithContentHash(ctx, project, contentHash)
 		if err != nil {
 			return nil, fmt.Errorf("dedup check: %w", err)
 		}
 		if exists {
 			skipped++
-			slog.Debug("handleMemoryIngest: skipping duplicate", "hash", hash[:8], "project", project)
+			slog.Debug("handleMemoryIngest: skipping duplicate", "hash", contentHash[:8], "project", project)
 			continue
 		}
 		if err := h.Engine.Store(ctx, m); err != nil {


### PR DESCRIPTION
## Summary

- **#172** — Add `conflict_count` to single-project recall response; both paths now return the same schema when `include_conflicts=true`
- **#173** — Export `ContentHash` from `db` package; `tools.go` now calls `db.ContentHash` instead of independent `sha256`+`hex.EncodeToString` — eliminates the DRY violation
- **#171** — Restore cross-service temporal test case (Redis → Memcached); shares exactly 5 significant words at the >=5 threshold, so the change was unnecessary
- **#170** — Add `TestMemoryIngest_PartialOverlap` boundary test: one duplicate + one new memory in a single ingest call

All 15 packages pass `go test ./... -count=1 -race`.

## Closes

Closes #170, #171, #172, #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)