### PR TITLE
fix(claude): enforce charCap as hard limit in QueryDocument (#195)

### DIFF
--- a/internal/claude/document_query.go
+++ b/internal/claude/document_query.go
@@ -160,12 +160,16 @@ func QueryDocument(ctx context.Context, c *Client, content string, q DocumentQue
 				for remaining > 0 && !utf8.RuneStart(text[remaining]) {
 					remaining--
 				}
-				text = text[:remaining]
-				spans = append(spans, DocumentSpan{
-					Offset:  m.start,
-					Text:    text,
-					Matched: m.matched,
-				})
+				// Re-check: walk-back can reduce remaining to 0 when the span
+				// window starts mid-rune. Skip the append in that case.
+				if remaining > 0 {
+					text = text[:remaining]
+					spans = append(spans, DocumentSpan{
+						Offset:  m.start,
+						Text:    text,
+						Matched: m.matched,
+					})
+				}
 			}
 			truncated = true
 			break

--- a/internal/claude/document_query.go
+++ b/internal/claude/document_query.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 // DocumentQuery holds the parsed args for a memory_query_document request.
@@ -143,25 +144,38 @@ func QueryDocument(ctx context.Context, c *Client, content string, q DocumentQue
 		}, nil
 	}
 
-	// Apply token budget — stop accumulating once we cross the char cap,
-	// but include the span that tipped us over so callers see a complete window.
+	// Apply token budget — truncate any span whose text would push total past
+	// charCap so callers receive content that strictly fits within the budget.
+	// Truncated=true signals that at least one span was cut short or omitted.
 	charCap := q.TokenBudget * charsPerToken
 	spans := make([]DocumentSpan, 0, len(merged))
 	total := 0
 	truncated := false
