### PR TITLE
fix(#228,#229,#230): entity backend leak, enqueue extraction refactor, memory_expand improvements

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -187,6 +187,12 @@ func run() error {
 	}
 	entityProjects = filteredProjects
 
+	var entityBackends []db.Backend
+	defer func() {
+		for _, b := range entityBackends {
+			b.Close()
+		}
+	}()
 	if cc != nil && len(entityProjects) > 0 {
 		for _, proj := range entityProjects {
 			proj := proj // capture for goroutine
@@ -196,6 +202,7 @@ func run() error {
 					"project", proj, "err", err)
 				continue
 			}
+			entityBackends = append(entityBackends, entityBackend)
 			adapter := &entityDBAdapter{backend: entityBackend}
 			extractor := entity.NewClaudeExtractor(cc)
 			w := entity.NewWorker(adapter, extractor, entity.WorkerConfig{

--- a/internal/mcp/entity_enqueue_test.go
+++ b/internal/mcp/entity_enqueue_test.go
@@ -1,7 +1,6 @@
 package mcp
 
-// Tests for extractResultID and the non-blocking enqueue behaviour wired into
-// the memory_store handler.
+// Tests for extractResultID and enqueueExtractionAsync.
 //
 // extractResultID is unexported so these tests live in package mcp (same
 // package, no _test suffix in the declaration). This follows the convention
@@ -98,7 +97,7 @@ func TestExtractResultID_HappyPath(t *testing.T) {
 	require.Equal(t, want, id)
 }
 
-// ── enqueue wrapper behaviour ─────────────────────────────────────────────────
+// ── enqueueExtractionAsync tests ─────────────────────────────────────────────
 
 // errBackend is a noopBackend override that makes EnqueueExtractionJob return
 // an error, so we can verify the handler proceeds without surfacing it.
@@ -116,58 +115,28 @@ func (errBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, err
 	return "", nil
 }
 
-// TestMemoryStoreHandler_NoEnqueueWhenNoID verifies that the memory_store
-// closure returns (result, nil) when extractResultID returns false — i.e. the
-// handler does not attempt to enqueue and does not return an error.
-func TestMemoryStoreHandler_NoEnqueueWhenNoID(t *testing.T) {
-	// A result with no "id" field — extractResultID will return false.
-	result := textResult(t, map[string]any{"status": "ok"})
-
-	id, ok := extractResultID(result)
-	require.False(t, ok, "pre-condition: result has no id")
-	require.Empty(t, id)
-
-	// If extractResultID returns false the goroutine is never spawned.
-	// Nothing to assert beyond the function returning false — no panic, no enqueue.
-}
-
-// TestMemoryStoreHandler_ReturnsResultEvenOnPoolGetFailure verifies that the
-// memory_store handler's return value is unaffected by pool.Get failures
-// (the goroutine logs and returns silently).
-//
-// We simulate this by building a pool whose factory returns an error and
-// calling the internal logic directly: the goroutine is fire-and-forget so the
-// only contract we can test synchronously is that the goroutine does NOT panic
-// and does NOT modify the return value.
-func TestMemoryStoreHandler_ReturnsResultEvenOnPoolGetFailure(t *testing.T) {
+// TestEnqueueExtractionAsync_PoolGetFailure verifies that a pool.Get error is
+// swallowed: the function logs a warning and returns without panicking.
+func TestEnqueueExtractionAsync_PoolGetFailure(t *testing.T) {
 	failPool := NewEnginePool(func(_ context.Context, _ string) (*EngineHandle, error) {
 		return nil, errors.New("pool: backend unavailable")
 	})
+	// Must not panic; failure is logged and swallowed.
+	enqueueExtractionAsync(failPool, "mem_test99", "test-project")
+}
 
-	const memID = "mem_test99"
-	result := textResult(t, map[string]any{"id": memID})
+// TestEnqueueExtractionAsync_EnqueueJobError verifies that an EnqueueExtractionJob
+// error is also swallowed: the function logs a warning and returns without panicking.
+func TestEnqueueExtractionAsync_EnqueueJobError(t *testing.T) {
+	pool := newPoolWithBackend(t, errBackend{})
+	// Must not panic; EnqueueExtractionJob error is logged and swallowed.
+	enqueueExtractionAsync(pool, "mem_abc", "test-project")
+}
 
-	id, ok := extractResultID(result)
-	require.True(t, ok, "pre-condition: result has a valid id")
-	require.Equal(t, memID, id)
-
-	// Mimic what the closure does — spawn the goroutine.
-	// The goroutine must not panic; it will log a warning and return.
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		ctx, cancel := context.WithTimeout(context.Background(), 5)
-		defer cancel()
-		h, herr := failPool.Get(ctx, "test-project")
-		if herr != nil {
-			// Expected: pool factory returned an error. Handler logs, returns.
-			return
-		}
-		// Should not reach here in this test.
-		_ = h.Engine.Backend().EnqueueExtractionJob(ctx, memID, "test-project")
-	}()
-	<-done // goroutine finished without panic
-
-	// The original result is untouched.
-	require.NotNil(t, result)
+// TestEnqueueExtractionAsync_HappyPath verifies that the function completes
+// without error when the pool and backend both succeed.
+func TestEnqueueExtractionAsync_HappyPath(t *testing.T) {
+	pool := newTestNoopPool(t)
+	// noopBackend.EnqueueExtractionJob returns nil — must not panic.
+	enqueueExtractionAsync(pool, "mem_happy", "test-project")
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -317,20 +317,7 @@ func (s *Server) registerTools() {
 				args := req.GetArguments()
 				project := getString(args, "project", "default")
 				if memID, ok := extractResultID(result); ok {
-					go func() {
-						enqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-						defer cancel()
-						h, herr := pool.Get(enqCtx, project)
-						if herr != nil {
-							slog.Warn("memory_store: enqueue pool.Get failed",
-								"id", memID, "project", project, "err", herr)
-							return
-						}
-						if eerr := h.Engine.Backend().EnqueueExtractionJob(enqCtx, memID, project); eerr != nil {
-							slog.Warn("memory_store: enqueue extraction job failed",
-								"id", memID, "project", project, "err", eerr)
-						}
-					}()
+					go enqueueExtractionAsync(pool, memID, project)
 				}
 				return result, nil
 			}},
@@ -459,7 +446,7 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryQuickStore(ctx, pool, req)
 			}},
-		{"memory_query", "Search memories with automatic graph expansion. Simplified front door for memory_recall.",
+		{"memory_query", "Simplified front door for memory_recall. Accepts a 'limit' param instead of top_k; sensible defaults applied.",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryQuery(ctx, pool, req, cfg)
 			}},
@@ -535,5 +522,22 @@ func (s *Server) registerTools() {
 				return handleMemoryAsk(ctx, pool, req, cfg)
 			},
 		)
+	}
+}
+
+// enqueueExtractionAsync submits memID to the entity extraction queue via pool.
+// Intended to run in a detached goroutine; all failures are logged, never surfaced.
+func enqueueExtractionAsync(pool *EnginePool, memID, project string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	h, herr := pool.Get(ctx, project)
+	if herr != nil {
+		slog.Warn("memory_store: enqueue pool.Get failed",
+			"id", memID, "project", project, "err", herr)
+		return
+	}
+	if eerr := h.Engine.Backend().EnqueueExtractionJob(ctx, memID, project); eerr != nil {
+		slog.Warn("memory_store: enqueue extraction job failed",
+			"id", memID, "project", project, "err", eerr)
 	}
 }

