### PR TITLE
feat: GraphRAG improvements — entity graph, eval harness, simplified front door (Tasks 1–6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,8 @@ test:
 ## Run the explore-context soak test (50 synthetic questions, p95 iters ≤4, p95 tokens ≤15K)
 test-explore-soak:
 	go test ./bench/... -v -run TestExploreContext -timeout 60s
+
+.PHONY: eval
+## Run retrieval evaluation harness
+eval:
+	go run ./cmd/eval/main.go $(EVAL_ARGS)

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -18,9 +18,11 @@ import (
 	"github.com/petersimmons1972/engram/internal/claude"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/entity"
 	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/summarize"
+	"github.com/petersimmons1972/engram/internal/types"
 
 	// Register pprof HTTP handlers at /debug/pprof/ (localhost only).
 	_ "net/http/pprof"
@@ -172,6 +174,39 @@ func run() error {
 			"rerank", *claudeRerank)
 	}
 
+	// Start entity extraction worker if Claude is enabled and projects are configured.
+	// The worker polls each project's extraction job queue and runs Claude to identify
+	// named entities and relations, building the GraphRAG entity index.
+	entityProjects := strings.Split(envOr("ENGRAM_ENTITY_PROJECTS", ""), ",")
+	filteredProjects := entityProjects[:0]
+	for _, p := range entityProjects {
+		if p != "" {
+			filteredProjects = append(filteredProjects, p)
+		}
+	}
+	entityProjects = filteredProjects
+
+	if cc != nil && len(entityProjects) > 0 {
+		for _, proj := range entityProjects {
+			proj := proj // capture for goroutine
+			entityBackend, err := db.NewPostgresBackend(ctx, proj, dsn)
+			if err != nil {
+				slog.Warn("entity worker: could not open backend, skipping project",
+					"project", proj, "err", err)
+				continue
+			}
+			adapter := &entityDBAdapter{backend: entityBackend}
+			extractor := entity.NewClaudeExtractor(cc)
+			w := entity.NewWorker(adapter, extractor, entity.WorkerConfig{
+				Projects:     []string{proj},
+				PollInterval: time.Duration(envInt("ENGRAM_ENTITY_POLL_SECONDS", 5)) * time.Second,
+				BatchSize:    envInt("ENGRAM_ENTITY_BATCH_SIZE", 10),
+			})
+			go w.Run(ctx)
+			slog.Info("entity extraction worker started", "project", proj)
+		}
+	}
+
 	// Start pprof profiling server on localhost:6060.
 	// Bound to loopback only — not reachable from outside the host.
 	// Requires no auth because it's loopback-only and the API key protects
@@ -262,4 +297,41 @@ func envDuration(key string, def time.Duration) time.Duration {
 		}
 	}
 	return def
+}
+
+// entityDBAdapter adapts db.Backend to entity.WorkerBackend.
+// The only mismatch between the two interfaces is ClaimExtractionJobs:
+// db.Backend returns []db.ExtractionJob, while entity.WorkerBackend returns
+// []entity.ExtractionJob. Both types have identical fields (ID, MemoryID,
+// Project). All other methods are signature-compatible.
+type entityDBAdapter struct {
+	backend db.Backend
+}
+
+func (a *entityDBAdapter) ClaimExtractionJobs(ctx context.Context, project string, limit int) ([]entity.ExtractionJob, error) {
+	dbJobs, err := a.backend.ClaimExtractionJobs(ctx, project, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]entity.ExtractionJob, len(dbJobs))
+	for i, j := range dbJobs {
+		out[i] = entity.ExtractionJob{ID: j.ID, MemoryID: j.MemoryID, Project: j.Project}
+	}
+	return out, nil
+}
+
+func (a *entityDBAdapter) CompleteExtractionJob(ctx context.Context, jobID string, err error) error {
+	return a.backend.CompleteExtractionJob(ctx, jobID, err)
+}
+
+func (a *entityDBAdapter) GetMemory(ctx context.Context, id string) (*types.Memory, error) {
+	return a.backend.GetMemory(ctx, id)
+}
+
+func (a *entityDBAdapter) GetEntitiesByProject(ctx context.Context, project string) ([]entity.Entity, error) {
+	return a.backend.GetEntitiesByProject(ctx, project)
+}
+
+func (a *entityDBAdapter) UpsertEntity(ctx context.Context, e *entity.Entity) (string, error) {
+	return a.backend.UpsertEntity(ctx, e)
 }

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -1,0 +1,46 @@
+// engram-eval runs golden-set retrieval evaluation.
+// Usage: engram-eval -golden golden.json -k 5
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/petersimmons1972/engram/internal/eval"
+)
+
+type goldenEntry struct {
+	Query       string   `json:"query"`
+	RelevantIDs []string `json:"relevant_ids"`
+}
+
+func main() {
+	goldenFile := flag.String("golden", "", "Path to golden set JSON file")
+	k := flag.Int("k", 5, "k for precision@k and NDCG@k")
+	flag.Parse()
+
+	if *goldenFile == "" {
+		log.Fatal("--golden required")
+	}
+
+	data, err := os.ReadFile(*goldenFile)
+	if err != nil {
+		log.Fatalf("read golden file: %v", err)
+	}
+	var golden []goldenEntry
+	if err := json.Unmarshal(data, &golden); err != nil {
+		log.Fatalf("parse golden file: %v", err)
+	}
+
+	fmt.Printf("Loaded %d golden queries. k=%d\n", len(golden), *k)
+	fmt.Printf("Metrics: precision@%d, MRR, NDCG@%d\n", *k, *k)
+	fmt.Println("Wire to a live engram-go instance via ENGRAM_URL env var for full evaluation.")
+
+	// Verify metric functions compile correctly.
+	_ = eval.PrecisionAtK
+	_ = eval.MRR
+	_ = eval.NDCG
+}

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -1,13 +1,20 @@
-// engram-eval runs golden-set retrieval evaluation.
-// Usage: engram-eval -golden golden.json -k 5
+// engram-eval runs golden-set retrieval evaluation against a live engram-go MCP server.
+// Usage: engram-eval -golden golden.json -k 5 -project default
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/petersimmons1972/engram/internal/eval"
 )
@@ -17,15 +24,42 @@ type goldenEntry struct {
 	RelevantIDs []string `json:"relevant_ids"`
 }
 
+// recallResponse mirrors the JSON shape returned by memory_recall.
+type recallResponse struct {
+	Results []struct {
+		Memory struct {
+			ID string `json:"id"`
+		} `json:"memory"`
+		Score float64 `json:"score"`
+	} `json:"results"`
+	Count int `json:"count"`
+}
+
 func main() {
-	goldenFile := flag.String("golden", "", "Path to golden set JSON file")
+	goldenFile := flag.String("golden", "", "Path to golden set JSON file (required)")
 	k := flag.Int("k", 5, "k for precision@k and NDCG@k")
+	project := flag.String("project", "default", "Engram project name to query")
+	outputFile := flag.String("output", "", "Write baseline summary to this file (optional)")
+	urlFlag := flag.String("url", "", "Override ENGRAM_URL env var")
+	apiKeyFlag := flag.String("api-key", "", "Override ENGRAM_API_KEY env var")
 	flag.Parse()
 
 	if *goldenFile == "" {
-		log.Fatal("--golden required")
+		log.Fatal("--golden is required")
 	}
 
+	// Resolve server URL and credentials — flags beat env vars.
+	serverURL := envOr("ENGRAM_URL", "http://localhost:8788")
+	if *urlFlag != "" {
+		serverURL = *urlFlag
+	}
+	apiKey := os.Getenv("ENGRAM_API_KEY")
+	if *apiKeyFlag != "" {
+		apiKey = *apiKeyFlag
+	}
+	provider := envOr("ENGRAM_EMBED_PROVIDER", "ollama")
+
+	// Load golden set.
 	data, err := os.ReadFile(*goldenFile)
 	if err != nil {
 		log.Fatalf("read golden file: %v", err)
@@ -34,13 +68,153 @@ func main() {
 	if err := json.Unmarshal(data, &golden); err != nil {
 		log.Fatalf("parse golden file: %v", err)
 	}
+	if len(golden) == 0 {
+		log.Fatal("golden set is empty")
+	}
 
-	fmt.Printf("Loaded %d golden queries. k=%d\n", len(golden), *k)
-	fmt.Printf("Metrics: precision@%d, MRR, NDCG@%d\n", *k, *k)
-	fmt.Println("Wire to a live engram-go instance via ENGRAM_URL env var for full evaluation.")
+	// Connect to MCP server via SSE.
+	sseURL := strings.TrimRight(serverURL, "/") + "/sse"
 
-	// Verify metric functions compile correctly.
-	_ = eval.PrecisionAtK
-	_ = eval.MRR
-	_ = eval.NDCG
+	headers := map[string]string{}
+	if apiKey != "" {
+		headers["Authorization"] = "Bearer " + apiKey
+	}
+
+	mcpClient, err := client.NewSSEMCPClient(sseURL, transport.WithHeaders(headers))
+	if err != nil {
+		log.Fatalf("create SSE client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if err := mcpClient.Start(ctx); err != nil {
+		log.Fatalf("start SSE client: %v", err)
+	}
+
+	_, err = mcpClient.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "engram-eval",
+				Version: "1.0.0",
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("initialize MCP session: %v", err)
+	}
+
+	// Run evaluation.
+	total := len(golden)
+	var sumP, sumMRR, sumNDCG float64
+
+	for i, entry := range golden {
+		ids, callErr := recallIDs(ctx, mcpClient, entry.Query, *project, *k)
+		if callErr != nil {
+			// Log warning and count this query as all-zeros — do not abort.
+			log.Printf("WARN [%d/%d] memory_recall failed for %q: %v", i+1, total, entry.Query, callErr)
+			fmt.Printf("[%d/%d] %q -> P@%d=0.00 MRR=0.00 NDCG@%d=0.00  (recall error)\n",
+				i+1, total, entry.Query, *k, *k)
+			continue
+		}
+
+		relevantSet := make(map[string]bool, len(entry.RelevantIDs))
+		for _, id := range entry.RelevantIDs {
+			relevantSet[id] = true
+		}
+
+		p := eval.PrecisionAtK(ids, relevantSet, *k)
+		mrr := eval.MRR(ids, relevantSet)
+		ndcg := eval.NDCG(ids, relevantSet, *k)
+
+		sumP += p
+		sumMRR += mrr
+		sumNDCG += ndcg
+
+		fmt.Printf("[%d/%d] %q -> P@%d=%.2f MRR=%.2f NDCG@%d=%.2f\n",
+			i+1, total, entry.Query, *k, p, mrr, *k, ndcg)
+	}
+
+	avgP := sumP / float64(total)
+	avgMRR := sumMRR / float64(total)
+	avgNDCG := sumNDCG / float64(total)
+
+	summary := buildSummary(total, *k, avgP, avgMRR, avgNDCG, provider, *outputFile)
+	fmt.Println(summary)
+
+	if *outputFile != "" {
+		if writeErr := os.WriteFile(*outputFile, []byte(summary), 0o644); writeErr != nil {
+			log.Printf("WARN failed to write output file %q: %v", *outputFile, writeErr)
+		}
+	}
+}
+
+// recallIDs calls memory_recall and returns the ordered list of memory IDs.
+func recallIDs(ctx context.Context, c *client.Client, query, project string, k int) ([]string, error) {
+	result, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "memory_recall",
+			Arguments: map[string]any{
+				"query":   query,
+				"project": project,
+				"top_k":   k,
+				"detail":  "summary",
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CallTool: %w", err)
+	}
+	if result.IsError {
+		// Surface tool-level error text for diagnostics.
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(mcp.TextContent); ok {
+				return nil, fmt.Errorf("tool error: %s", tc.Text)
+			}
+		}
+		return nil, fmt.Errorf("tool returned IsError=true")
+	}
+	if len(result.Content) == 0 {
+		return nil, fmt.Errorf("tool returned no content")
+	}
+
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return nil, fmt.Errorf("expected TextContent, got %T", result.Content[0])
+	}
+
+	var resp recallResponse
+	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
+		return nil, fmt.Errorf("parse recall response: %w", err)
+	}
+
+	ids := make([]string, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		ids = append(ids, r.Memory.ID)
+	}
+	return ids, nil
+}
+
+// buildSummary formats the final evaluation summary block.
+func buildSummary(total, k int, avgP, avgMRR, avgNDCG float64, provider, outputFile string) string {
+	var sb strings.Builder
+	sb.WriteString("--- Evaluation Summary ---\n")
+	fmt.Fprintf(&sb, "Queries:      %d\n", total)
+	fmt.Fprintf(&sb, "Avg P@%d:      %.2f\n", k, avgP)
+	fmt.Fprintf(&sb, "Avg MRR:      %.2f\n", avgMRR)
+	fmt.Fprintf(&sb, "Avg NDCG@%d:   %.2f\n", k, avgNDCG)
+	fmt.Fprintf(&sb, "Provider:     %s\n", provider)
+	if outputFile != "" {
+		fmt.Fprintf(&sb, "Written to:   %s\n", outputFile)
+	}
+	return sb.String()
+}
+
+// envOr returns the value of the named env var, or fallback when unset/empty.
+func envOr(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
 }

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -6,8 +6,16 @@ import (
 	"context"
 	"time"
 
+	"github.com/petersimmons1972/engram/internal/entity"
 	"github.com/petersimmons1972/engram/internal/types"
 )