-	for i, m := range merged {
+	for _, m := range merged {
 		text := content[m.start:m.end]
+		if charCap > 0 && total+len(text) > charCap {
+			remaining := charCap - total
+			if remaining > 0 {
+				// Walk back to a valid UTF-8 rune boundary.
+				for remaining > 0 && !utf8.RuneStart(text[remaining]) {
+					remaining--
+				}
+				text = text[:remaining]
+				spans = append(spans, DocumentSpan{
+					Offset:  m.start,
+					Text:    text,
+					Matched: m.matched,
+				})
+			}
+			truncated = true
+			break
+		}
 		spans = append(spans, DocumentSpan{
 			Offset:  m.start,
 			Text:    text,
 			Matched: m.matched,
 		})
 		total += len(text)
-		// Fix #186: only mark truncated when more spans remain after this one.
-		if total > charCap && i < len(merged)-1 {
-			truncated = true
-			break
-		}
 	}
 
 	// Build the user prompt by concatenating spans with dividers.

--- a/internal/claude/document_query_test.go
+++ b/internal/claude/document_query_test.go
@@ -178,30 +178,29 @@ func TestQueryDocument_RegexTooLong(t *testing.T) {
 	require.Contains(t, err.Error(), "filter.regex exceeds")
 }
 
-// Fix #186: Truncated must be false when the span that tips the budget is the last one.
-func TestQueryDocument_TruncatedFalseOnLastSpan(t *testing.T) {
+// Fix #195: charCap is a hard limit — when the last span would push total past
+// the cap it is truncated to fit and Truncated=true is set.
+func TestQueryDocument_LastSpanTruncatedToFitCap(t *testing.T) {
 	srv := newStubClaudeServer("ok")
 	defer srv.Close()
 	c, _ := claude.New("test")
 	c.BaseURL = srv.URL
 
-	// Produce exactly two non-overlapping spans each 40 chars wide (WindowChars=40, half=20).
-	// Span 1: HIT at offset 500 → window [480,523) = 43 chars
-	// Span 2: HIT at offset 1003 → window [983,1043) = 40 chars if content is long enough
-	// Use budget=20 → charCap=80. Span1(43) + Span2(40) = 83 > 80, so the last (second)
-	// span tips the cap. With fix, Truncated stays false; without fix it would be true.
+	// Two ASCII spans; span1≈43 chars, span2≈43 chars, charCap=80.
+	// Span2 would push total to ~86 > 80, so it gets truncated to ~37 chars.
 	content := strings.Repeat("x", 500) + "HIT" + strings.Repeat("y", 500) + "HIT" + strings.Repeat("z", 100)
-	// Verify span2 is really the last: the content has exactly two HITs.
 	q := claude.DocumentQuery{
 		Question:    "?",
 		FilterSubs:  []string{"HIT"},
 		WindowChars: 40,
-		TokenBudget: 20, // charCap = 80; span1=43 + span2=40 = 83 > 80, last span tips cap
+		TokenBudget: 20, // charCap = 80
 	}
 	res, err := claude.QueryDocument(context.Background(), c, content, q)
 	require.NoError(t, err)
-	require.Len(t, res.Spans, 2, "both spans should be included")
-	require.False(t, res.Truncated, "should not be truncated when last span tips the budget")
+	require.Len(t, res.Spans, 2, "both spans present (second truncated, not dropped)")
+	require.True(t, res.Truncated, "Truncated must be true when a span was cut short")
+	total := len(res.Spans[0].Text) + len(res.Spans[1].Text)
+	require.LessOrEqual(t, total, 80, "total chars must not exceed charCap")
 }
 
 // Fix #188: Empty content must short-circuit with a canned answer, no LLM call.

--- a/internal/claude/document_query_test.go
+++ b/internal/claude/document_query_test.go
@@ -222,6 +222,42 @@ func TestQueryDocument_EmptyContent(t *testing.T) {
 	require.Equal(t, "No content available for this memory.", res.Answer)
 }
 
+// TestQueryDocument_UTF8BoundaryTruncation verifies that when the cap falls
+// inside a multi-byte rune the walk-back produces a valid UTF-8 string.
+func TestQueryDocument_UTF8BoundaryTruncation(t *testing.T) {
+	srv := newStubClaudeServer("ok")
+	defer srv.Close()
+	c, _ := claude.New("test")
+	c.BaseURL = srv.URL
+
+	// Each "é" is 2 bytes (U+00E9). Build content so that the cap lands
+	// in the middle of one of its bytes, forcing the walk-back to fire.
+	// charCap = TokenBudget*4 = 5*4 = 20 bytes.
+	// WindowChars=30 → span covers 30 bytes of multi-byte content.
+	// With 20-byte cap the slice point lands inside a 2-byte rune; walk-back
+	// must retreat to the preceding rune boundary.
+	content := strings.Repeat("é", 100) // each é = 2 bytes → 200 bytes total
+	q := claude.DocumentQuery{
+		Question:    "?",
+		FilterSubs:  []string{"é"},
+		WindowChars: 30,
+		TokenBudget: 5, // charCap = 20
+	}
+	res, err := claude.QueryDocument(context.Background(), c, content, q)
+	require.NoError(t, err)
+	require.True(t, res.Truncated)
+	require.NotEmpty(t, res.Spans)
+	for _, s := range res.Spans {
+		require.True(t, strings.ToValidUTF8(s.Text, "") == s.Text,
+			"span text must be valid UTF-8 after boundary truncation")
+	}
+	total := 0
+	for _, s := range res.Spans {
+		total += len(s.Text)
+	}
+	require.LessOrEqual(t, total, 20, "total bytes must not exceed charCap")
+}
+
 func TestQueryDocument_TokenBudget(t *testing.T) {
 	srv := newStubClaudeServer("ok")
 	defer srv.Close()


### PR DESCRIPTION
## Summary
- `QueryDocument` was including the last span in full even when it exceeded `charCap`, with `Truncated=false`
- Now any span that would push total past `charCap` is truncated at a valid UTF-8 rune boundary; `Truncated=true` and the loop exits
- Callers always receive content that strictly fits within `q.TokenBudget * 4` chars

## Changes
- `internal/claude/document_query.go`: rewrote span-budget loop to truncate at cap rather than overflow then stop; added `unicode/utf8` import for boundary-safe truncation
- `internal/claude/document_query_test.go`: replaced `TestQueryDocument_TruncatedFalseOnLastSpan` (testing superseded #186 semantics) with `TestQueryDocument_LastSpanTruncatedToFitCap` asserting `Truncated=true` and `total ≤ charCap`

## Test Plan
- [x] `go test ./internal/claude/... -count=1 -race` — all passing
- [x] `TestQueryDocument_LastSpanTruncatedToFitCap` specifically validates the cap is enforced and second span is truncated (not dropped)
- [x] All other `TestQueryDocument_*` tests continue to pass

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)