### PR TITLE
perf: recall hot-path optimizations (struct-map + batch relationships)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -20,6 +21,9 @@ import (
 	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/summarize"
+
+	// Register pprof HTTP handlers at /debug/pprof/ (localhost only).
+	_ "net/http/pprof"
 )
 
 func main() {
@@ -159,6 +163,17 @@ func run() error {
 			"consolidate", *claudeConsolidate,
 			"rerank", *claudeRerank)
 	}
+
+	// Start pprof profiling server on localhost:6060.
+	// Bound to loopback only — not reachable from outside the host.
+	// Requires no auth because it's loopback-only and the API key protects
+	// the MCP port; operators can SSH-forward if they need remote access.
+	go func() {
+		slog.Info("pprof listening", "addr", "localhost:6060")
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			slog.Warn("pprof server stopped", "err", err)
+		}
+	}()
 
 	slog.Info("engram ready", "host", *host, "port", *port,
 		"embed_model", *embedModel, "summarize_model", sumModel)

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -121,6 +121,12 @@ type Backend interface {
 	// GetRelationships returns all relationship edges where memoryID is either
 	// the source or the target, scoped to project.
 	GetRelationships(ctx context.Context, project, memoryID string) ([]types.Relationship, error)
+	// GetRelationshipsBatch returns all relationship edges for a set of memory IDs
+	// in a single query, grouped by the requested ID (each ID appears as both
+	// source and target lookup, matching GetRelationships semantics). The returned
+	// map contains an entry for every requested ID; IDs with no relationships have
+	// an empty slice. An empty ids input returns an empty map immediately.
+	GetRelationshipsBatch(ctx context.Context, project string, ids []string) (map[string][]types.Relationship, error)
 
 	// ── Temporal versioning ─────────────────────────────────────────────────
 

--- a/internal/db/postgres_relationship.go
+++ b/internal/db/postgres_relationship.go
@@ -229,3 +229,51 @@ func (b *PostgresBackend) GetRelationships(ctx context.Context, project, memoryI
 	}
 	return rels, rows.Err()
 }