+
+// ExtractionJob is a pending entity extraction task.
+type ExtractionJob struct {
+	ID       string
+	MemoryID string
+	Project  string
+}
 
 // Backend is the storage interface for the Engram memory system.
 // All implementations must be safe for concurrent use from multiple goroutines.
@@ -262,6 +270,20 @@ type Backend interface {
 	// SetMemoryDocumentID links a memory to a document by setting
 	// memories.document_id = documentID.
 	SetMemoryDocumentID(ctx context.Context, memoryID, documentID string) error
+
+	// ── Entity graph ─────────────────────────────────────────────────────────
+
+	// UpsertEntity inserts or updates a canonical entity. Returns the entity ID.
+	UpsertEntity(ctx context.Context, e *entity.Entity) (id string, err error)
+	// GetEntitiesByProject returns all canonical entities for a project.
+	GetEntitiesByProject(ctx context.Context, project string) ([]entity.Entity, error)
+	// EnqueueExtractionJob enqueues a pending entity extraction task for a memory.
+	EnqueueExtractionJob(ctx context.Context, memoryID, project string) error
+	// ClaimExtractionJobs atomically claims up to limit pending extraction jobs
+	// for a project, marking them as processing.
+	ClaimExtractionJobs(ctx context.Context, project string, limit int) ([]ExtractionJob, error)
+	// CompleteExtractionJob marks an extraction job done (jobErr == nil) or failed.
+	CompleteExtractionJob(ctx context.Context, jobID string, err error) error
 
 	// ── Transactions ────────────────────────────────────────────────────────
 

--- a/internal/db/postgres_entity.go
+++ b/internal/db/postgres_entity.go
@@ -12,13 +12,19 @@ func (p *PostgresBackend) UpsertEntity(ctx context.Context, e *entity.Entity) (s
 	if e.ID == "" {
 		e.ID = uuid.New().String()
 	}
-	_, err := p.pool.Exec(ctx, `
+	var id string
+	err := p.pool.QueryRow(ctx, `
 		INSERT INTO canonical_entities (id, name, aliases, project, updated_at)
 		VALUES ($1, $2, $3, $4, NOW())
-		ON CONFLICT (id) DO UPDATE
-			SET aliases = $3, updated_at = NOW()`,
-		e.ID, e.Name, e.Aliases, e.Project)
-	return e.ID, err
+		ON CONFLICT (project, lower(name)) DO UPDATE
+			SET aliases = EXCLUDED.aliases, updated_at = NOW()
+		RETURNING id`,
+		e.ID, e.Name, e.Aliases, e.Project).Scan(&id)
+	if err != nil {
+		return "", err
+	}
+	e.ID = id
+	return id, nil
 }
 
 func (p *PostgresBackend) GetEntitiesByProject(ctx context.Context, project string) ([]entity.Entity, error) {
@@ -41,9 +47,10 @@ func (p *PostgresBackend) GetEntitiesByProject(ctx context.Context, project stri
 }
 
 func (p *PostgresBackend) EnqueueExtractionJob(ctx context.Context, memoryID, project string) error {
-	_, err := p.pool.Exec(ctx,
-		`INSERT INTO entity_extraction_jobs (id, memory_id, project) VALUES ($1, $2, $3)
-		 ON CONFLICT DO NOTHING`,
+	_, err := p.pool.Exec(ctx, `
+		INSERT INTO entity_extraction_jobs (id, memory_id, project)
+		VALUES ($1, $2, $3)
+		ON CONFLICT ON CONSTRAINT uq_entity_jobs_pending DO NOTHING`,
 		uuid.New().String(), memoryID, project)
 	return err
 }
@@ -75,18 +82,23 @@ func (p *PostgresBackend) ClaimExtractionJobs(ctx context.Context, project strin
 	return jobs, rows.Err()
 }
 
+func truncateString(s string, maxRunes int) string {
+	r := []rune(s)
+	if len(r) > maxRunes {
+		return string(r[:maxRunes])
+	}
+	return s
+}
+
 func (p *PostgresBackend) CompleteExtractionJob(ctx context.Context, jobID string, jobErr error) error {
 	errMsg := ""
 	status := "done"
 	if jobErr != nil {
-		errMsg = jobErr.Error()
-		if len(errMsg) > 500 {
-			errMsg = errMsg[:500]
-		}
+		errMsg = truncateString(strings.TrimSpace(jobErr.Error()), 500)
 		status = "failed"
 	}
 	_, err := p.pool.Exec(ctx,
 		`UPDATE entity_extraction_jobs SET status=$1, error=$2, processed_at=NOW() WHERE id=$3`,
-		status, strings.TrimSpace(errMsg), jobID)
+		status, errMsg, jobID)
 	return err
 }

--- a/internal/db/postgres_entity.go
+++ b/internal/db/postgres_entity.go
@@ -17,7 +17,8 @@ func (p *PostgresBackend) UpsertEntity(ctx context.Context, e *entity.Entity) (s
 		INSERT INTO canonical_entities (id, name, aliases, project, updated_at)
 		VALUES ($1, $2, $3, $4, NOW())
 		ON CONFLICT (project, lower(name)) DO UPDATE
-			SET aliases = EXCLUDED.aliases, updated_at = NOW()
+			SET aliases = ARRAY(SELECT DISTINCT unnest(canonical_entities.aliases || EXCLUDED.aliases)),
+			    updated_at = NOW()
 		RETURNING id`,
 		e.ID, e.Name, e.Aliases, e.Project).Scan(&id)
 	if err != nil {

--- a/internal/db/postgres_entity.go
+++ b/internal/db/postgres_entity.go
@@ -1,0 +1,92 @@
+package db
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/petersimmons1972/engram/internal/entity"
+)
+
+func (p *PostgresBackend) UpsertEntity(ctx context.Context, e *entity.Entity) (string, error) {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+	_, err := p.pool.Exec(ctx, `
+		INSERT INTO canonical_entities (id, name, aliases, project, updated_at)
+		VALUES ($1, $2, $3, $4, NOW())
+		ON CONFLICT (id) DO UPDATE
+			SET aliases = $3, updated_at = NOW()`,
+		e.ID, e.Name, e.Aliases, e.Project)
+	return e.ID, err
+}
+
+func (p *PostgresBackend) GetEntitiesByProject(ctx context.Context, project string) ([]entity.Entity, error) {
+	rows, err := p.pool.Query(ctx,
+		`SELECT id, name, aliases, project FROM canonical_entities WHERE project = $1`,
+		project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var entities []entity.Entity
+	for rows.Next() {
+		var e entity.Entity
+		if err := rows.Scan(&e.ID, &e.Name, &e.Aliases, &e.Project); err != nil {
+			return nil, err
+		}
+		entities = append(entities, e)
+	}
+	return entities, rows.Err()
+}
+
+func (p *PostgresBackend) EnqueueExtractionJob(ctx context.Context, memoryID, project string) error {
+	_, err := p.pool.Exec(ctx,
+		`INSERT INTO entity_extraction_jobs (id, memory_id, project) VALUES ($1, $2, $3)
+		 ON CONFLICT DO NOTHING`,
+		uuid.New().String(), memoryID, project)
+	return err
+}
+
+func (p *PostgresBackend) ClaimExtractionJobs(ctx context.Context, project string, limit int) ([]ExtractionJob, error) {
+	rows, err := p.pool.Query(ctx, `
+		UPDATE entity_extraction_jobs
+		SET status = 'processing'
+		WHERE id IN (
+			SELECT id FROM entity_extraction_jobs
+			WHERE project = $1 AND status = 'pending'
+			ORDER BY created_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING id, memory_id, project`, project, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var jobs []ExtractionJob
+	for rows.Next() {
+		var j ExtractionJob
+		if err := rows.Scan(&j.ID, &j.MemoryID, &j.Project); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs, rows.Err()
+}
+
+func (p *PostgresBackend) CompleteExtractionJob(ctx context.Context, jobID string, jobErr error) error {
+	errMsg := ""
+	status := "done"
+	if jobErr != nil {
+		errMsg = jobErr.Error()
+		if len(errMsg) > 500 {
+			errMsg = errMsg[:500]
+		}
+		status = "failed"
+	}
+	_, err := p.pool.Exec(ctx,
+		`UPDATE entity_extraction_jobs SET status=$1, error=$2, processed_at=NOW() WHERE id=$3`,
+		status, strings.TrimSpace(errMsg), jobID)
+	return err
+}

--- a/internal/entity/dedup.go
+++ b/internal/entity/dedup.go
@@ -41,9 +41,8 @@ func Deduplicate(existing []Entity, candidates []Entity) (merged []Entity, fresh
 				updated[idx] = ent
 			}
 			mergedSet[idx] = true
-		} else if fi, seen := freshIndex[key]; seen {
-			// Duplicate new candidate: merge aliases into the existing fresh entry.
-			_ = fi // no alias field on candidate in this design; skip
+		} else if _, seen := freshIndex[key]; seen {
+			// Duplicate new candidate already in fresh — skip.
 		} else {
 			fresh = append(fresh, c)
 			freshIndex[key] = len(fresh) - 1

--- a/internal/entity/dedup.go
+++ b/internal/entity/dedup.go
@@ -1,0 +1,44 @@
+package entity
+
+import "strings"
+
+// Deduplicate matches candidates against existing entities by name/alias (case-insensitive).
+// Returns (updated existing entities that matched, genuinely new entities).
+func Deduplicate(existing []Entity, candidates []Entity) (merged []Entity, fresh []Entity) {
+	index := make(map[string]int, len(existing)*3)
+	for i, e := range existing {
+		index[strings.ToLower(e.Name)] = i
+		for _, a := range e.Aliases {
+			index[strings.ToLower(a)] = i
+		}
+	}
+
+	updated := make([]Entity, len(existing))
+	copy(updated, existing)
+
+	for _, c := range candidates {
+		key := strings.ToLower(c.Name)
+		if idx, ok := index[key]; ok {
+			ent := updated[idx]
+			if !containsAlias(ent.Aliases, c.Name) && strings.ToLower(ent.Name) != key {
+				ent.Aliases = append(ent.Aliases, c.Name)
+				updated[idx] = ent
+			}
+			merged = append(merged, updated[idx])
+		} else {
+			fresh = append(fresh, c)
+			index[key] = -1
+		}
+	}
+	return merged, fresh
+}
+
+func containsAlias(aliases []string, name string) bool {
+	lower := strings.ToLower(name)
+	for _, a := range aliases {
+		if strings.ToLower(a) == lower {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/entity/dedup.go
+++ b/internal/entity/dedup.go
@@ -5,6 +5,7 @@ import "strings"
 // Deduplicate matches candidates against existing entities by name/alias (case-insensitive).
 // Returns (updated existing entities that matched, genuinely new entities).
 func Deduplicate(existing []Entity, candidates []Entity) (merged []Entity, fresh []Entity) {
+	// Build case-insensitive lookup: lower(name/alias) → index in existing
 	index := make(map[string]int, len(existing)*3)
 	for i, e := range existing {
 		index[strings.ToLower(e.Name)] = i
@@ -13,22 +14,45 @@ func Deduplicate(existing []Entity, candidates []Entity) (merged []Entity, fresh
 		}
 	}
 
+	// Deep-copy existing so we can mutate Aliases without aliasing the caller's slices.
 	updated := make([]Entity, len(existing))
 	copy(updated, existing)
+	for i := range updated {
+		src := existing[i].Aliases
+		if len(src) > 0 {
+			dst := make([]string, len(src))
+			copy(dst, src)
+			updated[i].Aliases = dst
+		}
+	}
+
+	// Track which existing indices were matched (for dedup of merged return).
+	mergedSet := make(map[int]bool)
+	// Track which new names were already added to fresh (key → index in fresh).
+	freshIndex := make(map[string]int)
 
 	for _, c := range candidates {
 		key := strings.ToLower(c.Name)
 		if idx, ok := index[key]; ok {
+			// Matched an existing entity.
 			ent := updated[idx]
 			if !containsAlias(ent.Aliases, c.Name) && strings.ToLower(ent.Name) != key {
 				ent.Aliases = append(ent.Aliases, c.Name)
 				updated[idx] = ent
 			}
-			merged = append(merged, updated[idx])
+			mergedSet[idx] = true
+		} else if fi, seen := freshIndex[key]; seen {
+			// Duplicate new candidate: merge aliases into the existing fresh entry.
+			_ = fi // no alias field on candidate in this design; skip
 		} else {
 			fresh = append(fresh, c)
-			index[key] = -1
+			freshIndex[key] = len(fresh) - 1
 		}
+	}
+
+	// Collect merged results once per matched existing entity (no duplicates).
+	for idx := range mergedSet {
+		merged = append(merged, updated[idx])
 	}
 	return merged, fresh
 }

--- a/internal/entity/dedup_test.go
+++ b/internal/entity/dedup_test.go
@@ -1,0 +1,44 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/petersimmons1972/engram/internal/entity"
+)
+
+func TestDedup_ExactMatch(t *testing.T) {
+	existing := []entity.Entity{{ID: "e1", Name: "New York City", Aliases: []string{"NYC"}}}
+	candidates := []entity.Entity{{Name: "NYC"}}
+	merged, fresh := entity.Deduplicate(existing, candidates)
+	assert.Len(t, fresh, 0)
+	assert.Len(t, merged, 1)
+	assert.Contains(t, merged[0].Aliases, "NYC")
+	assert.Equal(t, "e1", merged[0].ID)
+}
+
+func TestDedup_NewEntity(t *testing.T) {
+	existing := []entity.Entity{}
+	candidates := []entity.Entity{{Name: "Amazon"}}
+	merged, fresh := entity.Deduplicate(existing, candidates)
+	assert.Len(t, fresh, 1)
+	assert.Equal(t, "Amazon", fresh[0].Name)
+	assert.Len(t, merged, 0)
+}
+
+func TestDedup_NormalizationMatch(t *testing.T) {
+	existing := []entity.Entity{{ID: "e2", Name: "openai", Aliases: []string{}}}
+	candidates := []entity.Entity{{Name: "OpenAI"}}
+	merged, fresh := entity.Deduplicate(existing, candidates)
+	assert.Len(t, fresh, 0)
+	assert.Len(t, merged, 1)
+	assert.Equal(t, "e2", merged[0].ID)
+}
+
+func TestDedup_AliasMatch(t *testing.T) {
+	existing := []entity.Entity{{ID: "e3", Name: "Kubernetes", Aliases: []string{"k8s", "kube"}}}
+	candidates := []entity.Entity{{Name: "kube"}}
+	merged, fresh := entity.Deduplicate(existing, candidates)
+	assert.Len(t, fresh, 0)
+	assert.Equal(t, "e3", merged[0].ID)
+}

--- a/internal/entity/dedup_test.go
+++ b/internal/entity/dedup_test.go
@@ -42,3 +42,36 @@ func TestDedup_AliasMatch(t *testing.T) {
 	assert.Len(t, fresh, 0)
 	assert.Equal(t, "e3", merged[0].ID)
 }
+
+func TestDedup_DuplicateCandidatesBatch(t *testing.T) {
+	// Two candidates with same name, both new — must not panic, fresh has 1 entry.
+	existing := []entity.Entity{}
+	candidates := []entity.Entity{{Name: "Amazon"}, {Name: "amazon"}}
+	merged, fresh := entity.Deduplicate(existing, candidates)
+	assert.Len(t, merged, 0)
+	assert.Len(t, fresh, 1, "duplicate new candidates should collapse to one fresh entry")
+}
+
+func TestDedup_EmptyInputs(t *testing.T) {
+	merged, fresh := entity.Deduplicate(nil, nil)
+	assert.Nil(t, merged)
+	assert.Nil(t, fresh)
+}
+
+func TestDedup_SliceAliasIsolation(t *testing.T) {
+	// Caller's existing aliases slice must not be mutated.
+	original := []string{"NYC"}
+	existing := []entity.Entity{{ID: "e1", Name: "New York City", Aliases: original}}
+	candidates := []entity.Entity{{Name: "Big Apple"}}
+	entity.Deduplicate(existing, candidates)
+	assert.Equal(t, []string{"NYC"}, original, "caller aliases slice must not be mutated")
+}
+
+func TestDedup_MultiCandidateSameExisting(t *testing.T) {
+	// Two candidates both matching the same existing entity → merged has exactly 1 entry.
+	existing := []entity.Entity{{ID: "e1", Name: "Kubernetes", Aliases: []string{"k8s", "kube"}}}
+	candidates := []entity.Entity{{Name: "k8s"}, {Name: "kube"}}
+	merged, fresh := entity.Deduplicate(existing, candidates)
+	assert.Len(t, fresh, 0)
+	assert.Len(t, merged, 1, "same existing entity matched by two candidates must appear once in merged")
+}

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -1,0 +1,17 @@
+package entity
+
+// Entity is a canonical named concept with zero or more aliases.
+type Entity struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Aliases []string `json:"aliases"`
+	Project string   `json:"project"`
+}
+
+// Relation represents a directed relationship extracted between two entities.
+type Relation struct {
+	SourceName string  `json:"source_name"`
+	TargetName string  `json:"target_name"`
+	RelType    string  `json:"rel_type"`
+	Strength   float64 `json:"strength"`
+}

--- a/internal/entity/extract.go
+++ b/internal/entity/extract.go
@@ -74,8 +74,8 @@ type extractionResponse struct {
 // Extract calls Claude and parses the JSON result into Entity and Relation slices.
 // Content is silently truncated to 4 000 characters before sending.
 func (e *ClaudeExtractor) Extract(ctx context.Context, content string) ([]Entity, []Relation, error) {
-	if len(content) > maxContentChars {
-		content = content[:maxContentChars]
+	if len([]rune(content)) > maxContentChars {
+		content = string([]rune(content)[:maxContentChars])
 	}
 
 	prompt := "Extract entities and relations from the following text:\n\n" + content

--- a/internal/entity/extract.go
+++ b/internal/entity/extract.go
@@ -1,0 +1,131 @@
+package entity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Extractor extracts entities and relations from text.
+type Extractor interface {
+	Extract(ctx context.Context, content string) ([]Entity, []Relation, error)
+}
+
+// ClaudeCompleter is the narrow interface satisfied by *claude.Client.
+// Declared here so the entity package does not import the claude package directly,
+// keeping the dependency direction clean.
+type ClaudeCompleter interface {
+	Complete(ctx context.Context, system, prompt, executorModel, advisorModel string, advisorMaxUses, maxTokens int) (string, error)
+}
+
+// ClaudeExtractor uses a Claude language model to extract entities and
+// relations from freeform text. It truncates input to 4 000 characters before
+// sending so that extraction prompts stay well within the token budget.
+type ClaudeExtractor struct {
+	client ClaudeCompleter
+}
+
+// NewClaudeExtractor returns a ClaudeExtractor backed by client.
+func NewClaudeExtractor(client ClaudeCompleter) *ClaudeExtractor {
+	return &ClaudeExtractor{client: client}
+}
+
+const maxContentChars = 4000
+
+const extractionSystem = `You are an entity and relation extraction assistant.
+Given a passage of text, identify the key named entities (people, organizations,
+technologies, concepts, projects) and the relationships between them.
+
+Return ONLY a JSON object — no prose, no markdown fences — in this exact schema:
+{
+  "entities": [
+    {"name": "<canonical name>", "aliases": ["<alt name>", ...]}
+  ],
+  "relations": [
+    {
+      "source_name": "<entity name>",
+      "target_name": "<entity name>",
+      "rel_type": "relates_to|depends_on|caused_by|supersedes",
+      "strength": <0.0–1.0>
+    }
+  ]
+}
+
+Rules:
+- Use the most specific canonical name you can identify.
+- Only include relations whose source and target appear in the entities list.
+- If there is nothing to extract, return {"entities":[],"relations":[]}.`
+
+// extractionResponse is the JSON structure returned by Claude.
+type extractionResponse struct {
+	Entities []struct {
+		Name    string   `json:"name"`
+		Aliases []string `json:"aliases"`
+	} `json:"entities"`
+	Relations []struct {
+		SourceName string  `json:"source_name"`
+		TargetName string  `json:"target_name"`
+		RelType    string  `json:"rel_type"`
+		Strength   float64 `json:"strength"`
+	} `json:"relations"`
+}
+
+// Extract calls Claude and parses the JSON result into Entity and Relation slices.
+// Content is silently truncated to 4 000 characters before sending.
+func (e *ClaudeExtractor) Extract(ctx context.Context, content string) ([]Entity, []Relation, error) {
+	if len(content) > maxContentChars {
+		content = content[:maxContentChars]
+	}
+
+	prompt := "Extract entities and relations from the following text:\n\n" + content
+
+	raw, err := e.client.Complete(ctx, extractionSystem, prompt,
+		"claude-sonnet-4-6", "claude-opus-4-6", 0, 1024)
+	if err != nil {
+		return nil, nil, fmt.Errorf("entity extraction: claude call failed: %w", err)
+	}
+
+	// Claude sometimes wraps JSON in markdown code fences — strip them.
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "```") {
+		// Remove opening fence (```json or ```)
+		if idx := strings.Index(raw, "\n"); idx != -1 {
+			raw = raw[idx+1:]
+		}
+		// Remove closing fence
+		if idx := strings.LastIndex(raw, "```"); idx != -1 {
+			raw = raw[:idx]
+		}
+		raw = strings.TrimSpace(raw)
+	}
+
+	var resp extractionResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, nil, fmt.Errorf("entity extraction: failed to parse response JSON: %w", err)
+	}
+
+	entities := make([]Entity, 0, len(resp.Entities))
+	for _, re := range resp.Entities {
+		aliases := re.Aliases
+		if aliases == nil {
+			aliases = []string{}
+		}
+		entities = append(entities, Entity{
+			Name:    re.Name,
+			Aliases: aliases,
+		})
+	}
+
+	relations := make([]Relation, 0, len(resp.Relations))
+	for _, rr := range resp.Relations {
+		relations = append(relations, Relation{
+			SourceName: rr.SourceName,
+			TargetName: rr.TargetName,
+			RelType:    rr.RelType,
+			Strength:   rr.Strength,
+		})
+	}
+
+	return entities, relations, nil
+}

--- a/internal/entity/extract_test.go
+++ b/internal/entity/extract_test.go
@@ -1,0 +1,87 @@
+package entity_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/petersimmons1972/engram/internal/entity"
+)
+
+// stubCompleter implements entity.ClaudeCompleter for tests.
+type stubCompleter struct {
+	response string
+	err      error
+}
+
+func (s *stubCompleter) Complete(ctx context.Context, system, prompt, executorModel, advisorModel string, advisorMaxUses, maxTokens int) (string, error) {
+	return s.response, s.err
+}
+
+func TestClaudeExtractor_ParsesEntitiesAndRelations(t *testing.T) {
+	stub := &stubCompleter{
+		response: `{"entities":[{"name":"Kubernetes","aliases":["k8s"]},{"name":"Docker","aliases":[]}],"relations":[{"source_name":"Kubernetes","target_name":"Docker","rel_type":"depends_on","strength":0.9}]}`,
+	}
+	ext := entity.NewClaudeExtractor(stub)
+	entities, relations, err := ext.Extract(context.Background(), "Kubernetes depends on Docker.")
+	require.NoError(t, err)
+	assert.Len(t, entities, 2)
+	assert.Equal(t, "Kubernetes", entities[0].Name)
+	assert.Equal(t, []string{"k8s"}, entities[0].Aliases)
+	assert.Len(t, relations, 1)
+	assert.Equal(t, "depends_on", relations[0].RelType)
+	assert.InDelta(t, 0.9, relations[0].Strength, 0.001)
+}
+
+func TestClaudeExtractor_EmptyContent(t *testing.T) {
+	stub := &stubCompleter{
+		response: `{"entities":[],"relations":[]}`,
+	}
+	ext := entity.NewClaudeExtractor(stub)
+	entities, relations, err := ext.Extract(context.Background(), "")
+	require.NoError(t, err)
+	assert.Empty(t, entities)
+	assert.Empty(t, relations)
+}
+
+func TestClaudeExtractor_APIError(t *testing.T) {
+	stub := &stubCompleter{err: errors.New("api unavailable")}
+	ext := entity.NewClaudeExtractor(stub)
+	_, _, err := ext.Extract(context.Background(), "some content")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "api unavailable")
+}
+
+func TestClaudeExtractor_BadJSON(t *testing.T) {
+	stub := &stubCompleter{response: "not json at all"}
+	ext := entity.NewClaudeExtractor(stub)
+	_, _, err := ext.Extract(context.Background(), "some content")
+	assert.Error(t, err)
+}
+
+func TestClaudeExtractor_TruncatesLongContent(t *testing.T) {
+	// Build content longer than 4000 chars. Verify we don't error on huge input.
+	bigContent := strings.Repeat("a", 8000)
+	stub := &stubCompleter{
+		response: `{"entities":[],"relations":[]}`,
+	}
+	ext := entity.NewClaudeExtractor(stub)
+	_, _, err := ext.Extract(context.Background(), bigContent)
+	require.NoError(t, err)
+}
+
+func TestClaudeExtractor_PartialJSONWrapped(t *testing.T) {
+	// Claude sometimes wraps JSON in markdown code fences.
+	stub := &stubCompleter{
+		response: "```json\n{\"entities\":[{\"name\":\"OpenAI\",\"aliases\":[]}],\"relations\":[]}\n```",
+	}
+	ext := entity.NewClaudeExtractor(stub)
+	entities, _, err := ext.Extract(context.Background(), "OpenAI released GPT-4.")
+	require.NoError(t, err)
+	assert.Len(t, entities, 1)
+	assert.Equal(t, "OpenAI", entities[0].Name)
+}

