### PR TITLE
fix: aggregate nice-to-haves from Rickover audit (#198–204)

### DIFF
--- a/internal/db/postgres_aggregate_test.go
+++ b/internal/db/postgres_aggregate_test.go
@@ -145,7 +145,7 @@ func TestAggregateMemories_ByType_SingleTypeOnly(t *testing.T) {
 
 	ctxRow := findRowByLabel(rows, types.MemoryTypeContext)
 	require.NotNil(t, ctxRow, "expected row with label=context")
-	require.GreaterOrEqual(t, ctxRow.Count, 1, "count must be >= 1")
+	require.Equal(t, 3, ctxRow.Count, "all three inserted memories must be counted")
 }
 
 // TestAggregateMemories_EmptyProject calls AggregateMemories on a project

--- a/internal/db/postgres_aggregate_test.go
+++ b/internal/db/postgres_aggregate_test.go
@@ -126,6 +126,28 @@ func TestAggregateMemories_ByType(t *testing.T) {
 	require.Equal(t, 1, errRow.Count)
 }
 
+// TestAggregateMemories_ByType_SingleTypeOnly inserts memories that all share the
+// same memory_type ("context") and asserts that AggregateMemories returns exactly
+// one row — absent types must be excluded, not zero-filled.
+func TestAggregateMemories_ByType_SingleTypeOnly(t *testing.T) {
+	proj := uniqueProject("agg-bytype-single")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	storeMemoryWithType(t, b, proj, "context memory one", types.MemoryTypeContext)
+	storeMemoryWithType(t, b, proj, "context memory two", types.MemoryTypeContext)
+	storeMemoryWithType(t, b, proj, "context memory three", types.MemoryTypeContext)
+
+	rows, err := b.AggregateMemories(ctx, proj, "type", "", 20)
+	require.NoError(t, err)
+
+	require.Len(t, rows, 1, "only one type present — expect exactly one row")
+
+	ctxRow := findRowByLabel(rows, types.MemoryTypeContext)
+	require.NotNil(t, ctxRow, "expected row with label=context")
+	require.GreaterOrEqual(t, ctxRow.Count, 1, "count must be >= 1")
+}
+
 // TestAggregateMemories_EmptyProject calls AggregateMemories on a project
 // that has no memories and asserts a non-nil empty slice is returned.
 func TestAggregateMemories_EmptyProject(t *testing.T) {

--- a/internal/mcp/aggregate_test.go
+++ b/internal/mcp/aggregate_test.go
@@ -158,33 +158,32 @@ func TestHandleMemoryAggregate_LimitClamping(t *testing.T) {
 // ── memory_feedback with failure_class tests ──────────────────────────────────
 
 // TestHandleMemoryFeedback_WithClass calls memory_feedback with a valid
-// failure_class="vocabulary_mismatch". A fake event_id is used; the handler
-// may return an error about the event not being found (acceptable), but it
-// must NOT return an error about an invalid failure_class.
+// failure_class="vocabulary_mismatch". A syntactically valid UUID is used for
+// event_id so UUID validation passes; the handler may still return an error
+// about the event not being found in the DB (acceptable), but it must NOT
+// return an error about an invalid failure_class or invalid UUID format.
 func TestHandleMemoryFeedback_WithClass(t *testing.T) {
 	ctx := context.Background()
 	dsn := testDSN_agg(t)
 	proj := uniqueProject_agg("fb-class")
 	pool := mcp.NewTestPoolWithDSN(t, ctx, dsn, proj)
 
-	// We use a fake event_id. The valid-class path must not reject the class
-	// itself; any error must be about the missing event, not about the class value.
 	out := mcp.CallHandleMemoryFeedbackWithClass(ctx, t, pool, map[string]any{
 		"project":       proj,
-		"event_id":      "fake-event-123",
+		"event_id":      "00000000-0000-0000-0000-000000000001",
 		"memory_ids":    []any{},
 		"failure_class": "vocabulary_mismatch",
 	})
 
-	// If we reach here without a fatal, the handler accepted the class.
-	// The status field must be present (success path) or we just confirmed
-	// no class-validation error was raised.
+	// nil means a DB-level error (event not found) — acceptable at this layer.
+	// A non-nil result means the full path succeeded.
 	_ = out
 }
 
 // TestHandleMemoryFeedback_InvalidClass calls memory_feedback with an
 // unrecognised failure_class value. The handler must reject it at the MCP
 // boundary — before any DB access — and return an error.
+// Uses a valid UUID for event_id so UUID validation does not mask the class error.
 func TestHandleMemoryFeedback_InvalidClass(t *testing.T) {
 	ctx := context.Background()
 	dsn := testDSN_agg(t)
@@ -193,8 +192,23 @@ func TestHandleMemoryFeedback_InvalidClass(t *testing.T) {
 
 	mcp.CallHandleMemoryFeedbackWithClassExpectError(ctx, t, pool, map[string]any{
 		"project":       proj,
-		"event_id":      "fake-event-123",
+		"event_id":      "00000000-0000-0000-0000-000000000001",
 		"memory_ids":    []any{},
 		"failure_class": "not_a_valid_class",
+	})
+}
+
+// TestHandleMemoryFeedback_InvalidEventID verifies that a non-UUID event_id is
+// rejected at the MCP boundary before any DB access. Uses the noop pool since
+// UUID validation fires before any database interaction.
+func TestHandleMemoryFeedback_InvalidEventID(t *testing.T) {
+	ctx := context.Background()
+	pool := mcp.NewTestNoopPool(t)
+
+	mcp.CallHandleMemoryFeedbackWithClassExpectError(ctx, t, pool, map[string]any{
+		"project":       "test",
+		"event_id":      "fake-event-123",
+		"memory_ids":    []any{},
+		"failure_class": "vocabulary_mismatch",
 	})
 }

--- a/internal/mcp/aggregate_test.go
+++ b/internal/mcp/aggregate_test.go
@@ -132,10 +132,10 @@ func TestHandleMemoryAggregate_InvalidBy(t *testing.T) {
 	})
 }
 
-// TestHandleMemoryAggregate_LimitClamping verifies that passing limit=-1 does not
-// produce an error at the MCP handler boundary. The handler silently clamps any
-// limit < 1 to 20 before forwarding to the engine, so the call must succeed and
-// return a valid aggregate response with a "rows" key.
+// TestHandleMemoryAggregate_LimitClamping verifies that passing a representative
+// non-positive limit (limit=-1) does not produce an error at the MCP handler
+// boundary. The handler silently clamps limit < 1 to 20 before forwarding to
+// the engine, so the call must succeed and return a valid aggregate response with a "rows" key.
 func TestHandleMemoryAggregate_LimitClamping(t *testing.T) {
 	ctx := context.Background()
 	// Use the noopBackend-backed pool so this test runs without a real database.

--- a/internal/mcp/aggregate_test.go
+++ b/internal/mcp/aggregate_test.go
@@ -132,6 +132,29 @@ func TestHandleMemoryAggregate_InvalidBy(t *testing.T) {
 	})
 }
 
+// TestHandleMemoryAggregate_LimitClamping verifies that passing limit=-1 does not
+// produce an error at the MCP handler boundary. The handler silently clamps any
+// limit < 1 to 20 before forwarding to the engine, so the call must succeed and
+// return a valid aggregate response with a "rows" key.
+func TestHandleMemoryAggregate_LimitClamping(t *testing.T) {
+	ctx := context.Background()
+	// Use the noopBackend-backed pool so this test runs without a real database.
+	pool := mcp.NewTestNoopPool(t)
+
+	out := mcp.CallHandleMemoryAggregate(ctx, t, pool, map[string]any{
+		"project": "test",
+		"by":      "tag",
+		"limit":   float64(-1),
+	})
+
+	require.NotNil(t, out, "response must not be nil")
+
+	rows, ok := out["rows"]
+	require.True(t, ok, "response must include 'rows' key")
+	_, isSlice := rows.([]any)
+	require.True(t, isSlice, "'rows' must be a []any, got %T", rows)
+}
+
 // ── memory_feedback with failure_class tests ──────────────────────────────────
 
 // TestHandleMemoryFeedback_WithClass calls memory_feedback with a valid

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -392,9 +392,10 @@ func CallHandleMemoryAggregateExpectError(ctx context.Context, t *testing.T, poo
 	}
 }
 