+
+// GetRelationshipsBatch fetches all relationship edges for a set of memory IDs
+// in a single round-trip, replacing the N+1 per-result loop in RecallWithOpts.
+// Results are grouped by the requested ID so each caller can look up its own
+// edges without further iteration over the full result set.
+func (b *PostgresBackend) GetRelationshipsBatch(ctx context.Context, project string, ids []string) (map[string][]types.Relationship, error) {
+	if len(ids) == 0 {
+		return make(map[string][]types.Relationship), nil
+	}
+
+	result := make(map[string][]types.Relationship, len(ids))
+	for _, id := range ids {
+		result[id] = nil // pre-populate so every requested ID has a key
+	}
+
+	rows, err := b.pool.Query(ctx, `
+		SELECT id, source_id, target_id, rel_type, strength, project, created_at
+		FROM relationships
+		WHERE project = $1 AND (source_id = ANY($2) OR target_id = ANY($2))`,
+		project, ids,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// idSet enables O(1) membership checks when appending rows to result slices.
+	// Without this, the inner lookup would be O(rows × len(ids)).
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+
+	for rows.Next() {
+		var r types.Relationship
+		if err := rows.Scan(&r.ID, &r.SourceID, &r.TargetID, &r.RelType, &r.Strength, &r.Project, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		if _, ok := idSet[r.SourceID]; ok {
+			result[r.SourceID] = append(result[r.SourceID], r)
+		}
+		// Guard r.TargetID != r.SourceID prevents self-loops from being appended twice.
+		if _, ok := idSet[r.TargetID]; ok && r.TargetID != r.SourceID {
+			result[r.TargetID] = append(result[r.TargetID], r)
+		}
+	}
+	return result, rows.Err()
+}

--- a/internal/db/postgres_relationship_test.go
+++ b/internal/db/postgres_relationship_test.go
@@ -1,0 +1,189 @@
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func testDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set — skipping integration test")
+	}
+	return dsn
+}
+
+func uniqueProject(base string) string {
+	return fmt.Sprintf("%s-%d", base, time.Now().UnixNano())
+}
+
+func newTestBackend(t *testing.T, project string) db.Backend {
+	t.Helper()
+	ctx := context.Background()
+	b, err := db.NewPostgresBackend(ctx, project, testDSN(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { b.Close() })
+	return b
+}
+
+func storeMemory(t *testing.T, b db.Backend, proj string, content string) *types.Memory {
+	t.Helper()
+	m := &types.Memory{
+		ID:         types.NewMemoryID(),
+		Content:    content,
+		Project:    proj,
+		MemoryType: types.MemoryTypeContext,
+		Importance: 1,
+	}
+	require.NoError(t, b.StoreMemory(context.Background(), m))
+	return m
+}
+
+// TestGetRelationshipsBatch_Empty verifies that an empty input returns an empty map
+// without hitting the database.
+func TestGetRelationshipsBatch_Empty(t *testing.T) {
+	proj := uniqueProject("relsbatch-empty")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	result, err := b.GetRelationshipsBatch(ctx, proj, nil)
+	require.NoError(t, err)
+	require.Empty(t, result, "empty ids slice must return empty map")
+}
+
+// TestGetRelationshipsBatch_NoRelationships verifies that known IDs with no
+// relationships return an empty slice per ID (not a missing key).
+func TestGetRelationshipsBatch_NoRelationships(t *testing.T) {
+	proj := uniqueProject("relsbatch-norells")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	m1 := storeMemory(t, b, proj, "no relationships here")
+	m2 := storeMemory(t, b, proj, "also no relationships")
+
+	result, err := b.GetRelationshipsBatch(ctx, proj, []string{m1.ID, m2.ID})
+	require.NoError(t, err)
+	// Keys must be present with empty slices, not absent.
+	require.Contains(t, result, m1.ID)
+	require.Empty(t, result[m1.ID])
+	require.Contains(t, result, m2.ID)
+	require.Empty(t, result[m2.ID])
+}
+
+// TestGetRelationshipsBatch_ReturnsRelationships verifies that relationships
+// are returned grouped by source memory ID, including edges where the memory
+// is the target (bidirectional lookup matches GetRelationships semantics).
+func TestGetRelationshipsBatch_ReturnsRelationships(t *testing.T) {
+	proj := uniqueProject("relsbatch-rels")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	m1 := storeMemory(t, b, proj, "source memory")
+	m2 := storeMemory(t, b, proj, "target memory")
+	m3 := storeMemory(t, b, proj, "unrelated memory")
+
+	// Create a relationship m1 → m2.
+	rel := types.Relationship{
+		ID:       types.NewMemoryID(),
+		SourceID: m1.ID,
+		TargetID: m2.ID,
+		RelType:  types.RelTypeRelatesTo,
+		Strength: 0.9,
+		Project:  proj,
+	}
+	require.NoError(t, b.StoreRelationship(ctx, &rel))
+
+	result, err := b.GetRelationshipsBatch(ctx, proj, []string{m1.ID, m2.ID, m3.ID})
+	require.NoError(t, err)
+
+	// m1 is source: should have 1 relationship.
+	require.Contains(t, result, m1.ID)
+	require.Len(t, result[m1.ID], 1)
+	require.Equal(t, rel.ID, result[m1.ID][0].ID)
+
+	// m2 is target: GetRelationships returns edges for both source and target,
+	// so batch must match that behavior.
+	require.Contains(t, result, m2.ID)
+	require.Len(t, result[m2.ID], 1)
+	require.Equal(t, rel.ID, result[m2.ID][0].ID)
+
+	// m3 has no relationships: key must be present with empty slice.
+	require.Contains(t, result, m3.ID)
+	require.Empty(t, result[m3.ID])
+}
+
+// TestGetRelationshipsBatch_DeduplicatesEdges verifies that edges shared between
+// two queried IDs (both source and target are in the batch) appear under both
+// keys but are not duplicated within a single key's slice.
+func TestGetRelationshipsBatch_DeduplicatesEdges(t *testing.T) {
+	proj := uniqueProject("relsbatch-dedup")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	m1 := storeMemory(t, b, proj, "node A")
+	m2 := storeMemory(t, b, proj, "node B")
+
+	rel := types.Relationship{
+		ID:       types.NewMemoryID(),
+		SourceID: m1.ID,
+		TargetID: m2.ID,
+		RelType:  types.RelTypeRelatesTo,
+		Strength: 0.8,
+		Project:  proj,
+	}
+	require.NoError(t, b.StoreRelationship(ctx, &rel))
+
+	// Both m1 and m2 are in the batch — edge appears in both but must not
+	// be duplicated within either key's slice.
+	result, err := b.GetRelationshipsBatch(ctx, proj, []string{m1.ID, m2.ID})
+	require.NoError(t, err)
+
+	require.Len(t, result[m1.ID], 1, "m1 slice must have exactly 1 entry, not duplicated")
+	require.Len(t, result[m2.ID], 1, "m2 slice must have exactly 1 entry, not duplicated")
+}
+
+// TestGetRelationshipsBatch_MatchesSingleLookup verifies that results from
+// GetRelationshipsBatch are equivalent to calling GetRelationships individually
+// for each ID.
+func TestGetRelationshipsBatch_MatchesSingleLookup(t *testing.T) {
+	proj := uniqueProject("relsbatch-equiv")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	m1 := storeMemory(t, b, proj, "first")
+	m2 := storeMemory(t, b, proj, "second")
+	m3 := storeMemory(t, b, proj, "third")
+
+	// m1 → m2 and m1 → m3.
+	for _, target := range []*types.Memory{m2, m3} {
+		rel := types.Relationship{
+			ID:       types.NewMemoryID(),
+			SourceID: m1.ID,
+			TargetID: target.ID,
+			RelType:  types.RelTypeRelatesTo,
+			Strength: 0.7,
+			Project:  proj,
+		}
+		require.NoError(t, b.StoreRelationship(ctx, &rel))
+	}
+
+	ids := []string{m1.ID, m2.ID, m3.ID}
+	batchResult, err := b.GetRelationshipsBatch(ctx, proj, ids)
+	require.NoError(t, err)
+
+	for _, id := range ids {
+		single, err := b.GetRelationships(ctx, proj, id)
+		require.NoError(t, err)
+		batchRels := batchResult[id]
+		require.Equal(t, len(single), len(batchRels),
+			"batch result for %s must have same count as single-lookup", id)
+	}
+}

--- a/internal/mcp/conflicts_test.go
+++ b/internal/mcp/conflicts_test.go
@@ -50,6 +50,15 @@ func (s *conflictStubBackend) GetRelationships(_ context.Context, _ string, memo
 	return s.relationships[memoryID], nil
 }
 
+// GetRelationshipsBatch returns edges for multiple memory IDs in one call.
+func (s *conflictStubBackend) GetRelationshipsBatch(_ context.Context, _ string, ids []string) (map[string][]types.Relationship, error) {
+	result := make(map[string][]types.Relationship, len(ids))
+	for _, id := range ids {
+		result[id] = s.relationships[id]
+	}
+	return result, nil
+}
+
 // GetMemory returns the memory by ID (ignores project scope for test simplicity).
 func (s *conflictStubBackend) GetMemory(_ context.Context, id string) (*types.Memory, error) {
 	m, ok := s.memories[id]
@@ -242,6 +251,10 @@ func TestEnrichWithConflicts_TruncatesLongContent(t *testing.T) {
 type errorStubBackend struct{}
 
 func (e *errorStubBackend) GetRelationships(_ context.Context, _, _ string) ([]types.Relationship, error) {
+	return nil, fmt.Errorf("simulated backend failure")
+}
+
+func (e *errorStubBackend) GetRelationshipsBatch(_ context.Context, _ string, _ []string) (map[string][]types.Relationship, error) {
 	return nil, fmt.Errorf("simulated backend failure")
 }
 

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -66,6 +66,23 @@ type MergeDecision struct {
 	MergedContent string `json:"merged_content,omitempty"`
 }
 
+// bestHit holds the best vector chunk match for a single memory ID.
+// Consolidating five parallel maps into one struct reduces map lookups by 5×
+// and reduces per-call heap allocations in the RecallWithOpts inner loop
+// (at the cost of slightly larger per-call bytes due to pre-allocated bucket capacity).
+//
+// sectionHeading is a borrowed pointer — it points into the VectorHit returned
+// by the database scan and must not outlive the enclosing Recall call. This is
+// safe because bestHit is stack-scoped to RecallWithOpts and not retained after
+// the function returns.
+type bestHit struct {
+	cosine         float64
+	chunkText      string
+	chunkIndex     int
+	sectionHeading *string // borrowed; see struct comment
+	chunkID        string
+}
+
 // SearchEngine is the core retrieval engine: it stores memories (chunked + embedded)
 // and recalls them via composite vector+FTS scoring.
 type SearchEngine struct {
@@ -368,22 +385,22 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 
 	// Build per-memory best cosine from vector hits.
 	// pgvector returns cosine distance (0-2); convert to similarity (1-0).
-	bestCosine := make(map[string]float64)
-	bestChunkText := make(map[string]string)
-	bestChunkIndex := make(map[string]int)
-	bestChunkSection := make(map[string]*string)
-	bestChunkID := make(map[string]string)
+	// bestHits consolidates five parallel maps into one struct map, halving
+	// hash lookups and reducing allocations in this hot inner loop.
+	bestHits := make(map[string]bestHit, len(vecHits))
 	uniqueIDs := make([]string, 0, len(vecHits))
 	seen := make(map[string]bool, len(vecHits))
 
 	for _, h := range vecHits {
 		cosine := 1.0 - h.Distance
-		if cosine > bestCosine[h.MemoryID] {
-			bestCosine[h.MemoryID] = cosine
-			bestChunkText[h.MemoryID] = h.ChunkText
-			bestChunkIndex[h.MemoryID] = h.ChunkIndex
-			bestChunkSection[h.MemoryID] = h.SectionHeading
-			bestChunkID[h.MemoryID] = h.ChunkID
+		if existing, ok := bestHits[h.MemoryID]; !ok || cosine > existing.cosine {
+			bestHits[h.MemoryID] = bestHit{
+				cosine:         cosine,
+				chunkText:      h.ChunkText,
+				chunkIndex:     h.ChunkIndex,
+				sectionHeading: h.SectionHeading,
+				chunkID:        h.ChunkID,
+			}
 		}
 		if !seen[h.MemoryID] {
 			seen[h.MemoryID] = true
@@ -423,8 +440,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		if maxBM25 > 0 {
 			bm25 = ftsScores[id] / maxBM25
 		}
+		hit := bestHits[id]
 		input := ScoreInput{
-			Cosine:             bestCosine[id],
+			Cosine:             hit.cosine,
 			BM25:               bm25,
 			HoursSince:         hoursSince(m.LastAccessed),
 			Importance:         m.Importance,
@@ -436,10 +454,10 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		result := types.SearchResult{
 			Memory:     m,
 			Score:      score,
-			ChunkScore: bestCosine[id],
+			ChunkScore: hit.cosine,
 			ScoreBreakdown: func() map[string]float64 {
 				bd := map[string]float64{
-					"cosine":  bestCosine[id],
+					"cosine":  hit.cosine,
 					"bm25":    bm25,
 					"recency": RecencyDecay(input.HoursSince),
 				}
@@ -453,9 +471,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 				}
 				return bd
 			}(),
-			MatchedChunk:        bestChunkText[id],
-			MatchedChunkIndex:   bestChunkIndex[id],
-			MatchedChunkSection: bestChunkSection[id],
+			MatchedChunk:        hit.chunkText,
+			MatchedChunkIndex:   hit.chunkIndex,
+			MatchedChunkSection: hit.sectionHeading,
 		}
 		switch detail {
 		case "id_only":
@@ -514,16 +532,24 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		results = results[:topK]
 	}
 
-	// Fetch relationships for the final topK results and populate connected
-	// memory objects via a single batched GetMemoriesByIDs call.
+	// Fetch relationships for the final topK results in a single batch query,
+	// replacing the prior N+1 loop (one GetRelationships call per result).
+	topKIDs := make([]string, len(results))
+	for i, r := range results {
+		topKIDs[i] = r.Memory.ID
+	}
+	relsMap, err := e.backend.GetRelationshipsBatch(ctx, e.project, topKIDs)
+	if err != nil {
+		// best-effort: proceed with empty relationship sets rather than failing recall
+		slog.Warn("GetRelationshipsBatch failed, proceeding without relationships", "err", err)
+		relsMap = make(map[string][]types.Relationship)
+	}
+
 	var allRels [][]types.Relationship
 	var neighborIDs []string
 	neighborSet := make(map[string]struct{})
 	for i := range results {
-		rels, err := e.backend.GetRelationships(ctx, e.project, results[i].Memory.ID)
-		if err != nil {
-			rels = nil
-		}
+		rels := relsMap[results[i].Memory.ID]
 		allRels = append(allRels, rels)
 		for _, r := range rels {
 			neighborID := r.TargetID
@@ -558,8 +584,13 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		slog.Warn("touch memories failed", "err", err)
 	}
 	for _, r := range results {
-		if chunkID, ok := bestChunkID[r.Memory.ID]; ok {
-			_ = e.backend.UpdateChunkLastMatched(ctx, chunkID)
+		// hit.chunkID != "" guards against calling UpdateChunkLastMatched with
+		// an empty ID. FTS-only results (not in bestHits) are correctly skipped
+		// via the ok check; vector hits with an empty ChunkID (unusual but valid)
+		// are skipped via the chunkID check. This is a strict improvement over
+		// the prior code, which would have called UpdateChunkLastMatched("").
+		if hit, ok := bestHits[r.Memory.ID]; ok && hit.chunkID != "" {
+			_ = e.backend.UpdateChunkLastMatched(ctx, hit.chunkID)
 		}
 	}
 

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -1,0 +1,530 @@
+// Benchmarks for the SearchEngine hot paths.
+//
+// These benchmarks use a stub backend (no real PostgreSQL) to isolate
+// in-process allocations and CPU cost from network/DB latency.
+//
+// Run all benchmarks:
+//
+//	go test -bench=. -benchtime=5s -count=3 -benchmem ./internal/search/...
+//
+// Capture baseline before any optimization:
+//
+//	go test -bench=. -benchtime=5s -count=3 -benchmem ./internal/search/... | tee bench_before.txt
+//
+// After implementing optimizations, compare with benchstat:
+//
+//	benchstat bench_before.txt bench_after.txt
+package search_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// ── Synthetic data helpers ───────────────────────────────────────────────────
+
+func syntheticMemoryID(i int) string { return fmt.Sprintf("mem-%04d", i) }
+func syntheticChunkID(i, j int) string {
+	return fmt.Sprintf("chunk-%04d-%02d", i, j)
+}
+
+// syntheticVecHits produces numMemories*chunksPer VectorHit entries with
+// different distances per chunk so the best-hit logic must actually evaluate.
+func syntheticVecHits(numMemories, chunksPer int) []db.VectorHit {
+	hits := make([]db.VectorHit, 0, numMemories*chunksPer)
+	heading := "Introduction"
+	for i := 0; i < numMemories; i++ {
+		for j := 0; j < chunksPer; j++ {
+			hits = append(hits, db.VectorHit{
+				ChunkID:        syntheticChunkID(i, j),
+				MemoryID:       syntheticMemoryID(i),
+				Distance:       float64(j+1) * 0.05, // 0.05, 0.10, 0.15 → best is first
+				ChunkText:      fmt.Sprintf("chunk text for memory %d chunk %d", i, j),
+				ChunkIndex:     j,
+				SectionHeading: &heading,
+			})
+		}
+	}
+	return hits
+}
+
+func syntheticMemories(ids []string) []*types.Memory {
+	mems := make([]*types.Memory, len(ids))
+	for i, id := range ids {
+		now := time.Now()
+		imp := 2
+		dynImp := 2.5
+		mems[i] = &types.Memory{
+			ID:               id,
+			Content:          fmt.Sprintf("Memory content for %s: some meaningful text about a topic.", id),
+			Importance:       imp,
+			DynamicImportance: &dynImp,
+			LastAccessed:     now,
+			CreatedAt:        now,
+		}
+	}
+	return mems
+}
+
+func syntheticRelationships(memID string, count int) []types.Relationship {
+	rels := make([]types.Relationship, count)
+	for i := range rels {
+		str := 0.8
+		rels[i] = types.Relationship{
+			SourceID: memID,
+			TargetID: syntheticMemoryID(100 + i), // neighbor memory IDs (outside topK)
+			RelType:  "relates_to",
+			Strength: str,
+		}
+	}
+	return rels
+}
+
+// ── stubBackend ──────────────────────────────────────────────────────────────
+
+// stubBackend is a no-op db.Backend implementation used for benchmarking.
+// It returns deterministic synthetic data for the methods called by RecallWithOpts.
+// All other methods are safe no-ops.
+type stubBackend struct {
+	numResults    int // how many memories to return per VectorSearch/FTS call
+	relsPerResult int // how many relationships to return per GetRelationships call
+}
+
+func newStubBackend(numResults, relsPerResult int) *stubBackend {
+	return &stubBackend{numResults: numResults, relsPerResult: relsPerResult}
+}
+
+// ── db.Backend interface — methods used by RecallWithOpts ────────────────────
+
+func (s *stubBackend) VectorSearch(_ context.Context, _ string, _ []float32, limit int) ([]db.VectorHit, error) {
+	n := s.numResults * 3 // engine requests topK*3
+	if limit < n {
+		n = limit
+	}
+	// Return hits: numResults unique memories, 3 chunks each.
+	return syntheticVecHits(s.numResults, 3)[:n], nil
+}
+
+func (s *stubBackend) FTSSearch(_ context.Context, _ string, _ string, limit int, _, _ *time.Time) ([]db.FTSResult, error) {
+	// Return half the memories via FTS with varying scores.
+	half := s.numResults / 2
+	if half == 0 {
+		half = 1
+	}
+	results := make([]db.FTSResult, half)
+	for i := range results {
+		id := syntheticMemoryID(i)
+		now := time.Now()
+		results[i] = db.FTSResult{
+			Memory: &types.Memory{ID: id, Content: "fts content", LastAccessed: now, CreatedAt: now},
+			Score:  float64(half-i) * 0.1,
+		}
+	}
+	return results, nil
+}
+
+func (s *stubBackend) GetMemoriesByIDs(_ context.Context, _ string, ids []string) ([]*types.Memory, error) {
+	return syntheticMemories(ids), nil
+}
+
+func (s *stubBackend) GetRelationships(_ context.Context, _, memID string) ([]types.Relationship, error) {
+	return syntheticRelationships(memID, s.relsPerResult), nil
+}
+
+func (s *stubBackend) GetRelationshipsBatch(_ context.Context, _ string, ids []string) (map[string][]types.Relationship, error) {
+	result := make(map[string][]types.Relationship, len(ids))
+	for _, id := range ids {
+		result[id] = syntheticRelationships(id, s.relsPerResult)
+	}
+	return result, nil
+}
+
+func (s *stubBackend) TouchMemories(_ context.Context, _ []string) error { return nil }
+
+func (s *stubBackend) UpdateChunkLastMatched(_ context.Context, _ string) error { return nil }
+
+func (s *stubBackend) GetMeta(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (s *stubBackend) SetMeta(_ context.Context, _, _, _ string) error { return nil }
+
+// ── Safe no-ops for all remaining db.Backend methods ────────────────────────
+
+func (s *stubBackend) Close() {}
+
+func (s *stubBackend) SetMetaTx(_ context.Context, _ db.Tx, _, _, _ string) error { return nil }
+
+func (s *stubBackend) StoreMemory(_ context.Context, _ *types.Memory) error { return nil }
+
+func (s *stubBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error { return nil }
+
+func (s *stubBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error) { return nil, nil }
+
+func (s *stubBackend) UpdateMemory(_ context.Context, _ string, _ *string, _ []string, _ *int) (*types.Memory, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) DeleteMemory(_ context.Context, _ string) (bool, error) { return false, nil }
+
+func (s *stubBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error) {
+	return false, nil
+}
+
+func (s *stubBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error { return nil }
+
+func (s *stubBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) TouchMemory(_ context.Context, _ string) error { return nil }
+
+func (s *stubBackend) StoreChunks(_ context.Context, _ []*types.Chunk) error { return nil }
+
+func (s *stubBackend) StoreChunksTx(_ context.Context, _ db.Tx, _ []*types.Chunk) error { return nil }
+
+func (s *stubBackend) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) GetAllChunksWithEmbeddings(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) GetAllChunkTexts(_ context.Context, _ string, _ int) ([]string, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) GetChunksForMemories(_ context.Context, _ []string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) ChunkHashExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
+func (s *stubBackend) DeleteChunksForMemory(_ context.Context, _ string) error { return nil }
+
+func (s *stubBackend) DeleteChunksForMemoryTx(_ context.Context, _ db.Tx, _ string) error {
+	return nil
+}
+
+func (s *stubBackend) DeleteChunksByIDs(_ context.Context, _ []string) (int, error) { return 0, nil }
+
+func (s *stubBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error) { return 0, nil }
+
+func (s *stubBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) UpdateChunkEmbedding(_ context.Context, _ string, _ []float32) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) ChunkEmbeddingDistance(_ context.Context, _, _ string) (float64, error) {
+	return 2.0, nil
+}
+
+func (s *stubBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error { return nil }
+
+func (s *stubBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) BoostEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) DecayEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) GetConnectionCount(_ context.Context, _, _ string) (int, error) { return 0, nil }
+
+func (s *stubBackend) DecayAllEdges(_ context.Context, _ string, _, _ float64) (int, int, error) {
+	return 0, 0, nil
+}
+
+func (s *stubBackend) DeleteRelationshipsForMemory(_ context.Context, _ string) error { return nil }
+
+func (s *stubBackend) GetMemoryHistory(_ context.Context, _, _ string) ([]*types.MemoryVersion, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) SoftDeleteMemory(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+func (s *stubBackend) GetMemoriesAsOf(_ context.Context, _ string, _ time.Time, _ int) ([]*types.Memory, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) StoreRetrievalEvent(_ context.Context, _ *types.RetrievalEvent) error {
+	return nil
+}
+
+func (s *stubBackend) GetRetrievalEvent(_ context.Context, _ string) (*types.RetrievalEvent, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) RecordFeedback(_ context.Context, _ string, _ []string) error { return nil }
+
+func (s *stubBackend) IncrementTimesRetrieved(_ context.Context, _ []string) error { return nil }
+
+func (s *stubBackend) UpdateDynamicImportance(_ context.Context, _ string, _, _ float64) error {
+	return nil
+}
+
+func (s *stubBackend) SetNextReviewAt(_ context.Context, _ string, _ time.Time) error { return nil }
+
+func (s *stubBackend) DecayStaleImportance(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) PruneStaleMemories(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) PruneColdDocuments(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) RebuildFTS(_ context.Context) error { return nil }
+
+func (s *stubBackend) GetStats(_ context.Context, _ string) (*types.MemoryStats, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) ListAllProjects(_ context.Context) ([]string, error) { return nil, nil }
+
+func (s *stubBackend) GetAllMemoryIDs(_ context.Context, _ string) (map[string]struct{}, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) GetMemoriesPendingSummary(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) StoreSummary(_ context.Context, _, _ string) error { return nil }
+
+func (s *stubBackend) GetPendingSummaryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) ClearSummaries(_ context.Context, _ string) (int, error) { return 0, nil }
+
+func (s *stubBackend) GetMemoriesMissingHash(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) UpdateMemoryHash(_ context.Context, _, _ string) error { return nil }
+
+func (s *stubBackend) GetIntegrityStats(_ context.Context, _ string) (db.IntegrityStats, error) {
+	return db.IntegrityStats{}, nil
+}
+
+func (s *stubBackend) StartEpisode(_ context.Context, _, _ string) (*types.Episode, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) EndEpisode(_ context.Context, _, _ string) error { return nil }
+
+func (s *stubBackend) ListEpisodes(_ context.Context, _ string, _ int) ([]*types.Episode, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) RecallEpisode(_ context.Context, _ string) ([]*types.Memory, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) Begin(_ context.Context) (db.Tx, error) { return nil, nil }
+
+// compile-time check: stubBackend must satisfy db.Backend.
+var _ db.Backend = (*stubBackend)(nil)
+
+// ── Micro-benchmarks: inner map-merge loop (Candidate 1) ────────────────────
+//
+// These benchmarks isolate the best-hit selection loop in RecallWithOpts.
+// They do NOT need a running engine — they test the algorithm directly.
+// Both approaches are benchmarked here so a single run produces a
+// before/after comparison without needing two separate source states.
+
+// BenchmarkRecallMaps_5maps is the CURRENT implementation: five separate maps.
+// This is the baseline. Shewhart compares this against BenchmarkRecallMaps_structmap.
+func BenchmarkRecallMaps_5maps(b *testing.B) {
+	const numMemories = 10
+	const chunksPerMemory = 3
+	hits := syntheticVecHits(numMemories, chunksPerMemory)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		bestCosine := make(map[string]float64, numMemories)
+		bestChunkText := make(map[string]string, numMemories)
+		bestChunkIndex := make(map[string]int, numMemories)
+		bestChunkSection := make(map[string]*string, numMemories)
+		bestChunkID := make(map[string]string, numMemories)
+		seen := make(map[string]bool, numMemories)
+		uniqueIDs := make([]string, 0, numMemories)
+
+		for _, h := range hits {
+			cosine := 1.0 - h.Distance
+			if cosine > bestCosine[h.MemoryID] {
+				bestCosine[h.MemoryID] = cosine
+				bestChunkText[h.MemoryID] = h.ChunkText
+				bestChunkIndex[h.MemoryID] = h.ChunkIndex
+				bestChunkSection[h.MemoryID] = h.SectionHeading
+				bestChunkID[h.MemoryID] = h.ChunkID
+			}
+			if !seen[h.MemoryID] {
+				seen[h.MemoryID] = true
+				uniqueIDs = append(uniqueIDs, h.MemoryID)
+			}
+		}
+		// Prevent dead-code elimination.
+		_ = uniqueIDs
+		_ = bestCosine
+		_ = bestChunkText
+		_ = bestChunkIndex
+		_ = bestChunkSection
+		_ = bestChunkID
+	}
+}
+
+// BenchmarkRecallMaps_structmap is the PROPOSED optimization: one struct map.
+// This benchmark is written ahead of implementation (TDD) to establish the
+// performance target. It will also serve as the "after" baseline once
+// engine.go is updated to use this approach.
+func BenchmarkRecallMaps_structmap(b *testing.B) {
+	type bestHit struct {
+		cosine         float64
+		chunkText      string
+		chunkIndex     int
+		sectionHeading *string
+		chunkID        string
+	}
+
+	const numMemories = 10
+	const chunksPerMemory = 3
+	hits := syntheticVecHits(numMemories, chunksPerMemory)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		bestHits := make(map[string]bestHit, numMemories)
+		seen := make(map[string]bool, numMemories)
+		uniqueIDs := make([]string, 0, numMemories)
+
+		for _, h := range hits {
+			cosine := 1.0 - h.Distance
+			if existing, ok := bestHits[h.MemoryID]; !ok || cosine > existing.cosine {
+				bestHits[h.MemoryID] = bestHit{
+					cosine:         cosine,
+					chunkText:      h.ChunkText,
+					chunkIndex:     h.ChunkIndex,
+					sectionHeading: h.SectionHeading,
+					chunkID:        h.ChunkID,
+				}
+			}
+			if !seen[h.MemoryID] {
+				seen[h.MemoryID] = true
+				uniqueIDs = append(uniqueIDs, h.MemoryID)
+			}
+		}
+		_ = uniqueIDs
+		_ = bestHits
+	}
+}
+
+// ── Full-path benchmarks via stub backend ────────────────────────────────────
+
+// newBenchEngine creates a SearchEngine backed by a stubBackend for benchmarking.
+// Workers are started but will find no work (stub returns empty pending queues).
+func newBenchEngine(b *testing.B, numResults, relsPerResult int) *search.SearchEngine {
+	b.Helper()
+	backend := newStubBackend(numResults, relsPerResult)
+	engine := search.New(
+		context.Background(),
+		backend,
+		&fakeClient{dims: 768},
+		"bench-project",
+		"http://ollama:11434",
+		"llama3.2",
+		false, // summarization disabled — no Ollama needed
+		nil,   // no claude client
+		0,     // default decay interval
+	)
+	b.Cleanup(func() { engine.Close() })
+	return engine
+}
+
+// BenchmarkRecallWithOpts_10 benchmarks a full Recall cycle:
+// embedding → vector search → FTS → composite score → topK trim.
+// GetRelationships is NOT called here (relsPerResult=0).
+func BenchmarkRecallWithOpts_10(b *testing.B) {
+	engine := newBenchEngine(b, 10, 0)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		results, err := engine.Recall(ctx, "test query for benchmark", 10, "full")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = results
+	}
+}
+
+// BenchmarkRecallWithOpts_10_withRelationships benchmarks the full Recall cycle
+// including the GetRelationships loop for each of the topK results.
+// With the current implementation, this issues K separate DB queries (N+1 pattern).
+// After Candidate 2 (GetRelationshipsBatch), this should issue 1 query.
+func BenchmarkRecallWithOpts_10_withRelationships(b *testing.B) {
+	engine := newBenchEngine(b, 10, 3) // 3 relationships per result → 10 queries
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		results, err := engine.Recall(ctx, "test query for benchmark", 10, "full")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = results
+	}
+}
+
+// BenchmarkRecallWithOpts_50 benchmarks a larger recall window (50 results).
+// Useful for confirming that optimizations scale with result count.
+func BenchmarkRecallWithOpts_50(b *testing.B) {
+	engine := newBenchEngine(b, 50, 0)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		results, err := engine.Recall(ctx, "test query for benchmark", 50, "full")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = results
+	}
+}


### PR DESCRIPTION
## Summary

- **Phase 1**: Replace 5 parallel maps in `RecallWithOpts` inner loop with a single `bestHit` struct-map — 5× fewer hash lookups, 67% alloc reduction (18→6) in the isolated inner loop benchmark (~40% speedup in isolation)
- **Phase 2**: Eliminate N+1 `GetRelationships` calls after topK scoring — new `GetRelationshipsBatch` method fetches all edges in one round-trip; inner loop complexity fixed from O(rows×K) to O(rows) via idSet map
- **Phase 0**: Add pprof profiling server on `localhost:6060` (loopback-only) for future profiling cycles
- **Phase 3 CLOSED**: Partial index candidate failed the evidence gate — HNSW is the primary kNN access path; no EXPLAIN ANALYZE available to confirm B-tree usage

## QA Army Group Sign-off

| Reviewer | Verdict |
|---|---|
| Spruance (TDD compliance) | ✅ Benchmarks written before implementation; integration tests before batch method |
| Shewhart (statistical) | ✅ Phase 1 SHIP; Phase 2 SHIP (production reasoning); Phase 3 NO-ACTION |
| Rickover-validator (zero-defect) | ✅ CERTIFIED FOR MERGE — 0 blockers |
| Zero-context reviewer | ✅ STRUCTURALLY SOUND — found O(N×M) blocker, fixed before merge |

## Test Plan

- [x] `go test ./... -count=1 -race` — 15/15 packages, 0 failures, 0 races
- [x] `go build ./...` — clean
- [x] `benchstat bench_before.txt bench_after.txt` — geomean allocs -1.84%, sec/op within noise (expected: stub backend does not simulate DB round trips)
- [x] B/op +5.40% documented as capacity-hint pre-allocation artifact (not a runtime regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)