--- a/internal/entity/worker.go
+++ b/internal/entity/worker.go
@@ -1,0 +1,143 @@
+package entity
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// ExtractionJob is the minimal job descriptor the Worker needs from the database.
+// It mirrors db.ExtractionJob exactly so callers can convert between them without
+// an import of the db package from within the entity package (which would create
+// an import cycle, since db imports entity for the Entity type).
+type ExtractionJob struct {
+	ID       string
+	MemoryID string
+	Project  string
+}
+
+// WorkerBackend is the narrow database interface required by the Worker.
+// It is satisfied by the dbAdapter type in cmd/engram/main.go, and by test
+// stubs, without requiring the entity package to import the db package
+// (which would create an import cycle).
+//
+// Note: UpsertEntity returns (id string, err error) to match db.Backend.
+type WorkerBackend interface {
+	ClaimExtractionJobs(ctx context.Context, project string, limit int) ([]ExtractionJob, error)
+	CompleteExtractionJob(ctx context.Context, jobID string, err error) error
+	GetMemory(ctx context.Context, id string) (*types.Memory, error)
+	GetEntitiesByProject(ctx context.Context, project string) ([]Entity, error)
+	UpsertEntity(ctx context.Context, e *Entity) (string, error)
+}
+
+// WorkerConfig controls how the extraction worker polls the database.
+type WorkerConfig struct {
+	// PollInterval is how often the worker checks for new extraction jobs.
+	// Defaults to 5 seconds if zero.
+	PollInterval time.Duration
+	// BatchSize is the maximum number of jobs claimed per poll tick.
+	// Defaults to 10 if zero.
+	BatchSize int
+	// Projects is the list of project names to poll.
+	Projects []string
+}
+
+// Worker polls the database for pending entity extraction jobs and processes them.
+// It is safe for concurrent use; start exactly one goroutine per Worker via Run.
+type Worker struct {
+	db     WorkerBackend
+	ext    Extractor
+	config WorkerConfig
+}
+
+// NewWorker creates a Worker. Zero values in cfg are replaced by sensible defaults.
+func NewWorker(backend WorkerBackend, ext Extractor, cfg WorkerConfig) *Worker {
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = 5 * time.Second
+	}
+	if cfg.BatchSize == 0 {
+		cfg.BatchSize = 10
+	}
+	return &Worker{db: backend, ext: ext, config: cfg}
+}
+
+// Run blocks until ctx is cancelled, polling for extraction jobs on each tick.
+func (w *Worker) Run(ctx context.Context) {
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.processBatch(ctx)
+		}
+	}
+}
+
+// processBatch claims and processes a batch of jobs for every configured project.
+func (w *Worker) processBatch(ctx context.Context) {
+	for _, project := range w.config.Projects {
+		jobs, err := w.db.ClaimExtractionJobs(ctx, project, w.config.BatchSize)
+		if err != nil {
+			slog.Warn("entity worker: claim jobs failed", "project", project, "err", err)
+			continue
+		}
+		for _, job := range jobs {
+			w.processJob(ctx, job)
+		}
+	}
+}
+
+// processJob processes a single extraction job:
+//  1. Fetches the memory from the database.
+//  2. Extracts entities and relations via the Extractor.
+//  3. Deduplicates candidates against existing project entities.
+//  4. Upserts merged and fresh entities.
+//  5. Marks the job complete (or failed).
+func (w *Worker) processJob(ctx context.Context, job ExtractionJob) {
+	mem, err := w.db.GetMemory(ctx, job.MemoryID)
+	if err != nil {
+		slog.Warn("entity worker: fetch memory failed", "job", job.ID, "memory", job.MemoryID, "err", err)
+		if cerr := w.db.CompleteExtractionJob(ctx, job.ID, err); cerr != nil {
+			slog.Warn("entity worker: mark job failed (GetMemory path)", "job", job.ID, "err", cerr)
+		}
+		return
+	}
+
+	candidates, relations, err := w.ext.Extract(ctx, mem.Content)
+	if err != nil {
+		slog.Warn("entity worker: extraction failed", "job", job.ID, "err", err)
+		if cerr := w.db.CompleteExtractionJob(ctx, job.ID, err); cerr != nil {
+			slog.Warn("entity worker: mark job failed (Extract path)", "job", job.ID, "err", cerr)
+		}
+		return
+	}
+
+	existing, _ := w.db.GetEntitiesByProject(ctx, job.Project)
+	merged, fresh := Deduplicate(existing, candidates)
+
+	for i := range merged {
+		merged[i].Project = job.Project
+		if _, err := w.db.UpsertEntity(ctx, &merged[i]); err != nil {
+			slog.Warn("entity worker: upsert merged entity failed", "name", merged[i].Name, "err", err)
+		}
+	}
+	for i := range fresh {
+		fresh[i].Project = job.Project
+		if _, err := w.db.UpsertEntity(ctx, &fresh[i]); err != nil {
+			slog.Warn("entity worker: upsert fresh entity failed", "name", fresh[i].Name, "err", err)
+		}
+	}
+
+	if len(relations) > 0 {
+		slog.Debug("entity worker: relations extracted (not yet persisted)",
+			"job", job.ID, "count", len(relations))
+	}
+
+	if cerr := w.db.CompleteExtractionJob(ctx, job.ID, nil); cerr != nil {
+		slog.Warn("entity worker: mark job complete failed", "job", job.ID, "err", cerr)
+	}
+}

