### PR TITLE
fix: adversarial review — all 14 issues (#213–226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ make setup    # writes bearer token to ~/.claude/mcp_servers.json
 
 The server starts on port 8788. Cold start: under 200ms. Memory at idle: 18 MB.
 
+> **Docker users:** `docker-compose.yml` now sets `ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1` automatically. If you run engram outside Docker and need `/setup-token` accessible from RFC1918 addresses (e.g. a LAN host), add this variable to your environment. Without it, `/setup-token` only accepts loopback (127.0.0.1 / ::1).
+
 Run `/mcp` in Claude Code after setup to connect. All 30 core tools are available immediately. Five optional AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`, `memory_diagnose`) activate when `ANTHROPIC_API_KEY` is set.
 
 ---

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -162,6 +162,7 @@ func run() error {
 		MaxDocumentBytes:         envInt("ENGRAM_MAX_DOCUMENT_BYTES", 8*1024*1024),
 		RawDocumentMaxBytes:      envInt("ENGRAM_RAW_DOCUMENT_MAX_BYTES", 50*1024*1024),
 		RAGMaxTokens:             envInt("ENGRAM_RAG_MAX_TOKENS", 4096),
+		AllowRFC1918SetupToken:   envBool("ENGRAM_SETUP_TOKEN_ALLOW_RFC1918", false),
 	}
 	srv := internalmcp.NewServer(pool, cfg)
 	if cc != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,9 @@ services:
       - ENGRAM_CLAUDE_SUMMARIZE=${ENGRAM_CLAUDE_SUMMARIZE:-false}
       - ENGRAM_CLAUDE_CONSOLIDATE=${ENGRAM_CLAUDE_CONSOLIDATE:-false}
       - ENGRAM_CLAUDE_RERANK=${ENGRAM_CLAUDE_RERANK:-false}
+      # Allow /setup-token from Docker bridge IPs (RFC1918). Required because the
+      # host appears as a gateway IP (172.x, 10.x) rather than 127.0.0.1 via NAT.
+      - ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1
     depends_on:
       postgres:
         condition: service_healthy

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -103,6 +103,18 @@ func (b *PostgresBackend) runMigrations(ctx context.Context) error {
 	}
 	defer conn.Release()
 
+	// Set lock_timeout so a hung migration on another node can't block startup forever.
+	lockTimeoutMs := 30000
+	if deadline, ok := ctx.Deadline(); ok {
+		if rem := int(time.Until(deadline).Milliseconds()); rem < lockTimeoutMs {
+			lockTimeoutMs = rem
+		}
+	}
+	if _, err := conn.Exec(ctx,
+		fmt.Sprintf("SET LOCAL lock_timeout = '%dms'", lockTimeoutMs),
+	); err != nil {
+		return fmt.Errorf("set lock_timeout: %w", err)
+	}
 	if _, err := conn.Exec(ctx,
 		`SELECT pg_advisory_lock($1, hashtext($2::text))`, lockClass, b.project,
 	); err != nil {
@@ -391,7 +403,10 @@ func rowToFTSResult(row pgx.CollectableRow) (FTSResult, error) {
 	}
 	var tagSlice []string
 	if len(tags) > 0 {
-		_ = json.Unmarshal(tags, &tagSlice)
+		if err := json.Unmarshal(tags, &tagSlice); err != nil {
+			slog.Warn("tags unmarshal failed — empty tags returned", "memory_id", id, "err", err)
+			tagSlice = []string{}
+		}
 	}
 	if tagSlice == nil {
 		tagSlice = []string{}

--- a/internal/db/postgres_relationship.go
+++ b/internal/db/postgres_relationship.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -130,7 +131,10 @@ ORDER BY bfs.neighbor_id, bfs.hop ASC`,
 			return nil, err
 		}
 		if tagsJSON != nil {
-			_ = json.Unmarshal(tagsJSON, &m.Tags)
+			if err := json.Unmarshal(tagsJSON, &m.Tags); err != nil {
+				slog.Warn("tags unmarshal failed — empty tags returned", "memory_id", m.ID, "err", err)
+				m.Tags = []string{}
+			}
 		}
 		m.ExpiresAt = expiresAt
 		m.ValidTo = validTo

--- a/internal/mcp/ingest_document.go
+++ b/internal/mcp/ingest_document.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -289,6 +290,9 @@ const (
 	maxUploadIDLen    = 128
 )
 