--- a/internal/mcp/simple_tools_test.go
+++ b/internal/mcp/simple_tools_test.go
@@ -11,6 +11,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -249,7 +250,7 @@ func TestMemoryExpand_HappyPath(t *testing.T) {
 			{
 				Memory:    &types.Memory{ID: "mem_neighbor", Content: "linked content"},
 				RelType:   "supports",
-				Direction: "outbound",
+				Direction: "outgoing",
 				Strength:  0.85,
 			},
 		},
@@ -279,7 +280,7 @@ func TestMemoryExpand_HappyPath(t *testing.T) {
 	require.Equal(t, "mem_neighbor", item["id"])
 	require.Equal(t, "linked content", item["content"])
 	require.Equal(t, "supports", item["rel_type"])
-	require.Equal(t, "outbound", item["direction"])
+	require.Equal(t, "outgoing", item["direction"])
 	require.InDelta(t, 0.85, item["strength"], 0.001)
 }
 
@@ -300,6 +301,66 @@ func TestMemoryExpand_DepthClamping(t *testing.T) {
 		out := parseSimpleResult(t, res)
 		require.InDelta(t, 2.0, out["depth"], 0.001, "depth=%v must be clamped to 2", badDepth)
 	}
+}
+
+// ── capturing backend (verifies injected defaults) ───────────────────────────
+
+// capturingBackend records memories passed via StoreMemoryTx for assertion.
+type capturingBackend struct {
+	storeCapableBackend
+	mu     sync.Mutex
+	stored []*types.Memory
+}
+
+func (c *capturingBackend) StoreMemoryTx(_ context.Context, _ db.Tx, m *types.Memory) error {
+	c.mu.Lock()
+	c.stored = append(c.stored, m)
+	c.mu.Unlock()
+	return nil
+}
+
+func newCapturingPool(t *testing.T) (*EnginePool, *capturingBackend) {
+	t.Helper()
+	cap := &capturingBackend{}
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, cap, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory), cap
+}
+
+// TestMemoryQuickStore_DefaultMemoryType_Injected verifies the handler actually
+// writes memory_type="context" to the backend (not just that no error occurs).
+func TestMemoryQuickStore_DefaultMemoryType_Injected(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"content": "context-only content",
+		"project": "test",
+	}
+
+	_, err := handleMemoryQuickStore(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.Len(t, cap.stored, 1)
+	require.Equal(t, "context", cap.stored[0].MemoryType)
+}
+
+// TestMemoryQuickStore_DefaultImportance_Injected verifies the handler actually
+// writes importance=2 to the backend when the caller omits the field.
+func TestMemoryQuickStore_DefaultImportance_Injected(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"content": "importance-default test",
+		"project": "test",
+	}
+
+	_, err := handleMemoryQuickStore(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.Len(t, cap.stored, 1)
+	require.Equal(t, 2, cap.stored[0].Importance)
 }
 
 // ── no-op Tx and Store-capable backend ───────────────────────────────────────

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1646,6 +1646,8 @@ func handleMemoryQuickStore(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 	for k, v := range args {
 		merged[k] = v
 	}
+	// Defaults are pinned here independently of handleMemoryStore's own defaults
+	// so this wrapper's contract stays stable even if upstream defaults drift.
 	if _, ok := merged["memory_type"]; !ok {
 		merged["memory_type"] = "context"
 	}
@@ -1697,7 +1699,8 @@ func handleMemoryExpand(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if memoryID == "" {
 		return nil, fmt.Errorf("memory_id is required")
 	}
-	depth := getInt(args, "depth", 2)
+	requestedDepth := getInt(args, "depth", 2)
+	depth := requestedDepth
 	if depth < 1 || depth > 5 {
 		depth = 2
 	}
@@ -1713,29 +1716,45 @@ func handleMemoryExpand(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 
 	type connItem struct {
-		ID        string  `json:"id"`
-		Content   string  `json:"content"`
-		RelType   string  `json:"rel_type"`
-		Direction string  `json:"direction"`
-		Strength  float64 `json:"strength"`
+		ID         string   `json:"id"`
+		Content    string   `json:"content"`
+		MemoryType string   `json:"memory_type"`
+		Project    string   `json:"project"`
+		Tags       []string `json:"tags"`
+		CreatedAt  string   `json:"created_at,omitempty"`
+		RelType    string   `json:"rel_type"`
+		Direction  string   `json:"direction"`
+		Strength   float64  `json:"strength"`
 	}
 	items := make([]connItem, 0, len(connected))
 	for _, c := range connected {
 		if c.Memory == nil {
 			continue
 		}
+		createdAt := ""
+		if !c.Memory.CreatedAt.IsZero() {
+			createdAt = c.Memory.CreatedAt.Format(time.RFC3339)
+		}
 		items = append(items, connItem{
-			ID:        c.Memory.ID,
-			Content:   c.Memory.Content,
-			RelType:   c.RelType,
-			Direction: c.Direction,
-			Strength:  c.Strength,
+			ID:         c.Memory.ID,
+			Content:    c.Memory.Content,
+			MemoryType: c.Memory.MemoryType,
+			Project:    c.Memory.Project,
+			Tags:       c.Memory.Tags,
+			CreatedAt:  createdAt,
+			RelType:    c.RelType,
+			Direction:  c.Direction,
+			Strength:   c.Strength,
 		})
 	}
 
-	return toolResult(map[string]any{
+	out := map[string]any{
 		"memory_id": memoryID,
 		"depth":     depth,
 		"connected": items,
-	})
+	}
+	if requestedDepth != depth {
+		out["requested_depth"] = requestedDepth
+	}
+	return toolResult(out)
 }


### PR DESCRIPTION
## Summary

- **#228** — Entity worker backends now collected and closed via deferred loop; eliminates connection leak on shutdown
- **#229** — \`enqueueExtractionAsync\` extracted from anonymous goroutine closure; 3 new tests cover pool failure, backend error, and happy path
- **#230** — Six sub-fixes: injection-verification tests (NB-1), richer \`connItem\` output (NB-2), "outgoing" direction fix (NB-3), \`requested_depth\` in clamped response (NB-4), accurate tool description (NB-5), pinning comment on default constants (NB-6)

## Test plan

- [x] \`go test ./... -count=1 -race\` — all 20 packages pass
- [x] New \`TestEnqueueExtractionAsync_*\` tests verify pool/backend error paths and happy path
- [x] New \`TestMemoryQuickStore_DefaultMemoryType_Injected\` and \`TestMemoryQuickStore_DefaultImportance_Injected\` verify actual backend writes
- [x] \`TestMemoryExpand_HappyPath\` fixture and assertion both use \`"outgoing"\` (matching backend.go:314 contract)

Closes #228, #229, #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)