### PR TITLE
feat(engram): Phase A3 — memory_explore iterative RLM-style synthesis tool

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -156,6 +156,9 @@ func run() error {
 		DataDir:                  *dataDir,
 		RecallDefaultMode:        envOr("ENGRAM_RECALL_DEFAULT_MODE", ""),
 		FetchMaxBytes:            envInt("ENGRAM_FETCH_MAX_BYTES", 65536),
+		ExploreMaxIters:          envInt("ENGRAM_EXPLORE_MAX_ITERS", 5),
+		ExploreMaxWorkers:        envInt("ENGRAM_EXPLORE_MAX_WORKERS", 8),
+		ExploreTokenBudget:       envInt("ENGRAM_EXPLORE_TOKEN_BUDGET", 20000),
 	}
 	srv := internalmcp.NewServer(pool, cfg)
 	if cc != nil {

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -154,6 +154,8 @@ func run() error {
 		ClaudeConsolidateEnabled: *claudeConsolidate,
 		ClaudeRerankEnabled:      *claudeRerank,
 		DataDir:                  *dataDir,
+		RecallDefaultMode:        envOr("ENGRAM_RECALL_DEFAULT_MODE", ""),
+		FetchMaxBytes:            envInt("ENGRAM_FETCH_MAX_BYTES", 65536),
 	}
 	srv := internalmcp.NewServer(pool, cfg)
 	if cc != nil {

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -51,6 +51,21 @@ func New(apiKey string) (*Client, error) {
 const claudeAPITimeout = 90 * time.Second
 
 func (c *Client) Complete(ctx context.Context, system, prompt, executorModel, advisorModel string, advisorMaxUses, maxTokens int) (string, error) {
+	text, _, err := c.CompleteWithUsage(ctx, system, prompt, executorModel, advisorModel, advisorMaxUses, maxTokens)
+	return text, err
+}
+
+// TokenUsage reports token accounting for a single completion call.
+type TokenUsage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// Total returns the sum of input + output tokens.
+func (u TokenUsage) Total() int { return u.InputTokens + u.OutputTokens }
+
+// CompleteWithUsage is like Complete but also returns token usage from the response.
+func (c *Client) CompleteWithUsage(ctx context.Context, system, prompt, executorModel, advisorModel string, advisorMaxUses, maxTokens int) (string, TokenUsage, error) {
 	// Apply a per-request deadline if the caller's context has none.
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
@@ -77,12 +92,12 @@ func (c *Client) Complete(ctx context.Context, system, prompt, executorModel, ad
 
 	encoded, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("claude: marshal request: %w", err)
+		return "", TokenUsage{}, fmt.Errorf("claude: marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/messages", bytes.NewReader(encoded))
 	if err != nil {
-		return "", fmt.Errorf("claude: build request: %w", err)
+		return "", TokenUsage{}, fmt.Errorf("claude: build request: %w", err)
 	}
 	req.Header.Set("x-api-key", c.apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
@@ -90,25 +105,29 @@ func (c *Client) Complete(ctx context.Context, system, prompt, executorModel, ad
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("claude: HTTP request: %w", err)
+		return "", TokenUsage{}, fmt.Errorf("claude: HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return "", fmt.Errorf("claude: HTTP %d: %s", resp.StatusCode, body)
+		return "", TokenUsage{}, fmt.Errorf("claude: HTTP %d: %s", resp.StatusCode, body)
 	}
 
 	var result messagesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("claude: decode response: %w", err)
+		return "", TokenUsage{}, fmt.Errorf("claude: decode response: %w", err)
 	}
 
 	if len(result.Content) == 0 {
-		return "", fmt.Errorf("claude: empty content in response")
+		return "", TokenUsage{}, fmt.Errorf("claude: empty content in response")
 	}
 
-	return extractJSON(result.Content[0].Text), nil
+	usage := TokenUsage{
+		InputTokens:  result.Usage.InputTokens,
+		OutputTokens: result.Usage.OutputTokens,
+	}
+	return extractJSON(result.Content[0].Text), usage, nil
 }
 
 // extractJSON strips leading/trailing ```json / ``` markdown fences if present.
@@ -153,4 +172,8 @@ type messagesResponse struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
 	} `json:"content"`
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
 }

--- a/internal/claude/explore.go
+++ b/internal/claude/explore.go
@@ -1,0 +1,371 @@
+// Package claude: iterative RLM-style synthesis (memory_explore).
+//
+// Explore runs a bounded recall → score → refine loop server-side, collapsing
+// N client round-trips into a single synchronous call. The client sees only
+// the final synthesized answer plus grounding metadata.
+
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// Recaller retrieves memories by semantic query. Declared here to avoid a
+// circular import on the search package.
+type Recaller interface {
+	Recall(ctx context.Context, query string, topK int, detail string) ([]types.SearchResult, error)
+}
+
+// RelationshipGetter fetches relationships for conflict detection. Declared
+// here to avoid a circular import on the db package.
+type RelationshipGetter interface {
+	GetRelationships(ctx context.Context, project, memoryID string) ([]types.Relationship, error)
+}
+
+// ExploreRequest is the input envelope for Explore.
+type ExploreRequest struct {
+	Project             string
+	Question            string
+	MaxIterations       int
+	ConfidenceThreshold float64
+	TokenBudget         int
+	IncludeTrace        bool
+}
+
+// TraceStep records one iteration of the explore loop for debugging.
+type TraceStep struct {
+	Iteration    int      `json:"iteration"`
+	Query        string   `json:"query"`
+	NewMemoryIDs []string `json:"new_memory_ids"`
+	Confidence   float64  `json:"confidence"`
+	Gaps         []string `json:"gaps"`
+	RefinedQuery string   `json:"refined_query,omitempty"`
+	Stop         bool     `json:"stop"`
+	TokensUsed   int      `json:"tokens_used"`
+}
+
+// ExploreResult is the output envelope from Explore.
+type ExploreResult struct {
+	Answer     string         `json:"answer"`
+	MemoryIDs  []string       `json:"memory_ids"`
+	Iterations int            `json:"iterations"`
+	Confidence float64        `json:"confidence"`
+	Conflicts  []ConflictPair `json:"conflicts"`
+	Truncated  bool           `json:"truncated,omitempty"`
+	Warnings   []string       `json:"warnings,omitempty"`
+	Trace      []TraceStep    `json:"trace,omitempty"`
+}
+
+const exploreScoringSystem = `You are a memory recall quality scorer. Evaluate the retrieved memory corpus against the question on exactly three criteria:
+1. Direct answer: Do the retrieved memories directly answer the question?
+2. Contradictions: Are there unresolved contradictions among the memories?
+3. Missing entities: Are there named entities in the question or memories that have NOT been retrieved?
+
+Respond with valid JSON only (no markdown fences):
+{"confidence": <0.0-1.0>, "gaps": [<string>], "refined_query": <string or null>, "stop": <bool>}
+- confidence: 0.0=no answer, 1.0=fully answered
+- gaps: list of specific missing entities or information
+- refined_query: a better search query to fill gaps, or null if none needed
+- stop: true if corpus has enough information to answer the question`
+
+// scoringResponse is what the sub-Claude scoring call should produce.
+type scoringResponse struct {
+	Confidence   float64  `json:"confidence"`
+	Gaps         []string `json:"gaps"`
+	RefinedQuery *string  `json:"refined_query"`
+	Stop         bool     `json:"stop"`
+}
+
+// exploreSynthThreshold is the corpus size above which Explore fans out to
+// sharded synthesis. Below this, it goes straight to conflict-aware reasoning.
+const exploreSynthThreshold = 20
+
+// budgetTracker tracks cumulative token usage and flags exhaustion.
+type budgetTracker struct {
+	used   int
+	budget int
+}
+
+func (b *budgetTracker) add(u TokenUsage) { b.used += u.Total() }
+func (b *budgetTracker) exhausted() bool  { return b.budget > 0 && b.used >= b.budget }
+
+// Explore runs the iterative recall+score+synthesis loop.
+//
+// Contract:
+//   - Stops when confidence >= threshold && gaps empty, or iter >= max_iterations,
+//     or tokens >= budget (sets Truncated=true), or refined_query == previous,
+//     or two consecutive zero-new-memory iterations.
+//   - Returns a grounded answer; ungrounded UUID-like citations are stripped and
+//     reported as warnings.
+func Explore(ctx context.Context, c *Client, r Recaller, rels RelationshipGetter, req ExploreRequest) (*ExploreResult, error) {
+	if c == nil {
+		return nil, fmt.Errorf("explore: claude client is nil")
+	}
+	if r == nil {
+		return nil, fmt.Errorf("explore: recaller is nil")
+	}
+	if strings.TrimSpace(req.Question) == "" {
+		return nil, fmt.Errorf("explore: question is required")
+	}
+	maxIter := req.MaxIterations
+	if maxIter < 1 {
+		maxIter = 5
+	}
+	if maxIter > 10 {
+		maxIter = 10
+	}
+	threshold := req.ConfidenceThreshold
+	if threshold <= 0 {
+		threshold = 0.75
+	}
+	budget := req.TokenBudget
+	if budget <= 0 {
+		budget = 20000
+	}
+
+	result := &ExploreResult{}
+	tracker := &budgetTracker{budget: budget}
+
+	// Ordered corpus (ID → *Memory) so we preserve insertion order.
+	corpus := make(map[string]*corpusEntry)
+	var corpusOrder []string
+	corpusIDs := make(map[string]bool)
+
+	query := req.Question
+	prevQuery := ""
+	zeroNewStreak := 0
+	var lastConfidence float64
+	truncated := false
+
+	iter := 0
+	for iter < maxIter {
+		if tracker.exhausted() {
+			truncated = true
+			break
+		}
+
+		// 1. Recall.
+		results, err := r.Recall(ctx, query, 15, "summary")
+		if err != nil {
+			return nil, fmt.Errorf("explore: recall iter %d: %w", iter, err)
+		}
+
+		// 2. Filter already-seen IDs.
+		var newIDs []string
+		for _, sr := range results {
+			if sr.Memory == nil {
+				continue
+			}
+			id := sr.Memory.ID
+			if _, seen := corpus[id]; seen {
+				continue
+			}
+			corpus[id] = &corpusEntry{mem: sr.Memory}
+			corpusOrder = append(corpusOrder, id)
+			corpusIDs[id] = true
+			newIDs = append(newIDs, id)
+		}
+
+		// 3. Score.
+		score, usage, scoreErr := scoreCorpus(ctx, c, req.Question, corpus, corpusOrder)
+		tracker.add(usage)
+
+		step := TraceStep{
+			Iteration:    iter,
+			Query:        query,
+			NewMemoryIDs: newIDs,
+			TokensUsed:   usage.Total(),
+		}
+		if scoreErr == nil {
+			step.Confidence = score.Confidence
+			step.Gaps = score.Gaps
+			if score.RefinedQuery != nil {
+				step.RefinedQuery = *score.RefinedQuery
+			}
+			step.Stop = score.Stop
+			lastConfidence = score.Confidence
+		}
+		result.Trace = append(result.Trace, step)
+
+		iter++
+
+		if scoreErr != nil {
+			// Scoring failed — treat as low confidence, keep going unless other
+			// stop condition triggers.
+			if iter >= maxIter {
+				break
+			}
+			if tracker.exhausted() {
+				truncated = true
+				break
+			}
+			continue
+		}
+
+		// 4. Stop conditions.
+		// Budget exhausted.
+		if tracker.exhausted() {
+			truncated = true
+			break
+		}
+		// Confidence high enough + no gaps.
+		if score.Confidence >= threshold && len(score.Gaps) == 0 {
+			break
+		}
+		// Explicit stop flag.
+		if score.Stop {
+			break
+		}
+		// Zero-new-memory streak (two in a row).
+		if len(newIDs) == 0 {
+			zeroNewStreak++
+			if zeroNewStreak >= 2 {
+				break
+			}
+		} else {
+			zeroNewStreak = 0
+		}
+		// No refined query → nothing to try next.
+		if score.RefinedQuery == nil || *score.RefinedQuery == "" {
+			break
+		}
+		// Refined query equals previous query → no progress.
+		if *score.RefinedQuery == prevQuery || *score.RefinedQuery == query {
+			break
+		}
+		prevQuery = query
+		query = *score.RefinedQuery
+	}
+
+	result.Iterations = iter
+	result.Truncated = truncated
+
+	// Build ordered memory list.
+	memories := make([]*types.Memory, 0, len(corpusOrder))
+	for _, id := range corpusOrder {
+		memories = append(memories, corpus[id].mem)
+	}
+
+	// Build evidence map for conflicts (best-effort).
+	var allRels []types.Relationship
+	if rels != nil {
+		seen := make(map[string]bool)
+		for _, m := range memories {
+			rs, err := rels.GetRelationships(ctx, req.Project, m.ID)
+			if err != nil {
+				continue
+			}
+			for _, rel := range rs {
+				if !seen[rel.ID] {
+					seen[rel.ID] = true
+					allRels = append(allRels, rel)
+				}
+			}
+		}
+	}
+	ev := DiagnoseMemories(memories, allRels)
+	result.Conflicts = ev.Conflicts
+	if len(allRels) > 0 {
+		result.Confidence = ev.Confidence
+	} else {
+		result.Confidence = lastConfidence
+	}
+
+	// Synthesis.
+	var answer string
+	var synthErr error
+	if len(memories) == 0 {
+		answer, synthErr = c.ReasonOverMemories(ctx, req.Question, memories)
+	} else if len(memories) > exploreSynthThreshold {
+		answer, synthErr = FanOutReason(ctx, c, req.Question, memories, 8, 15)
+	} else {
+		answer, synthErr = c.ReasonWithConflictAwareness(ctx, req.Question, ev)
+	}
+	if synthErr != nil {
+		return nil, fmt.Errorf("explore: synthesis: %w", synthErr)
+	}
+
+	// 6. Citation guard.
+	cleanAnswer, warnings := validateCitations(answer, corpusIDs)
+	result.Answer = cleanAnswer
+	result.Warnings = append(result.Warnings, warnings...)
+
+	// Build the memory_ids list.
+	ids := make([]string, 0, len(memories))
+	for _, m := range memories {
+		ids = append(ids, m.ID)
+	}
+	result.MemoryIDs = ids
+
+	if !req.IncludeTrace {
+		result.Trace = nil
+	}
+
+	return result, nil
+}
+
+// scoreCorpus runs one scoring sub-Claude call.
+func scoreCorpus(ctx context.Context, c *Client, question string, corpus map[string]*corpusEntry, order []string) (scoringResponse, TokenUsage, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Question: %s\n\n", question)
+	if len(order) == 0 {
+		sb.WriteString("(No memories retrieved yet.)\n")
+	} else {
+		sb.WriteString("Retrieved memories:\n")
+		for i, id := range order {
+			m := corpus[id].mem
+			content := m.Content
+			if len(content) > 400 {
+				content = content[:400]
+			}
+			fmt.Fprintf(&sb, "[%d] ID:%s %s\n", i+1, id, content)
+		}
+	}
+	sb.WriteString("\nEmit ONLY the scoring JSON object.")
+
+	text, usage, err := c.CompleteWithUsage(ctx, exploreScoringSystem, sb.String(), "claude-sonnet-4-6", "claude-opus-4-6", 1, 512)
+	if err != nil {
+		return scoringResponse{}, usage, err
+	}
+	var out scoringResponse
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		return scoringResponse{}, usage, fmt.Errorf("parse scoring JSON: %w", err)
+	}
+	return out, usage, nil
+}
+
+// corpusEntry wraps a memory in the explore corpus. Single-field struct so
+// future fields (e.g. score breakdown) can be added without refactoring.
+type corpusEntry struct {
+	mem *types.Memory
+}
+
+// citationPattern matches bare 32-char lowercase-hex identifiers on word
+// boundaries.
+var citationPattern = regexp.MustCompile(`\b[0-9a-f]{32}\b`)
+
+// validateCitations scans answer for 32-char hex strings not in corpusIDs,
+// strips them, and returns warnings.
+func validateCitations(answer string, corpusIDs map[string]bool) (string, []string) {
+	var warnings []string
+	stripped := false
+	cleaned := citationPattern.ReplaceAllStringFunc(answer, func(match string) string {
+		if corpusIDs[match] {
+			return match
+		}
+		stripped = true
+		return ""
+	})
+	if stripped {
+		// Collapse runs of whitespace introduced by the strip.
+		cleaned = strings.Join(strings.Fields(cleaned), " ")
+		warnings = append(warnings, "ungrounded_citation_stripped")
+	}
+	return cleaned, warnings
+}

--- a/internal/claude/explore.go
+++ b/internal/claude/explore.go
@@ -55,6 +55,8 @@ type ExploreRequest struct {
 	TokenBudget         int
 	IncludeTrace        bool
 	Scope               ExploreScope
+	// MaxWorkers caps FanOutReason concurrency. Defaults to 8 when zero or negative.
+	MaxWorkers int
 }
 
 // TraceStep records one iteration of the explore loop for debugging.
@@ -317,7 +319,11 @@ func Explore(ctx context.Context, c *Client, r Recaller, fetcher MemoryFetcher, 
 	if len(memories) == 0 {
 		answer, synthErr = c.ReasonOverMemories(ctx, req.Question, memories)
 	} else if len(memories) > exploreSynthThreshold {
-		answer, synthErr = FanOutReason(ctx, c, req.Question, memories, 8, 15)
+		maxWorkers := req.MaxWorkers
+		if maxWorkers < 1 {
+			maxWorkers = 8
+		}
+		answer, synthErr = FanOutReason(ctx, c, req.Question, memories, maxWorkers, 15)
 	} else {
 		answer, synthErr = c.ReasonWithConflictAwareness(ctx, req.Question, ev)
 	}
@@ -380,11 +386,11 @@ type corpusEntry struct {
 	mem *types.Memory
 }
 
-// citationPattern matches bare 32-char lowercase-hex identifiers on word
-// boundaries.
-var citationPattern = regexp.MustCompile(`\b[0-9a-f]{32}\b`)
+// citationPattern matches standard dashed UUID identifiers on word boundaries.
+// All memory IDs in this system use the canonical xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx format.
+var citationPattern = regexp.MustCompile(`\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`)
 
-// validateCitations scans answer for 32-char hex strings not in corpusIDs,
+// validateCitations scans answer for dashed UUID strings not in corpusIDs,
 // strips them, and returns warnings.
 func validateCitations(answer string, corpusIDs map[string]bool) (string, []string) {
 	var warnings []string

--- a/internal/claude/explore.go
+++ b/internal/claude/explore.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/types"
 )
@@ -28,6 +29,23 @@ type RelationshipGetter interface {
 	GetRelationships(ctx context.Context, project, memoryID string) ([]types.Relationship, error)
 }
 
+// MemoryFetcher retrieves a single memory by ID at full detail.
+// Passed to Explore to upgrade corpus entries to full content before synthesis.
+// Implementations may ignore the project parameter if the backend is project-agnostic.
+type MemoryFetcher interface {
+	FetchMemory(ctx context.Context, project, memoryID string) (*types.Memory, error)
+}
+
+// ExploreScope constrains which memories are eligible for recall during Explore.
+// All non-zero fields are applied as AND conditions. Applied by the handler via
+// a scopedRecaller wrapper — Explore itself does not filter.
+type ExploreScope struct {
+	Tags      []string   `json:"tags,omitempty"`
+	EpisodeID string     `json:"episode_id,omitempty"`
+	Since     *time.Time `json:"since,omitempty"`
+	Until     *time.Time `json:"until,omitempty"`
+}
+
 // ExploreRequest is the input envelope for Explore.
 type ExploreRequest struct {
 	Project             string
@@ -36,6 +54,7 @@ type ExploreRequest struct {
 	ConfidenceThreshold float64
 	TokenBudget         int
 	IncludeTrace        bool
+	Scope               ExploreScope
 }
 
 // TraceStep records one iteration of the explore loop for debugging.
@@ -101,9 +120,12 @@ func (b *budgetTracker) exhausted() bool  { return b.budget > 0 && b.used >= b.b
 //   - Stops when confidence >= threshold && gaps empty, or iter >= max_iterations,
 //     or tokens >= budget (sets Truncated=true), or refined_query == previous,
 //     or two consecutive zero-new-memory iterations.
+//   - If fetcher is non-nil, corpus entries are upgraded to full-detail content
+//     after the loop completes and before synthesis (best-effort: errors keep
+//     the summary-level content).
 //   - Returns a grounded answer; ungrounded UUID-like citations are stripped and
 //     reported as warnings.
-func Explore(ctx context.Context, c *Client, r Recaller, rels RelationshipGetter, req ExploreRequest) (*ExploreResult, error) {
+func Explore(ctx context.Context, c *Client, r Recaller, fetcher MemoryFetcher, rels RelationshipGetter, req ExploreRequest) (*ExploreResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("explore: claude client is nil")
 	}
@@ -245,6 +267,18 @@ func Explore(ctx context.Context, c *Client, r Recaller, rels RelationshipGetter
 
 	result.Iterations = iter
 	result.Truncated = truncated
+
+	// Final synthesis: upgrade corpus entries to full-detail content so the
+	// synthesis call has the richest possible evidence. Best-effort: on any
+	// fetch error the summary-level memory is retained.
+	if fetcher != nil {
+		for _, id := range corpusOrder {
+			full, err := fetcher.FetchMemory(ctx, req.Project, id)
+			if err == nil && full != nil {
+				corpus[id] = &corpusEntry{mem: full}
+			}
+		}
+	}
 
 	// Build ordered memory list.
 	memories := make([]*types.Memory, 0, len(corpusOrder))

--- a/internal/claude/explore_test.go
+++ b/internal/claude/explore_test.go
@@ -176,7 +176,7 @@ func TestExplore_NoProgress(t *testing.T) {
 }
 
 func TestExplore_UngroundedCitationStripped(t *testing.T) {
-	ungrounded := "ffffffffffffffffffffffffffffffff"
+	ungrounded := "ffffffff-ffff-ffff-ffff-ffffffffffff"
 	var callCount int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&callCount, 1)
@@ -199,7 +199,7 @@ func TestExplore_UngroundedCitationStripped(t *testing.T) {
 	require.NoError(t, err)
 	c.BaseURL = srv.URL
 
-	goodID := strings.Repeat("a", 31) + "1"
+	goodID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	recaller := &mockRecaller{
 		calls: [][]types.SearchResult{
 			{makeResult(goodID, "m1")},

--- a/internal/claude/explore_test.go
+++ b/internal/claude/explore_test.go
@@ -1,0 +1,251 @@
+package claude_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/claude"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRecaller struct {
+	calls [][]types.SearchResult
+	idx   int
+}
+
+func (m *mockRecaller) Recall(_ context.Context, _ string, _ int, _ string) ([]types.SearchResult, error) {
+	if m.idx >= len(m.calls) {
+		return nil, nil
+	}
+	r := m.calls[m.idx]
+	m.idx++
+	return r, nil
+}
+
+type nilRelGetter struct{}
+
+func (nilRelGetter) GetRelationships(_ context.Context, _, _ string) ([]types.Relationship, error) {
+	return nil, nil
+}
+
+func makeResult(id, content string) types.SearchResult {
+	return types.SearchResult{
+		Memory: &types.Memory{ID: id, Content: content},
+		Score:  0.8,
+	}
+}
+
+func TestExplore_HappyTwoIterConvergence(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.4,"gaps":["more info"],"refined_query":"refined","stop":false}`}},
+				"usage":   map[string]int{"input_tokens": 100, "output_tokens": 50},
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 150, "output_tokens": 50},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": "The answer is based on the memories."}},
+				"usage":   map[string]int{"input_tokens": 200, "output_tokens": 100},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{
+			{makeResult("id1", "m1"), makeResult("id2", "m2"), makeResult("id3", "m3")},
+			{makeResult("id4", "m4"), makeResult("id5", "m5")},
+		},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "what?",
+		MaxIterations:       5,
+		ConfidenceThreshold: 0.75,
+		TokenBudget:         20000,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Iterations)
+	require.NotEmpty(t, result.Answer)
+	require.False(t, result.Truncated)
+}
+
+func TestExplore_BudgetExhaustion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content": []map[string]string{{"type": "text", "text": `{"confidence":0.3,"gaps":["more"],"refined_query":"q2","stop":false}`}},
+			"usage":   map[string]int{"input_tokens": 10000, "output_tokens": 5000},
+		})
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{
+			{makeResult("id1", "m1")},
+			{makeResult("id2", "m2")},
+			{makeResult("id3", "m3")},
+		},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "q?",
+		MaxIterations:       5,
+		ConfidenceThreshold: 0.99,
+		TokenBudget:         10,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	require.NoError(t, err)
+	require.True(t, result.Truncated)
+}
+
+func TestExplore_NoProgress(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content": []map[string]string{{"type": "text", "text": `{"confidence":0.4,"gaps":["more"],"refined_query":"same","stop":false}`}},
+			"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+		})
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	// Recaller always returns the same memory.
+	same := []types.SearchResult{makeResult("id1", "m1")}
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{same, same, same, same, same},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "q?",
+		MaxIterations:       10,
+		ConfidenceThreshold: 0.99,
+		TokenBudget:         100000,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	require.NoError(t, err)
+	// After iter 0 (3 new), iter 1 (0 new), iter 2 (0 new) should stop.
+	// Or refined_query == prev stops even sooner.
+	require.LessOrEqual(t, result.Iterations, 3)
+}
+
+func TestExplore_UngroundedCitationStripped(t *testing.T) {
+	ungrounded := "ffffffffffffffffffffffffffffffff"
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.95,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": "Answer cites " + ungrounded + " which is fake."}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	goodID := strings.Repeat("a", 31) + "1"
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{
+			{makeResult(goodID, "m1")},
+		},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "q?",
+		MaxIterations:       3,
+		ConfidenceThreshold: 0.75,
+		TokenBudget:         20000,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	require.NoError(t, err)
+	require.NotContains(t, result.Answer, ungrounded)
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "ungrounded_citation_stripped") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected ungrounded_citation_stripped warning: %v", result.Warnings)
+}
+
+func TestExplore_EmptyRecall(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 5, "output_tokens": 3},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": "No relevant memories found."}},
+				"usage":   map[string]int{"input_tokens": 5, "output_tokens": 3},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	recaller := &mockRecaller{calls: [][]types.SearchResult{{}}}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "q?",
+		MaxIterations:       3,
+		ConfidenceThreshold: 0.75,
+		TokenBudget:         20000,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Iterations)
+	require.NotEmpty(t, result.Answer)
+}

--- a/internal/claude/explore_test.go
+++ b/internal/claude/explore_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockFetcher records which IDs were fetched and returns upgraded memories.
+type mockFetcher struct {
+	fetched []string
+	upgrade map[string]*types.Memory // id → full-detail memory to return
+}
+
+func (f *mockFetcher) FetchMemory(_ context.Context, _ string, id string) (*types.Memory, error) {
+	f.fetched = append(f.fetched, id)
+	if m, ok := f.upgrade[id]; ok {
+		return m, nil
+	}
+	return nil, nil
+}
+
 type mockRecaller struct {
 	calls [][]types.SearchResult
 	idx   int
@@ -84,7 +98,7 @@ func TestExplore_HappyTwoIterConvergence(t *testing.T) {
 		ConfidenceThreshold: 0.75,
 		TokenBudget:         20000,
 	}
-	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
 	require.NoError(t, err)
 	require.Equal(t, 2, result.Iterations)
 	require.NotEmpty(t, result.Answer)
@@ -120,7 +134,7 @@ func TestExplore_BudgetExhaustion(t *testing.T) {
 		ConfidenceThreshold: 0.99,
 		TokenBudget:         10,
 	}
-	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
 	require.NoError(t, err)
 	require.True(t, result.Truncated)
 }
@@ -154,7 +168,7 @@ func TestExplore_NoProgress(t *testing.T) {
 		ConfidenceThreshold: 0.99,
 		TokenBudget:         100000,
 	}
-	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
 	require.NoError(t, err)
 	// After iter 0 (3 new), iter 1 (0 new), iter 2 (0 new) should stop.
 	// Or refined_query == prev stops even sooner.
@@ -199,7 +213,7 @@ func TestExplore_UngroundedCitationStripped(t *testing.T) {
 		ConfidenceThreshold: 0.75,
 		TokenBudget:         20000,
 	}
-	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
 	require.NoError(t, err)
 	require.NotContains(t, result.Answer, ungrounded)
 	found := false
@@ -244,8 +258,171 @@ func TestExplore_EmptyRecall(t *testing.T) {
 		ConfidenceThreshold: 0.75,
 		TokenBudget:         20000,
 	}
-	result, err := claude.Explore(context.Background(), c, recaller, nilRelGetter{}, req)
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Iterations)
 	require.NotEmpty(t, result.Answer)
+}
+
+// TestExplore_ScopedRequest verifies that a non-empty Scope field is accepted
+// and that the Recaller is still invoked (scope filtering happens inside the
+// handler-level scopedRecaller, not inside Explore itself).
+func TestExplore_ScopedRequest(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": "Scoped answer."}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{
+			{makeResult("id1", "scoped memory")},
+		},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "scoped question?",
+		MaxIterations:       3,
+		ConfidenceThreshold: 0.75,
+		TokenBudget:         20000,
+		Scope: claude.ExploreScope{
+			Tags:      []string{"important"},
+			EpisodeID: "ep-abc",
+		},
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
+	require.NoError(t, err)
+	// The recaller was called — scope is parsed and stored but filtering is
+	// applied by the handler wrapper, not Explore.
+	require.Equal(t, 1, recaller.idx, "recaller should have been called once")
+	require.NotEmpty(t, result.Answer)
+}
+
+// TestExplore_FetcherUpgradesCorpus verifies that a non-nil MemoryFetcher is
+// called for each corpus ID after the loop, upgrading entries to full detail.
+func TestExplore_FetcherUpgradesCorpus(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			// Scoring: confident, stop immediately.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		} else {
+			// Synthesis.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": "Answer from full-detail memories."}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{
+			{makeResult("id1", "summary content"), makeResult("id2", "summary content 2")},
+		},
+	}
+
+	// Fetcher returns upgraded memories with full content.
+	fetcher := &mockFetcher{
+		upgrade: map[string]*types.Memory{
+			"id1": {ID: "id1", Content: "full content of id1"},
+			"id2": {ID: "id2", Content: "full content of id2"},
+		},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "q?",
+		MaxIterations:       3,
+		ConfidenceThreshold: 0.75,
+		TokenBudget:         20000,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, fetcher, nilRelGetter{}, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Answer)
+	// Both corpus IDs must have been fetched.
+	require.Len(t, fetcher.fetched, 2)
+	require.ElementsMatch(t, []string{"id1", "id2"}, fetcher.fetched)
+}
+
+// TestExplore_ZeroRecallFirstIterRefinement exercises the path where the first
+// iteration returns zero memories (triggering a refined-query second attempt)
+// and the second iteration finds results and stops.
+func TestExplore_ZeroRecallFirstIterRefinement(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch n {
+		case 1:
+			// Iter 0 scoring: zero recall, low confidence, provide refined query.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.2,"gaps":["needs more context"],"refined_query":"better search terms","stop":false}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		case 2:
+			// Iter 1 scoring: results found, high confidence, stop.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		default:
+			// Synthesis call (n=3).
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": "Answer synthesized from memories."}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	recaller := &mockRecaller{
+		calls: [][]types.SearchResult{
+			{},                                                         // iter 0: zero results
+			{makeResult("id1", "m1"), makeResult("id2", "m2")}, // iter 1: two results
+		},
+	}
+
+	req := claude.ExploreRequest{
+		Project:             "test",
+		Question:            "what?",
+		MaxIterations:       5,
+		ConfidenceThreshold: 0.75,
+		TokenBudget:         20000,
+	}
+	result, err := claude.Explore(context.Background(), c, recaller, nil, nilRelGetter{}, req)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Iterations)
+	require.NotEmpty(t, result.Answer)
+	require.False(t, result.Truncated)
 }

--- a/internal/claude/worker.go
+++ b/internal/claude/worker.go
@@ -1,0 +1,85 @@
+package claude
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/petersimmons1972/engram/internal/types"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	reducerSystem = "You are a synthesis reducer. Multiple partial answers about the same question have been independently generated from memory shards. " +
+		"Combine them into a single coherent answer, eliminating redundancy and resolving contradictions. " +
+		"Preserve all cited memory IDs from the partial answers."
+
+	maxReducerPartialBytes = 4096
+)
+
+// FanOutReason shards memories into groups of shardSize and runs ReasonOverMemories
+// per shard concurrently (limited to maxWorkers), then reduces partial answers
+// with a single Complete call. If len(memories) <= shardSize, calls
+// ReasonOverMemories directly.
+func FanOutReason(ctx context.Context, c *Client, question string, memories []*types.Memory, maxWorkers, shardSize int) (string, error) {
+	if shardSize < 1 {
+		shardSize = 15
+	}
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+	if len(memories) <= shardSize {
+		return c.ReasonOverMemories(ctx, question, memories)
+	}
+
+	// Build shards.
+	var shards [][]*types.Memory
+	for i := 0; i < len(memories); i += shardSize {
+		end := i + shardSize
+		if end > len(memories) {
+			end = len(memories)
+		}
+		shards = append(shards, memories[i:end])
+	}
+
+	partials := make([]string, len(shards))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxWorkers)
+
+	for idx, shard := range shards {
+		idx, shard := idx, shard
+		g.Go(func() error {
+			ans, err := c.ReasonOverMemories(gctx, question, shard)
+			if err != nil {
+				return fmt.Errorf("shard %d: %w", idx, err)
+			}
+			partials[idx] = ans
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return "", err
+	}
+
+	// Reducer prompt — cap combined partials at maxReducerPartialBytes.
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Question: %s\n\nPartial answers:\n", question)
+	remaining := maxReducerPartialBytes
+	for i, p := range partials {
+		if remaining <= 0 {
+			break
+		}
+		content := p
+		if len(content) > remaining {
+			content = content[:remaining]
+		}
+		fmt.Fprintf(&sb, "[%d] %s\n\n", i+1, content)
+		remaining -= len(content)
+	}
+
+	reduced, err := c.Complete(ctx, reducerSystem, sb.String(), "claude-sonnet-4-6", "claude-opus-4-6", 2, 2048)
+	if err != nil {
+		return "", fmt.Errorf("reducer: %w", err)
+	}
+	return reduced, nil
+}

--- a/internal/claude/worker_test.go
+++ b/internal/claude/worker_test.go
@@ -1,0 +1,71 @@
+package claude_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/claude"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMemories(n int) []*types.Memory {
+	out := make([]*types.Memory, n)
+	for i := 0; i < n; i++ {
+		out[i] = &types.Memory{
+			ID:      strings.Repeat("a", 31) + string(rune('0'+i%10)),
+			Content: "mem content",
+		}
+	}
+	return out
+}
+
+func TestFanOutReason_SmallCorpus(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content": []map[string]string{{"type": "text", "text": "answer for small corpus"}},
+			"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+		})
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	answer, err := claude.FanOutReason(context.Background(), c, "q?", makeMemories(10), 8, 15)
+	require.NoError(t, err)
+	require.Contains(t, answer, "answer")
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "small corpus should trigger 1 call")
+}
+
+func TestFanOutReason_LargeCorpus(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content": []map[string]string{{"type": "text", "text": "partial answer"}},
+			"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+		})
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	answer, err := claude.FanOutReason(context.Background(), c, "q?", makeMemories(30), 8, 15)
+	require.NoError(t, err)
+	require.NotEmpty(t, answer)
+	// 30 memories → 2 shards + 1 reducer = 3 calls minimum.
+	require.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(3))
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -1,0 +1,313 @@
+package mcp
+
+// Internal tests for handleMemoryExplore and parseExploreScope.
+// Uses a no-op db.Backend stub + fake embedder so no PostgreSQL is required.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/claude"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ── no-op db.Backend stub ────────────────────────────────────────────────────
+
+// noopBackend implements db.Backend with all methods returning zero values.
+// Used to create a SearchEngine without a real PostgreSQL instance.
+type noopBackend struct{}
+
+func (noopBackend) Close()                                                     {}
+func (noopBackend) GetMeta(_ context.Context, _, _ string) (string, bool, error) { return "", false, nil }
+func (noopBackend) SetMeta(_ context.Context, _, _, _ string) error            { return nil }
+func (noopBackend) SetMetaTx(_ context.Context, _ db.Tx, _, _, _ string) error { return nil }
+func (noopBackend) StoreMemory(_ context.Context, _ *types.Memory) error       { return nil }
+func (noopBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error {
+	return nil
+}
+func (noopBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error) { return nil, nil }
+func (noopBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) UpdateMemory(_ context.Context, _ string, _ *string, _ []string, _ *int) (*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) DeleteMemory(_ context.Context, _ string) (bool, error)           { return false, nil }
+func (noopBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error) {
+	return false, nil
+}
+func (noopBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error { return nil }
+func (noopBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) TouchMemory(_ context.Context, _ string) error              { return nil }
+func (noopBackend) TouchMemories(_ context.Context, _ []string) error          { return nil }
+func (noopBackend) StoreChunks(_ context.Context, _ []*types.Chunk) error      { return nil }
+func (noopBackend) StoreChunksTx(_ context.Context, _ db.Tx, _ []*types.Chunk) error { return nil }
+func (noopBackend) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) GetAllChunksWithEmbeddings(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) GetAllChunkTexts(_ context.Context, _ string, _ int) ([]string, error) {
+	return nil, nil
+}
+func (noopBackend) GetChunksForMemories(_ context.Context, _ []string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) ChunkHashExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+func (noopBackend) DeleteChunksForMemory(_ context.Context, _ string) error      { return nil }
+func (noopBackend) DeleteChunksForMemoryTx(_ context.Context, _ db.Tx, _ string) error { return nil }
+func (noopBackend) DeleteChunksByIDs(_ context.Context, _ []string) (int, error) { return 0, nil }
+func (noopBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error)   { return 0, nil }
+func (noopBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
+	return 0, nil
+}
+func (noopBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) UpdateChunkEmbedding(_ context.Context, _ string, _ []float32) (int, error) {
+	return 0, nil
+}
+func (noopBackend) VectorSearch(_ context.Context, _ string, _ []float32, _ int) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (noopBackend) ChunkEmbeddingDistance(_ context.Context, _, _ string) (float64, error) {
+	return 2.0, nil
+}
+func (noopBackend) UpdateChunkLastMatched(_ context.Context, _ string) error  { return nil }
+func (noopBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error { return nil }
+func (noopBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
+	return nil, nil
+}
+func (noopBackend) BoostEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (noopBackend) DecayEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (noopBackend) GetConnectionCount(_ context.Context, _, _ string) (int, error) { return 0, nil }
+func (noopBackend) DecayAllEdges(_ context.Context, _ string, _, _ float64) (int, int, error) {
+	return 0, 0, nil
+}
+func (noopBackend) DeleteRelationshipsForMemory(_ context.Context, _ string) error { return nil }
+func (noopBackend) GetRelationships(_ context.Context, _, _ string) ([]types.Relationship, error) {
+	return nil, nil
+}
+func (noopBackend) GetRelationshipsBatch(_ context.Context, _ string, _ []string) (map[string][]types.Relationship, error) {
+	return nil, nil
+}
+func (noopBackend) GetMemoryHistory(_ context.Context, _, _ string) ([]*types.MemoryVersion, error) {
+	return nil, nil
+}
+func (noopBackend) SoftDeleteMemory(_ context.Context, _, _, _ string) (bool, error) { return false, nil }
+func (noopBackend) GetMemoriesAsOf(_ context.Context, _ string, _ time.Time, _ int) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) StoreRetrievalEvent(_ context.Context, _ *types.RetrievalEvent) error { return nil }
+func (noopBackend) GetRetrievalEvent(_ context.Context, _ string) (*types.RetrievalEvent, error) {
+	return nil, nil
+}
+func (noopBackend) RecordFeedback(_ context.Context, _ string, _ []string) error { return nil }
+func (noopBackend) IncrementTimesRetrieved(_ context.Context, _ []string) error  { return nil }
+func (noopBackend) UpdateDynamicImportance(_ context.Context, _ string, _, _ float64) error {
+	return nil
+}
+func (noopBackend) SetNextReviewAt(_ context.Context, _ string, _ time.Time) error { return nil }
+func (noopBackend) DecayStaleImportance(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (noopBackend) PruneStaleMemories(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+func (noopBackend) PruneColdDocuments(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+func (noopBackend) FTSSearch(_ context.Context, _, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	return nil, nil
+}
+func (noopBackend) RebuildFTS(_ context.Context) error                               { return nil }
+func (noopBackend) GetStats(_ context.Context, _ string) (*types.MemoryStats, error) { return nil, nil }
+func (noopBackend) ListAllProjects(_ context.Context) ([]string, error)              { return nil, nil }
+func (noopBackend) GetAllMemoryIDs(_ context.Context, _ string) (map[string]struct{}, error) {
+	return nil, nil
+}
+func (noopBackend) GetMemoriesPendingSummary(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+func (noopBackend) StoreSummary(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) GetPendingSummaryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (noopBackend) ClearSummaries(_ context.Context, _ string) (int, error) { return 0, nil }
+func (noopBackend) GetMemoriesMissingHash(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+func (noopBackend) UpdateMemoryHash(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) ExistsWithContentHash(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (noopBackend) GetIntegrityStats(_ context.Context, _ string) (db.IntegrityStats, error) {
+	return db.IntegrityStats{}, nil
+}
+func (noopBackend) StartEpisode(_ context.Context, _, _ string) (*types.Episode, error) {
+	return nil, nil
+}
+func (noopBackend) EndEpisode(_ context.Context, _, _ string) error    { return nil }
+func (noopBackend) ListEpisodes(_ context.Context, _ string, _ int) ([]*types.Episode, error) {
+	return nil, nil
+}
+func (noopBackend) RecallEpisode(_ context.Context, _ string) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) Begin(_ context.Context) (db.Tx, error) { return nil, nil }
+
+var _ db.Backend = noopBackend{}
+
+// ── fake embedder ─────────────────────────────────────────────────────────────
+
+type noopEmbedder struct{}
+
+func (noopEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, 384), nil
+}
+func (noopEmbedder) Name() string    { return "noop" }
+func (noopEmbedder) Dimensions() int { return 384 }
+
+var _ embed.Client = noopEmbedder{}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// newTestExplorePool builds an EnginePool backed by a noopBackend + noopEmbedder.
+// Suitable for unit tests that do not require real search results.
+func newTestExplorePool(t *testing.T) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, noopBackend{}, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+// ── TestHandleMemoryExplore_EmptyQuestion ────────────────────────────────────
+
+// TestHandleMemoryExplore_EmptyQuestion verifies that the handler returns a
+// tool error (isError:true content) when question is empty, without making any
+// backend or Claude API calls.
+func TestHandleMemoryExplore_EmptyQuestion(t *testing.T) {
+	pool := newTestExplorePool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":  "test",
+		"question": "",
+	}
+
+	result, err := handleMemoryExplore(context.Background(), pool, req, Config{})
+	require.NoError(t, err, "handler must not return a Go error for empty question")
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "expected tool-error result for empty question")
+}
+
+// ── TestHandleMemoryExplore_HappyPath ────────────────────────────────────────
+
+// TestHandleMemoryExplore_HappyPath registers a minimal Claude API stub, calls
+// the handler with a valid question and project, and asserts a non-error response
+// with a non-empty answer field.
+func TestHandleMemoryExplore_HappyPath(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			// Scoring call: high confidence, stop immediately.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		} else {
+			// Synthesis call.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"content": []map[string]string{{"type": "text", "text": "The answer is 42."}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	pool := newTestExplorePool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":  "test",
+		"question": "what is the answer?",
+	}
+
+	result, err := handleMemoryExplore(context.Background(), pool, req, Config{
+		claudeClient: c,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "unexpected tool error: %+v", result.Content)
+
+	require.NotEmpty(t, result.Content, "expected at least one content item")
+	tc, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	answer, ok := out["answer"].(string)
+	require.True(t, ok, "answer field missing or wrong type")
+	require.NotEmpty(t, answer, "answer must be non-empty")
+}
+
+// ── TestParseExploreScope_PopulatedScope ─────────────────────────────────────
+
+// TestParseExploreScope_PopulatedScope verifies that all scope fields are
+// parsed correctly from a fully-populated args map.
+func TestParseExploreScope_PopulatedScope(t *testing.T) {
+	since := "2024-01-01T00:00:00Z"
+	until := "2024-06-30T23:59:59Z"
+
+	args := map[string]any{
+		"scope": map[string]any{
+			"tags":       []any{"important", "project-a"},
+			"episode_id": "ep-abc123",
+			"since":      since,
+			"until":      until,
+		},
+	}
+
+	scope := parseExploreScope(args)
+
+	require.Equal(t, []string{"important", "project-a"}, scope.Tags)
+	require.Equal(t, "ep-abc123", scope.EpisodeID)
+
+	require.NotNil(t, scope.Since, "Since must be parsed")
+	wantSince, err := time.Parse(time.RFC3339, since)
+	require.NoError(t, err)
+	require.True(t, scope.Since.Equal(wantSince), "Since mismatch: got %v, want %v", scope.Since, wantSince)
+
+	require.NotNil(t, scope.Until, "Until must be parsed")
+	wantUntil, err := time.Parse(time.RFC3339, until)
+	require.NoError(t, err)
+	require.True(t, scope.Until.Equal(wantUntil), "Until mismatch: got %v, want %v", scope.Until, wantUntil)
+}

--- a/internal/mcp/fetch_exec_test.go
+++ b/internal/mcp/fetch_exec_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+// Internal tests for execFetch — the testable core of handleMemoryFetch.
+// Uses fakeFetcher (implements backendFetcher) to avoid needing a real Postgres.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeFetcher struct {
+	mem      *types.Memory
+	chunks   []*types.Chunk
+	memErr   error
+	chunkErr error
+}
+
+func (f *fakeFetcher) GetMemory(_ context.Context, _ string) (*types.Memory, error) {
+	return f.mem, f.memErr
+}
+
+func (f *fakeFetcher) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
+	return f.chunks, f.chunkErr
+}
+
+func TestExecFetch_SummaryDetail(t *testing.T) {
+	sum := "A brief summary"
+	ff := &fakeFetcher{
+		mem: &types.Memory{
+			ID:      "m1",
+			Summary: &sum,
+			Content: "full content that should not appear",
+		},
+	}
+	result, err := execFetch(context.Background(), ff, "m1", "summary", 65536, nil)
+	require.NoError(t, err)
+	require.Equal(t, "m1", result["id"])
+	require.Equal(t, "A brief summary", result["summary"])
+	_, hasContent := result["content"]
+	require.False(t, hasContent, "summary detail must not include full content")
+}
+
+func TestExecFetch_SummaryDetail_NilSummary(t *testing.T) {
+	ff := &fakeFetcher{
+		mem: &types.Memory{ID: "m2", Summary: nil, Content: "body"},
+	}
+	result, err := execFetch(context.Background(), ff, "m2", "summary", 65536, nil)
+	require.NoError(t, err)
+	require.Equal(t, "", result["summary"])
+}
+
+func TestExecFetch_IDNotFound(t *testing.T) {
+	ff := &fakeFetcher{mem: nil}
+	_, err := execFetch(context.Background(), ff, "missing", "full", 65536, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestExecFetch_FullDetailByteCapApplied(t *testing.T) {
+	bigContent := string(make([]byte, 200_000))
+	ff := &fakeFetcher{
+		mem: &types.Memory{ID: "m3", Content: bigContent},
+	}
+	result, err := execFetch(context.Background(), ff, "m3", "full", 65536, nil)
+	require.NoError(t, err)
+	content, ok := result["content"].(string)
+	require.True(t, ok)
+	require.LessOrEqual(t, len(content), 65536)
+	truncated, _ := result["truncated"].(bool)
+	require.True(t, truncated)
+}
+
+func TestExecFetch_FullDetailUnderCap_NotTruncated(t *testing.T) {
+	ff := &fakeFetcher{
+		mem: &types.Memory{ID: "m4", Content: "short"},
+	}
+	result, err := execFetch(context.Background(), ff, "m4", "full", 65536, nil)
+	require.NoError(t, err)
+	require.Equal(t, "short", result["content"])
+	truncated, _ := result["truncated"].(bool)
+	require.False(t, truncated)
+}
+
+func TestExecFetch_ChunkDetail_AllChunks(t *testing.T) {
+	ff := &fakeFetcher{
+		mem: &types.Memory{ID: "m5"},
+		chunks: []*types.Chunk{
+			{ID: "c1", ChunkIndex: 0, ChunkText: "chunk zero"},
+			{ID: "c2", ChunkIndex: 1, ChunkText: "chunk one"},
+		},
+	}
+	result, err := execFetch(context.Background(), ff, "m5", "chunk", 65536, nil)
+	require.NoError(t, err)
+	chunks, ok := result["chunks"].([]*types.Chunk)
+	require.True(t, ok)
+	require.Len(t, chunks, 2)
+}
+
+func TestExecFetch_ChunkDetail_FilterByIDs(t *testing.T) {
+	ff := &fakeFetcher{
+		mem: &types.Memory{ID: "m6"},
+		chunks: []*types.Chunk{
+			{ID: "c1", ChunkIndex: 0, ChunkText: "zero"},
+			{ID: "c2", ChunkIndex: 1, ChunkText: "one"},
+			{ID: "c3", ChunkIndex: 2, ChunkText: "two"},
+		},
+	}
+	result, err := execFetch(context.Background(), ff, "m6", "chunk", 65536, []string{"c1", "c3"})
+	require.NoError(t, err)
+	chunks, ok := result["chunks"].([]*types.Chunk)
+	require.True(t, ok)
+	require.Len(t, chunks, 2)
+	ids := []string{chunks[0].ID, chunks[1].ID}
+	require.ElementsMatch(t, []string{"c1", "c3"}, ids)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -427,5 +427,12 @@ func (s *Server) registerTools() {
 				return handleMemoryReason(ctx, pool, req, cfg)
 			},
 		)
+		s.mcp.AddTool(
+			mcpgo.NewTool("memory_explore",
+				mcpgo.WithDescription("Iterative recall+score+synthesis loop — returns a single grounded answer (A3)")),
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryExplore(ctx, pool, req, cfg)
+			},
+		)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -287,6 +287,10 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryRecall(ctx, pool, req, cfg)
 			}},
+		{"memory_fetch", "Fetch a single memory by ID; detail=summary|chunk|full",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryFetch(ctx, pool, req, cfg)
+			}},
 		{"memory_list", "List memories with optional filters",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryList(ctx, pool, req)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1305,6 +1305,97 @@ func handleMemoryReason(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	return mcpgo.NewToolResultText(string(data)), nil
 }
 
+// exploreScopedRecaller wraps a Recaller and a scope, filtering recalled
+// memories to those matching the scope constraints. Filtering is post-recall
+// since the underlying search engine does not expose scope-aware APIs.
+type exploreScopedRecaller struct {
+	inner claude.Recaller
+	scope claude.ExploreScope
+}
+
+func (s *exploreScopedRecaller) Recall(ctx context.Context, query string, topK int, detail string) ([]types.SearchResult, error) {
+	results, err := s.inner.Recall(ctx, query, topK, detail)
+	if err != nil {
+		return nil, err
+	}
+	// If no scope constraints are set, return results as-is.
+	if len(s.scope.Tags) == 0 && s.scope.EpisodeID == "" && s.scope.Since == nil && s.scope.Until == nil {
+		return results, nil
+	}
+	filtered := results[:0]
+	for _, r := range results {
+		if r.Memory == nil {
+			continue
+		}
+		m := r.Memory
+		// Episode filter.
+		if s.scope.EpisodeID != "" && m.EpisodeID != s.scope.EpisodeID {
+			continue
+		}
+		// Time filters.
+		if s.scope.Since != nil && m.CreatedAt.Before(*s.scope.Since) {
+			continue
+		}
+		if s.scope.Until != nil && m.CreatedAt.After(*s.scope.Until) {
+			continue
+		}
+		// Tag filter: memory must contain all requested tags.
+		if len(s.scope.Tags) > 0 {
+			tagSet := make(map[string]bool, len(m.Tags))
+			for _, t := range m.Tags {
+				tagSet[t] = true
+			}
+			match := true
+			for _, want := range s.scope.Tags {
+				if !tagSet[want] {
+					match = false
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered, nil
+}
+
+// exploreMemFetcher implements claude.MemoryFetcher using the engine backend.
+type exploreMemFetcher struct {
+	backend backendFetcher
+}
+
+func (f *exploreMemFetcher) FetchMemory(ctx context.Context, _ string, id string) (*types.Memory, error) {
+	return f.backend.GetMemory(ctx, id)
+}
+
+// parseExploreScope extracts the optional scope sub-object from MCP args.
+func parseExploreScope(args map[string]any) claude.ExploreScope {
+	raw, ok := args["scope"]
+	if !ok {
+		return claude.ExploreScope{}
+	}
+	scopeMap, ok := raw.(map[string]any)
+	if !ok {
+		return claude.ExploreScope{}
+	}
+	var scope claude.ExploreScope
+	scope.Tags = toStringSlice(scopeMap["tags"])
+	scope.EpisodeID = getString(scopeMap, "episode_id", "")
+	if since := getString(scopeMap, "since", ""); since != "" {
+		if t, err := time.Parse(time.RFC3339, since); err == nil {
+			scope.Since = &t
+		}
+	}
+	if until := getString(scopeMap, "until", ""); until != "" {
+		if t, err := time.Parse(time.RFC3339, until); err == nil {
+			scope.Until = &t
+		}
+	}
+	return scope
+}
+
 // handleMemoryExplore runs the iterative recall+score+synthesis loop (A3).
 func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
@@ -1336,19 +1427,30 @@ func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		budget = 20000
 	}
 	includeTrace := getBool(args, "include_trace", false)
+	scope := parseExploreScope(args)
 
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, fmt.Errorf("get engine for %q: %w", project, err)
 	}
 
-	result, err := claude.Explore(ctx, cfg.claudeClient, h.Engine, h.Engine.Backend(), claude.ExploreRequest{
+	// Wrap the engine in a scope-filtering recaller.
+	recaller := claude.Recaller(h.Engine)
+	if len(scope.Tags) > 0 || scope.EpisodeID != "" || scope.Since != nil || scope.Until != nil {
+		recaller = &exploreScopedRecaller{inner: h.Engine, scope: scope}
+	}
+
+	// Wrap the backend as a MemoryFetcher for full-detail corpus upgrade.
+	fetcher := &exploreMemFetcher{backend: h.Engine.Backend()}
+
+	result, err := claude.Explore(ctx, cfg.claudeClient, recaller, fetcher, h.Engine.Backend(), claude.ExploreRequest{
 		Project:             project,
 		Question:            question,
 		MaxIterations:       maxIter,
 		ConfidenceThreshold: threshold,
 		TokenBudget:         budget,
 		IncludeTrace:        includeTrace,
+		Scope:               scope,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("explore: %w", err)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -38,6 +38,13 @@ type Config struct {
 	// Defaults to 65536 (64 KB). Set via ENGRAM_FETCH_MAX_BYTES env var.
 	FetchMaxBytes int
 	claudeClient  *claude.Client // set via Server.SetClaudeClient
+
+	// ExploreMaxIters caps memory_explore loop iterations (default 5).
+	ExploreMaxIters int
+	// ExploreMaxWorkers bounds FanOutReason concurrency (default 8).
+	ExploreMaxWorkers int
+	// ExploreTokenBudget caps cumulative scoring-call tokens (default 20000).
+	ExploreTokenBudget int
 }
 
 // backendFetcher is the narrow interface required by execFetch.
@@ -1295,5 +1302,58 @@ func handleMemoryReason(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		"invalidated_sources": ev.InvalidatedSources,
 	}
 	data, _ := json.Marshal(out)
+	return mcpgo.NewToolResultText(string(data)), nil
+}
+
+// handleMemoryExplore runs the iterative recall+score+synthesis loop (A3).
+func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	project := getString(args, "project", "default")
+	question := getString(args, "question", "")
+	if question == "" {
+		return mcpgo.NewToolResultError("question is required"), nil
+	}
+	if cfg.claudeClient == nil {
+		return mcpgo.NewToolResultError("memory_explore requires ANTHROPIC_API_KEY to be set"), nil
+	}
+
+	maxIter := getInt(args, "max_iterations", cfg.ExploreMaxIters)
+	if maxIter < 1 {
+		maxIter = 1
+	}
+	if maxIter > 10 {
+		maxIter = 10
+	}
+	threshold := getFloat(args, "confidence_threshold", 0.75)
+	if threshold < 0 {
+		threshold = 0
+	}
+	if threshold > 1 {
+		threshold = 1
+	}
+	budget := getInt(args, "token_budget", cfg.ExploreTokenBudget)
+	if budget <= 0 {
+		budget = 20000
+	}
+	includeTrace := getBool(args, "include_trace", false)
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, fmt.Errorf("get engine for %q: %w", project, err)
+	}
+
+	result, err := claude.Explore(ctx, cfg.claudeClient, h.Engine, h.Engine.Backend(), claude.ExploreRequest{
+		Project:             project,
+		Question:            question,
+		MaxIterations:       maxIter,
+		ConfidenceThreshold: threshold,
+		TokenBudget:         budget,
+		IncludeTrace:        includeTrace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("explore: %w", err)
+	}
+
+	data, _ := json.Marshal(result)
 	return mcpgo.NewToolResultText(string(data)), nil
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -29,8 +29,121 @@ type Config struct {
 	// DataDir is the base directory for all file-system operations (export,
 	// import, ingest). Paths provided by callers are validated to stay within
 	// this directory. Must be set; file-operation tools return an error if empty.
-	DataDir      string
-	claudeClient *claude.Client // set via Server.SetClaudeClient
+	DataDir string
+	// RecallDefaultMode controls the default recall response format.
+	// "" or "full" returns complete SearchResults; "handle" returns lightweight
+	// Handle references. Set via ENGRAM_RECALL_DEFAULT_MODE env var.
+	RecallDefaultMode string
+	// FetchMaxBytes caps the content returned by memory_fetch detail=full.
+	// Defaults to 65536 (64 KB). Set via ENGRAM_FETCH_MAX_BYTES env var.
+	FetchMaxBytes int
+	claudeClient  *claude.Client // set via Server.SetClaudeClient
+}
+
+// backendFetcher is the narrow interface required by execFetch.
+// Satisfied by db.Backend; declared separately so tests can inject a stub.
+type backendFetcher interface {
+	GetMemory(ctx context.Context, id string) (*types.Memory, error)
+	GetChunksForMemory(ctx context.Context, id string) ([]*types.Chunk, error)
+}
+
+// execFetch is the testable core of handleMemoryFetch.
+// detail: "summary" | "chunk" | "full"
+// requestedChunkIDs: when non-empty, only those chunk IDs are returned (chunk mode only).
+// maxBytes: byte cap applied to content in full mode; 0 means no cap.
+func execFetch(ctx context.Context, f backendFetcher, id, detail string, maxBytes int, requestedChunkIDs []string) (map[string]any, error) {
+	m, err := f.GetMemory(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if m == nil {
+		return nil, fmt.Errorf("memory %q not found", id)
+	}
+
+	switch detail {
+	case "chunk":
+		chunks, err := f.GetChunksForMemory(ctx, m.ID)
+		if err != nil {
+			return nil, err
+		}
+		if len(requestedChunkIDs) > 0 {
+			want := make(map[string]bool, len(requestedChunkIDs))
+			for _, cid := range requestedChunkIDs {
+				want[cid] = true
+			}
+			filtered := chunks[:0]
+			for _, c := range chunks {
+				if want[c.ID] {
+					filtered = append(filtered, c)
+				}
+			}
+			chunks = filtered
+		}
+		return map[string]any{
+			"id":          m.ID,
+			"memory_type": m.MemoryType,
+			"project":     m.Project,
+			"chunks":      chunks,
+			"chunk_count": len(chunks),
+		}, nil
+
+	case "full":
+		content := m.Content
+		truncated := false
+		if maxBytes > 0 && len(content) > maxBytes {
+			content = content[:maxBytes]
+			truncated = true
+		}
+		out := map[string]any{
+			"id":          m.ID,
+			"memory_type": m.MemoryType,
+			"project":     m.Project,
+			"content":     content,
+			"truncated":   truncated,
+		}
+		if m.Summary != nil {
+			out["summary"] = *m.Summary
+		}
+		return out, nil
+
+	default: // "summary" and anything unrecognised
+		sum := ""
+		if m.Summary != nil {
+			sum = *m.Summary
+		}
+		return map[string]any{
+			"id":          m.ID,
+			"memory_type": m.MemoryType,
+			"project":     m.Project,
+			"summary":     sum,
+		}, nil
+	}
+}
+
+// handleMemoryFetch implements the memory_fetch MCP tool.
+func handleMemoryFetch(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	project := getString(args, "project", "default")
+	id := getString(args, "id", "")
+	if id == "" {
+		return nil, fmt.Errorf("id is required")
+	}
+	detail := getString(args, "detail", "summary")
+	chunkIDs := toStringSlice(args["chunk_ids"])
+	maxBytes := cfg.FetchMaxBytes
+	if maxBytes == 0 {
+		maxBytes = 65536
+	}
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	result, err := execFetch(ctx, h.Engine.Backend(), id, detail, maxBytes, chunkIDs)
+	if err != nil {
+		return nil, err
+	}
+	return toolResult(result)
 }
 
 // claudeMergeAdapter adapts *claude.Client to search.MergeReviewer by converting
@@ -348,6 +461,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 	detail := getString(args, "detail", "summary")
 	includeConflicts := getBool(args, "include_conflicts", false)
+	mode := getString(args, "mode", cfg.RecallDefaultMode)
 
 	// Federated path: "projects" overrides the single-project recall.
 	projectNames := toStringSlice(args["projects"])
@@ -384,6 +498,13 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		results, err := search.RecallAcrossEngines(ctx, engines, query, topK, detail)
 		if err != nil {
 			return nil, err
+		}
+		if mode == "handle" {
+			return toolResult(map[string]any{
+				"handles":    search.ToHandles(results),
+				"count":      len(results),
+				"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
+			})
 		}
 		out := map[string]any{"results": results, "count": len(results)}
 		if includeConflicts && firstHandle != nil {
@@ -452,6 +573,13 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		}
 	}
 
+	if mode == "handle" {
+		return toolResult(map[string]any{
+			"handles":    search.ToHandles(results),
+			"count":      len(results),
+			"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
+		})
+	}
 	out := map[string]any{"results": results, "count": len(results)}
 	if eventID != "" {
 		out["event_id"] = eventID

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1451,6 +1451,7 @@ func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		TokenBudget:         budget,
 		IncludeTrace:        includeTrace,
 		Scope:               scope,
+		MaxWorkers:          cfg.ExploreMaxWorkers,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("explore: %w", err)

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -48,6 +48,40 @@ type RerankResult struct {
 // RecallOpts controls optional post-processing for Recall.
 type RecallOpts struct {
 	Reranker ResultReranker // nil = skip re-ranking
+	// Mode controls response format. "" or "full" returns complete SearchResults;
+	// "handle" returns lightweight Handle references (content omitted).
+	Mode string
+}
+
+// ToHandles projects a slice of SearchResults into lightweight Handle references.
+// Handles carry only the summary and metadata needed to decide whether to fetch;
+// full content is never loaded. Entries with a nil Memory are skipped.
+func ToHandles(results []types.SearchResult) []types.Handle {
+	if len(results) == 0 {
+		return nil
+	}
+	const fetchHint = "call memory_fetch with this id and detail=summary|chunk|full"
+	out := make([]types.Handle, 0, len(results))
+	for _, r := range results {
+		if r.Memory == nil {
+			continue
+		}
+		sum := ""
+		if r.Memory.Summary != nil {
+			sum = *r.Memory.Summary
+		}
+		out = append(out, types.Handle{
+			ID:          r.Memory.ID,
+			Project:     r.Memory.Project,
+			Summary:     sum,
+			Score:       r.Score,
+			StorageMode: r.Memory.StorageMode,
+			Bytes:       len(r.Memory.Content),
+			IsHandle:    true,
+			FetchHint:   fetchHint,
+		})
+	}
+	return out
 }
 
 // MergeCandidate is a pair of memories with their similarity score.

--- a/internal/search/handle_test.go
+++ b/internal/search/handle_test.go
@@ -1,0 +1,60 @@
+package search_test
+
+import (
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToHandles_HappyPath(t *testing.T) {
+	sum := "A useful memory about foo"
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:          "abc-1",
+				Project:     "proj",
+				Summary:     &sum,
+				StorageMode: "focused",
+				Content:     "full content here",
+			},
+			Score: 0.85,
+		},
+	}
+	handles := search.ToHandles(results)
+	require.Len(t, handles, 1)
+	h := handles[0]
+	require.Equal(t, "abc-1", h.ID)
+	require.Equal(t, "proj", h.Project)
+	require.Equal(t, sum, h.Summary)
+	require.InDelta(t, 0.85, h.Score, 0.001)
+	require.Equal(t, "focused", h.StorageMode)
+	require.Equal(t, len("full content here"), h.Bytes)
+	require.True(t, h.IsHandle)
+	require.NotEmpty(t, h.FetchHint)
+}
+
+func TestToHandles_EmptyInput(t *testing.T) {
+	require.Empty(t, search.ToHandles(nil))
+	require.Empty(t, search.ToHandles([]types.SearchResult{}))
+}
+
+func TestToHandles_NilSummaryBecomesEmptyString(t *testing.T) {
+	results := []types.SearchResult{
+		{Memory: &types.Memory{ID: "x", Project: "p"}, Score: 0.5},
+	}
+	handles := search.ToHandles(results)
+	require.Len(t, handles, 1)
+	require.Equal(t, "", handles[0].Summary)
+}
+
+func TestToHandles_NilMemorySkipped(t *testing.T) {
+	results := []types.SearchResult{
+		{Memory: nil, Score: 0.9},
+		{Memory: &types.Memory{ID: "y", Project: "p"}, Score: 0.3},
+	}
+	handles := search.ToHandles(results)
+	require.Len(t, handles, 1)
+	require.Equal(t, "y", handles[0].ID)
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -264,6 +264,21 @@ type ConnectedMemory struct {
 	Strength  float64 `json:"strength"`
 }
 
+// Handle is a lightweight reference returned by handle-mode recall.
+// The caller fetches content on demand via memory_fetch, keeping the transcript
+// free of large memory payloads until they are actually needed.
+type Handle struct {
+	ID          string  `json:"id"`
+	Project     string  `json:"project"`
+	Summary     string  `json:"summary"`       // "" if not yet summarized
+	Score       float64 `json:"score"`
+	StorageMode string  `json:"storage_mode"`
+	ChunkCount  int     `json:"chunk_count"`   // 0 if unknown at recall time
+	Bytes       int     `json:"bytes"`         // len(content)
+	IsHandle    bool    `json:"is_handle"`     // always true; signals paged-out result
+	FetchHint   string  `json:"fetch_hint"`    // human-readable usage hint
+}
+
 // MemoryStats summarizes the contents of the store. Returned by the status endpoint.
 type MemoryStats struct {
 	TotalMemories       int            `json:"total_memories"`


### PR DESCRIPTION
## Summary

- New `memory_explore` MCP tool: server-side iterative recall→score→synthesize loop collapsing N round-trips into one synchronous call
- Adds `MemoryFetcher` interface for full-detail corpus upgrade before synthesis; `ExploreScope` for tag/episode/time-window scoping; `BudgetTracker` for token-budget enforcement; citation guard validating dashed-UUID citations against corpus
- Adds `FanOutReason` fan-out worker for large corpora (>20 memories): errgroup-parallel sharded synthesis + reducer call
- Wires `ENGRAM_EXPLORE_MAX_ITERS`, `ENGRAM_EXPLORE_MAX_WORKERS`, `ENGRAM_EXPLORE_TOKEN_BUDGET` env vars through to config

## Commits

- `a9fe046` feat: initial A3 implementation (explore.go, worker.go, client.go TokenUsage, MCP registration)
- `bb7c349` fix: spec compliance — scope params, full-detail refetch, zero-recall refinement test
- `a6a8ce1` fix: code quality — citation UUID regex (dashed format), MaxWorkers wiring, handler tests

## Test Plan

- [x] `go test ./... -count=1 -race` — all 15 packages pass
- [x] Coverage ≥82% on new files (claude package) — above 70% spec target and 60% CI gate
- [x] Spec compliance review: all A3 requirements verified by Spruance
- [x] Code quality review: approved (citation regex, MaxWorkers wiring, handler coverage)

## Adversarial Review Required (CLAUDE.md AI-generated PR policy)

Per `CLAUDE.md`: this PR is labeled `ai-generated` and requires:
- [ ] **Rickover** — correctness audit (boundary conditions, logic bugs, error handling)
- [ ] **Spruance** — coverage audit (≥70% function coverage on new files)
- [ ] **Zero-context reviewer** — fresh-eyes structural review (receives only the diff)

Merge gate: all three must return zero `severity/blocker` findings.

## Context

Part of the engram-go context-minimization plan (`~/.claude/plans/how-do-we-take-purring-hearth.md`). A1+A2 (handle-mode recall + `memory_fetch`) merged in d426537. A3 is this PR. A4–A5 (tiered large-document ingest) and A7 (benchmarks + soak tests) are follow-on sessions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)