+// uploadIDRE restricts upload_id to safe filesystem-friendly characters.
+var uploadIDRE = regexp.MustCompile(`^[a-zA-Z0-9_\-\.]+$`)
+
 // evictExpiredUploadsLocked drops sessions whose lastActivity (falling back to
 // createdAt) is older than the TTL. Caller must hold s.uploadMu.
 func (s *Server) evictExpiredUploadsLocked(now time.Time) {
@@ -392,6 +396,9 @@ func handleMemoryIngestDocumentStream(ctx context.Context, s *Server, pool *Engi
 	case "start":
 		if len(uploadID) == 0 || len(uploadID) > maxUploadIDLen {
 			return nil, fmt.Errorf("upload_id must be 1–%d characters", maxUploadIDLen)
+		}
+		if !uploadIDRE.MatchString(uploadID) {
+			return nil, fmt.Errorf("upload_id may only contain letters, digits, hyphens, underscores, and dots")
 		}
 		if _, err := s.startUploadSession(uploadID, project); err != nil {
 			return nil, err

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -16,7 +16,7 @@ import (
 
 // maxPoolSize is the maximum number of project engines kept in memory at once.
 // When exceeded, the least-recently-used engine is evicted and its connection
-// pool released. 50 projects × ~10 PG connections each = 500 max connections,
+// pool released. 50 projects × 2–10 PG connections each = 100–500 connections,
 // well within typical PostgreSQL limits.
 const maxPoolSize = 50
 
@@ -111,7 +111,7 @@ func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, er
 			e.lastAccess.Store(time.Now().UnixNano())
 			return e.handle, nil
 		}
-		if len(p.engines) >= maxPoolSize {
+		for len(p.engines) >= maxPoolSize {
 			p.evictLRULocked()
 		}
 		entry := &engineEntry{handle: h}
@@ -132,7 +132,7 @@ func (p *EnginePool) evictLRULocked() {
 	lruNano := int64(math.MaxInt64) // #131: init to max so any real value wins
 	for k, e := range p.engines {
 		nano := e.lastAccess.Load()
-		if nano < lruNano {
+		if nano < lruNano || (nano == lruNano && k < lruKey) {
 			lruKey = k
 			lruNano = nano
 		}

--- a/internal/mcp/safety.go
+++ b/internal/mcp/safety.go
@@ -114,7 +114,7 @@ func handleCheckConstraints(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 	project := getString(args, "project", "default")
 	proposedAction := getString(args, "proposed_action", "")
 	if proposedAction == "" {
-		return nil, fmt.Errorf("proposed_action is required")
+		return mcpgo.NewToolResultError("proposed_action is required"), nil
 	}
 	limit := getInt(args, "limit", defaultConstraintLimit)
 	if limit < 1 || limit > 50 {
@@ -148,7 +148,7 @@ func handleVerifyBeforeActing(ctx context.Context, pool *EnginePool, req mcpgo.C
 	project := getString(args, "project", "default")
 	proposedAction := getString(args, "proposed_action", "")
 	if proposedAction == "" {
-		return nil, fmt.Errorf("proposed_action is required")
+		return mcpgo.NewToolResultError("proposed_action is required"), nil
 	}
 	limit := getInt(args, "limit", defaultConstraintLimit)
 	if limit < 1 || limit > 50 {
@@ -726,17 +726,19 @@ func actionTagMatchesProfile(tag string, profile actionProfile, actionLower stri
 
 // ── Decision ratchet ──────────────────────────────────────────────────────────
 
-// elevateDecision returns the higher-severity of current and next.
+// decisionRank maps decision strings to severity ordinals for elevateDecision.
 // Order: proceed(0) < warn(1) < require_approval(2) < block(3).
+var decisionRank = map[string]int{
+	"proceed":          0,
+	"warn":             1,
+	"require_approval": 2,
+	"block":            3,
+}
+
+// elevateDecision returns the higher-severity of current and next.
 // The decision never decreases — this is the one-directional ratchet.
 func elevateDecision(current, next string) string {
-	rank := map[string]int{
-		"proceed":          0,
-		"warn":             1,
-		"require_approval": 2,
-		"block":            3,
-	}
-	if rank[next] > rank[current] {
+	if decisionRank[next] > decisionRank[current] {
 		return next
 	}
 	return current

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -33,9 +33,10 @@ type rateLimiterEntry struct {
 }
 
 // newRateLimiter creates a rate limiter that evicts idle IPs every 5 minutes.
-func newRateLimiter() *rateLimiter {
+// The eviction goroutine stops when ctx is cancelled.
+func newRateLimiter(ctx context.Context) *rateLimiter {
 	rl := &rateLimiter{clients: make(map[string]*rateLimiterEntry)}
-	go rl.evict()
+	go rl.evictLoop(ctx)
 	return rl
 }
 
@@ -56,18 +57,28 @@ func (rl *rateLimiter) allow(ip string) bool {
 	return ok
 }
 
-// evict removes entries not seen in the last 5 minutes.
-func (rl *rateLimiter) evict() {
+// evictLoop removes idle IP entries every 5 minutes until ctx is cancelled.
+func (rl *rateLimiter) evictLoop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		rl.mu.Lock()
-		for ip, e := range rl.clients {
-			if time.Since(e.lastSeen) > 5*time.Minute {
-				delete(rl.clients, ip)
-			}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rl.evict()
 		}
-		rl.mu.Unlock()
+	}
+}
+
+// evict removes entries not seen in the last 5 minutes.
+func (rl *rateLimiter) evict() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	for ip, e := range rl.clients {
+		if time.Since(e.lastSeen) > 5*time.Minute {
+			delete(rl.clients, ip)
+		}
 	}
 }
 
@@ -153,7 +164,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// The token is equivalent in sensitivity to ~/.claude.json which is already on disk.
 	mux.HandleFunc("/setup-token", func(w http.ResponseWriter, r *http.Request) {
 		remoteHost, _, _ := net.SplitHostPort(r.RemoteAddr)
-		if !isLocalAddress(remoteHost) {
+		if !isLocalAddress(remoteHost, s.cfg.AllowRFC1918SetupToken) {
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
@@ -176,8 +187,24 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	mux.HandleFunc("/.well-known/oauth-protected-resource", notFound)
 
 	// All other routes require Bearer authentication and per-IP rate limiting (#140).
-	rl := newRateLimiter()
+	rl := newRateLimiter(ctx)
 	mux.Handle("/", s.applyMiddleware(sse, apiKey, rl))
+
+	// Background sweeper clears stale upload sessions on a 5-minute interval.
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				s.uploadMu.Lock()
+				s.evictExpiredUploadsLocked(now)
+				s.uploadMu.Unlock()
+			}
+		}
+	}()
 
 	const maxRequestBodyBytes = 2 * 1024 * 1024 // 2 MiB (#6)
 	httpServer := &http.Server{
@@ -237,10 +264,11 @@ func (s *Server) applyMiddleware(next http.Handler, apiKey string, rl *rateLimit
 	})
 }
 
-// isLocalAddress reports whether the IP string is a loopback or RFC1918 private address.
-// Used by /setup-token to accept requests arriving via Docker's NAT gateway (which presents
-// as a Docker bridge IP, not 127.0.0.1, even when the port is host-loopback-bound).
-func isLocalAddress(ipStr string) bool {
+// isLocalAddress reports whether ipStr is a loopback address.
+// When allowRFC1918 is true, private RFC1918 ranges are also accepted — required
+// for Docker setups where the host appears as a bridge IP (172.x, 10.x, 192.168.x)
+// rather than 127.0.0.1 due to NAT. Enable via ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1.
+func isLocalAddress(ipStr string, allowRFC1918 bool) bool {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return false
@@ -249,11 +277,15 @@ func isLocalAddress(ipStr string) bool {
 		ip = ip4
 	}
 	local := []string{
-		"127.0.0.0/8",    // loopback
-		"::1/128",        // IPv6 loopback
-		"10.0.0.0/8",     // RFC1918 — Docker bridge networks (10.x.x.x)
-		"172.16.0.0/12",  // RFC1918 — Docker default bridge (172.17-31.x.x)
-		"192.168.0.0/16", // RFC1918 — Docker custom networks
+		"127.0.0.0/8", // loopback
+		"::1/128",     // IPv6 loopback
+	}
+	if allowRFC1918 {
+		local = append(local,
+			"10.0.0.0/8",     // RFC1918 — Docker bridge networks
+			"172.16.0.0/12",  // RFC1918 — Docker default bridge
+			"192.168.0.0/16", // RFC1918 — Docker custom networks
+		)
 	}
 	for _, cidr := range local {
 		_, n, _ := net.ParseCIDR(cidr)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -58,6 +58,11 @@ type Config struct {
 	// RAGMaxTokens caps the context window assembled for memory_ask prompt
 	// synthesis. Defaults to 4096. Set via ENGRAM_RAG_MAX_TOKENS env var.
 	RAGMaxTokens int
+	// AllowRFC1918SetupToken extends /setup-token access to RFC1918 private
+	// addresses (10.x, 172.16-31.x, 192.168.x) in addition to loopback.
+	// Required for Docker setups where the host appears as a bridge IP.
+	// Set via ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1.
+	AllowRFC1918SetupToken bool
 	claudeClient *claude.Client // set via Server.SetClaudeClient
 }
 

--- a/internal/reembed/worker.go
+++ b/internal/reembed/worker.go
@@ -48,11 +48,17 @@ func NewWorkerFromMeta(ctx context.Context, backend db.Backend, embedder embed.C
 
 // Start launches the background goroutine if active.
 func (w *Worker) Start() {
+	w.StartWithContext(context.Background())
+}
+
+// StartWithContext launches the background goroutine using ctx as the parent
+// lifecycle context. The worker stops when ctx is cancelled.
+func (w *Worker) StartWithContext(ctx context.Context) {
 	if !w.active {
 		close(w.done)
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
 	go w.run(ctx)
 }
@@ -82,7 +88,12 @@ func (w *Worker) run(ctx context.Context) {
 			return
 		}
 		if done {
-			_ = w.backend.SetMeta(ctx, w.project, "embedding_migration_in_progress", "false")
+			// ctx is already cancelled here; use a fresh context for the flag write.
+			flagCtx, flagCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer flagCancel()
+			if err := w.backend.SetMeta(flagCtx, w.project, "embedding_migration_in_progress", "false"); err != nil {
+				slog.Warn("reembed: failed to clear migration flag", "project", w.project, "err", err)
+			}
 			slog.Info("reembed complete", "project", w.project)
 			return
 		}

--- a/internal/search/decay.go
+++ b/internal/search/decay.go
@@ -42,7 +42,13 @@ func NewDecayWorker(backend db.Backend, project string, interval time.Duration) 
 
 // Start launches the background decay goroutine.
 func (w *DecayWorker) Start() {
-	ctx, cancel := context.WithCancel(context.Background())
+	w.StartWithContext(context.Background())
+}
+
+// StartWithContext launches the background decay goroutine using ctx as the
+// parent lifecycle context. The worker stops when ctx is cancelled.
+func (w *DecayWorker) StartWithContext(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
 	go w.run(ctx)
 }
@@ -61,11 +67,6 @@ func (w *DecayWorker) Stop() {
 
 func (w *DecayWorker) run(ctx context.Context) {
 	defer close(w.done)
-	defer func() {
-		if r := recover(); r != nil {
-			slog.Error("decay worker panic", "project", w.project, "panic", r)
-		}
-	}()
 
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
@@ -75,9 +76,21 @@ func (w *DecayWorker) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			w.runOnce(ctx)
+			w.safeRunOnce(ctx)
 		}
 	}
+}
+
+// safeRunOnce wraps runOnce with per-iteration panic recovery so a single bad
+// row cannot kill the worker goroutine permanently.
+func (w *DecayWorker) safeRunOnce(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("decay worker panic — will retry next tick",
+				"project", w.project, "panic", r)
+		}
+	}()
+	w.runOnce(ctx)
 }
 
 func (w *DecayWorker) runOnce(ctx context.Context) {

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -125,6 +125,7 @@ type SearchEngine struct {
 	embedder   embed.Client
 	project    string
 	ollamaURL  string
+	ctx        context.Context // parent lifecycle context — passed to workers via StartWithContext
 	summarizer *summarize.Worker
 	reembedder *reembed.Worker
 	decayer    *DecayWorker
@@ -153,19 +154,20 @@ func New(ctx context.Context, backend db.Backend, embedder embed.Client, project
 	claudeClient summarize.ClaudeCompleter, decayInterval time.Duration) *SearchEngine {
 
 	sum := summarize.NewWorkerWithClaude(backend, project, ollamaURL, summarizeModel, summarizeEnabled, claudeClient)
-	sum.Start()
+	sum.StartWithContext(ctx)
 
 	reb := reembed.NewWorkerFromMeta(ctx, backend, embedder, project)
-	reb.Start()
+	reb.StartWithContext(ctx)
 
 	dec := NewDecayWorker(backend, project, decayInterval)
-	dec.Start()
+	dec.StartWithContext(ctx)
 
 	return &SearchEngine{
 		backend:    backend,
 		embedder:   embedder,
 		project:    project,
 		ollamaURL:  ollamaURL,
+		ctx:        ctx,
 		summarizer: sum,
 		reembedder: reb,
 		decayer:    dec,
@@ -456,7 +458,10 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	ftsCh := make(chan ftsResult, 1)
 	go func() {
 		res, err := e.backend.FTSSearch(ctx, e.project, query, topK*3, nil, nil)
-		ftsCh <- ftsResult{res, err}
+		select {
+		case ftsCh <- ftsResult{res, err}:
+		case <-ctx.Done():
+		}
 	}()
 
 	// Build per-memory best cosine from vector hits.
@@ -495,7 +500,12 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	}
 
 	// Merge FTS results.
-	ftsRes := <-ftsCh
+	var ftsRes ftsResult
+	select {
+	case ftsRes = <-ftsCh:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	if ftsRes.err != nil {
 		return nil, ftsRes.err
 	}
@@ -991,6 +1001,7 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 	// and never runs because its done channel was already closed at construction.
 	e.reembedder.Stop()
 
+	// ctx is used only for the startup probe; the returned client is context-independent.
 	newEmbedder, err := embed.NewOllamaClient(ctx, e.ollamaURL, newModel)
 	if err != nil {
 		return nil, fmt.Errorf("create embedder for new model %q: %w", newModel, err)
@@ -1000,7 +1011,7 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 	e.embedMu.Unlock()
 
 	e.reembedder = reembed.NewWorker(e.backend, newEmbedder, e.project, true)
-	e.reembedder.Start()
+	e.reembedder.StartWithContext(e.ctx)
 
 	return map[string]any{
 		"chunks_nulled": nulled,

--- a/internal/summarize/worker.go
+++ b/internal/summarize/worker.go
@@ -193,11 +193,17 @@ func NewWorkerWithClaude(backend db.Backend, project, ollamaURL, model string, e
 
 // Start launches the background goroutine. Safe to call if disabled.
 func (w *Worker) Start() {
+	w.StartWithContext(context.Background())
+}
+
+// StartWithContext launches the background goroutine using ctx as the parent
+// lifecycle context. The worker stops when ctx is cancelled.
+func (w *Worker) StartWithContext(ctx context.Context) {
 	if !w.enabled {
 		close(w.done)
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
 	go w.run(ctx)
 }


### PR DESCRIPTION
## Summary

Fixes all 14 issues filed from the three-reviewer adversarial audit (Rickover #213–226). Grouped into four batches:

**Batch 1 — Structural**
- **#219** `StartWithContext(ctx)` added to summarize, reembed, and decay workers; `SearchEngine` stores parent ctx and passes it to workers at construction
- **#218** Reembed migration flag write now uses a fresh 10s context (the old ctx is cancelled by the time this line runs); error is logged instead of swallowed
- **#216** Rate limiter eviction goroutine now exits on `ctx.Done()` via `evictLoop(ctx)` + pure `evict()` helper
- **#220** Background upload-session TTL sweeper added to `Server.Start()` — evicts stale sessions every 5 min, stops on `ctx.Done()`
- **#213, #221** Pool evict-before-create: `if` → `for` loop; deterministic LRU tie-break by key; doc comment corrected (100–500 connections)

**Batch 2 — Security**
- **#215** `/setup-token` is now loopback-only by default. RFC1918 access requires `ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1`. `docker-compose.yml` sets this flag; README documents the change.
- **#226** `upload_id` validated against `^[a-zA-Z0-9_\-\.]+$` before session creation

**Batch 3 — Error handling**
- **#217** Silent `_ = json.Unmarshal(tags, ...)` replaced with `slog.Warn` + `[]string{}` fallback in two DB row mappers
- **#222** `handleCheckConstraints` and `handleVerifyBeforeActing` return `mcpgo.NewToolResultError` (tool-level error) for missing `proposed_action` instead of a bare `fmt.Errorf` (server-level error)

**Batch 4 — Polish**
- **#224** Decay worker gets per-iteration `safeRunOnce` panic recovery — one bad row can no longer kill the worker permanently
- **#223** FTS goroutine uses `select { case ftsCh <- …: case <-ctx.Done(): }` in both send and receive paths
- **#225** `SET LOCAL lock_timeout` before `pg_advisory_lock` — timeout respects `ctx.Deadline()`
- **#222 polish** `elevateDecision` rank map promoted to package-level `var` (one alloc per call → zero)
- **#214** Confirmed LOW severity — `embed.NewOllamaClient` uses ctx only for probe; clarifying comment added at call site; issue closed

## Test plan

- [ ] `go test ./... -count=1 -race` — all 17 packages pass ✅
- [ ] `go vet ./...` — clean ✅
- [ ] Docker smoke: start without `ENGRAM_SETUP_TOKEN_ALLOW_RFC1918` → RFC1918 request returns 403
- [ ] Docker smoke: start with `ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1` → `/setup-token` returns token

🤖 Generated with [Claude Code](https://claude.com/claude-code)