-// CallHandleMemoryFeedbackWithClass verifies that a valid failure_class passes
-// MCP boundary validation. Errors from the DB layer (e.g. event not found) are
-// silently ignored — the test only cares that no class-validation error is raised.
+// CallHandleMemoryFeedbackWithClass tests MCP boundary validation only
+// (failure_class format and event_id requirement). It does not validate DB state.
+// DB errors (e.g. event not found, unknown event_id) are expected and silently
+// skipped — a nil return means the handler's input parsing accepted the arguments.
 func CallHandleMemoryFeedbackWithClass(ctx context.Context, t *testing.T, pool *EnginePool, args map[string]any) map[string]any {
 	t.Helper()
 	req := mcpgo.CallToolRequest{}

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -356,6 +356,13 @@ func CallHandleMemoryIngest(
 	return res
 }
 
+// NewTestNoopPool returns an EnginePool backed by a noopBackend + noopEmbedder.
+// Use this in unit tests that do not require a real PostgreSQL database.
+func NewTestNoopPool(t *testing.T) *EnginePool {
+	t.Helper()
+	return newTestExplorePool(t)
+}
+
 // CallHandleMemoryAggregate invokes handleMemoryAggregate with the given
 // arguments and returns the decoded output map. Fatals on any error.
 func CallHandleMemoryAggregate(ctx context.Context, t *testing.T, pool *EnginePool, args map[string]any) map[string]any {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -337,7 +337,7 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryFeedback(ctx, pool, req)
 			}},