--- a/internal/entity/worker_test.go
+++ b/internal/entity/worker_test.go
@@ -1,0 +1,196 @@
+package entity_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/petersimmons1972/engram/internal/entity"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// workerBackend satisfies entity.WorkerBackend for Worker tests.
+type workerBackend struct {
+	mu         sync.Mutex
+	jobs       []entity.ExtractionJob
+	memories   map[string]*types.Memory
+	entities   []entity.Entity
+	completed  []string
+	failedJobs []string
+}
+
+func (b *workerBackend) ClaimExtractionJobs(_ context.Context, project string, limit int) ([]entity.ExtractionJob, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var out []entity.ExtractionJob
+	for _, j := range b.jobs {
+		if j.Project == project && len(out) < limit {
+			out = append(out, j)
+		}
+	}
+	// Remove claimed jobs.
+	claimed := make(map[string]bool, len(out))
+	for _, j := range out {
+		claimed[j.ID] = true
+	}
+	remaining := b.jobs[:0]
+	for _, j := range b.jobs {
+		if !claimed[j.ID] {
+			remaining = append(remaining, j)
+		}
+	}
+	b.jobs = remaining
+	return out, nil
+}
+
+func (b *workerBackend) CompleteExtractionJob(_ context.Context, jobID string, err error) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err != nil {
+		b.failedJobs = append(b.failedJobs, jobID)
+	} else {
+		b.completed = append(b.completed, jobID)
+	}
+	return nil
+}
+
+func (b *workerBackend) GetMemory(_ context.Context, id string) (*types.Memory, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	m, ok := b.memories[id]
+	if !ok {
+		return nil, errors.New("memory not found")
+	}
+	return m, nil
+}
+
+func (b *workerBackend) GetEntitiesByProject(_ context.Context, _ string) ([]entity.Entity, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.entities, nil
+}
+
+func (b *workerBackend) UpsertEntity(_ context.Context, e *entity.Entity) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entities = append(b.entities, *e)
+	return e.ID, nil
+}
+
+// stubExtractor is an Extractor that returns canned results.
+type stubExtractor struct {
+	entities  []entity.Entity
+	relations []entity.Relation
+	err       error
+}
+
+func (s *stubExtractor) Extract(_ context.Context, _ string) ([]entity.Entity, []entity.Relation, error) {
+	return s.entities, s.relations, s.err
+}
+
+func newWorkerBackend() *workerBackend {
+	return &workerBackend{memories: make(map[string]*types.Memory)}
+}
+
+func TestWorker_ProcessesJobSuccessfully(t *testing.T) {
+	backend := newWorkerBackend()
+	backend.memories["mem1"] = &types.Memory{ID: "mem1", Content: "Claude is an AI assistant."}
+	backend.jobs = []entity.ExtractionJob{{ID: "job1", MemoryID: "mem1", Project: "test"}}
+
+	ext := &stubExtractor{entities: []entity.Entity{{Name: "Claude"}}}
+	w := entity.NewWorker(backend, ext, entity.WorkerConfig{
+		Projects:     []string{"test"},
+		PollInterval: 50 * time.Millisecond,
+		BatchSize:    5,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Contains(t, backend.completed, "job1")
+	assert.Empty(t, backend.failedJobs)
+	// Entity should have been upserted.
+	require.Len(t, backend.entities, 1)
+	assert.Equal(t, "Claude", backend.entities[0].Name)
+	assert.Equal(t, "test", backend.entities[0].Project)
+}
+
+func TestWorker_HandlesExtractError(t *testing.T) {
+	backend := newWorkerBackend()
+	backend.memories["mem2"] = &types.Memory{ID: "mem2", Content: "some text"}
+	backend.jobs = []entity.ExtractionJob{{ID: "job2", MemoryID: "mem2", Project: "proj"}}
+
+	ext := &stubExtractor{err: errors.New("claude unavailable")}
+	w := entity.NewWorker(backend, ext, entity.WorkerConfig{
+		Projects:     []string{"proj"},
+		PollInterval: 50 * time.Millisecond,
+		BatchSize:    5,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	// Job should be completed as failed, not left dangling.
+	assert.Contains(t, backend.failedJobs, "job2")
+	assert.Empty(t, backend.completed)
+}
+
+func TestWorker_HandlesMemoryNotFound(t *testing.T) {
+	backend := newWorkerBackend()
+	// No memory stored for "missing"
+	backend.jobs = []entity.ExtractionJob{{ID: "job3", MemoryID: "missing", Project: "proj"}}
+
+	ext := &stubExtractor{entities: []entity.Entity{{Name: "SomeEntity"}}}
+	w := entity.NewWorker(backend, ext, entity.WorkerConfig{
+		Projects:     []string{"proj"},
+		PollInterval: 50 * time.Millisecond,
+		BatchSize:    5,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Contains(t, backend.failedJobs, "job3")
+}
+
+func TestWorker_DefaultConfig(t *testing.T) {
+	// NewWorker must fill in zero PollInterval and BatchSize.
+	w := entity.NewWorker(nil, nil, entity.WorkerConfig{})
+	assert.NotNil(t, w)
+}
+
+func TestWorker_ExitsOnContextCancel(t *testing.T) {
+	backend := newWorkerBackend()
+	ext := &stubExtractor{}
+	w := entity.NewWorker(backend, ext, entity.WorkerConfig{
+		Projects:     []string{"p"},
+		PollInterval: 10 * time.Second, // very long — should not fire
+		BatchSize:    1,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after context cancel")
+	}
+}

--- a/internal/eval/golden_test.go
+++ b/internal/eval/golden_test.go
@@ -1,0 +1,63 @@
+package eval_test
+
+import (
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/eval"
+)
+
+func TestPrecisionAtK(t *testing.T) {
+	retrieved := []string{"a", "b", "c", "d", "e"}
+	relevant := map[string]bool{"a": true, "c": true, "e": true}
+
+	got := eval.PrecisionAtK(retrieved, relevant, 5)
+	if got < 0.59 || got > 0.61 {
+		t.Errorf("PrecisionAtK(k=5) = %f, want ~0.6", got)
+	}
+	got1 := eval.PrecisionAtK(retrieved, relevant, 1)
+	if got1 < 0.99 {
+		t.Errorf("PrecisionAtK(k=1) = %f, want 1.0 (a is relevant)", got1)
+	}
+	got0 := eval.PrecisionAtK(nil, relevant, 5)
+	if got0 != 0 {
+		t.Errorf("PrecisionAtK(nil) = %f, want 0", got0)
+	}
+	gotNegK := eval.PrecisionAtK(retrieved, relevant, 0)
+	if gotNegK != 0 {
+		t.Errorf("PrecisionAtK(k=0) = %f, want 0", gotNegK)
+	}
+}
+
+func TestMRR(t *testing.T) {
+	retrieved := []string{"x", "a", "b"}
+	relevant := map[string]bool{"a": true}
+	got := eval.MRR(retrieved, relevant)
+	if got < 0.49 || got > 0.51 {
+		t.Errorf("MRR = %f, want ~0.5 (first hit at rank 2)", got)
+	}
+	got0 := eval.MRR(nil, relevant)
+	if got0 != 0 {
+		t.Errorf("MRR(nil) = %f, want 0", got0)
+	}
+	gotNoHit := eval.MRR(retrieved, map[string]bool{})
+	if gotNoHit != 0 {
+		t.Errorf("MRR(no relevant) = %f, want 0", gotNoHit)
+	}
+}
+
+func TestNDCG(t *testing.T) {
+	retrieved := []string{"a", "b", "c"}
+	relevant := map[string]bool{"a": true, "c": true}
+	score := eval.NDCG(retrieved, relevant, 3)
+	if score <= 0 || score > 1 {
+		t.Errorf("NDCG = %f, want (0,1]", score)
+	}
+	score0 := eval.NDCG(nil, relevant, 3)
+	if score0 != 0 {
+		t.Errorf("NDCG(nil) = %f, want 0", score0)
+	}
+	scoreEmpty := eval.NDCG(retrieved, map[string]bool{}, 3)
+	if scoreEmpty != 0 {
+		t.Errorf("NDCG(no relevant) = %f, want 0", scoreEmpty)
+	}
+}

--- a/internal/eval/harness.go
+++ b/internal/eval/harness.go
@@ -1,0 +1,72 @@
+package eval
+
+import "math"
+
+// PrecisionAtK computes the fraction of the top-k retrieved items that are relevant.
+// Returns 0 for k<=0 or empty retrieved.
+func PrecisionAtK(retrieved []string, relevant map[string]bool, k int) float64 {
+	if k <= 0 || len(retrieved) == 0 {
+		return 0
+	}
+	limit := k
+	if limit > len(retrieved) {
+		limit = len(retrieved)
+	}
+	hits := 0
+	for i := 0; i < limit; i++ {
+		if relevant[retrieved[i]] {
+			hits++
+		}
+	}
+	return float64(hits) / float64(limit)
+}
+
+// MRR computes the Reciprocal Rank of the first relevant item.
+// Returns 0 when no relevant item is found or retrieved is empty.
+func MRR(retrieved []string, relevant map[string]bool) float64 {
+	for i, id := range retrieved {
+		if relevant[id] {
+			return 1.0 / float64(i+1)
+		}
+	}
+	return 0
+}
+
+// NDCG computes Normalized Discounted Cumulative Gain at k.
+// Returns 0 when retrieved or relevant is empty, or idealDCG is 0.
+func NDCG(retrieved []string, relevant map[string]bool, k int) float64 {
+	if len(retrieved) == 0 || len(relevant) == 0 {
+		return 0
+	}
+	limit := k
+	if limit > len(retrieved) {
+		limit = len(retrieved)
+	}
+	dcg := 0.0
+	for i := 0; i < limit; i++ {
+		if relevant[retrieved[i]] {
+			dcg += 1.0 / math.Log2(float64(i+2))
+		}
+	}
+	idealLimit := len(relevant)
+	if idealLimit > k {
+		idealLimit = k
+	}
+	idealDCG := 0.0
+	for i := 0; i < idealLimit; i++ {
+		idealDCG += 1.0 / math.Log2(float64(i+2))
+	}
+	if idealDCG == 0 {
+		return 0
+	}
+	return dcg / idealDCG
+}
+
+// QueryResult holds evaluation metrics for one golden query.
+type QueryResult struct {
+	Query      string
+	PrecisionK float64
+	MRR        float64
+	NDCG       float64
+	Retrieved  []string
+}

--- a/internal/mcp/entity_enqueue_test.go
+++ b/internal/mcp/entity_enqueue_test.go
@@ -1,0 +1,173 @@
+package mcp
+
+// Tests for extractResultID and the non-blocking enqueue behaviour wired into
+// the memory_store handler.
+//
+// extractResultID is unexported so these tests live in package mcp (same
+// package, no _test suffix in the declaration). This follows the convention
+// established by safety_test.go and fetch_recall_test.go in this directory.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/entity"
+	"github.com/stretchr/testify/require"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// textResult builds a CallToolResult whose first Content element is
+// TextContent with the given JSON payload.
+func textResult(t *testing.T, payload map[string]any) *mcpgo.CallToolResult {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return mcpgo.NewToolResultText(string(b))
+}
+
+// ── extractResultID unit tests ────────────────────────────────────────────────
+
+func TestExtractResultID_NilResult(t *testing.T) {
+	id, ok := extractResultID(nil)
+	require.False(t, ok, "nil result must return false")
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_EmptyContent(t *testing.T) {
+	result := &mcpgo.CallToolResult{}
+	id, ok := extractResultID(result)
+	require.False(t, ok, "empty Content must return false")
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_ContentNotTextContent(t *testing.T) {
+	// ImageContent satisfies the Content interface but is not TextContent.
+	result := &mcpgo.CallToolResult{
+		Content: []mcpgo.Content{
+			mcpgo.ImageContent{Type: "image", Data: "abc", MIMEType: "image/png"},
+		},
+	}
+	id, ok := extractResultID(result)
+	require.False(t, ok, "non-TextContent must return false")
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_InvalidJSON(t *testing.T) {
+	result := &mcpgo.CallToolResult{
+		Content: []mcpgo.Content{
+			mcpgo.TextContent{Type: "text", Text: "not-json"},
+		},
+	}
+	id, ok := extractResultID(result)
+	require.False(t, ok, "invalid JSON must return false")
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_NoIDField(t *testing.T) {
+	result := textResult(t, map[string]any{"status": "ok"})
+	id, ok := extractResultID(result)
+	require.False(t, ok, "JSON without id field must return false")
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_EmptyStringID(t *testing.T) {
+	result := textResult(t, map[string]any{"id": ""})
+	id, ok := extractResultID(result)
+	require.False(t, ok, `id="" must return false`)
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_NonStringID(t *testing.T) {
+	// id is a number — type assertion to string should fail.
+	result := textResult(t, map[string]any{"id": 42})
+	id, ok := extractResultID(result)
+	require.False(t, ok, "non-string id must return false")
+	require.Empty(t, id)
+}
+
+func TestExtractResultID_HappyPath(t *testing.T) {
+	const want = "mem_abc123"
+	result := textResult(t, map[string]any{"id": want, "status": "stored"})
+	id, ok := extractResultID(result)
+	require.True(t, ok, "valid id must return true")
+	require.Equal(t, want, id)
+}
+
+// ── enqueue wrapper behaviour ─────────────────────────────────────────────────
+
+// errBackend is a noopBackend override that makes EnqueueExtractionJob return
+// an error, so we can verify the handler proceeds without surfacing it.
+type errBackend struct{ noopBackend }
+
+func (errBackend) EnqueueExtractionJob(_ context.Context, _, _ string) error {
+	return errors.New("enqueue failed: simulated error")
+}
+
+var _ db.Backend = errBackend{}
+
+// errEntityBackend also satisfies the entity UpsertEntity signature (unchanged
+// from noopBackend — zero values).
+func (errBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error) {
+	return "", nil
+}
+
+// TestMemoryStoreHandler_NoEnqueueWhenNoID verifies that the memory_store
+// closure returns (result, nil) when extractResultID returns false — i.e. the
+// handler does not attempt to enqueue and does not return an error.
+func TestMemoryStoreHandler_NoEnqueueWhenNoID(t *testing.T) {
+	// A result with no "id" field — extractResultID will return false.
+	result := textResult(t, map[string]any{"status": "ok"})
+
+	id, ok := extractResultID(result)
+	require.False(t, ok, "pre-condition: result has no id")
+	require.Empty(t, id)
+
+	// If extractResultID returns false the goroutine is never spawned.
+	// Nothing to assert beyond the function returning false — no panic, no enqueue.
+}
+
+// TestMemoryStoreHandler_ReturnsResultEvenOnPoolGetFailure verifies that the
+// memory_store handler's return value is unaffected by pool.Get failures
+// (the goroutine logs and returns silently).
+//
+// We simulate this by building a pool whose factory returns an error and
+// calling the internal logic directly: the goroutine is fire-and-forget so the
+// only contract we can test synchronously is that the goroutine does NOT panic
+// and does NOT modify the return value.
+func TestMemoryStoreHandler_ReturnsResultEvenOnPoolGetFailure(t *testing.T) {
+	failPool := NewEnginePool(func(_ context.Context, _ string) (*EngineHandle, error) {
+		return nil, errors.New("pool: backend unavailable")
+	})
+
+	const memID = "mem_test99"
+	result := textResult(t, map[string]any{"id": memID})
+
+	id, ok := extractResultID(result)
+	require.True(t, ok, "pre-condition: result has a valid id")
+	require.Equal(t, memID, id)
+
+	// Mimic what the closure does — spawn the goroutine.
+	// The goroutine must not panic; it will log a warning and return.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx, cancel := context.WithTimeout(context.Background(), 5)
+		defer cancel()
+		h, herr := failPool.Get(ctx, "test-project")
+		if herr != nil {
+			// Expected: pool factory returned an error. Handler logs, returns.
+			return
+		}
+		// Should not reach here in this test.
+		_ = h.Engine.Backend().EnqueueExtractionJob(ctx, memID, "test-project")
+	}()
+	<-done // goroutine finished without panic
+
+	// The original result is untouched.
+	require.NotNil(t, result)
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/claude"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/entity"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/require"
@@ -190,6 +191,18 @@ func (noopBackend) SearchChunksWithinMemory(_ context.Context, _ []float32, _ st
 func (noopBackend) StoreDocument(_ context.Context, _, _ string) (string, error) { return "", nil }
 func (noopBackend) GetDocument(_ context.Context, _ string) (string, error)      { return "", nil }
 func (noopBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error     { return nil }
+
+func (noopBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error) {
+	return "", nil
+}
+func (noopBackend) GetEntitiesByProject(_ context.Context, _ string) ([]entity.Entity, error) {
+	return nil, nil
+}
+func (noopBackend) EnqueueExtractionJob(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db.ExtractionJob, error) {
+	return nil, nil
+}
+func (noopBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error { return nil }
 
 var _ db.Backend = noopBackend{}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -420,6 +420,21 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryAdopt(ctx, pool, req)
 			}},
+		// Simplified front-door tools — wrappers over the expert-surface tools
+		// with sensible defaults injected. Designed for LLM orchestrators that
+		// do not need the full parameter surface.
+		{"memory_quick_store", "Store a memory and automatically extract entities. Simplified front door for memory_store.",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryQuickStore(ctx, pool, req)
+			}},
+		{"memory_query", "Search memories with automatic graph expansion. Simplified front door for memory_recall.",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryQuery(ctx, pool, req, cfg)
+			}},
+		{"memory_expand", "Explore the relationship graph neighbourhood of a known memory.",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryExpand(ctx, pool, req)
+			}},
 		// Safety constraint verification tools
 		{"get_constraints", "List constraint and policy memories relevant to an optional query",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -275,7 +275,24 @@ func (s *Server) registerTools() {
 	}{
 		{"memory_store", "Store a focused memory (<=10k chars)",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-				return handleMemoryStore(ctx, pool, req)
+				result, err := handleMemoryStore(ctx, pool, req)
+				if err != nil {
+					return result, err
+				}
+				// Enqueue entity extraction asynchronously. Non-fatal: if the enqueue
+				// fails the store has already succeeded; we log and continue.
+				args := req.GetArguments()
+				project := getString(args, "project", "default")
+				if memID, ok := extractResultID(result); ok {
+					h, herr := pool.Get(ctx, project)
+					if herr == nil {
+						if eerr := h.Engine.Backend().EnqueueExtractionJob(ctx, memID, project); eerr != nil {
+							slog.Warn("memory_store: enqueue extraction job failed",
+								"id", memID, "project", project, "err", eerr)
+						}
+					}
+				}
+				return result, nil
 			}},
 		{"memory_store_document", "Store a large document (auto-tiered up to 50 MB via synopsis + raw blob storage)",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -279,18 +279,26 @@ func (s *Server) registerTools() {
 				if err != nil {
 					return result, err
 				}
-				// Enqueue entity extraction asynchronously. Non-fatal: if the enqueue
-				// fails the store has already succeeded; we log and continue.
+				// Enqueue entity extraction asynchronously. Runs in a detached
+				// goroutine with its own context so it never blocks memory_store.
+				// Non-fatal: if the enqueue fails the store has already succeeded.
 				args := req.GetArguments()
 				project := getString(args, "project", "default")
 				if memID, ok := extractResultID(result); ok {
-					h, herr := pool.Get(ctx, project)
-					if herr == nil {
-						if eerr := h.Engine.Backend().EnqueueExtractionJob(ctx, memID, project); eerr != nil {
+					go func() {
+						enqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+						defer cancel()
+						h, herr := pool.Get(enqCtx, project)
+						if herr != nil {
+							slog.Warn("memory_store: enqueue pool.Get failed",
+								"id", memID, "project", project, "err", herr)
+							return
+						}
+						if eerr := h.Engine.Backend().EnqueueExtractionJob(enqCtx, memID, project); eerr != nil {
 							slog.Warn("memory_store: enqueue extraction job failed",
 								"id", memID, "project", project, "err", eerr)
 						}
-					}
+					}()
 				}
 				return result, nil
 			}},

--- a/internal/mcp/simple_tools_test.go
+++ b/internal/mcp/simple_tools_test.go
@@ -1,0 +1,359 @@
+package mcp
+
+// Tests for the three simplified front-door MCP tools:
+//   - memory_quick_store  (simplified wrapper over memory_store)
+//   - memory_query        (simplified wrapper over memory_recall)
+//   - memory_expand       (graph neighbourhood explorer)
+//
+// All tests use the noopBackend + newTestNoopPool helpers defined in
+// explore_handler_test.go (same package).
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// parseSimpleResult decodes the first TextContent item from a non-error result.
+func parseSimpleResult(t *testing.T, res *mcpgo.CallToolResult) map[string]any {
+	t.Helper()
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "expected non-error tool result, content: %+v", res.Content)
+	require.NotEmpty(t, res.Content)
+	text, ok := res.Content[0].(mcpgo.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", res.Content[0])
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &out))
+	return out
+}
+
+// ── memory_quick_store tests ──────────────────────────────────────────────────
+
+// TestMemoryQuickStore_HappyPath: content + project → returns id + status "stored".
+func TestMemoryQuickStore_HappyPath(t *testing.T) {
+	pool := newStorePool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"content": "important observation about the system",
+		"project": "test",
+	}
+
+	res, err := handleMemoryQuickStore(context.Background(), pool, req)
+	require.NoError(t, err)
+	out := parseSimpleResult(t, res)
+	require.NotEmpty(t, out["id"], "id must be present")
+	require.Equal(t, "stored", out["status"])
+}
+
+// TestMemoryQuickStore_DefaultMemoryType: when memory_type is absent it must
+// default to "context" (verified by no validation error from handleMemoryStore).
+func TestMemoryQuickStore_DefaultMemoryType(t *testing.T) {
+	pool := newStorePool(t)
+	req := mcpgo.CallToolRequest{}
+	// No memory_type supplied — handler must inject "context".
+	req.Params.Arguments = map[string]any{
+		"content": "context-only content",
+		"project": "test",
+	}
+
+	res, err := handleMemoryQuickStore(context.Background(), pool, req)
+	require.NoError(t, err, "default memory_type must not cause a validation error")
+	out := parseSimpleResult(t, res)
+	require.Equal(t, "stored", out["status"])
+}
+
+// TestMemoryQuickStore_DefaultImportance: when importance is absent it must
+// default to 2 (no validation error from handleMemoryStore which allows 0–4).
+func TestMemoryQuickStore_DefaultImportance(t *testing.T) {
+	pool := newStorePool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"content": "importance-default test",
+		"project": "test",
+	}
+
+	_, err := handleMemoryQuickStore(context.Background(), pool, req)
+	require.NoError(t, err, "default importance=2 must be accepted by handleMemoryStore")
+}
+
+// TestMemoryQuickStore_MissingContent: missing content → error.
+func TestMemoryQuickStore_MissingContent(t *testing.T) {
+	pool := newStorePool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		// content intentionally absent
+	}
+
+	_, err := handleMemoryQuickStore(context.Background(), pool, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "content is required")
+}
+
+// TestMemoryQuickStore_DoesNotMutateOriginal: merged args must not bleed back
+// into the caller's args map.
+func TestMemoryQuickStore_DoesNotMutateOriginal(t *testing.T) {
+	pool := newStorePool(t)
+	original := map[string]any{
+		"content": "test content",
+		"project": "test",
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = original
+
+	_, _ = handleMemoryQuickStore(context.Background(), pool, req)
+
+	// Original map must not have acquired new keys injected by the handler.
+	_, hasMemoryType := original["memory_type"]
+	_, hasImportance := original["importance"]
+	require.False(t, hasMemoryType, "handler must not mutate the original args map")
+	require.False(t, hasImportance, "handler must not mutate the original args map")
+}
+
+// ── memory_query tests ────────────────────────────────────────────────────────
+
+// TestMemoryQuery_HappyPath: query + project → delegates to handleMemoryRecall
+// and returns a non-error result.
+func TestMemoryQuery_HappyPath(t *testing.T) {
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query":   "some interesting topic",
+		"project": "test",
+	}
+
+	res, err := handleMemoryQuery(context.Background(), pool, req, Config{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError)
+}
+
+// TestMemoryQuery_LimitMapsToTopK: limit param must map to top_k before
+// delegating to handleMemoryRecall, and limit must be removed from the args.
+func TestMemoryQuery_LimitMapsToTopK(t *testing.T) {
+	pool := newTestNoopPool(t)
+	// We verify this indirectly: if limit is translated to top_k=3 the recall
+	// succeeds (noopBackend returns no results, which is valid).
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query":   "topic",
+		"project": "test",
+		"limit":   3,
+	}
+
+	res, err := handleMemoryQuery(context.Background(), pool, req, Config{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError)
+}
+
+// TestMemoryQuery_DefaultLimit: when neither limit nor top_k are provided,
+// top_k defaults to 5 (no error from recall).
+func TestMemoryQuery_DefaultLimit(t *testing.T) {
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"query":   "default limit topic",
+		"project": "test",
+		// neither limit nor top_k
+	}
+
+	res, err := handleMemoryQuery(context.Background(), pool, req, Config{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError)
+}
+
+// TestMemoryQuery_MissingQuery: missing query → error from delegated recall.
+func TestMemoryQuery_MissingQuery(t *testing.T) {
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		// query intentionally absent
+	}
+
+	_, err := handleMemoryQuery(context.Background(), pool, req, Config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "query is required")
+}
+
+// TestMemoryQuery_DoesNotMutateOriginal: original args map must not be modified.
+func TestMemoryQuery_DoesNotMutateOriginal(t *testing.T) {
+	pool := newTestNoopPool(t)
+	original := map[string]any{
+		"query":   "topic",
+		"project": "test",
+		"limit":   7,
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = original
+
+	_, _ = handleMemoryQuery(context.Background(), pool, req, Config{})
+
+	// limit must still be in original (handler must work on a copy).
+	_, hasLimit := original["limit"]
+	require.True(t, hasLimit, "handler must not delete limit from the original args map")
+}
+
+// ── memory_expand tests ───────────────────────────────────────────────────────
+
+// TestMemoryExpand_MissingMemoryID: missing memory_id → error.
+func TestMemoryExpand_MissingMemoryID(t *testing.T) {
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		// memory_id intentionally absent
+	}
+
+	_, err := handleMemoryExpand(context.Background(), pool, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "memory_id is required")
+}
+
+// TestMemoryExpand_EmptyConnected: noopBackend.GetConnected returns nil → handler
+// returns empty slice without error.
+func TestMemoryExpand_EmptyConnected(t *testing.T) {
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"memory_id": "mem_abc123",
+		"project":   "test",
+	}
+
+	res, err := handleMemoryExpand(context.Background(), pool, req)
+	require.NoError(t, err)
+	out := parseSimpleResult(t, res)
+
+	require.Equal(t, "mem_abc123", out["memory_id"])
+	connected, ok := out["connected"].([]any)
+	require.True(t, ok, "connected must be a JSON array, got %T", out["connected"])
+	require.Empty(t, connected)
+}
+
+// TestMemoryExpand_HappyPath: backend returns connected results → all fields
+// are present in the output items.
+func TestMemoryExpand_HappyPath(t *testing.T) {
+	// Build a pool backed by a stub that returns one connected result.
+	stub := &connectedStubBackend{
+		results: []db.ConnectedResult{
+			{
+				Memory:    &types.Memory{ID: "mem_neighbor", Content: "linked content"},
+				RelType:   "supports",
+				Direction: "outbound",
+				Strength:  0.85,
+			},
+		},
+	}
+	pool := newPoolWithBackend(t, stub)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"memory_id": "mem_source",
+		"project":   "test",
+		"depth":     2,
+	}
+
+	res, err := handleMemoryExpand(context.Background(), pool, req)
+	require.NoError(t, err)
+	out := parseSimpleResult(t, res)
+
+	require.Equal(t, "mem_source", out["memory_id"])
+	require.InDelta(t, 2.0, out["depth"], 0.001)
+
+	connected, ok := out["connected"].([]any)
+	require.True(t, ok)
+	require.Len(t, connected, 1)
+
+	item, ok := connected[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "mem_neighbor", item["id"])
+	require.Equal(t, "linked content", item["content"])
+	require.Equal(t, "supports", item["rel_type"])
+	require.Equal(t, "outbound", item["direction"])
+	require.InDelta(t, 0.85, item["strength"], 0.001)
+}
+
+// TestMemoryExpand_DepthClamping: depth outside [1,5] must be reset to 2.
+func TestMemoryExpand_DepthClamping(t *testing.T) {
+	pool := newTestNoopPool(t)
+
+	for _, badDepth := range []any{0, 6, -1, 99} {
+		req := mcpgo.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"memory_id": "mem_clamp_test",
+			"project":   "test",
+			"depth":     badDepth,
+		}
+
+		res, err := handleMemoryExpand(context.Background(), pool, req)
+		require.NoError(t, err, "depth=%v must not error (should be clamped to 2)", badDepth)
+		out := parseSimpleResult(t, res)
+		require.InDelta(t, 2.0, out["depth"], 0.001, "depth=%v must be clamped to 2", badDepth)
+	}
+}
+
+// ── no-op Tx and Store-capable backend ───────────────────────────────────────
+
+// noopTx is a do-nothing implementation of db.Tx.
+type noopTx struct{}
+
+func (noopTx) Commit(_ context.Context) error   { return nil }
+func (noopTx) Rollback(_ context.Context) error { return nil }
+
+var _ db.Tx = noopTx{}
+
+// storeCapableBackend embeds noopBackend and overrides Begin to return a
+// noopTx, allowing engine.Store to succeed without a real database.
+type storeCapableBackend struct {
+	noopBackend
+}
+
+func (storeCapableBackend) Begin(_ context.Context) (db.Tx, error) {
+	return noopTx{}, nil
+}
+
+// newStorePool builds an EnginePool whose backend supports Store operations.
+func newStorePool(t *testing.T) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, storeCapableBackend{}, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+// ── stub backend for memory_expand happy path ─────────────────────────────────
+
+// connectedStubBackend embeds noopBackend and overrides GetConnected.
+type connectedStubBackend struct {
+	noopBackend
+	results []db.ConnectedResult
+}
+
+func (s *connectedStubBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
+	return s.results, nil
+}
+
+// newPoolWithBackend builds an EnginePool backed by the given db.Backend.
+func newPoolWithBackend(t *testing.T, backend db.Backend) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, backend, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1622,3 +1622,115 @@ func handleMemoryAsk(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRe
 	data, _ := json.Marshal(out)
 	return mcpgo.NewToolResultText(string(data)), nil
 }
+
+// ── Simplified front-door tools ───────────────────────────────────────────────
+//
+// These three handlers are genuine wrappers over the expert-surface tools.
+// They exist to reduce the surface area that LLM orchestrators need to know
+// about: sensible defaults are injected so callers only supply the minimum.
+
+// handleMemoryQuickStore is a simplified front door for handleMemoryStore.
+// It injects defaults for memory_type ("context") and importance (2) when
+// those fields are absent from the request, then delegates to handleMemoryStore.
+// The original args map is never mutated — a copy is used for the injection.
+func handleMemoryQuickStore(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+
+	// Build a merged copy so we never mutate the caller's map.
+	merged := make(map[string]any, len(args)+2)
+	for k, v := range args {
+		merged[k] = v
+	}
+	if _, ok := merged["memory_type"]; !ok {
+		merged["memory_type"] = "context"
+	}
+	if _, ok := merged["importance"]; !ok {
+		merged["importance"] = 2
+	}
+
+	req2 := req
+	req2.Params.Arguments = merged
+	return handleMemoryStore(ctx, pool, req2)
+}
+
+// handleMemoryQuery is a simplified front door for handleMemoryRecall.
+// It maps the caller-friendly "limit" parameter to "top_k", defaulting to 5
+// when neither is provided, then delegates to handleMemoryRecall.
+// The original args map is never mutated — a copy is used.
+func handleMemoryQuery(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+
+	// Build a merged copy so we never mutate the caller's map.
+	merged := make(map[string]any, len(args)+1)
+	for k, v := range args {
+		merged[k] = v
+	}
+
+	// Map "limit" → "top_k". If both are supplied, top_k wins.
+	if limit, ok := merged["limit"]; ok {
+		if _, hasTopK := merged["top_k"]; !hasTopK {
+			merged["top_k"] = limit
+		}
+		delete(merged, "limit")
+	} else if _, hasTopK := merged["top_k"]; !hasTopK {
+		merged["top_k"] = 5
+	}
+
+	req2 := req
+	req2.Params.Arguments = merged
+	return handleMemoryRecall(ctx, pool, req2, cfg)
+}
+
+// handleMemoryExpand explores the relationship-graph neighbourhood of a known
+// memory. It calls GetConnected on the engine's backend and returns all
+// reachable nodes within depth hops.
+func handleMemoryExpand(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+
+	project := getString(args, "project", "default")
+	memoryID := getString(args, "memory_id", "")
+	if memoryID == "" {
+		return nil, fmt.Errorf("memory_id is required")
+	}
+	depth := getInt(args, "depth", 2)
+	if depth < 1 || depth > 5 {
+		depth = 2
+	}
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+
+	connected, err := h.Engine.Backend().GetConnected(ctx, memoryID, depth)
+	if err != nil {
+		return nil, err
+	}
+
+	type connItem struct {
+		ID        string  `json:"id"`
+		Content   string  `json:"content"`
+		RelType   string  `json:"rel_type"`
+		Direction string  `json:"direction"`
+		Strength  float64 `json:"strength"`
+	}
+	items := make([]connItem, 0, len(connected))
+	for _, c := range connected {
+		if c.Memory == nil {
+			continue
+		}
+		items = append(items, connItem{
+			ID:        c.Memory.ID,
+			Content:   c.Memory.Content,
+			RelType:   c.RelType,
+			Direction: c.Direction,
+			Strength:  c.Strength,
+		})
+	}
+
+	return toolResult(map[string]any{
+		"memory_id": memoryID,
+		"depth":     depth,
+		"connected": items,
+	})
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -239,6 +239,25 @@ func toolResult(v any) (*mcpgo.CallToolResult, error) {
 	return mcpgo.NewToolResultText(string(b)), nil
 }
 
+// extractResultID pulls the "id" field from a toolResult JSON payload.
+// Returns ("", false) if the result is nil or the id field is absent/non-string.
+func extractResultID(result *mcpgo.CallToolResult) (string, bool) {
+	if result == nil || len(result.Content) == 0 {
+		return "", false
+	}
+	// Content[0] is a TextContent whose Text is the JSON payload.
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok {
+		return "", false
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
+		return "", false
+	}
+	id, ok := m["id"].(string)
+	return id, ok && id != ""
+}
+
 // getString extracts a string arg with a fallback default.
 func getString(args map[string]any, key, def string) string {
 	if v, ok := args[key]; ok {

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/entity"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 )
@@ -376,6 +377,18 @@ func (s *stubBackend) StoreDocument(_ context.Context, _, _ string) (string, err
 }
 func (s *stubBackend) GetDocument(_ context.Context, _ string) (string, error) { return "", nil }
 func (s *stubBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error { return nil }
+
+func (s *stubBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error) {
+	return "", nil
+}
+func (s *stubBackend) GetEntitiesByProject(_ context.Context, _ string) ([]entity.Entity, error) {
+	return nil, nil
+}
+func (s *stubBackend) EnqueueExtractionJob(_ context.Context, _, _ string) error { return nil }
+func (s *stubBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db.ExtractionJob, error) {
+	return nil, nil
+}
+func (s *stubBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error { return nil }
 
 // compile-time check: stubBackend must satisfy db.Backend.
 var _ db.Backend = (*stubBackend)(nil)

--- a/migrations/012_canonical_entities.sql
+++ b/migrations/012_canonical_entities.sql
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS entity_extraction_jobs (
     status      TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','processing','done','failed')),
     error       TEXT,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    processed_at TIMESTAMPTZ
+    processed_at TIMESTAMPTZ,
+    CONSTRAINT uq_entity_jobs_pending UNIQUE (memory_id, project)
 );
 
 CREATE INDEX IF NOT EXISTS idx_entity_jobs_pending ON entity_extraction_jobs(project, created_at) WHERE status = 'pending';

--- a/migrations/012_canonical_entities.sql
+++ b/migrations/012_canonical_entities.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS canonical_entities (
+    id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    name        TEXT NOT NULL,
+    aliases     TEXT[] NOT NULL DEFAULT '{}',
+    project     TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_entities_project ON canonical_entities(project);
+CREATE INDEX IF NOT EXISTS idx_canonical_entities_name ON canonical_entities(project, lower(name));
+
+CREATE TABLE IF NOT EXISTS entity_extraction_jobs (
+    id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    memory_id   TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    project     TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','processing','done','failed')),
+    error       TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_jobs_pending ON entity_extraction_jobs(project, status) WHERE status = 'pending';
+
+COMMIT;

--- a/migrations/012_canonical_entities.sql
+++ b/migrations/012_canonical_entities.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS canonical_entities (
 );
 
 CREATE INDEX IF NOT EXISTS idx_canonical_entities_project ON canonical_entities(project);
-CREATE INDEX IF NOT EXISTS idx_canonical_entities_name ON canonical_entities(project, lower(name));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_canonical_entities_name ON canonical_entities(project, lower(name));
 
 CREATE TABLE IF NOT EXISTS entity_extraction_jobs (
     id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
@@ -22,6 +22,18 @@ CREATE TABLE IF NOT EXISTS entity_extraction_jobs (
     processed_at TIMESTAMPTZ
 );
 
-CREATE INDEX IF NOT EXISTS idx_entity_jobs_pending ON entity_extraction_jobs(project, status) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_entity_jobs_pending ON entity_extraction_jobs(project, created_at) WHERE status = 'pending';
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_canonical_entities_updated_at
+    BEFORE UPDATE ON canonical_entities
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 
 COMMIT;

--- a/testdata/baseline-engram-ollama-768.txt
+++ b/testdata/baseline-engram-ollama-768.txt
@@ -1,0 +1,7 @@
+--- Evaluation Summary ---
+Queries:      5
+Avg P@5:      0.36
+Avg MRR:      1.00
+Avg NDCG@5:   0.93
+Provider:     ollama
+Written to:   testdata/baseline-engram-ollama-768.txt

--- a/testdata/baseline-homelab-ollama-768.txt
+++ b/testdata/baseline-homelab-ollama-768.txt
@@ -1,0 +1,7 @@
+--- Evaluation Summary ---
+Queries:      5
+Avg P@5:      0.24
+Avg MRR:      1.00
+Avg NDCG@5:   0.98
+Provider:     ollama
+Written to:   testdata/baseline-homelab-ollama-768.txt

--- a/testdata/golden-engram.json
+++ b/testdata/golden-engram.json
@@ -1,0 +1,37 @@
+[
+  {
+    "query": "embedding provider migration background reembedder",
+    "relevant_ids": [
+      "336895573af84fed8f156d52d6a483a3",
+      "4cefb4eb34a247488e54c7341a49b0e2"
+    ]
+  },
+  {
+    "query": "PostgreSQL SQLite backend architecture decision",
+    "relevant_ids": [
+      "9231705f81f544e18de912ed8c03d3c6",
+      "95a445c59aa5424c87f7ab8d4d66bb91"
+    ]
+  },
+  {
+    "query": "Store Big Retrieve Small chunker semantic document mode",
+    "relevant_ids": [
+      "6998cd95f5b3489f8a23a615ffaa226c",
+      "e7831773dc4e4a099966e3504225403b",
+      "3e4b4cdbd3d24296824ce2e71b6f5211"
+    ]
+  },
+  {
+    "query": "knowledge graph relationships memory optimization session handoff",
+    "relevant_ids": [
+      "3e4b4cdbd3d24296824ce2e71b6f5211"
+    ]
+  },
+  {
+    "query": "compression context window reduce token cost summaries",
+    "relevant_ids": [
+      "ccf39316cab94d5c898238946a660b67",
+      "95a445c59aa5424c87f7ab8d4d66bb91"
+    ]
+  }
+]

--- a/testdata/golden-example.json
+++ b/testdata/golden-example.json
@@ -1,0 +1,6 @@
+[
+  {
+    "query": "replace with a real query against your stored memories",
+    "relevant_ids": ["replace-with-actual-memory-id"]
+  }
+]

--- a/testdata/golden-homelab.json
+++ b/testdata/golden-homelab.json
@@ -1,0 +1,33 @@
+[
+  {
+    "query": "Longhorn storage decommission K8s cluster CPU reduction",
+    "relevant_ids": [
+      "c0608cbf92e7432f8ef86ef84aea1422",
+      "f6e3d80a65d4417ab6642945ba835943"
+    ]
+  },
+  {
+    "query": "Postgres database consolidation single instance ExternalName service",
+    "relevant_ids": [
+      "953c2dc418b546c2b7629034f9cbeef4"
+    ]
+  },
+  {
+    "query": "StatefulSet Deployment CrashLoop archive scale zero",
+    "relevant_ids": [
+      "019d7fe2-058b-70f5-ad20-c4851d6bd406"
+    ]
+  },
+  {
+    "query": "ConfigMap kubectl --from-file subdirectory keys missing mount",
+    "relevant_ids": [
+      "fe7d2d45e807408fbdc124ea938b477e"
+    ]
+  },
+  {
+    "query": "nginx Chainguard security headers server block default.conf",
+    "relevant_ids": [
+      "3654155b8a2d43cca13bac1a98046438"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Implements six of seven planned GraphRAG improvements from the April 2026 comparison report. Task 7 (Voyage AI embedding provider) was **permanently rejected** — it requires a third-party API key and violates the local-only design goal.

### What shipped

- **Task 1 — Schema**: `migrations/012_canonical_entities.sql` — `canonical_entities` table + `entity_extraction_jobs` outbox table with indexes and triggers
- **Task 2 — Entity types + dedup**: `internal/entity/` — `Entity`/`Relation` types, case-insensitive Jaccard dedup (name + aliases), 4 unit tests
- **Task 3 — Entity DB operations**: `internal/db/postgres_entity.go` — `UpsertEntity` (alias union-merge on conflict), `GetEntitiesByProject`, `EnqueueExtractionJob` (ON CONFLICT DO NOTHING), `ClaimExtractionJobs` (FOR UPDATE SKIP LOCKED), `CompleteExtractionJob`; `Backend` interface extended with all five methods + `ExtractionJob` struct
- **Task 4 — Async extraction worker**: `internal/entity/extract.go` + `worker.go` — `ClaudeExtractor` with markdown fence stripping + rune-safe 4000-char truncation; `Worker` polls outbox via `WorkerBackend` interface; entity enqueue wired into `memory_store` as a non-blocking goroutine with detached `context.Background()` (never delays the store response)
- **Task 5 — 3-tool simplified front door**: `memory_quick_store` (not `memory_ingest` — that name is taken by existing file ingestion tool), `memory_query`, `memory_expand` — thin wrappers over expert-surface tools with sensible defaults; mutation-safe (never mutate caller's args map)
- **Task 6 — Retrieval eval harness**: `internal/eval/harness.go` (P@k, MRR, NDCG), `cmd/eval/main.go` (engram-eval CLI via SSE MCP client), golden sets + Ollama 768-dim baselines recorded

### Task 7 rejected (permanent)

Voyage AI (`ENGRAM_VOYAGE_API_KEY`, `voyageai.com`) requires an external third-party service. This violates the established local-only / no-third-party design constraint. Task 7 is cancelled; the Ollama 768-dim baseline files in `testdata/` serve as the permanent embedding baseline.

### Naming note

`memory_quick_store` (not `memory_ingest`) — `memory_ingest` is already registered for file/directory ingestion. The simplified store tool uses `memory_quick_store` to avoid the conflict.

### SSE URL note

The eval CLI (`cmd/eval/main.go`) must connect to `http://127.0.0.1:8788/sse`, not `http://localhost:8788/sse`. mcp-go validates that the SSE connection origin matches the `endpoint` event URL; the server advertises `127.0.0.1` — using `localhost` triggers an origin mismatch error.

### Eval baselines (Ollama 768-dim, 5 queries each)

| Dataset | P@5 | MRR | NDCG@5 |
|---------|-----|-----|--------|
| engram  | 0.36 | 1.00 | 0.93 |
| homelab | 0.24 | 1.00 | 0.98 |

These are the pre-migration baselines. Any future embedding change must beat these numbers before rolling out.

## Test plan

- [ ] `go test ./internal/entity/... -race` — dedup, extraction, worker tests
- [ ] `go test ./internal/eval/... -race` — P@k, MRR, NDCG metric tests
- [ ] `go test ./internal/mcp/... -race` — entity enqueue, simple tools, explore handler tests
- [ ] `go build ./...` — full build clean
- [ ] `go vet ./...` — no vet issues
- [ ] `psql $DATABASE_URL -f migrations/012_canonical_entities.sql` — migration applies cleanly
- [ ] Adversarial review: Rickover (correctness), Spruance (coverage ≥70% new files), Zero-context reviewer (structural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)