### PR TITLE
fix: address all adversarial-review issues (#182–191)

### DIFF
--- a/internal/claude/document_query.go
+++ b/internal/claude/document_query.go
@@ -68,9 +68,19 @@ func QueryDocument(ctx context.Context, c *Client, content string, q DocumentQue
 	half := q.WindowChars / 2
 	n := len(content)
 
+	// Fix #188: empty content — no LLM call, return canned answer.
+	if len(content) == 0 {
+		return &DocumentQueryResult{Spans: []DocumentSpan{}, Answer: "No content available for this memory."}, nil
+	}
+
 	var raws []rawSpan
 	switch {
 	case q.FilterRegex != "":
+		// Fix #184: reject regex patterns exceeding the length cap (ReDoS mitigation).
+		const maxFilterRegexLen = 1024
+		if len(q.FilterRegex) > maxFilterRegexLen {
+			return nil, fmt.Errorf("filter.regex exceeds %d character limit", maxFilterRegexLen)
+		}
 		re, err := regexp.Compile(q.FilterRegex)
 		if err != nil {
 			return nil, fmt.Errorf("invalid filter.regex: %w", err)
@@ -139,7 +149,7 @@ func QueryDocument(ctx context.Context, c *Client, content string, q DocumentQue
 	spans := make([]DocumentSpan, 0, len(merged))
 	total := 0
 	truncated := false
-	for _, m := range merged {
+	for i, m := range merged {
 		text := content[m.start:m.end]
 		spans = append(spans, DocumentSpan{
 			Offset:  m.start,
@@ -147,7 +157,8 @@ func QueryDocument(ctx context.Context, c *Client, content string, q DocumentQue
 			Matched: m.matched,
 		})
 		total += len(text)
-		if total > charCap {
+		// Fix #186: only mark truncated when more spans remain after this one.
+		if total > charCap && i < len(merged)-1 {
 			truncated = true
 			break
 		}

--- a/internal/claude/document_query_test.go
+++ b/internal/claude/document_query_test.go
@@ -158,6 +158,71 @@ func TestQueryDocument_NoFilter(t *testing.T) {
 	require.Equal(t, 0, res.Spans[0].Offset)
 }
 
+// --- Tests for fixes #184, #186, #188 ---
+
+// Fix #184: FilterRegex longer than 1024 chars must be rejected before compile.
+func TestQueryDocument_RegexTooLong(t *testing.T) {
+	srv := panicOnCallServer(t)
+	defer srv.Close()
+	c, _ := claude.New("test")
+	c.BaseURL = srv.URL
+
+	q := claude.DocumentQuery{
+		Question:    "?",
+		FilterRegex: strings.Repeat("a", 1025), // one byte over the 1024-char limit
+		WindowChars: 40,
+		TokenBudget: 4000,
+	}
+	_, err := claude.QueryDocument(context.Background(), c, "some content", q)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "filter.regex exceeds")
+}
+
+// Fix #186: Truncated must be false when the span that tips the budget is the last one.
+func TestQueryDocument_TruncatedFalseOnLastSpan(t *testing.T) {
+	srv := newStubClaudeServer("ok")
+	defer srv.Close()
+	c, _ := claude.New("test")
+	c.BaseURL = srv.URL
+
+	// Produce exactly two non-overlapping spans each 40 chars wide (WindowChars=40, half=20).
+	// Span 1: HIT at offset 500 → window [480,523) = 43 chars
+	// Span 2: HIT at offset 1003 → window [983,1043) = 40 chars if content is long enough
+	// Use budget=20 → charCap=80. Span1(43) + Span2(40) = 83 > 80, so the last (second)
+	// span tips the cap. With fix, Truncated stays false; without fix it would be true.
+	content := strings.Repeat("x", 500) + "HIT" + strings.Repeat("y", 500) + "HIT" + strings.Repeat("z", 100)
+	// Verify span2 is really the last: the content has exactly two HITs.
+	q := claude.DocumentQuery{
+		Question:    "?",
+		FilterSubs:  []string{"HIT"},
+		WindowChars: 40,
+		TokenBudget: 20, // charCap = 80; span1=43 + span2=40 = 83 > 80, last span tips cap
+	}
+	res, err := claude.QueryDocument(context.Background(), c, content, q)
+	require.NoError(t, err)
+	require.Len(t, res.Spans, 2, "both spans should be included")
+	require.False(t, res.Truncated, "should not be truncated when last span tips the budget")
+}
+
+// Fix #188: Empty content must short-circuit with a canned answer, no LLM call.
+func TestQueryDocument_EmptyContent(t *testing.T) {
+	srv := panicOnCallServer(t)
+	defer srv.Close()
+	c, _ := claude.New("test")
+	c.BaseURL = srv.URL
+
+	q := claude.DocumentQuery{
+		Question:    "anything?",
+		WindowChars: 4000,
+		TokenBudget: 6000,
+	}
+	res, err := claude.QueryDocument(context.Background(), c, "", q)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Empty(t, res.Spans)
+	require.Equal(t, "No content available for this memory.", res.Answer)
+}
+
 func TestQueryDocument_TokenBudget(t *testing.T) {
 	srv := newStubClaudeServer("ok")
 	defer srv.Close()

--- a/internal/db/content_hash_test.go
+++ b/internal/db/content_hash_test.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// TestContentHash_KnownValues verifies ContentHash produces the canonical
+// SHA-256 hex digest for well-known inputs, matching the standard library.
+func TestContentHash_KnownValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		wantHex string
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantHex: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:    "hello world",
+			input:   "hello world",
+			wantHex: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+		{
+			name:    "unicode content",
+			input:   "日本語テスト — nanoseconds rule",
+			wantHex: stdHex("日本語テスト — nanoseconds rule"),
+		},
+		{
+			name:    "long content ~600KB",
+			input:   strings.Repeat("The most dangerous phrase in the language is: we've always done it this way.\n", 8000),
+			wantHex: stdHex(strings.Repeat("The most dangerous phrase in the language is: we've always done it this way.\n", 8000)),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ContentHash(tc.input)
+			if got != tc.wantHex {
+				t.Errorf("ContentHash(%q...) = %q, want %q", tc.input[:min(len(tc.input), 40)], got, tc.wantHex)
+			}
+		})
+	}
+}
+
+// TestContentHash_ConsistentWithStdlib verifies the streaming implementation
+// produces bit-for-bit identical output to sha256.Sum256 on the same input.
+// This is the regression guard for the double-copy fix (issue #182).
+func TestContentHash_ConsistentWithStdlib(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"",
+		"a",
+		"short content",
+		strings.Repeat("x", 1024),
+		strings.Repeat("Grace Hopper built the first compiler.\n", 10000), // ~390KB
+	}
+
+	for _, s := range inputs {
+		got := ContentHash(s)
+		want := stdHex(s)
+		if got != want {
+			t.Errorf("ContentHash mismatch for input len=%d: got %s, want %s", len(s), got, want)
+		}
+	}
+}
+
+// stdHex returns the canonical sha256 hex digest using the standard Sum256
+// approach — used as the ground-truth reference in tests.
+func stdHex(s string) string {
+	b := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(b[:])
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -3,8 +3,10 @@ package db
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"strings"
@@ -18,8 +20,9 @@ import (
 // Used by both the storage layer and the ingest dedup path to guarantee
 // identical hash values from the same input string.
 func ContentHash(content string) string {
-	h := sha256.Sum256([]byte(content))
-	return fmt.Sprintf("%x", h)
+	h := sha256.New()
+	io.WriteString(h, content) //nolint:errcheck // hash.Hash.Write never returns an error
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func (b *PostgresBackend) StoreMemory(ctx context.Context, m *types.Memory) error {

--- a/internal/mcp/ingest_document.go
+++ b/internal/mcp/ingest_document.go
@@ -268,18 +268,19 @@ func (a backendDocumentAdapter) SetMemoryDocumentID(ctx context.Context, memoryI
 // ── memory_ingest_document_stream tool ──────────────────────────────────────
 
 // uploadSession holds assembled parts for an in-flight chunked upload. Keyed
-// by caller-chosen upload_id in uploadRegistry.
+// by caller-chosen upload_id in Server.uploads.
 type uploadSession struct {
 	mu      sync.Mutex
 	project string
 	buf     []byte
 	// nextPart is the expected index for the next Write; enforces ordering so
 	// callers cannot silently produce a corrupt blob by re-ordering parts.
-	nextPart  int
-	createdAt time.Time
+	nextPart     int
+	createdAt    time.Time
+	lastActivity time.Time // updated on every successful append; used for TTL eviction (#187)
 }
 
-// Caps on the in-memory upload registry. These exist so a misbehaving or
+// Caps on the per-Server upload registry. These exist so a misbehaving or
 // malicious caller cannot pin unbounded memory by starting sessions and never
 // finishing them.
 const (
@@ -288,20 +289,16 @@ const (
 	maxUploadIDLen    = 128
 )
 
-// uploadRegistry is process-local — chunked uploads do not survive a restart.
-// This matches the intent (large documents should be ingested in one burst or
-// retried from scratch on failure). All access must go through uploadRegistryMu.
-var (
-	uploadRegistryMu sync.Mutex
-	uploadRegistry   = make(map[string]*uploadSession)
-)
-
-// evictExpiredUploadsLocked drops sessions whose createdAt is older than the
-// TTL. Caller must hold uploadRegistryMu.
-func evictExpiredUploadsLocked(now time.Time) {
-	for id, s := range uploadRegistry {
-		if now.Sub(s.createdAt) > uploadSessionTTL {
-			delete(uploadRegistry, id)
+// evictExpiredUploadsLocked drops sessions whose lastActivity (falling back to
+// createdAt) is older than the TTL. Caller must hold s.uploadMu.
+func (s *Server) evictExpiredUploadsLocked(now time.Time) {
+	for id, sess := range s.uploads {
+		activity := sess.lastActivity
+		if activity.IsZero() {
+			activity = sess.createdAt
+		}
+		if now.Sub(activity) > uploadSessionTTL {
+			delete(s.uploads, id)
 		}
 	}
 }
@@ -309,37 +306,37 @@ func evictExpiredUploadsLocked(now time.Time) {
 // startUploadSession atomically evicts expired sessions, enforces the cap, and
 // creates a fresh session under uploadID. Returns an error if the cap has been
 // reached or if a session already exists for uploadID.
-func startUploadSession(uploadID, project string) (*uploadSession, error) {
-	uploadRegistryMu.Lock()
-	defer uploadRegistryMu.Unlock()
-	evictExpiredUploadsLocked(time.Now())
-	if _, exists := uploadRegistry[uploadID]; exists {
+func (s *Server) startUploadSession(uploadID, project string) (*uploadSession, error) {
+	s.uploadMu.Lock()
+	defer s.uploadMu.Unlock()
+	s.evictExpiredUploadsLocked(time.Now())
+	if _, exists := s.uploads[uploadID]; exists {
 		return nil, fmt.Errorf("upload_id already in use")
 	}
-	if len(uploadRegistry) >= maxUploadSessions {
+	if len(s.uploads) >= maxUploadSessions {
 		return nil, fmt.Errorf("too many in-progress uploads")
 	}
-	s := &uploadSession{project: project, createdAt: time.Now()}
-	uploadRegistry[uploadID] = s
-	return s, nil
+	sess := &uploadSession{project: project, createdAt: time.Now()}
+	s.uploads[uploadID] = sess
+	return sess, nil
 }
 
 // lookupUploadSession returns an existing session or an error if missing.
-func lookupUploadSession(uploadID string) (*uploadSession, error) {
-	uploadRegistryMu.Lock()
-	defer uploadRegistryMu.Unlock()
-	evictExpiredUploadsLocked(time.Now())
-	s, ok := uploadRegistry[uploadID]
+func (s *Server) lookupUploadSession(uploadID string) (*uploadSession, error) {
+	s.uploadMu.Lock()
+	defer s.uploadMu.Unlock()
+	s.evictExpiredUploadsLocked(time.Now())
+	sess, ok := s.uploads[uploadID]
 	if !ok {
 		return nil, fmt.Errorf("unknown upload_id %q (expired or never started)", uploadID)
 	}
-	return s, nil
+	return sess, nil
 }
 
-func dropUpload(uploadID string) {
-	uploadRegistryMu.Lock()
-	defer uploadRegistryMu.Unlock()
-	delete(uploadRegistry, uploadID)
+func (s *Server) dropUpload(uploadID string) {
+	s.uploadMu.Lock()
+	defer s.uploadMu.Unlock()
+	delete(s.uploads, uploadID)
 }
 
 // handleMemoryIngestDocumentStream exposes two ingestion modes:
@@ -352,7 +349,11 @@ func dropUpload(uploadID string) {
 //
 // Either mode ends in a call to execStoreDocument so Tier-1 / Tier-2 routing
 // is shared with handleMemoryStoreDocument.
-func handleMemoryIngestDocumentStream(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
+//
+// s carries the per-Server upload registry. When s is nil (unit tests that only
+// exercise the path/file branch) the chunked-upload actions will panic — tests
+// must supply a non-nil *Server for those code paths.
+func handleMemoryIngestDocumentStream(ctx context.Context, s *Server, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
 	project := getString(args, "project", "default")
 	maxDoc, rawMax := configOrDefaults(cfg)
@@ -392,7 +393,7 @@ func handleMemoryIngestDocumentStream(ctx context.Context, pool *EnginePool, req
 		if len(uploadID) == 0 || len(uploadID) > maxUploadIDLen {
 			return nil, fmt.Errorf("upload_id must be 1–%d characters", maxUploadIDLen)
 		}
-		if _, err := startUploadSession(uploadID, project); err != nil {
+		if _, err := s.startUploadSession(uploadID, project); err != nil {
 			return nil, err
 		}
 		return toolResult(map[string]any{
@@ -412,12 +413,17 @@ func handleMemoryIngestDocumentStream(ctx context.Context, pool *EnginePool, req
 		if part < 0 {
 			return nil, fmt.Errorf("part is required for append (0-indexed)")
 		}
-		b64Data, _ := args["data"].(string)
+		// Fix #183: require a string 'data' field; reject missing/wrong-type values
+		// that would otherwise silently decode to zero bytes and advance the counter.
+		b64Data, ok := args["data"].(string)
+		if !ok {
+			return nil, fmt.Errorf("action=append requires a string 'data' field")
+		}
 		decoded, err := base64.StdEncoding.DecodeString(b64Data)
 		if err != nil {
 			return nil, fmt.Errorf("data must be base64-encoded: %w", err)
 		}
-		sess, err := lookupUploadSession(uploadID)
+		sess, err := s.lookupUploadSession(uploadID)
 		if err != nil {
 			return nil, err
 		}
@@ -435,12 +441,18 @@ func handleMemoryIngestDocumentStream(ctx context.Context, pool *EnginePool, req
 			return nil, fmt.Errorf("part out of order: expected %d, got %d", sess.nextPart, part)
 		}
 		if len(sess.buf)+len(decoded) > rawMax {
+			// Fix #189: zero buf under the lock before unlocking so a concurrent
+			// finish cannot race into runStreamIngest with a truncated body.
+			// After unlock the session is also removed from the registry.
+			wouldBeSize := len(sess.buf) + len(decoded)
+			sess.buf = nil
 			sess.mu.Unlock()
-			dropUpload(uploadID)
-			return nil, fmt.Errorf("document exceeds maximum size (%d bytes > %d)", len(sess.buf)+len(decoded), rawMax)
+			s.dropUpload(uploadID)
+			return nil, fmt.Errorf("document exceeds maximum size (%d bytes > %d)", wouldBeSize, rawMax)
 		}
 		sess.buf = append(sess.buf, decoded...)
 		sess.nextPart++
+		sess.lastActivity = time.Now() // Fix #187: reset TTL clock on every successful append
 		received := len(sess.buf)
 		partsReceived := sess.nextPart
 		sess.mu.Unlock()
@@ -455,7 +467,7 @@ func handleMemoryIngestDocumentStream(ctx context.Context, pool *EnginePool, req
 		if uploadID == "" {
 			return nil, fmt.Errorf("upload_id is required for finish")
 		}
-		sess, err := lookupUploadSession(uploadID)
+		sess, err := s.lookupUploadSession(uploadID)
 		if err != nil {
 			return nil, err
 		}
@@ -467,9 +479,14 @@ func handleMemoryIngestDocumentStream(ctx context.Context, pool *EnginePool, req
 			return nil, fmt.Errorf("project mismatch: upload started with project %q, got %q", sess.project, project)
 		}
 		sess.mu.Lock()
+		// Fix #189: guard against a nil buf set by a concurrent overflow-eviction.
+		if sess.buf == nil {
+			sess.mu.Unlock()
+			return nil, fmt.Errorf("upload %q was aborted (size overflow in a concurrent append)", uploadID)
+		}
 		body := string(sess.buf)
 		sess.mu.Unlock()
-		dropUpload(uploadID)
+		s.dropUpload(uploadID)
 		return runStreamIngest(ctx, pool, sess.project, body, cfg, maxDoc, rawMax)
 
 	default:

--- a/internal/mcp/ingest_document_test.go
+++ b/internal/mcp/ingest_document_test.go
@@ -239,19 +239,16 @@ func TestConfigOrDefaults_RespectsSetValues(t *testing.T) {
 }
 
 // ── handleMemoryIngestDocumentStream: registry + action dispatch ──────────────
-// These tests exercise start/append validation and the uploadRegistry's TTL,
-// cap, and mutex without needing a live EnginePool. The finish action routes
-// into runStreamIngest which requires a real SearchEngine, covered by the
-// integration tests in e2e.
+// These tests exercise start/append validation and the per-Server upload map's
+// TTL, cap, and mutex without needing a live EnginePool. The finish action
+// routes into runStreamIngest which requires a real SearchEngine, covered by
+// the integration tests in e2e.
 
-// resetUploadRegistry wipes the process-global registry between tests.
-func resetUploadRegistry(t *testing.T) {
-	t.Helper()
-	uploadRegistryMu.Lock()
-	defer uploadRegistryMu.Unlock()
-	for k := range uploadRegistry {
-		delete(uploadRegistry, k)
-	}
+// newTestServer returns a minimal *Server suitable for upload-registry tests.
+// The EnginePool and MCP server fields are not initialised; only the upload map
+// is ready for use.
+func newTestServer() *Server {
+	return &Server{uploads: make(map[string]*uploadSession)}
 }
 
 func streamReq(args map[string]any) mcpgo.CallToolRequest {
@@ -276,11 +273,11 @@ func resultMap(t *testing.T, r *mcpgo.CallToolResult) map[string]any {
 // engine and is covered by e2e tests — this test stops after the second append
 // and verifies the registry state is exactly what finish would consume.
 func TestHandleStream_ChunkedUpload_AppendHappyPath(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
 	// start
-	out, err := handleMemoryIngestDocumentStream(ctx, nil,
+	out, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "uA", "project": "p"}),
 		Config{})
 	require.NoError(t, err)
@@ -288,7 +285,7 @@ func TestHandleStream_ChunkedUpload_AppendHappyPath(t *testing.T) {
 
 	// append part 0
 	part0 := base64.StdEncoding.EncodeToString([]byte("hello "))
-	out, err = handleMemoryIngestDocumentStream(ctx, nil,
+	out, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "append", "upload_id": "uA", "part": float64(0), "data": part0}),
 		Config{})
 	require.NoError(t, err)
@@ -298,7 +295,7 @@ func TestHandleStream_ChunkedUpload_AppendHappyPath(t *testing.T) {
 
 	// append part 1
 	part1 := base64.StdEncoding.EncodeToString([]byte("world"))
-	out, err = handleMemoryIngestDocumentStream(ctx, nil,
+	out, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "append", "upload_id": "uA", "part": float64(1), "data": part1}),
 		Config{})
 	require.NoError(t, err)
@@ -307,23 +304,23 @@ func TestHandleStream_ChunkedUpload_AppendHappyPath(t *testing.T) {
 	require.Equal(t, float64(11), m["bytes_received"])
 
 	// Session should hold the combined buffer, ready for finish.
-	sess, err := lookupUploadSession("uA")
+	sess, err := srv.lookupUploadSession("uA")
 	require.NoError(t, err)
 	require.Equal(t, "hello world", string(sess.buf))
 }
 
 // Test B: out-of-order part is rejected.
 func TestHandleStream_OutOfOrderPart(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "uB", "project": "p"}),
 		Config{})
 	require.NoError(t, err)
 
 	data := base64.StdEncoding.EncodeToString([]byte("x"))
-	_, err = handleMemoryIngestDocumentStream(ctx, nil,
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "append", "upload_id": "uB", "part": float64(1), "data": data}),
 		Config{})
 	require.Error(t, err)
@@ -332,19 +329,19 @@ func TestHandleStream_OutOfOrderPart(t *testing.T) {
 
 // Test C: size overflow rejects append once accumulated bytes cross rawMax.
 func TestHandleStream_SizeOverflow(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
 	// Tight cap so the test finishes fast.
 	cfg := Config{MaxDocumentBytes: 1024, RawDocumentMaxBytes: 16}
 
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "uC", "project": "p"}),
 		cfg)
 	require.NoError(t, err)
 
 	big := base64.StdEncoding.EncodeToString(make([]byte, 32)) // 32 bytes > 16 cap
-	_, err = handleMemoryIngestDocumentStream(ctx, nil,
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "append", "upload_id": "uC", "part": float64(0), "data": big}),
 		cfg)
 	require.Error(t, err)
@@ -353,11 +350,11 @@ func TestHandleStream_SizeOverflow(t *testing.T) {
 
 // Test D: upload_id length validation on start.
 func TestHandleStream_UploadIDValidation(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
 	// empty
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "", "project": "p"}),
 		Config{})
 	require.Error(t, err)
@@ -365,7 +362,7 @@ func TestHandleStream_UploadIDValidation(t *testing.T) {
 
 	// 129 chars (one over the cap)
 	tooLong := strings.Repeat("a", maxUploadIDLen+1)
-	_, err = handleMemoryIngestDocumentStream(ctx, nil,
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": tooLong, "project": "p"}),
 		Config{})
 	require.Error(t, err)
@@ -373,7 +370,7 @@ func TestHandleStream_UploadIDValidation(t *testing.T) {
 
 	// valid
 	valid := strings.Repeat("a", maxUploadIDLen)
-	_, err = handleMemoryIngestDocumentStream(ctx, nil,
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": valid, "project": "p"}),
 		Config{})
 	require.NoError(t, err)
@@ -381,19 +378,19 @@ func TestHandleStream_UploadIDValidation(t *testing.T) {
 
 // Test E: session cap.
 func TestHandleStream_TooManySessions(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
 	// Fill the registry directly to avoid making maxUploadSessions handler calls.
-	uploadRegistryMu.Lock()
+	srv.uploadMu.Lock()
 	now := time.Now()
 	for i := 0; i < maxUploadSessions; i++ {
 		id := fmt.Sprintf("sess-%d", i)
-		uploadRegistry[id] = &uploadSession{project: "p", createdAt: now}
+		srv.uploads[id] = &uploadSession{project: "p", createdAt: now}
 	}
-	uploadRegistryMu.Unlock()
+	srv.uploadMu.Unlock()
 
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "overflow", "project": "p"}),
 		Config{})
 	require.Error(t, err)
@@ -401,36 +398,38 @@ func TestHandleStream_TooManySessions(t *testing.T) {
 }
 
 // TTL eviction: stale sessions are dropped before the cap check, freeing slots.
+// The TTL is measured from lastActivity (Fix #187): sessions with stale
+// lastActivity must be evicted even if createdAt was recent.
 func TestHandleStream_TTLEviction(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
-	uploadRegistryMu.Lock()
+	srv.uploadMu.Lock()
 	stale := time.Now().Add(-(uploadSessionTTL + time.Minute))
 	for i := 0; i < maxUploadSessions; i++ {
 		id := fmt.Sprintf("stale-%d", i)
-		uploadRegistry[id] = &uploadSession{project: "p", createdAt: stale}
+		srv.uploads[id] = &uploadSession{project: "p", createdAt: stale}
 	}
-	uploadRegistryMu.Unlock()
+	srv.uploadMu.Unlock()
 
 	// All stale — a fresh start should succeed because eviction frees the slots.
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "fresh", "project": "p"}),
 		Config{})
 	require.NoError(t, err)
 
-	uploadRegistryMu.Lock()
-	_, ok := uploadRegistry["fresh"]
-	count := len(uploadRegistry)
-	uploadRegistryMu.Unlock()
+	srv.uploadMu.Lock()
+	_, ok := srv.uploads["fresh"]
+	count := len(srv.uploads)
+	srv.uploadMu.Unlock()
 	require.True(t, ok, "fresh session should be registered")
 	require.Equal(t, 1, count, "all stale sessions should have been evicted")
 }
 
 // Unknown action is rejected.
 func TestHandleStream_UnknownAction(t *testing.T) {
-	resetUploadRegistry(t)
-	_, err := handleMemoryIngestDocumentStream(context.Background(), nil,
+	srv := newTestServer()
+	_, err := handleMemoryIngestDocumentStream(context.Background(), srv, nil,
 		streamReq(map[string]any{"action": "upload", "upload_id": "x"}),
 		Config{})
 	require.Error(t, err)
@@ -439,9 +438,9 @@ func TestHandleStream_UnknownAction(t *testing.T) {
 
 // Append against an unknown upload_id (e.g. expired) is rejected.
 func TestHandleStream_AppendUnknownUpload(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	data := base64.StdEncoding.EncodeToString([]byte("x"))
-	_, err := handleMemoryIngestDocumentStream(context.Background(), nil,
+	_, err := handleMemoryIngestDocumentStream(context.Background(), srv, nil,
 		streamReq(map[string]any{"action": "append", "upload_id": "ghost", "part": float64(0), "data": data}),
 		Config{})
 	require.Error(t, err)
@@ -524,15 +523,15 @@ func TestRunStreamIngest_PoolError(t *testing.T) {
 // guard: finish called under a different project than start must be
 // rejected so a caller cannot silently park a body in the wrong project.
 func TestHandleStream_FinishProjectMismatch(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "mismatch", "project": "A"}),
 		Config{})
 	require.NoError(t, err)
 
-	_, err = handleMemoryIngestDocumentStream(ctx, nil,
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "finish", "upload_id": "mismatch", "project": "B"}),
 		Config{})
 	require.Error(t, err)
@@ -541,16 +540,16 @@ func TestHandleStream_FinishProjectMismatch(t *testing.T) {
 
 // TestHandleStream_AppendProjectMismatch: same guard on the append path.
 func TestHandleStream_AppendProjectMismatch(t *testing.T) {
-	resetUploadRegistry(t)
+	srv := newTestServer()
 	ctx := context.Background()
 
-	_, err := handleMemoryIngestDocumentStream(ctx, nil,
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "start", "upload_id": "mm-app", "project": "A"}),
 		Config{})
 	require.NoError(t, err)
 
 	data := base64.StdEncoding.EncodeToString([]byte("x"))
-	_, err = handleMemoryIngestDocumentStream(ctx, nil,
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
 		streamReq(map[string]any{"action": "append", "upload_id": "mm-app", "part": float64(0), "data": data, "project": "B"}),
 		Config{})
 	require.Error(t, err)
@@ -575,6 +574,124 @@ func TestBuildSynopsis_UTF8BoundarySafe(t *testing.T) {
 	// result shrinks. We compare lengths to detect that case.
 	require.Equal(t, len([]rune(syn)), len([]rune(strings.ToValidUTF8(syn, ""))),
 		"synopsis must not end mid-rune")
+}
+
+// ── New tests for issues #183, #187, #189, #190 ──────────────────────────────
+
+// Issue #190: Two Server instances must not share upload sessions.
+// A session started on s1 must be invisible to s2.
+func TestUploadRegistry_IsolatedPerServer(t *testing.T) {
+	s1 := newTestServer()
+	s2 := newTestServer()
+	ctx := context.Background()
+
+	_, err := handleMemoryIngestDocumentStream(ctx, s1, nil,
+		streamReq(map[string]any{"action": "start", "upload_id": "isolated", "project": "p"}),
+		Config{})
+	require.NoError(t, err)
+
+	// s2 must not see s1's session.
+	data := base64.StdEncoding.EncodeToString([]byte("x"))
+	_, err = handleMemoryIngestDocumentStream(ctx, s2, nil,
+		streamReq(map[string]any{"action": "append", "upload_id": "isolated", "part": float64(0), "data": data}),
+		Config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown upload_id")
+}
+
+// Issue #187: lastActivity is updated on every successful append and is used
+// for TTL eviction. After an append, lastActivity must be after createdAt, and
+// a session whose lastActivity is recent must survive eviction even when
+// createdAt is old.
+func TestUploadSession_LastActivityUpdatedOnAppend(t *testing.T) {
+	srv := newTestServer()
+	ctx := context.Background()
+
+	before := time.Now()
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
+		streamReq(map[string]any{"action": "start", "upload_id": "la-test", "project": "p"}),
+		Config{})
+	require.NoError(t, err)
+
+	data := base64.StdEncoding.EncodeToString([]byte("hello"))
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
+		streamReq(map[string]any{"action": "append", "upload_id": "la-test", "part": float64(0), "data": data}),
+		Config{})
+	require.NoError(t, err)
+
+	sess, err := srv.lookupUploadSession("la-test")
+	require.NoError(t, err)
+	require.True(t, sess.lastActivity.After(before),
+		"lastActivity must be updated after a successful append")
+
+	// Simulate an old createdAt but recent lastActivity — session must NOT be evicted.
+	srv.uploadMu.Lock()
+	sess.createdAt = time.Now().Add(-(uploadSessionTTL + time.Minute))
+	srv.uploadMu.Unlock()
+
+	srv.uploadMu.Lock()
+	srv.evictExpiredUploadsLocked(time.Now())
+	_, stillPresent := srv.uploads["la-test"]
+	srv.uploadMu.Unlock()
+	require.True(t, stillPresent, "session with recent lastActivity must survive eviction even when createdAt is stale")
+}
+
+// Issue #189: concurrent append-overflow + finish. When an overflow is
+// detected, the session buffer is zeroed under the lock before dropUpload is
+// called. A finish that races in after the buf is zeroed must receive an error,
+// not silently ingest a truncated (nil) body.
+func TestUploadOverflow_ConcurrentFinishSeesError(t *testing.T) {
+	srv := newTestServer()
+	ctx := context.Background()
+
+	cfg := Config{MaxDocumentBytes: 1024, RawDocumentMaxBytes: 16}
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
+		streamReq(map[string]any{"action": "start", "upload_id": "race-id", "project": "p"}),
+		cfg)
+	require.NoError(t, err)
+
+	// Manually zero the buf (simulating what the overflow path does) so we can
+	// test finish without racing the real append goroutine.
+	srv.uploadMu.Lock()
+	sess := srv.uploads["race-id"]
+	srv.uploadMu.Unlock()
+	sess.mu.Lock()
+	sess.buf = nil
+	sess.mu.Unlock()
+
+	// finish must see the nil buf and return an error.
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
+		streamReq(map[string]any{"action": "finish", "upload_id": "race-id", "project": "p"}),
+		cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "aborted")
+}
+
+// Issue #183: action=append with a missing 'data' field must return an error,
+// not silently advance the part counter with zero bytes.
+func TestAppend_MissingDataFieldReturnsError(t *testing.T) {
+	srv := newTestServer()
+	ctx := context.Background()
+
+	_, err := handleMemoryIngestDocumentStream(ctx, srv, nil,
+		streamReq(map[string]any{"action": "start", "upload_id": "no-data", "project": "p"}),
+		Config{})
+	require.NoError(t, err)
+
+	// append without a 'data' key
+	_, err = handleMemoryIngestDocumentStream(ctx, srv, nil,
+		streamReq(map[string]any{"action": "append", "upload_id": "no-data", "part": float64(0)}),
+		Config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires a string 'data' field")
+
+	// The part counter must not have advanced — the session's nextPart is still 0.
+	sess, lookupErr := srv.lookupUploadSession("no-data")
+	require.NoError(t, lookupErr)
+	sess.mu.Lock()
+	nextPart := sess.nextPart
+	sess.mu.Unlock()
+	require.Equal(t, 0, nextPart, "part counter must not advance on missing-data error")
 }
 
 // Fix 4: Tier-1 response carries "summary" (string) not "summary_bytes" (int).

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -73,14 +73,16 @@ func (rl *rateLimiter) evict() {
 
 // Server wraps the MCP SSE server and owns the EnginePool.
 type Server struct {
-	pool *EnginePool
-	cfg  Config
-	mcp  *server.MCPServer
+	pool     *EnginePool
+	cfg      Config
+	mcp      *server.MCPServer
+	uploadMu sync.Mutex
+	uploads  map[string]*uploadSession
 }
 
 // NewServer constructs a Server with all MCP tools registered.
 func NewServer(pool *EnginePool, cfg Config) *Server {
-	s := &Server{pool: pool, cfg: cfg}
+	s := &Server{pool: pool, cfg: cfg, uploads: make(map[string]*uploadSession)}
 	mcpServer := server.NewMCPServer("engram", "1.0.0",
 		server.WithToolCapabilities(true),
 		server.WithHooks(&server.Hooks{}),
@@ -281,7 +283,7 @@ func (s *Server) registerTools() {
 			}},
 		{"memory_ingest_document_stream", "Ingest a very large document via server-local path or chunked base64 upload (auto-tiered, up to 50 MB)",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-				return handleMemoryIngestDocumentStream(ctx, pool, req, cfg)
+				return handleMemoryIngestDocumentStream(ctx, s, pool, req, cfg)
 			}},
 		{"memory_store_batch", "Store multiple memories in one call",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -294,11 +294,13 @@ func (e *SearchEngine) storeChunksForMemory(ctx context.Context, m *types.Memory
 // Store persists a memory: sets defaults, chunks content, deduplicates by hash,
 // embeds new chunks, and writes everything inside a single transaction.
 //
-// Store uses m.Content as the chunk source. For large documents where the
-// memory carries only a synopsis in Content, use StoreWithRawBody instead and
-// pass the original body so chunks stay grounded in the full text.
+// When m.RawBody is non-empty, Store uses it as the chunk source instead of
+// m.Content. Set m.RawBody before calling Store when m.Content holds only a
+// synopsis: this keeps recall grounded in the full text while the synopsis
+// stays context-window friendly. When m.RawBody is empty the behaviour is
+// identical to the previous version — chunks come from m.Content.
 func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
-	return e.StoreWithRawBody(ctx, m, "")
+	return e.StoreWithRawBody(ctx, m, m.RawBody)
 }
 
 // StoreWithRawBody is like Store, but chunks the given rawBody (rather than
@@ -320,12 +322,6 @@ func (e *SearchEngine) Store(ctx context.Context, m *types.Memory) error {
 //     with the full body themselves — there is no persisted raw body to
 //     recover from once a memory is stored with only a synopsis in Content.
 //
-// TODO(structural): the rawBody="" sentinel couples the API to an easily-
-// forgotten caller contract. A cleaner shape would thread RawBody through
-// *types.Memory (json:"-" so it is not serialised) or split into a dedicated
-// StoreSynopsis(ctx, m, body) method. Keeping the sentinel for now to avoid
-// cascading schema/test churn; re-evaluate once A4/A5 ship and the callers
-// settle.
 func (e *SearchEngine) StoreWithRawBody(ctx context.Context, m *types.Memory, rawBody string) error {
 	if m.ID == "" {
 		m.ID = types.NewMemoryID()

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -231,3 +231,58 @@ func TestRecallWithEvent_IncrementsTimesRetrieved(t *testing.T) {
 	require.Equal(t, baselineRetrieved+1, after.TimesRetrieved,
 		"times_retrieved must be auto-incremented by RecallWithEvent without explicit feedback")
 }
+
+// TestStore_RawBodyUsedForChunking verifies that Store() honours m.RawBody: when
+// RawBody is non-empty, chunks must be built from the raw body (the full original
+// text) rather than from m.Content (which holds only a synopsis). This tests the
+// fix for #191: Store() previously called StoreWithRawBody(m, "") unconditionally,
+// silently discarding any RawBody the caller set on the Memory.
+func TestStore_RawBodyUsedForChunking(t *testing.T) {
+	proj := uniqueProject("test-rawbody")
+	engine := newTestEngine(t, proj)
+	t.Cleanup(func() { engine.Close() })
+
+	ctx := context.Background()
+
+	// synopsis is what a Tier-1 ingest would store in Memory.Content — a short
+	// excerpt that fits in the context window.
+	synopsis := "Short synopsis: document discusses Go concurrency."
+	// rawBody is the original full content whose tokens should appear in chunks.
+	rawBody := "Go concurrency is built on goroutines and channels. " +
+		"Goroutines are lightweight threads managed by the Go runtime. " +
+		"Channels provide a typed conduit for communication between goroutines."
+
+	m := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     synopsis,
+		RawBody:     rawBody,
+		MemoryType:  types.MemoryTypeContext,
+		Importance:  2,
+		StorageMode: "focused",
+	}
+	require.NoError(t, engine.Store(ctx, m))
+
+	// Retrieve all chunks for this memory and assert they come from rawBody,
+	// not from the synopsis.
+	chunks, err := engine.Backend().GetAllChunksWithEmbeddings(ctx, proj, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, chunks, "at least one chunk must be stored")
+
+	for _, c := range chunks {
+		if c.MemoryID != m.ID {
+			continue
+		}
+		require.Contains(t, rawBody, c.ChunkText,
+			"chunk text must come from RawBody, not from the synopsis Content")
+		require.NotContains(t, synopsis, c.ChunkText[:min(len(c.ChunkText), len(synopsis))],
+			"chunk text must not be a substring of the synopsis alone")
+	}
+}
+
+// min is a local helper for Go 1.20 compatibility (builtin min arrived in 1.21).
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -101,8 +101,19 @@ func NewMemoryID() string {
 // MCP tool wire format.
 type Memory struct {
 	// ID is a UUID v7 string, time-sortable.
-	ID          string    `json:"id"`
-	Content     string    `json:"content"`
+	ID      string `json:"id"`
+	Content string `json:"content"`
+
+	// RawBody holds the original full content when a Tier-1 synopsis memory is
+	// constructed in-process. It is never serialised (json:"-") because it is
+	// only meaningful during the current Store call: once the memory is written
+	// to the database, Content (the synopsis) is the authoritative field.
+	//
+	// Usage: set this before calling Store() when m.Content holds a synopsis
+	// and you want chunks to be built from the full body. Store() passes
+	// m.RawBody to StoreWithRawBody, eliminating the magic-value "" sentinel.
+	// When RawBody is empty (normal memories), behaviour is unchanged.
+	RawBody string `json:"-"`
 	MemoryType  string    `json:"memory_type"`
 	Project     string    `json:"project"`
 	Tags        []string  `json:"tags"`


### PR DESCRIPTION
## Summary

- **#182** — `postgres_memory.go`: streaming sha256 to eliminate double-copy on large content
- **#183** — `ingest_document.go`: explicit type assertion on `data` field; missing field now returns error instead of silent zero-byte append
- **#184** — `document_query.go`: 1024-char length cap on `FilterRegex` before `regexp.Compile`
- **#186** — `document_query.go`: `Truncated=true` false positive — only set when there are spans after the tipping one
- **#187** — `ingest_document.go`: TTL eviction now uses `lastActivity` (updated on every append) instead of `createdAt`
- **#188** — `document_query.go`: empty content returns early with `"No content available"` instead of calling Claude with zero evidence
- **#189** — `ingest_document.go`: overflow path zeroes `sess.buf` under lock before unlocking, closing the concurrent-finish window
- **#190** — `ingest_document.go` / `server.go`: `uploadRegistry` moved from package globals to `*Server` fields; fully isolated per-instance
- **#191** — `types.Memory` / `engine.go`: `RawBody string \`json:"-"\`` added; `Store()` uses `m.RawBody` instead of `""` sentinel; Tier-1 rechunking now uses original content

## Test Plan
- [x] All 16 packages pass `go test ./... -count=1 -race`
- [x] TDD — failing test written before each fix
- [x] No new package-level globals introduced
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)