-		{"memory_aggregate", "Group and count memories by tag, type, or failure_class",
+		{"memory_aggregate", "Group and count memories. by=tag|type|failure_class. filter: optional ILIKE substring — tag mode only, error for failure_class.",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryAggregate(ctx, pool, req)
 			}},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -902,7 +902,7 @@ func handleMemoryFeedback(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 	eventID := getString(args, "event_id", "")
 	if eventID != "" {
 		if _, err := uuid.Parse(eventID); err != nil {
-			return nil, fmt.Errorf("event_id: must be a valid UUID")
+			return nil, fmt.Errorf("event_id: must be a valid UUID, got %q", eventID)
 		}
 	}
 	failureClass := getString(args, "failure_class", "")

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/google/uuid"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/claude"
 	consolidatepkg "github.com/petersimmons1972/engram/internal/consolidate"
@@ -899,6 +900,11 @@ func handleMemoryFeedback(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 		return nil, fmt.Errorf("memory_ids: too many IDs (%d), max 100", len(ids))
 	}
 	eventID := getString(args, "event_id", "")
+	if eventID != "" {
+		if _, err := uuid.Parse(eventID); err != nil {
+			return nil, fmt.Errorf("event_id: must be a valid UUID")
+		}
+	}
 	failureClass := getString(args, "failure_class", "")
 	if failureClass != "" {
 		if !types.ValidateFailureClass(failureClass) {

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1222,7 +1222,7 @@ func (e *SearchEngine) FeedbackWithEventAndClass(ctx context.Context, eventID st
 // Aggregate returns aggregated memory statistics grouped by the given dimension.
 // Supported values for by: "tag", "type", "failure_class".
 // filter is an optional prefix/value filter (not applicable for failure_class).
-// limit caps the number of rows returned.
+// limit caps the number of rows returned; limit < 1 is treated as the default (20).
 func (e *SearchEngine) Aggregate(ctx context.Context, by, filter string, limit int) ([]types.AggregateRow, error) {
 	if limit < 1 {
 		limit = 20

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1224,6 +1224,9 @@ func (e *SearchEngine) FeedbackWithEventAndClass(ctx context.Context, eventID st
 // filter is an optional prefix/value filter (not applicable for failure_class).
 // limit caps the number of rows returned.
 func (e *SearchEngine) Aggregate(ctx context.Context, by, filter string, limit int) ([]types.AggregateRow, error) {
+	if limit < 1 {
+		limit = 20
+	}
 	switch by {
 	case "tag", "type":
 		return e.backend.AggregateMemories(ctx, e.project, by, filter, limit)


### PR DESCRIPTION
## Summary

Closes #198, #199, #201, #202, #203, #204. Closes #200 (already correct — no code change, comment added to issue).

Six surgical fixes from the Rickover adversarial review of PR #197:

- **#203** `engine.go` `Aggregate`: clamp `limit < 1` to 20 at the engine layer (defense-in-depth alongside the existing handler clamp)
- **#201** `handleMemoryFeedback`: validate `event_id` is a valid UUID at the MCP boundary; echo the offending value in the error message
- **#199** `memory_aggregate` tool description: explicitly enumerate `by=tag|type|failure_class` and the tag-mode-only filter restriction
- **#204** `export_test.go` doc comment: clarify `CallHandleMemoryFeedbackWithClass` tests input-parsing only; DB errors expected and skipped
- **#198** New test `TestHandleMemoryAggregate_LimitClamping`: verifies `limit=-1` is silently clamped without error (noop pool, no DB required)
- **#202** New test `TestAggregateMemories_ByType_SingleTypeOnly`: verifies absent types are excluded (not zero-filled) when `by=type`

Follow-up filed as #206 for naming consistency of `newTestExplorePool` → `newTestNoopPool`.

## Test Plan

- [x] `go test ./internal/mcp/... ./internal/search/... -count=1 -race` — passes locally
- [x] `go build ./...` — zero errors
- [ ] CI integration tests (require postgres service, run in GitHub Actions)
- [ ] Adversarial review: Rickover + Spruance + zero-context (required by CLAUDE.md before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)