### PR TITLE
fix: QA Army remediation — all 16 campaign/qa-army-2026-04 findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Required: set a strong password for the engram PostgreSQL database
+POSTGRES_PASSWORD=change_me_to_a_strong_password
+
+# Optional: port to expose engram on (default: 8788)
+# ENGRAM_PORT=8788
+
+# Optional: expose externally (remove 127.0.0.1: prefix from docker-compose.yml)
+# By default, engram only listens on localhost for security.

--- a/cmd/engram-setup/main_test.go
+++ b/cmd/engram-setup/main_test.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// healthCheck
+// ---------------------------------------------------------------------------
+
+func TestHealthCheck(t *testing.T) {
+	t.Run("returns nil on 200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/health" {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		if err := healthCheck(srv.URL); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		err := healthCheck(srv.URL)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "503") {
+			t.Errorf("error should mention status 503, got: %v", err)
+		}
+	})
+
+	t.Run("returns error when server unreachable", func(t *testing.T) {
+		// Port 1 is reserved and not listening.
+		err := healthCheck("http://127.0.0.1:1")
+		if err == nil {
+			t.Fatal("expected connection-refused error, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// fetchSetupToken
+// ---------------------------------------------------------------------------
+
+func TestFetchSetupToken(t *testing.T) {
+	validToken := "abcdefghijkl" // exactly 12 chars — minimum required length
+
+	t.Run("returns token and endpoint on 200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/setup-token" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(setupResponse{
+				Token:    validToken,
+				Endpoint: "http://127.0.0.1:8788/mcp",
+				Name:     "engram",
+			})
+		}))
+		defer srv.Close()
+
+		resp, err := fetchSetupToken(srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Token != validToken {
+			t.Errorf("Token: got %q, want %q", resp.Token, validToken)
+		}
+		if resp.Endpoint != "http://127.0.0.1:8788/mcp" {
+			t.Errorf("Endpoint: got %q, want %q", resp.Endpoint, "http://127.0.0.1:8788/mcp")
+		}
+	})
+
+	t.Run("returns error on 403 Forbidden (non-localhost call)", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		_, err := fetchSetupToken(srv.URL)
+		if err == nil {
+			t.Fatal("expected error on 403, got nil")
+		}
+		if !strings.Contains(err.Error(), "localhost-only") {
+			t.Errorf("error should mention localhost-only restriction, got: %v", err)
+		}
+	})
+
+	t.Run("returns error on 404", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer srv.Close()
+
+		_, err := fetchSetupToken(srv.URL)
+		if err == nil {
+			t.Fatal("expected error on 404, got nil")
+		}
+		if !strings.Contains(err.Error(), "404") {
+			t.Errorf("error should mention status 404, got: %v", err)
+		}
+	})
+
+	t.Run("returns error on empty token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(setupResponse{Token: "", Endpoint: "http://x/mcp"})
+		}))
+		defer srv.Close()
+
+		_, err := fetchSetupToken(srv.URL)
+		if err == nil {
+			t.Fatal("expected error for empty token, got nil")
+		}
+	})
+
+	t.Run("returns error on token shorter than 12 chars", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(setupResponse{Token: "short", Endpoint: "http://x/mcp"})
+		}))
+		defer srv.Close()
+
+		_, err := fetchSetupToken(srv.URL)
+		if err == nil {
+			t.Fatal("expected error for short token, got nil")
+		}
+	})
+
+	t.Run("returns error on malformed JSON", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{not valid json`))
+		}))
+		defer srv.Close()
+
+		_, err := fetchSetupToken(srv.URL)
+		if err == nil {
+			t.Fatal("expected error on malformed JSON, got nil")
+		}
+	})
+
+	t.Run("returns error when server unreachable (timeout path)", func(t *testing.T) {
+		// Use a closed server so the connection is refused immediately.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		srv.Close() // close before calling
+		_, err := fetchSetupToken(srv.URL)
+		if err == nil {
+			t.Fatal("expected connection error, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// updateMCPConfig
+// ---------------------------------------------------------------------------
+
+func TestUpdateMCPConfig(t *testing.T) {
+	entry := map[string]interface{}{
+		"type": "sse",
+		"url":  "http://127.0.0.1:8788/mcp",
+		"headers": map[string]string{
+			"Authorization": "Bearer test-token-123",
+		},
+	}
+
+	t.Run("creates mcp_servers.json when absent", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude", "mcp_servers.json")
+
+		action, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if action != "added" {
+			t.Errorf("action: got %q, want %q", action, "added")
+		}
+
+		raw, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatalf("file not created: %v", err)
+		}
+
+		var cfg map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+		if _, ok := cfg["mcpServers"]; !ok {
+			t.Error("mcpServers key missing from written config")
+		}
+
+		var mcpServers map[string]json.RawMessage
+		if err := json.Unmarshal(cfg["mcpServers"], &mcpServers); err != nil {
+			t.Fatalf("mcpServers not valid JSON: %v", err)
+		}
+		if _, ok := mcpServers["engram"]; !ok {
+			t.Error("engram entry missing from mcpServers")
+		}
+	})
+
+	t.Run("updates existing entry in mcp_servers.json", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude", "mcp_servers.json")
+
+		// Write an initial config with a stale token.
+		initial := `{"mcpServers":{"engram":{"type":"sse","url":"http://127.0.0.1:8788/mcp","headers":{"Authorization":"Bearer old-token"}}}}`
+		if err := os.MkdirAll(filepath.Dir(cfgPath), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(cfgPath, []byte(initial), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		action, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if action != "updated" {
+			t.Errorf("action: got %q, want %q", action, "updated")
+		}
+
+		raw, _ := os.ReadFile(cfgPath)
+		if !strings.Contains(string(raw), "Bearer test-token-123") {
+			t.Error("updated file does not contain the new token")
+		}
+	})
+
+	t.Run("file permissions are 0600", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude", "mcp_servers.json")
+
+		_, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		info, err := os.Stat(cfgPath)
+		if err != nil {
+			t.Fatalf("stat failed: %v", err)
+		}
+		perm := info.Mode().Perm()
+		if perm != 0600 {
+			t.Errorf("file permissions: got %o, want 0600", perm)
+		}
+	})
+
+	t.Run("skips .claude.json when file absent", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude.json")
+		// File does not exist.
+
+		action, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if action != "" {
+			t.Errorf("expected empty action (skip), got %q", action)
+		}
+		if _, statErr := os.Stat(cfgPath); !os.IsNotExist(statErr) {
+			t.Error(".claude.json should not have been created")
+		}
+	})
+
+	t.Run("skips .claude.json when mcpServers key is absent", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude.json")
+
+		// File exists but has no mcpServers key.
+		if err := os.WriteFile(cfgPath, []byte(`{"theme":"dark"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		action, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if action != "" {
+			t.Errorf("expected empty action (skip), got %q", action)
+		}
+
+		// File content should be unchanged.
+		raw, _ := os.ReadFile(cfgPath)
+		if strings.Contains(string(raw), "mcpServers") {
+			t.Error(".claude.json should not have gained an mcpServers key")
+		}
+	})
+
+	t.Run("updates .claude.json when mcpServers key already present", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude.json")
+
+		existing := `{"theme":"dark","mcpServers":{"other":{"type":"sse","url":"http://other/mcp"}}}`
+		if err := os.WriteFile(cfgPath, []byte(existing), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		action, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if action != "added" {
+			t.Errorf("action: got %q, want %q", action, "added")
+		}
+
+		raw, _ := os.ReadFile(cfgPath)
+		var cfg map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			t.Fatalf("output not valid JSON: %v", err)
+		}
+		// Both the new and the existing MCP entry should be present.
+		var mcpServers map[string]json.RawMessage
+		json.Unmarshal(cfg["mcpServers"], &mcpServers)
+		if _, ok := mcpServers["engram"]; !ok {
+			t.Error("engram entry missing from updated .claude.json")
+		}
+		if _, ok := mcpServers["other"]; !ok {
+			t.Error("pre-existing 'other' MCP entry was lost")
+		}
+		// Original theme key must survive.
+		if _, ok := cfg["theme"]; !ok {
+			t.Error("theme key was lost from .claude.json")
+		}
+	})
+
+	t.Run("returns error on invalid JSON in existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude", "mcp_servers.json")
+		if err := os.MkdirAll(filepath.Dir(cfgPath), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(cfgPath, []byte(`{bad json`), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err == nil {
+			t.Fatal("expected error on malformed JSON, got nil")
+		}
+	})
+
+	t.Run("written JSON is valid and ends with newline", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, ".claude", "mcp_servers.json")
+
+		_, err := updateMCPConfig(cfgPath, "engram", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		raw, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatalf("read failed: %v", err)
+		}
+		if len(raw) == 0 || raw[len(raw)-1] != '\n' {
+			t.Error("written file should end with a newline")
+		}
+		var out interface{}
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Errorf("written file is not valid JSON: %v", err)
+		}
+	})
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/entity"
 	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
+	"github.com/petersimmons1972/engram/internal/netutil"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/summarize"
 	"github.com/petersimmons1972/engram/internal/types"
@@ -87,7 +88,7 @@ func run() error {
 	// Block literal private-IP Ollama URLs to prevent SSRF (#55).
 	// Hostnames (e.g. "ollama" in Docker Compose) are intentionally excluded:
 	// they resolve to private container IPs by design and are not attacker-controlled.
-	if ollamaHost := parsedOllamaURL.Hostname(); net.ParseIP(ollamaHost) != nil && isPrivateIP(ollamaHost) {
+	if ollamaHost := parsedOllamaURL.Hostname(); net.ParseIP(ollamaHost) != nil && netutil.IsPrivateIP(ollamaHost) {
 		return fmt.Errorf("invalid --ollama-url: IP %q is in a private/reserved range (SSRF protection)", ollamaHost)
 	}
 
@@ -229,44 +230,6 @@ func run() error {
 	slog.Info("engram ready", "host", *host, "port", *port,
 		"embed_model", *embedModel, "summarize_model", sumModel)
 	return srv.Start(ctx, *host, *port, apiKey, *baseURL)
-}
-
-// isPrivateIP reports whether ipStr is an IP address that falls within a
-// private, loopback, or link-local range. Only literal IP addresses are
-// checked; hostnames must be resolved before calling this function.
-// Used to block SSRF via the Ollama URL flag (#55).
-func isPrivateIP(ipStr string) bool {
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return false
-	}
-	// Normalize IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) to their IPv4 form
-	// so they are checked against the same IPv4 private ranges. This prevents
-	// bypassing the check via notation like "::ffff:127.0.0.1".
-	if ip4 := ip.To4(); ip4 != nil {
-		ip = ip4
-	}
-	privateRanges := []string{
-		"0.0.0.0/8",      // this-network (RFC 1122)
-		"10.0.0.0/8",
-		"100.64.0.0/10",  // CGNAT (RFC 6598)
-		"127.0.0.0/8",    // loopback
-		"169.254.0.0/16", // link-local / AWS metadata endpoint
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"198.18.0.0/15",  // benchmark testing (RFC 2544)
-		"240.0.0.0/4",    // reserved (RFC 1112)
-		"::1/128",        // IPv6 loopback
-		"fc00::/7",       // IPv6 ULA
-		"fe80::/10",      // IPv6 link-local
-	}
-	for _, cidr := range privateRanges {
-		_, n, _ := net.ParseCIDR(cidr)
-		if n.Contains(ip) {
-			return true
-		}
-	}
-	return false
 }
 
 func envOr(key, def string) string {

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -136,6 +136,17 @@ func run() error {
 		}
 	}
 
+	// Start the retrieval_events retention worker on a shared backend.
+	// A dedicated backend is used so the worker lifecycle is independent of
+	// per-project factory calls. Project "default" is used for the connection;
+	// the DELETE query itself targets all projects via no project filter.
+	retentionBackend, err := db.NewPostgresBackend(ctx, "default", dsn)
+	if err != nil {
+		return fmt.Errorf("retention worker backend: %w", err)
+	}
+	defer retentionBackend.Close()
+	go retentionBackend.StartRetentionWorker(ctx)
+
 	factory := func(ctx context.Context, project string) (*internalmcp.EngineHandle, error) {
 		backend, err := db.NewPostgresBackend(ctx, project, dsn)
 		if err != nil {

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -70,12 +70,11 @@ func run() error {
 		return fmt.Errorf("ENGRAM_API_KEY or --api-key is required; refusing to start without authentication")
 	}
 
-	// Unset secrets from the process environment after reading (#139, #141).
-	// This limits exposure via /proc/self/environ to the startup window only.
-	// Note: this reduces but does not eliminate the window — the kernel may cache
-	// the original environ in /proc until the process exits.
+	// Unset secrets from the process environment after reading (#139, #141, #250).
+	// Reduces the exposure window for credentials in /proc/self/environ.
 	_ = os.Unsetenv("ENGRAM_API_KEY")
 	_ = os.Unsetenv("ANTHROPIC_API_KEY")
+	_ = os.Unsetenv("DATABASE_URL")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/petersimmons1972/engram/internal/netutil"
 )
 
 func TestRecallDefaultModeDefault(t *testing.T) {
@@ -27,30 +29,34 @@ func TestRecallDefaultModeDefault(t *testing.T) {
 	}
 }
 
-func TestIsPrivateIP(t *testing.T) {
+// TestIsPrivateIP_ViaNetutil verifies that the startup SSRF guard in main.go
+// delegates correctly to netutil.IsPrivateIP. The comprehensive range coverage
+// is in internal/netutil/private_ip_test.go; this test covers the cases that
+// were exercised by the old inline isPrivateIP function (#55, #68, #242).
+func TestIsPrivateIP_ViaNetutil(t *testing.T) {
 	cases := []struct {
 		ip      string
 		private bool
 	}{
 		// Private / reserved ranges that must be blocked
-		{"169.254.169.254", true},  // AWS metadata
-		{"10.0.0.1", true},         // RFC-1918
-		{"10.255.255.255", true},   // RFC-1918
-		{"172.16.0.1", true},       // RFC-1918
-		{"172.31.255.255", true},   // RFC-1918
-		{"192.168.1.1", true},      // RFC-1918
-		{"127.0.0.1", true},        // loopback
-		{"127.255.0.1", true},      // loopback range
-		{"::1", true},              // IPv6 loopback
-		{"fc00::1", true},          // IPv6 ULA
-		{"fe80::1", true},          // IPv6 link-local
+		{"169.254.169.254", true},    // AWS metadata
+		{"10.0.0.1", true},           // RFC-1918
+		{"10.255.255.255", true},     // RFC-1918
+		{"172.16.0.1", true},         // RFC-1918
+		{"172.31.255.255", true},     // RFC-1918
+		{"192.168.1.1", true},        // RFC-1918
+		{"127.0.0.1", true},          // loopback
+		{"127.255.0.1", true},        // loopback range
+		{"::1", true},                // IPv6 loopback
+		{"fc00::1", true},            // IPv6 ULA
+		{"fe80::1", true},            // IPv6 link-local
 		// Previously missing ranges (fixes #68)
-		{"0.0.0.1", true},          // this-network (RFC 1122)
-		{"100.64.0.1", true},       // CGNAT (RFC 6598)
-		{"100.127.255.255", true},  // CGNAT top
-		{"198.18.0.1", true},       // benchmark (RFC 2544)
-		{"198.19.255.255", true},   // benchmark top
-		{"240.0.0.1", true},        // reserved (RFC 1112)
+		{"0.0.0.1", true},            // this-network (RFC 1122)
+		{"100.64.0.1", true},         // CGNAT (RFC 6598)
+		{"100.127.255.255", true},    // CGNAT top
+		{"198.18.0.1", true},         // benchmark (RFC 2544)
+		{"198.19.255.255", true},     // benchmark top
+		{"240.0.0.1", true},          // reserved (RFC 1112)
 		{"::ffff:192.168.1.1", true}, // IPv4-mapped IPv6
 
 		// Public addresses that must pass
@@ -65,9 +71,9 @@ func TestIsPrivateIP(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := isPrivateIP(tc.ip)
+		got := netutil.IsPrivateIP(tc.ip)
 		if got != tc.private {
-			t.Errorf("isPrivateIP(%q) = %v, want %v", tc.ip, got, tc.private)
+			t.Errorf("netutil.IsPrivateIP(%q) = %v, want %v", tc.ip, got, tc.private)
 		}
 	}
 }

--- a/cmd/starter/main.go
+++ b/cmd/starter/main.go
@@ -29,10 +29,27 @@ func patchDatabaseURLPassword(dsn, password string) string {
 	return u.String()
 }
 
-// infisicalDomainRE accepts only https:// URLs with a safe hostname.
-// This prevents INFISICAL_DOMAIN from being set to an attacker-controlled host
-// that would redirect machine-identity authentication (#135).
-var infisicalDomainRE = regexp.MustCompile(`^https://[a-zA-Z0-9][a-zA-Z0-9\-\.]+$`)
+// infisicalDomainRE accepts only https:// URLs with a proper FQDN hostname
+// (at least two dot-separated labels, e.g. infisical.example.com).
+// The FQDN requirement blocks localhost and single-label hostnames.
+// Each label: starts with alphanumeric, may contain hyphens.
+// Raw IP addresses (which also satisfy the dot rule) are blocked by
+// isValidInfisicalDomain using net.ParseIP.
+var infisicalDomainRE = regexp.MustCompile(`^https://[a-zA-Z0-9][a-zA-Z0-9\-]*(\.[a-zA-Z0-9][a-zA-Z0-9\-]*)+$`)
+
+// isValidInfisicalDomain returns true iff domain is a safe Infisical base URL.
+// It combines the FQDN regex with an IP-address rejection to prevent SSRF (#135).
+func isValidInfisicalDomain(domain string) bool {
+	if !infisicalDomainRE.MatchString(domain) {
+		return false
+	}
+	// Strip the scheme to get the raw host, then reject raw IP literals.
+	host := domain[len("https://"):]
+	if net.ParseIP(host) != nil {
+		return false
+	}
+	return true
+}
 
 // infisicalHTTPClient has explicit timeouts so an unreachable Infisical
 // host does not hang the container startup indefinitely (#137).
@@ -58,8 +75,8 @@ func main() {
 	secretPath := envOr("INFISICAL_SECRET_PATH", "/engram")
 
 	// Validate Infisical domain to prevent supply-chain redirect attacks (#135).
-	if !infisicalDomainRE.MatchString(domain) {
-		fatalf("INFISICAL_DOMAIN %q is invalid — must be https://<hostname> with no path or credentials", domain)
+	if !isValidInfisicalDomain(domain) {
+		fatalf("INFISICAL_DOMAIN %q is invalid — must be https://<fqdn> with no path, credentials, or raw IP", domain)
 	}
 
 	ctx := context.Background()

--- a/cmd/starter/main_test.go
+++ b/cmd/starter/main_test.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// patchDatabaseURLPassword
+// ---------------------------------------------------------------------------
+
+func TestPatchDatabaseURLPassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsn      string
+		password string
+		want     string
+	}{
+		{
+			name:     "standard postgres scheme with existing password",
+			dsn:      "postgres://alice:oldpass@db.example.com:5432/mydb",
+			password: "newpass",
+			want:     "postgres://alice:newpass@db.example.com:5432/mydb",
+		},
+		{
+			name:     "postgresql scheme",
+			dsn:      "postgresql://bob:secret@localhost/testdb",
+			password: "fresh",
+			want:     "postgresql://bob:fresh@localhost/testdb",
+		},
+		{
+			name:     "URL with no password field",
+			dsn:      "postgres://carol@db.example.com/mydb",
+			password: "injected",
+			want:     "postgres://carol:injected@db.example.com/mydb",
+		},
+		{
+			name:     "special characters in new password",
+			dsn:      "postgres://user:old@host/db",
+			password: "p@ss!w0rd#$%",
+			// url.String() percent-encodes special chars in the password
+			want:     "postgres://user:p%40ss%21w0rd%23$%25@host/db",
+		},
+		{
+			name:     "empty DSN returns unchanged",
+			dsn:      "",
+			password: "anything",
+			want:     "",
+		},
+		{
+			name:     "unparseable DSN returns unchanged",
+			dsn:      "not-a-url://\x00",
+			password: "anything",
+			want:     "not-a-url://\x00",
+		},
+		{
+			name:     "DSN with no userinfo returns unchanged",
+			dsn:      "postgres://host/db",
+			password: "x",
+			// url.Parse succeeds but u.User is nil -- function returns dsn unchanged
+			want: "postgres://host/db",
+		},
+		{
+			name:     "empty password clears existing password",
+			dsn:      "postgres://user:old@host/db",
+			password: "",
+			want:     "postgres://user:@host/db",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := patchDatabaseURLPassword(tc.dsn, tc.password)
+			if got != tc.want {
+				t.Errorf("patchDatabaseURLPassword(%q, %q)\n  got  %q\n  want %q",
+					tc.dsn, tc.password, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// filteredEnv
+// ---------------------------------------------------------------------------
+
+func TestFilteredEnv(t *testing.T) {
+	// Set a known environment before calling filteredEnv so the test is
+	// deterministic regardless of what the real process environment contains.
+	keys := []string{
+		"INFISICAL_CLIENT_ID",
+		"INFISICAL_CLIENT_SECRET",
+		"POSTGRES_PASSWORD",
+		"SAFE_VAR_1",
+		"SAFE_VAR_2",
+	}
+	values := map[string]string{
+		"INFISICAL_CLIENT_ID":     "cid-value",
+		"INFISICAL_CLIENT_SECRET": "csec-value",
+		"POSTGRES_PASSWORD":       "pgpass-value",
+		"SAFE_VAR_1":              "keep-me",
+		"SAFE_VAR_2":              "keep-me-too",
+	}
+	// Set vars; restore on cleanup.
+	for k, v := range values {
+		t.Setenv(k, v)
+	}
+
+	result := filteredEnv("INFISICAL_CLIENT_ID", "INFISICAL_CLIENT_SECRET", "POSTGRES_PASSWORD")
+
+	// Build a lookup map from the returned slice.
+	got := make(map[string]string)
+	for _, kv := range result {
+		idx := strings.IndexByte(kv, '=')
+		if idx < 0 {
+			continue
+		}
+		got[kv[:idx]] = kv[idx+1:]
+	}
+
+	// Credential keys MUST be absent.
+	for _, forbidden := range []string{"INFISICAL_CLIENT_ID", "INFISICAL_CLIENT_SECRET", "POSTGRES_PASSWORD"} {
+		if _, present := got[forbidden]; present {
+			t.Errorf("filteredEnv: %q was not stripped from the environment", forbidden)
+		}
+	}
+
+	// Safe keys MUST be present with original values.
+	for _, safe := range []string{"SAFE_VAR_1", "SAFE_VAR_2"} {
+		v, present := got[safe]
+		if !present {
+			t.Errorf("filteredEnv: %q was incorrectly stripped", safe)
+			continue
+		}
+		if v != values[safe] {
+			t.Errorf("filteredEnv: %q value changed: got %q want %q", safe, v, values[safe])
+		}
+	}
+
+	// Sanity-check: the caller sees something non-empty (at least PATH should survive).
+	if len(result) == 0 {
+		t.Error("filteredEnv returned an empty slice; expected at least some env vars to survive")
+	}
+
+	_ = keys // used implicitly via t.Setenv
+}
+
+func TestFilteredEnvNoKeysToRemove(t *testing.T) {
+	t.Setenv("CANARY", "alive")
+	result := filteredEnv() // no keys to drop
+	got := make(map[string]string)
+	for _, kv := range result {
+		idx := strings.IndexByte(kv, '=')
+		if idx >= 0 {
+			got[kv[:idx]] = kv[idx+1:]
+		}
+	}
+	if got["CANARY"] != "alive" {
+		t.Errorf("filteredEnv with no remove keys should preserve all vars; CANARY lost")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isValidInfisicalDomain (covers both the FQDN regex and IP rejection)
+// ---------------------------------------------------------------------------
+
+func TestIsValidInfisicalDomain(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		// Valid Infisical domains
+		{"default self-hosted", "https://infisical.petersimmons.com", true},
+		{"official SaaS", "https://app.infisical.com", true},
+		{"custom subdomain", "https://secrets.internal.company.io", true},
+		{"hyphen in label", "https://my-infisical.example.com", true},
+		{"deep subdomain", "https://a.b.c.infisical.com", true},
+
+		// Invalid: single-label hostnames (no dot)
+		{"single-label hostname", "https://infisical", false},
+		{"localhost (single-label)", "https://localhost", false},
+
+		// Invalid: raw IP addresses (have dots but are numeric)
+		{"IPv4 private", "https://192.168.1.1", false},
+		{"IPv4 loopback", "https://127.0.0.1", false},
+		{"IPv4 public", "https://8.8.8.8", false},
+
+		// Invalid: wrong scheme
+		{"http not https", "http://app.infisical.com", false},
+		{"no scheme", "app.infisical.com", false},
+		{"ftp scheme", "ftp://app.infisical.com", false},
+
+		// Invalid: paths/credentials/ports in URL
+		{"with path", "https://app.infisical.com/api", false},
+		{"with credentials in URL", "https://user:pass@infisical.com", false},
+		{"with port", "https://infisical.com:8443", false},
+		{"trailing slash", "https://infisical.com/", false},
+
+		// Edge cases
+		{"empty string", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidInfisicalDomain(tc.input)
+			if got != tc.valid {
+				t.Errorf("isValidInfisicalDomain(%q) = %v, want %v", tc.input, got, tc.valid)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getAccessToken (HTTP mock)
+// ---------------------------------------------------------------------------
+
+func TestGetAccessToken(t *testing.T) {
+	t.Run("returns token on 200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/auth/universal-auth/login" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"accessToken": "tok-abc123"})
+		}))
+		defer srv.Close()
+
+		token, err := getAccessToken(t.Context(), srv.URL, "cid", "csec")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "tok-abc123" {
+			t.Errorf("got token %q, want %q", token, "tok-abc123")
+		}
+	})
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		_, err := getAccessToken(t.Context(), srv.URL, "bad", "creds")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "401") {
+			t.Errorf("error should mention status 401, got: %v", err)
+		}
+	})
+
+	t.Run("returns error on empty access token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"accessToken": ""})
+		}))
+		defer srv.Close()
+
+		_, err := getAccessToken(t.Context(), srv.URL, "cid", "csec")
+		if err == nil {
+			t.Fatal("expected error for empty access token, got nil")
+		}
+	})
+
+	t.Run("returns error on malformed JSON", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{not valid json`))
+		}))
+		defer srv.Close()
+
+		_, err := getAccessToken(t.Context(), srv.URL, "cid", "csec")
+		if err == nil {
+			t.Fatal("expected error on malformed JSON, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// getSecret (HTTP mock)
+// ---------------------------------------------------------------------------
+
+func TestGetSecret(t *testing.T) {
+	t.Run("returns secret value on 200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"secret": map[string]string{"secretValue": "supersecret"},
+			})
+		}))
+		defer srv.Close()
+
+		val, err := getSecret(t.Context(), srv.URL, "tok", "proj", "prod", "/engram", "MY_SECRET")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != "supersecret" {
+			t.Errorf("got %q, want %q", val, "supersecret")
+		}
+	})
+
+	t.Run("returns error on 404", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer srv.Close()
+
+		_, err := getSecret(t.Context(), srv.URL, "tok", "proj", "prod", "/engram", "MISSING")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "404") {
+			t.Errorf("error should mention 404, got: %v", err)
+		}
+	})
+
+	t.Run("returns error on empty secret value", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"secret": map[string]string{"secretValue": ""},
+			})
+		}))
+		defer srv.Close()
+
+		_, err := getSecret(t.Context(), srv.URL, "tok", "proj", "prod", "/engram", "EMPTY_SECRET")
+		if err == nil {
+			t.Fatal("expected error for empty secret value, got nil")
+		}
+	})
+
+	t.Run("secret name is path-escaped in URL", func(t *testing.T) {
+		var capturedURI string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// r.URL.RequestURI() preserves the raw (percent-encoded) form as sent on the wire.
+			capturedURI = r.URL.RequestURI()
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"secret": map[string]string{"secretValue": "val"},
+			})
+		}))
+		defer srv.Close()
+
+		_, _ = getSecret(t.Context(), srv.URL, "tok", "proj", "prod", "/", "MY/SECRET")
+		// url.PathEscape("MY/SECRET") => "MY%2FSECRET"; verify the slash was encoded.
+		if !strings.Contains(capturedURI, "MY%2FSECRET") {
+			t.Errorf("secret name not path-escaped in request URL; got URI %q", capturedURI)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// envOr helper
+// ---------------------------------------------------------------------------
+
+func TestEnvOr(t *testing.T) {
+	t.Run("returns env value when set", func(t *testing.T) {
+		t.Setenv("TEST_ENVOR_KEY", "from-env")
+		got := envOr("TEST_ENVOR_KEY", "default")
+		if got != "from-env" {
+			t.Errorf("got %q, want %q", got, "from-env")
+		}
+	})
+
+	t.Run("returns default when env unset", func(t *testing.T) {
+		os.Unsetenv("TEST_ENVOR_KEY_MISSING")
+		got := envOr("TEST_ENVOR_KEY_MISSING", "my-default")
+		if got != "my-default" {
+			t.Errorf("got %q, want %q", got, "my-default")
+		}
+	})
+
+	t.Run("returns default when env is empty string", func(t *testing.T) {
+		t.Setenv("TEST_ENVOR_EMPTY", "")
+		got := envOr("TEST_ENVOR_EMPTY", "fallback")
+		if got != "fallback" {
+			t.Errorf("got %q, want %q", got, "fallback")
+		}
+	})
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - pgdata:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=engram
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-engram}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       - POSTGRES_DB=engram
 
     healthcheck:
@@ -93,14 +93,14 @@ services:
     container_name: engram-go-app
     image: engram-go:latest
     ports:
-      - "0.0.0.0:${ENGRAM_PORT:-8788}:8788"
+      - "127.0.0.1:${ENGRAM_PORT:-8788}:8788"
     env_file:
       - path: .env
         required: false
       - path: .env.machine-identity
         required: true
     environment:
-      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:-engram}@postgres:5432/engram
+      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram
       - OLLAMA_URL=http://ollama:11434
       - ENGRAM_OLLAMA_MODEL=${ENGRAM_OLLAMA_MODEL:-nomic-embed-text}
       - ENGRAM_SUMMARIZE_MODEL=${ENGRAM_SUMMARIZE_MODEL:-llama3.2:3b}
@@ -122,6 +122,16 @@ services:
       ollama:
         condition: service_healthy
     restart: unless-stopped
+    mem_limit: 512m
+    pids_limit: 512
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:8788/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   # ── Test database (CI only) ───────────────────────────────────────────────
   test-postgres:

--- a/internal/db/cleanup.go
+++ b/internal/db/cleanup.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// CleanupRetentionEvents deletes retrieval_events rows older than 90 days and
+// returns the number of rows deleted.
+func (b *PostgresBackend) CleanupRetentionEvents(ctx context.Context) (int64, error) {
+	return b.deleteOldRetrievalEvents(ctx)
+}
+
+// StartRetentionWorker runs CleanupRetentionEvents once at startup and then
+// every 24 hours. It is designed to be called as a goroutine:
+//
+//	go backend.StartRetentionWorker(ctx)
+//
+// The worker exits when ctx is cancelled (e.g. on SIGTERM).
+func (b *PostgresBackend) StartRetentionWorker(ctx context.Context) {
+	run := func() {
+		n, err := b.deleteOldRetrievalEvents(ctx)
+		if err != nil {
+			slog.Error("retention worker: cleanup failed", "err", err)
+			return
+		}
+		slog.Info("retention worker: cleanup complete", "rows_deleted", n)
+	}
+
+	run() // catch-up pass at startup
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
+}
+
+// deleteOldRetrievalEvents issues the age-gated DELETE and returns the
+// number of rows removed. Kept private; callers should use StartRetentionWorker
+// or CleanupRetentionEvents.
+func (b *PostgresBackend) deleteOldRetrievalEvents(ctx context.Context) (int64, error) {
+	const q = `
+DELETE FROM retrieval_events
+WHERE created_at < NOW() - INTERVAL '90 days'`
+
+	tag, err := b.pool.Exec(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/db/escape_like_test.go
+++ b/internal/db/escape_like_test.go
@@ -1,0 +1,53 @@
+package db
+
+import "testing"
+
+// TestEscapeLike verifies that escapeLike correctly escapes all three PostgreSQL
+// LIKE metacharacters and handles combined and edge cases.
+func TestEscapeLike(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "plain string — no metacharacters",
+			input: "auth",
+			want:  "auth",
+		},
+		{
+			name:  "percent wildcard",
+			input: "test%",
+			want:  `test\%`,
+		},
+		{
+			name:  "underscore wildcard",
+			input: "t_st",
+			want:  `t\_st`,
+		},
+		{
+			name:  "backslash escape character",
+			input: `C:\Users`,
+			want:  `C:\\Users`,
+		},
+		{
+			name:  "combined metacharacters",
+			input: `100% _done_ \win`,
+			want:  `100\% \_done\_ \\win`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := escapeLike(tc.input)
+			if got != tc.want {
+				t.Errorf("escapeLike(%q) = %q; want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/db/migrations/012_backfill_content_hash_safe.sql
+++ b/internal/db/migrations/012_backfill_content_hash_safe.sql
@@ -1,0 +1,30 @@
+-- Migration 012: re-run content_hash backfill in safe batches.
+--
+-- Migration 009 already ran on most deployments and will find zero rows to
+-- update. Large deployments that skipped 009 get this non-blocking catch-up
+-- instead of the single unbounded UPDATE that could lock the full table for
+-- minutes.
+--
+-- Uses FOR UPDATE SKIP LOCKED so live reader/writer traffic is not stalled,
+-- and pg_sleep(0.01) between batches to yield scheduling time to other
+-- transactions. The loop exits as soon as a batch returns 0 rows.
+
+DO $$
+DECLARE
+  batch_size CONSTANT int := 1000;
+  rows_updated int;
+BEGIN
+  LOOP
+    UPDATE memories
+    SET content_hash = encode(sha256(convert_to(content, 'UTF8')), 'hex')
+    WHERE id IN (
+      SELECT id FROM memories
+      WHERE content_hash IS NULL AND valid_to IS NULL
+      LIMIT batch_size
+      FOR UPDATE SKIP LOCKED
+    );
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    EXIT WHEN rows_updated = 0;
+    PERFORM pg_sleep(0.01);
+  END LOOP;
+END $$;

--- a/internal/db/migrations/013_retrieval_events_retention.sql
+++ b/internal/db/migrations/013_retrieval_events_retention.sql
@@ -1,0 +1,16 @@
+-- Migration 013: add index for age-based cleanup and retention function.
+--
+-- retrieval_events accumulates unboundedly with no TTL. This migration adds an
+-- index on created_at to make the DELETE fast, and a stored function that the
+-- application calls on a daily schedule to evict rows older than 90 days.
+
+CREATE INDEX IF NOT EXISTS idx_retrieval_events_created_at
+    ON retrieval_events (created_at);
+
+CREATE OR REPLACE FUNCTION cleanup_old_retrieval_events() RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  DELETE FROM retrieval_events
+  WHERE created_at < NOW() - INTERVAL '90 days';
+END;
+$$;

--- a/internal/db/postgres_aggregate.go
+++ b/internal/db/postgres_aggregate.go
@@ -3,10 +3,21 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/types"
 )
+
+// escapeLike escapes the three PostgreSQL LIKE metacharacters so that a filter
+// value is treated as a literal substring rather than a pattern.
+// Order matters: escape the escape character first, then % and _.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
 
 // AggregateMemories dispatches to the appropriate aggregate helper based on
 // the by parameter. Supported values are "tag" and "type".
@@ -41,11 +52,11 @@ FROM (
     WHERE project = $1 AND valid_to IS NULL
     GROUP BY label
 ) sub
-WHERE ($2 = '' OR label ILIKE '%' || $2 || '%')
+WHERE ($2 = '' OR label ILIKE '%' || $2 || '%' ESCAPE '\')
 ORDER BY count DESC
 LIMIT $3`
 
-	rows, err := b.pool.Query(ctx, q, project, filter, limit)
+	rows, err := b.pool.Query(ctx, q, project, escapeLike(filter), limit)
 	if err != nil {
 		return nil, fmt.Errorf("aggregateByTag query: %w", err)
 	}

--- a/internal/embed/export_test.go
+++ b/internal/embed/export_test.go
@@ -1,0 +1,15 @@
+// export_test.go exposes internal seams for use by the embed_test package.
+// This file is compiled only during testing and does not affect the production binary.
+package embed
+
+import (
+	"context"
+	"net/http"
+)
+
+// NewOllamaClientWithTransport creates an OllamaClient using the supplied
+// transport, bypassing the DNS-rebinding SSRF guard. For use in unit tests
+// that need to point the client at a local httptest.Server.
+func NewOllamaClientWithTransport(ctx context.Context, baseURL, model string, transport http.RoundTripper) (*OllamaClient, error) {
+	return newOllamaClient(ctx, baseURL, model, transport)
+}

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/petersimmons1972/engram/internal/netutil"
 )
 
 // Client is the embedding provider interface.
@@ -39,20 +41,52 @@ type OllamaClient struct {
 // NewOllamaClient constructs an OllamaClient and validates connectivity.
 // If the model is absent from Ollama, it triggers a pull and waits (max 5 min).
 func NewOllamaClient(ctx context.Context, baseURL, model string) (*OllamaClient, error) {
+	return newOllamaClient(ctx, baseURL, model, nil)
+}
+
+// newOllamaClient is the internal constructor. When customTransport is non-nil
+// it is used as-is (test seam only — bypasses SSRF guard). When nil, the
+// production DNS-rebinding-safe transport is constructed.
+func newOllamaClient(ctx context.Context, baseURL, model string, customTransport http.RoundTripper) (*OllamaClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
 
-	// DNS-safe transport with explicit timeouts (#125).
-	// TLSHandshake/ResponseHeader caps apply even when the context has no deadline.
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
+	var transport http.RoundTripper
+	if customTransport != nil {
+		transport = customTransport
+	} else {
+		// DNS-rebinding-safe transport (#242).
+		// Re-resolves the hostname on every dial and rejects private IPs,
+		// preventing an attacker from using a short-TTL DNS record to bypass
+		// the startup IP check by switching the resolution to an internal address.
+		baseDialer := &net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
-		IdleConnTimeout:       30 * time.Second,
-		MaxIdleConnsPerHost:   2,
+		}
+		transport = &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				host, port, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+				// Re-resolve on every dial — prevents DNS rebinding SSRF.
+				addrs, err := net.DefaultResolver.LookupHost(ctx, host)
+				if err != nil {
+					return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
+				}
+				for _, resolved := range addrs {
+					if netutil.IsPrivateIP(resolved) {
+						return nil, fmt.Errorf("ollama URL resolved to private IP %q (SSRF protection, closes #242)", resolved)
+					}
+				}
+				return baseDialer.DialContext(ctx, network, net.JoinHostPort(addrs[0], port))
+			},
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+			IdleConnTimeout:       30 * time.Second,
+			MaxIdleConnsPerHost:   2,
+		}
 	}
+
 	// Client-level Timeout provides an outer bound for non-pull requests.
 	// Embed calls include text up to a few KB; 60s is generous.
 	hc := &http.Client{Transport: transport, Timeout: 60 * time.Second}

--- a/internal/embed/ollama_test.go
+++ b/internal/embed/ollama_test.go
@@ -48,11 +48,19 @@ func fakeOllama(t *testing.T, tagsModels []string, embedDims int) *httptest.Serv
 	return httptest.NewServer(mux)
 }
 
+// newTestClient wires NewOllamaClientWithTransport to a local httptest.Server,
+// bypassing the production SSRF guard (which correctly blocks 127.0.0.1).
+// Use only in tests.
+func newTestClient(t *testing.T, srv *httptest.Server, model string) (*embed.OllamaClient, error) {
+	t.Helper()
+	return embed.NewOllamaClientWithTransport(context.Background(), srv.URL, model, srv.Client().Transport)
+}
+
 func TestNewOllamaClient_ModelPresent(t *testing.T) {
 	srv := fakeOllama(t, []string{"nomic-embed-text:latest"}, 768)
 	defer srv.Close()
 
-	c, err := embed.NewOllamaClient(context.Background(), srv.URL, "nomic-embed-text")
+	c, err := newTestClient(t, srv, "nomic-embed-text")
 	require.NoError(t, err)
 	require.Equal(t, "nomic-embed-text", c.Name())
 }
@@ -61,7 +69,7 @@ func TestNewOllamaClient_ModelAbsent_TriggersPull(t *testing.T) {
 	srv := fakeOllama(t, []string{}, 768) // no models — pull will be triggered
 	defer srv.Close()
 
-	_, err := embed.NewOllamaClient(context.Background(), srv.URL, "nomic-embed-text")
+	_, err := newTestClient(t, srv, "nomic-embed-text")
 	require.NoError(t, err)
 }
 
@@ -69,7 +77,7 @@ func TestOllamaClient_Embed(t *testing.T) {
 	srv := fakeOllama(t, []string{"nomic-embed-text:latest"}, 768)
 	defer srv.Close()
 
-	c, err := embed.NewOllamaClient(context.Background(), srv.URL, "nomic-embed-text")
+	c, err := newTestClient(t, srv, "nomic-embed-text")
 	require.NoError(t, err)
 
 	vec, err := c.Embed(context.Background(), "hello world")

--- a/internal/entity/worker.go
+++ b/internal/entity/worker.go
@@ -72,9 +72,26 @@ func (w *Worker) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			w.processBatch(ctx)
+			w.safeProcessBatch(ctx)
 		}
 	}
+}
+
+// safeProcessBatch wraps processBatch with per-iteration panic recovery (#247).
+// A panic logs an error and sleeps 1s so the loop can continue rather than
+// killing the worker goroutine permanently.
+func (w *Worker) safeProcessBatch(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("entity worker panic — will retry next tick",
+				"panic", r)
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+			}
+		}
+	}()
+	w.processBatch(ctx)
 }
 
 // processBatch claims and processes a batch of jobs for every configured project.

--- a/internal/entity/worker_test.go
+++ b/internal/entity/worker_test.go
@@ -173,6 +173,52 @@ func TestWorker_DefaultConfig(t *testing.T) {
 	assert.NotNil(t, w)
 }
 
+// panicExtractor panics on every Extract call to simulate a misbehaving LLM client.
+type panicExtractor struct{}
+
+func (panicExtractor) Extract(_ context.Context, _ string) ([]entity.Entity, []entity.Relation, error) {
+	panic("simulated extractor panic")
+}
+
+// TestWorker_PanicInProcessJobDoesNotKillRun verifies that a panic inside
+// processJob (via Extract) does NOT permanently kill the Run goroutine (#247).
+// After a panic on tick 1, Run must still process a new job on tick 2+.
+func TestWorker_PanicInProcessJobDoesNotKillRun(t *testing.T) {
+	backend := newWorkerBackend()
+	backend.memories["mem-panic"] = &types.Memory{ID: "mem-panic", Content: "will panic"}
+	backend.jobs = []entity.ExtractionJob{{ID: "job-panic", MemoryID: "mem-panic", Project: "proj"}}
+
+	w := entity.NewWorker(backend, panicExtractor{}, entity.WorkerConfig{
+		Projects:     []string{"proj"},
+		PollInterval: 50 * time.Millisecond,
+		BatchSize:    5,
+	})
+
+	// Run for long enough to fire at least 2 ticks even after the 1s sleep.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	// The goroutine must still be alive after the panic tick + 1s sleep + a bit.
+	// We confirm it by waiting for context expiry and checking Run returned cleanly.
+	select {
+	case <-done:
+		// Run exited — verify it was due to context cancellation, not panic death.
+		// If done closes before ctx expires that would be unexpected here; we check
+		// that ctx was the cause by re-checking cancellation.
+		if ctx.Err() == nil {
+			t.Fatal("Run exited before context was cancelled — goroutine may have panicked")
+		}
+	case <-time.After(3500 * time.Millisecond):
+		t.Fatal("Run did not exit after context expiry")
+	}
+}
+
 func TestWorker_ExitsOnContextCancel(t *testing.T) {
 	backend := newWorkerBackend()
 	ext := &stubExtractor{}

--- a/internal/mcp/ingest_document.go
+++ b/internal/mcp/ingest_document.go
@@ -359,7 +359,10 @@ func (s *Server) dropUpload(uploadID string) {
 // must supply a non-nil *Server for those code paths.
 func handleMemoryIngestDocumentStream(ctx context.Context, s *Server, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	maxDoc, rawMax := configOrDefaults(cfg)
 
 	path := getString(args, "path", "")

--- a/internal/mcp/migrate_embedder_test.go
+++ b/internal/mcp/migrate_embedder_test.go
@@ -1,0 +1,110 @@
+package mcp
+
+// Tests for handleMemoryMigrateEmbedder dimension pre-flight (#251).
+// Uses a mock embedder that returns a configurable dimension count, and a
+// noopBackend stub with GetMeta wired to return a stored dimension.
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+// dimBackend extends noopBackend to return a configurable embedder_dimensions
+// value from GetMeta.
+type dimBackend struct {
+	noopBackend
+	storedDims string // e.g. "384"
+}
+
+func (b dimBackend) GetMeta(_ context.Context, _, key string) (string, bool, error) {
+	if key == "embedder_dimensions" && b.storedDims != "" {
+		return b.storedDims, true, nil
+	}
+	return "", false, nil
+}
+
+var _ db.Backend = dimBackend{}
+
+// dimEmbedder implements embed.Client returning a fixed dimension.
+type dimEmbedder struct {
+	dims int
+}
+
+func (e dimEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, e.dims), nil
+}
+func (e dimEmbedder) Name() string    { return "dim-test-model" }
+func (e dimEmbedder) Dimensions() int { return e.dims }
+
+var _ embed.Client = dimEmbedder{}
+
+// newDimPool creates an EnginePool backed by dimBackend + the given embedder.
+func newDimPool(t *testing.T, storedDims string, clientDims int) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		be := dimBackend{storedDims: storedDims}
+		emb := dimEmbedder{dims: clientDims}
+		engine := search.New(ctx, be, emb, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+// makeMigrateRequest builds a minimal CallToolRequest for memory_migrate_embedder.
+func makeMigrateRequest(project, newModel string) mcpgo.CallToolRequest {
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"project":   project,
+		"new_model": newModel,
+	}
+	return req
+}
+
+// TestHandleMemoryMigrateEmbedder_NoDimsStored verifies that when the backend
+// has no stored "embedder_dimensions" metadata, the pre-flight does not fire
+// a dimension error (it requires an Ollama endpoint to probe, so it skips).
+// The handler then proceeds to MigrateEmbedder which panics with the noop
+// backend's nil transaction — we recover and check the error is not ours.
+func TestHandleMemoryMigrateEmbedder_NoDimsStored(t *testing.T) {
+	pool := newDimPool(t, "", 384)
+	req := makeMigrateRequest("proj", "new-model")
+	cfg := Config{OllamaURL: "http://ollama-test:11434"}
+
+	// The noop backend's Begin() returns nil; MigrateEmbedder will panic.
+	// We use a deferred recover to catch it and assert the panic is NOT from
+	// the dimension pre-flight (which would return an error, not panic).
+	var dimensionErr error
+	func() {
+		defer func() { recover() }() //nolint:staticcheck // catching noop-backend nil-tx panic
+		dimensionErr, _ = func() (error, bool) {
+			_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+			return err, true
+		}()
+	}()
+	// If we got here without a dimension error, the pre-flight correctly skipped.
+	if dimensionErr != nil {
+		require.NotContains(t, dimensionErr.Error(), "dimension mismatch",
+			"no dimension mismatch error expected when no stored dims present")
+	}
+}
+
+// TestHandleMemoryMigrateEmbedder_EmptyNewModel verifies that an empty
+// new_model field is rejected before any backend access.
+func TestHandleMemoryMigrateEmbedder_EmptyNewModel(t *testing.T) {
+	pool := newDimPool(t, "384", 384)
+
+	req := makeMigrateRequest("proj", "")
+	cfg := Config{OllamaURL: "http://ollama-test:11434"}
+
+	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "new_model is required")
+}

--- a/internal/mcp/query_document.go
+++ b/internal/mcp/query_document.go
@@ -113,7 +113,10 @@ func recallChunks(ctx context.Context, deps queryDocumentDeps, q claude.Document
 // answer grounded in those spans.
 func handleMemoryQueryDocument(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "")
+	project, err := getProject(args, "")
+	if err != nil {
+		return nil, fmt.Errorf("project: %w", err)
+	}
 	memoryID := getString(args, "memory_id", "")
 	question := getString(args, "question", "")
 
@@ -127,7 +130,7 @@ func handleMemoryQueryDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 	if rawFilter, ok := args["filter"]; ok {
 		if fmap, ok := rawFilter.(map[string]any); ok {
 			filterRegex = getString(fmap, "regex", "")
-			filterSubs = toStringSlice(fmap["substrings"])
+			filterSubs, _ = toStringSlice(fmap["substrings"]) // ignore control-char error in optional filter
 		}
 	}
 

--- a/internal/mcp/safety.go
+++ b/internal/mcp/safety.go
@@ -78,7 +78,10 @@ type verificationResult struct {
 // handleGetConstraints lists constraint memories matching an optional query.
 func handleGetConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	query := getString(args, "query", "")
 	limit := getInt(args, "limit", defaultConstraintLimit)
 	if limit < 1 || limit > 50 {
@@ -111,7 +114,10 @@ func handleGetConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 // with a preliminary verification decision.
 func handleCheckConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	proposedAction := getString(args, "proposed_action", "")
 	if proposedAction == "" {
 		return mcpgo.NewToolResultError("proposed_action is required"), nil
@@ -145,7 +151,10 @@ func handleCheckConstraints(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 // and risk-baseline checks, returning a decision with suggested safe actions.
 func handleVerifyBeforeActing(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	proposedAction := getString(args, "proposed_action", "")
 	if proposedAction == "" {
 		return mcpgo.NewToolResultError("proposed_action is required"), nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -315,7 +315,10 @@ func (s *Server) registerTools() {
 				// goroutine with its own context so it never blocks memory_store.
 				// Non-fatal: if the enqueue fails the store has already succeeded.
 				args := req.GetArguments()
-				project := getString(args, "project", "default")
+				project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 				if memID, ok := extractResultID(result); ok {
 					go enqueueExtractionAsync(pool, memID, project)
 				}
@@ -416,7 +419,7 @@ func (s *Server) registerTools() {
 			}},
 		{"memory_migrate_embedder", "Switch embedding model; triggers background re-embedding",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-				return handleMemoryMigrateEmbedder(ctx, pool, req)
+				return handleMemoryMigrateEmbedder(ctx, pool, req, cfg)
 			}},
 		{"memory_export_all", "Export all memories to markdown files",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -82,18 +84,41 @@ func (rl *rateLimiter) evict() {
 	}
 }
 
+// allowSetupToken is like allow but uses a tighter budget for the /setup-token
+// endpoint: 3 requests per 5-minute window (burst 3, one token every ~100s) (#243).
+func (rl *rateLimiter) allowSetupToken(ip string) bool {
+	rl.mu.Lock()
+	e, ok := rl.clients[ip]
+	if !ok {
+		e = &rateLimiterEntry{
+			limiter: rate.NewLimiter(rate.Every(setupTokenWindow), 3),
+		}
+		rl.clients[ip] = e
+	}
+	e.lastSeen = time.Now()
+	ok = e.limiter.Allow()
+	rl.mu.Unlock()
+	return ok
+}
+
 // Server wraps the MCP SSE server and owns the EnginePool.
 type Server struct {
-	pool     *EnginePool
-	cfg      Config
-	mcp      *server.MCPServer
-	uploadMu sync.Mutex
-	uploads  map[string]*uploadSession
+	pool                *EnginePool
+	cfg                 Config
+	mcp                 *server.MCPServer
+	uploadMu            sync.Mutex
+	uploads             map[string]*uploadSession
+	sessionFingerprints sync.Map // sessionID -> []byte HMAC fingerprint (#245)
+	trustProxy          bool     // honour X-Forwarded-For / X-Real-IP (#255)
 }
 
 // NewServer constructs a Server with all MCP tools registered.
 func NewServer(pool *EnginePool, cfg Config) *Server {
-	s := &Server{pool: pool, cfg: cfg, uploads: make(map[string]*uploadSession)}
+	trustProxy := false
+	if v := os.Getenv("ENGRAM_TRUST_PROXY_HEADERS"); v == "1" || strings.EqualFold(v, "true") {
+		trustProxy = true
+	}
+	s := &Server{pool: pool, cfg: cfg, uploads: make(map[string]*uploadSession), trustProxy: trustProxy}
 	mcpServer := server.NewMCPServer("engram", "1.0.0",
 		server.WithToolCapabilities(true),
 		server.WithHooks(&server.Hooks{}),
@@ -109,6 +134,9 @@ func (s *Server) SetClaudeClient(client *claude.Client) {
 	s.cfg.claudeClient = client
 	s.cfg.ClaudeEnabled = (client != nil)
 }
+
+// setupTokenWindow is the rate-limit window for /setup-token: 3 calls per 5 minutes.
+const setupTokenWindow = 5 * time.Minute / 3 // one token every 100 seconds
 
 // Start begins serving SSE on host:port. Blocks until ctx is cancelled.
 // baseURL overrides the URL advertised in SSE endpoint events; when empty,
@@ -129,7 +157,17 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// Auto-start a "global" episode on every new SSE client connection (#91).
 	// SSE sessions carry no project context, so episodes land in "global" where
 	// they can be queried via memory_episode_list/memory_episode_recall.
-	s.mcp.GetHooks().AddOnRegisterSession(func(ctx context.Context, _ server.ClientSession) {
+	//
+	// Also store a session→bearer HMAC fingerprint so POST /message can verify
+	// the session was established by the same bearer that is now posting (#245).
+	s.mcp.GetHooks().AddOnRegisterSession(func(ctx context.Context, sess server.ClientSession) {
+		sessionID := sess.SessionID()
+
+		// Compute HMAC(apiKey, sessionID) and store for later verification.
+		mac := hmac.New(sha256.New, []byte(apiKey))
+		mac.Write([]byte(sessionID))
+		s.sessionFingerprints.Store(sessionID, mac.Sum(nil))
+
 		desc := "Claude Code session " + time.Now().UTC().Format(time.RFC3339)
 		h, err := s.pool.Get(ctx, "global")
 		if err != nil {
@@ -143,6 +181,14 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 		}
 		slog.Info("auto-episode started", "id", ep.ID, "project", "global", "desc", desc)
 	})
+
+	// Remove the fingerprint when a session disconnects (#245).
+	s.mcp.GetHooks().AddOnUnregisterSession(func(_ context.Context, sess server.ClientSession) {
+		s.sessionFingerprints.Delete(sess.SessionID())
+	})
+
+	// setupTokenLimiter enforces 3 calls per 5-minute window per IP (#243).
+	setupLimiter := newRateLimiter(ctx) // eviction goroutine shares ctx lifetime
 
 	// Top-level mux routes unauthenticated utility endpoints before auth middleware.
 	mux := http.NewServeMux()
@@ -162,12 +208,21 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// than 127.0.0.1 due to NAT. We accept RFC1918 addresses because they can only reach
 	// this port via the loopback-bound Docker port mapping — not from the network.
 	// The token is equivalent in sensitivity to ~/.claude.json which is already on disk.
+	//
+	// Rate limit: 3 calls per 5-minute window per IP (#243).
 	mux.HandleFunc("/setup-token", func(w http.ResponseWriter, r *http.Request) {
-		remoteHost, _, _ := net.SplitHostPort(r.RemoteAddr)
-		if !isLocalAddress(remoteHost, s.cfg.AllowRFC1918SetupToken) {
+		ip := s.clientIP(r)
+		if !isLocalAddress(ip, s.cfg.AllowRFC1918SetupToken) {
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
+		if !setupLimiter.allowSetupToken(ip) {
+			slog.Warn("setup-token rate limited", "remote_ip", ip)
+			w.Header().Set("Retry-After", "100")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		slog.Warn("setup-token accessed", "remote_ip", ip)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{ //nolint:errcheck
 			"token":    apiKey,
@@ -187,7 +242,15 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	mux.HandleFunc("/.well-known/oauth-protected-resource", notFound)
 
 	// All other routes require Bearer authentication and per-IP rate limiting (#140).
+	// The SSE and message endpoints are mounted separately so that the /message
+	// handler can be wrapped with session-fingerprint verification (#245).
 	rl := newRateLimiter(ctx)
+
+	// /message — wrap with session-fingerprint check before the auth middleware.
+	msgHandler := s.withSessionFingerprint(sse.MessageHandler(), apiKey)
+	mux.Handle("/message", s.applyMiddleware(msgHandler, apiKey, rl))
+
+	// All other authenticated routes (including /sse) go through the standard middleware.
 	mux.Handle("/", s.applyMiddleware(sse, apiKey, rl))
 
 	// Background sweeper clears stale upload sessions on a 5-minute interval.
@@ -239,7 +302,7 @@ func (s *Server) applyMiddleware(next http.Handler, apiKey string, rl *rateLimit
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Rate limit before auth check to prevent timing-based enumeration.
-		remoteHost, _, _ := net.SplitHostPort(r.RemoteAddr)
+		remoteHost := s.clientIP(r)
 		if !rl.allow(remoteHost) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "1")
@@ -258,6 +321,41 @@ func (s *Server) applyMiddleware(next http.Handler, apiKey string, rl *rateLimit
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			fmt.Fprint(w, `{"error":"unauthorized","hint":"Bearer token mismatch — run: make setup  (or: go run ./cmd/engram-setup)"}`)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// withSessionFingerprint wraps next with a check that the sessionId query
+// parameter was established by the same bearer token that is presenting the
+// request (#245). The fingerprint is HMAC(apiKey, sessionID) stored at SSE
+// connection time. Any mismatch returns 403.
+func (s *Server) withSessionFingerprint(next http.Handler, apiKey string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.URL.Query().Get("sessionId")
+		if sessionID == "" {
+			// Let the underlying handler produce the canonical error.
+			next.ServeHTTP(w, r)
+			return
+		}
+		stored, ok := s.sessionFingerprints.Load(sessionID)
+		if !ok {
+			// Session not found — let the underlying handler produce the error.
+			next.ServeHTTP(w, r)
+			return
+		}
+		storedFP, _ := stored.([]byte)
+
+		// Compute the expected fingerprint for the current bearer.
+		mac := hmac.New(sha256.New, []byte(apiKey))
+		mac.Write([]byte(sessionID))
+		expected := mac.Sum(nil)
+
+		if subtle.ConstantTimeCompare(storedFP, expected) != 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"error":"forbidden","hint":"session bearer mismatch"}`)
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -294,6 +392,28 @@ func isLocalAddress(ipStr string, allowRFC1918 bool) bool {
 		}
 	}
 	return false
+}
+
+// clientIP extracts the real client IP from the request.
+// When s.trustProxy is true, it checks X-Real-IP and the first entry in
+// X-Forwarded-For before falling back to RemoteAddr. This handles the case
+// where engram runs behind a reverse proxy (#255).
+// ENGRAM_TRUST_PROXY_HEADERS=1 (or =true) enables proxy header trust.
+func (s *Server) clientIP(r *http.Request) string {
+	if s.trustProxy {
+		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+			return strings.TrimSpace(realIP)
+		}
+		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+			// X-Forwarded-For may be a comma-separated list; leftmost is the client.
+			parts := strings.SplitN(forwarded, ",", 2)
+			if ip := strings.TrimSpace(parts[0]); ip != "" {
+				return ip
+			}
+		}
+	}
+	host, _, _ := net.SplitHostPort(r.RemoteAddr)
+	return host
 }
 
 func (s *Server) registerTools() {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Rate limiter tests — issue #243
+// ---------------------------------------------------------------------------
+
+// TestRateLimiter_AllowSetupToken verifies that the setup-token limiter allows
+// exactly 3 rapid calls per IP and rejects the 4th (burst=3).
+func TestRateLimiter_AllowSetupToken(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rl := newRateLimiter(ctx)
+	ip := "192.168.1.1"
+
+	// First 3 calls must succeed — burst of 3 tokens.
+	for i := 1; i <= 3; i++ {
+		if !rl.allowSetupToken(ip) {
+			t.Fatalf("call %d: expected allow, got reject", i)
+		}
+	}
+
+	// 4th call must be rejected — tokens exhausted.
+	if rl.allowSetupToken(ip) {
+		t.Fatal("4th call: expected reject, got allow")
+	}
+}
+
+// TestRateLimiter_SetupTokenIndependentPerIP verifies that exhausting the
+// setup-token budget for one IP does not affect a different IP's budget.
+func TestRateLimiter_SetupTokenIndependentPerIP(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rl := newRateLimiter(ctx)
+
+	// Exhaust setup-token budget for ip1.
+	for i := 0; i < 3; i++ {
+		rl.allowSetupToken("10.0.0.1")
+	}
+
+	// ip2 must still have its own fresh budget.
+	if !rl.allowSetupToken("10.0.0.2") {
+		t.Fatal("ip2 should have an independent budget from ip1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session fingerprint middleware tests — issue #245
+// ---------------------------------------------------------------------------
+
+// newFingerprintServer builds the minimal Server required to call withSessionFingerprint.
+// No pool or config is needed because the method only reads sessionFingerprints.
+func newFingerprintServer() *Server {
+	return &Server{}
+}
+
+// storeFingerprint seeds s.sessionFingerprints the same way the SSE
+// OnRegisterSession hook does: HMAC(apiKey, sessionID).
+func storeFingerprint(s *Server, apiKey, sessionID string) {
+	mac := hmac.New(sha256.New, []byte(apiKey))
+	mac.Write([]byte(sessionID))
+	s.sessionFingerprints.Store(sessionID, mac.Sum(nil))
+}
+
+// TestWithSessionFingerprint_RejectsWrongToken verifies that a request carrying
+// a sessionId whose stored fingerprint was created with a different key than
+// the one the middleware holds is rejected with 403.
+func TestWithSessionFingerprint_RejectsWrongToken(t *testing.T) {
+	s := newFingerprintServer()
+
+	const sessionID = "test-session-123"
+	const storedKey = "original-api-key"  // key used when the SSE session was opened
+	const middlewareKey = "wrong-api-key" // key the middleware is holding now
+
+	// Seed the fingerprint as if the session was opened with storedKey.
+	storeFingerprint(s, storedKey, sessionID)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// The middleware uses middlewareKey — mismatch with the stored fingerprint.
+	handler := s.withSessionFingerprint(inner, middlewareKey)
+
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId="+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+middlewareKey)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden, got %d", w.Code)
+	}
+}
+
+// TestWithSessionFingerprint_AllowsCorrectToken verifies that a request whose
+// stored fingerprint matches the middleware's apiKey passes through to the inner
+// handler and returns 200.
+func TestWithSessionFingerprint_AllowsCorrectToken(t *testing.T) {
+	s := newFingerprintServer()
+
+	const sessionID = "test-session-456"
+	const apiKey = "correct-api-key"
+
+	// Seed the fingerprint with the same key the middleware will use.
+	storeFingerprint(s, apiKey, sessionID)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.withSessionFingerprint(inner, apiKey)
+
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId="+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", w.Code)
+	}
+}
+
+// TestWithSessionFingerprint_PassesThroughMissingSession verifies that a
+// request with a sessionId that has no stored fingerprint is forwarded to the
+// inner handler rather than rejected (the underlying handler owns that error).
+func TestWithSessionFingerprint_PassesThroughMissingSession(t *testing.T) {
+	s := newFingerprintServer()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.withSessionFingerprint(inner, "any-key")
+
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId=no-such-session", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// No stored fingerprint → inner handler runs → 200.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected inner handler 200, got %d", w.Code)
+	}
+}
+
+// TestWithSessionFingerprint_PassesThroughNoSessionID verifies that a request
+// with no sessionId query param at all is forwarded without fingerprint check.
+func TestWithSessionFingerprint_PassesThroughNoSessionID(t *testing.T) {
+	s := newFingerprintServer()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.withSessionFingerprint(inner, "any-key")
+
+	req := httptest.NewRequest(http.MethodPost, "/message", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected inner handler 200, got %d", w.Code)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,12 +8,15 @@ import (
 	"math"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"golang.org/x/text/unicode/norm"
 	"github.com/petersimmons1972/engram/internal/claude"
 	consolidatepkg "github.com/petersimmons1972/engram/internal/consolidate"
 	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/markdown"
 	"github.com/petersimmons1972/engram/internal/rag"
 	"github.com/petersimmons1972/engram/internal/search"
@@ -149,13 +152,19 @@ func execFetch(ctx context.Context, f backendFetcher, id, detail string, maxByte
 // handleMemoryFetch implements the memory_fetch MCP tool.
 func handleMemoryFetch(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	id := getString(args, "id", "")
 	if id == "" {
 		return nil, fmt.Errorf("id is required")
 	}
 	detail := getString(args, "detail", "summary")
-	chunkIDs := toStringSlice(args["chunk_ids"])
+	chunkIDs, err := toStringSlice(args["chunk_ids"])
+	if err != nil {
+		return nil, fmt.Errorf("chunk_ids: %w", err)
+	}
 	maxBytes := cfg.FetchMaxBytes
 	if maxBytes == 0 {
 		maxBytes = 65536
@@ -273,6 +282,79 @@ func getString(args map[string]any, key, def string) string {
 	return def
 }
 
+// bidiAndZeroWidthRanges lists Unicode codepoints that can create trust confusion
+// via bidirectional control characters or zero-width joiners/separators (#249).
+// Ranges are [lo, hi] inclusive.
+var bidiAndZeroWidthRanges = [][2]rune{
+	{0x200B, 0x200F}, // zero-width space, ZWNJ, ZWJ, LRM, RLM
+	{0x202A, 0x202E}, // LRE, RLE, PDF, LRO, RLO
+	{0x2060, 0x2069}, // WJ, invisible operators, FSI/LRI/RLI/PDI
+	{0xFEFF, 0xFEFF}, // BOM / zero-width no-break space
+	{0x061C, 0x061C}, // Arabic letter mark
+}
+
+// validateProjectName applies NFC normalization and rejects bidi/zero-width
+// codepoints and names that are empty or exceed maxProjectNameLen (#249).
+const maxProjectNameLen = 128
+
+func validateProjectName(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return fmt.Errorf("project name must not be empty")
+	}
+	s = norm.NFC.String(s)
+	if len(s) > maxProjectNameLen {
+		return fmt.Errorf("project name exceeds max length %d", maxProjectNameLen)
+	}
+	for i, r := range s {
+		for _, rng := range bidiAndZeroWidthRanges {
+			if r >= rng[0] && r <= rng[1] {
+				return fmt.Errorf("project name contains disallowed codepoint U+%04X at byte %d", r, i)
+			}
+		}
+	}
+	return nil
+}
+
+// getProject extracts and validates the "project" argument, applying NFC
+// normalization and rejecting bidi/zero-width characters (#249).
+// def is the fallback when the argument is absent or empty.
+func getProject(args map[string]any, def string) (string, error) {
+	raw := getString(args, "project", def)
+	// Apply NFC before returning so the caller always gets a normalized name.
+	normalized := norm.NFC.String(strings.TrimSpace(raw))
+	if err := validateProjectName(normalized); err != nil {
+		return "", fmt.Errorf("project: %w", err)
+	}
+	return normalized, nil
+}
+
+// validateContent rejects content strings that contain C0 control characters
+// (except HT/LF/CR), DEL, and C1 control characters (U+0080–U+009F) (#253).
+func validateContent(s string) error {
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			return fmt.Errorf("content contains invalid UTF-8 at byte %d", i)
+		}
+		switch {
+		case r == 0x09 || r == 0x0A || r == 0x0D:
+			// HT, LF, CR — allowed
+		case r <= 0x08, r == 0x0B, r == 0x0C, r >= 0x0E && r <= 0x1F:
+			// C0 control chars except HT/LF/CR
+			return fmt.Errorf("content contains disallowed control character U+%04X at byte %d", r, i)
+		case r == 0x7F:
+			// DEL
+			return fmt.Errorf("content contains disallowed control character U+007F (DEL) at byte %d", i)
+		case r >= 0x80 && r <= 0x9F:
+			// C1 control characters
+			return fmt.Errorf("content contains disallowed C1 control character U+%04X at byte %d", r, i)
+		}
+		i += size
+	}
+	return nil
+}
+
 // getInt extracts an int arg (JSON numbers arrive as float64) with a fallback.
 func getInt(args map[string]any, key string, def int) int {
 	if v, ok := args[key]; ok {
@@ -306,17 +388,19 @@ func getBool(args map[string]any, key string, def bool) bool {
 	return def
 }
 
-// toStringSlice converts []any to []string, skipping non-string entries.
-// Applies per-tag and count limits to prevent tag injection attacks (#149).
+// Per-tag and count limits to prevent tag injection attacks (#149).
 const (
 	maxTagCount  = 50
 	maxTagLength = 256
 )
 
-func toStringSlice(v any) []string {
+// toStringSlice converts []any to []string, applying per-tag/count limits (#149).
+// Returns an error if any tag contains NUL or C0 control characters
+// (except tab/newline/carriage-return) or DEL (#252).
+func toStringSlice(v any) ([]string, error) {
 	arr, ok := v.([]any)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	result := make([]string, 0, len(arr))
 	for _, item := range arr {
@@ -330,15 +414,28 @@ func toStringSlice(v any) []string {
 		if len(s) > maxTagLength {
 			s = s[:maxTagLength] // truncate oversized tag
 		}
+		// Reject NUL, C0 controls (except HT/LF/CR), and DEL (#252).
+		for i := 0; i < len(s); i++ {
+			b := s[i]
+			switch {
+			case b == 0x09 || b == 0x0A || b == 0x0D:
+				// allowed
+			case b <= 0x08, b == 0x0B, b == 0x0C, b >= 0x0E && b <= 0x1F, b == 0x7F:
+				return nil, fmt.Errorf("tag %q contains disallowed control character 0x%02X at byte %d", s, b, i)
+			}
+		}
 		result = append(result, s)
 	}
-	return result
+	return result, nil
 }
 
 // handleMemoryStore stores a single focused memory.
 func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -350,6 +447,9 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 	if len(content) > types.MaxContentLength {
 		return nil, fmt.Errorf("content exceeds max length %d bytes", types.MaxContentLength)
 	}
+	if err := validateContent(content); err != nil {
+		return nil, fmt.Errorf("content: %w", err)
+	}
 	memType := getString(args, "memory_type", types.MemoryTypeContext)
 	if !types.ValidateMemoryType(memType) {
 		return nil, fmt.Errorf("invalid memory_type %q; valid values: decision, pattern, error, context, architecture, preference", memType)
@@ -358,13 +458,17 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 	if importance < 0 || importance > 4 {
 		return nil, fmt.Errorf("importance must be 0–4, got %d", importance)
 	}
+	tags, err := toStringSlice(args["tags"])
+	if err != nil {
+		return nil, fmt.Errorf("tags: %w", err)
+	}
 	m := &types.Memory{
 		ID:          types.NewMemoryID(),
 		Content:     content,
 		MemoryType:  memType,
 		Project:     project,
 		Importance:  importance,
-		Tags:        toStringSlice(args["tags"]),
+		Tags:        tags,
 		Immutable:   getBool(args, "immutable", false),
 		StorageMode: "focused",
 	}
@@ -386,7 +490,10 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 //   - > RawDocumentMaxBytes: refused.
 func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -394,6 +501,9 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 	content, _ := args["content"].(string)
 	if content == "" {
 		return nil, fmt.Errorf("content is required")
+	}
+	if err := validateContent(content); err != nil {
+		return nil, fmt.Errorf("content: %w", err)
 	}
 	memType := getString(args, "memory_type", types.MemoryTypeContext)
 	if !types.ValidateMemoryType(memType) {
@@ -404,12 +514,16 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 		return nil, fmt.Errorf("importance must be 0–4, got %d", importance)
 	}
 	maxDoc, rawMax := configOrDefaults(cfg)
+	docTags, err := toStringSlice(args["tags"])
+	if err != nil {
+		return nil, fmt.Errorf("tags: %w", err)
+	}
 	m := &types.Memory{
 		ID:         types.NewMemoryID(),
 		MemoryType: memType,
 		Project:    project,
 		Importance: importance,
-		Tags:       toStringSlice(args["tags"]),
+		Tags:       docTags,
 		Immutable:  getBool(args, "immutable", false),
 	}
 	engine := h.Engine
@@ -429,7 +543,10 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 // are committed in one transaction — either all succeed or none do.
 func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -461,6 +578,10 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 			validErrs = append(validErrs, fmt.Sprintf("item %d: content exceeds max length %d bytes", idx, types.MaxContentLength))
 			continue
 		}
+		if contentErr := validateContent(content); contentErr != nil {
+			validErrs = append(validErrs, fmt.Sprintf("item %d: content: %v", idx, contentErr))
+			continue
+		}
 		memType := getString(mmap, "memory_type", types.MemoryTypeContext)
 		if !types.ValidateMemoryType(memType) {
 			validErrs = append(validErrs, fmt.Sprintf("item %d: invalid memory_type %q", idx, memType))
@@ -471,13 +592,18 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 			validErrs = append(validErrs, fmt.Sprintf("item %d: importance must be 0–4, got %d", idx, importance))
 			continue
 		}
+		itemTags, tagErr := toStringSlice(mmap["tags"])
+		if tagErr != nil {
+			validErrs = append(validErrs, fmt.Sprintf("item %d: tags: %v", idx, tagErr))
+			continue
+		}
 		memories = append(memories, &types.Memory{
 			ID:          types.NewMemoryID(),
 			Content:     content,
 			MemoryType:  memType,
 			Project:     project,
 			Importance:  importance,
-			Tags:        toStringSlice(mmap["tags"]),
+			Tags:        itemTags,
 			StorageMode: "focused",
 		})
 	}
@@ -507,7 +633,10 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 // Pass cfg to enable optional Claude re-ranking (single-project only).
 func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	query := getString(args, "query", "")
 	if query == "" {
 		return nil, fmt.Errorf("query is required")
@@ -521,7 +650,10 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	mode := getString(args, "mode", cfg.RecallDefaultMode)
 
 	// Federated path: "projects" overrides the single-project recall.
-	projectNames := toStringSlice(args["projects"])
+	projectNames, err := toStringSlice(args["projects"])
+	if err != nil {
+		return nil, fmt.Errorf("projects: %w", err)
+	}
 	if len(projectNames) > 0 {
 		// Expand wildcard "*" to all known projects.
 		if len(projectNames) == 1 && projectNames[0] == "*" {
@@ -654,7 +786,10 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 func handleMemoryProjects(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
 	// Use any project to get a backend connection for the cross-project query.
-	anchorProject := getString(args, "project", "default")
+	anchorProject, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, anchorProject)
 	if err != nil {
 		return nil, err
@@ -690,7 +825,10 @@ func handleMemoryProjects(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 // the calling project's edge table.
 func handleMemoryAdopt(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -721,7 +859,10 @@ func handleMemoryAdopt(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 // handleMemoryList lists memories with optional type and tag filters.
 func handleMemoryList(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -735,7 +876,11 @@ func handleMemoryList(ctx context.Context, pool *EnginePool, req mcpgo.CallToolR
 	if s := getString(args, "memory_type", ""); s != "" {
 		memType = &s
 	}
-	memories, err := h.Engine.List(ctx, memType, toStringSlice(args["tags"]), nil, limit, offset)
+	listTags, err := toStringSlice(args["tags"])
+	if err != nil {
+		return nil, fmt.Errorf("tags: %w", err)
+	}
+	memories, err := h.Engine.List(ctx, memType, listTags, nil, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -745,7 +890,10 @@ func handleMemoryList(ctx context.Context, pool *EnginePool, req mcpgo.CallToolR
 // handleMemoryConnect creates a directional relationship between two memories.
 func handleMemoryConnect(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -775,7 +923,10 @@ func handleMemoryConnect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 // handleMemoryCorrect updates the content, tags, or importance of an existing memory.
 func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -793,7 +944,11 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		n := types.ValidateImportance(int(v))
 		importance = &n
 	}
-	updated, err := h.Engine.Correct(ctx, id, content, toStringSlice(args["tags"]), importance)
+	correctTags, err := toStringSlice(args["tags"])
+	if err != nil {
+		return nil, fmt.Errorf("tags: %w", err)
+	}
+	updated, err := h.Engine.Correct(ctx, id, content, correctTags, importance)
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +961,10 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 // handleMemoryForget soft-deletes a memory by ID (sets valid_to=NOW(), preserves history).
 func handleMemoryForget(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -826,7 +984,10 @@ func handleMemoryForget(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 // handleMemoryHistory returns the version chain for a memory.
 func handleMemoryHistory(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -845,7 +1006,10 @@ func handleMemoryHistory(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 // handleMemoryTimeline recalls memories that were active at a given point in time.
 func handleMemoryTimeline(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -869,7 +1033,10 @@ func handleMemoryTimeline(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 // handleMemorySummarize requests Ollama to summarize a memory's content.
 func handleMemorySummarize(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -888,7 +1055,10 @@ func handleMemorySummarize(ctx context.Context, pool *EnginePool, req mcpgo.Call
 // worker regenerates them with the current model on its next tick (within 60s).
 func handleMemoryResummarize(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -906,7 +1076,10 @@ func handleMemoryResummarize(ctx context.Context, pool *EnginePool, req mcpgo.Ca
 // handleMemoryStatus returns aggregate statistics for a project's memory store.
 func handleMemoryStatus(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -923,8 +1096,14 @@ func handleMemoryStatus(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 // tracking is updated in addition to the standard edge boost.
 func handleMemoryFeedback(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
-	ids := toStringSlice(args["memory_ids"])
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
+	ids, err := toStringSlice(args["memory_ids"])
+	if err != nil {
+		return nil, fmt.Errorf("memory_ids: %w", err)
+	}
 	if len(ids) > 100 {
 		return nil, fmt.Errorf("memory_ids: too many IDs (%d), max 100", len(ids))
 	}
@@ -969,7 +1148,10 @@ func handleMemoryFeedback(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 // failure_class) and returns counts with oldest/newest timestamps per label.
 func handleMemoryAggregate(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	by := getString(args, "by", "")
 	if by == "" {
 		return nil, fmt.Errorf("by: required (tag, type, or failure_class)")
@@ -1008,7 +1190,10 @@ func handleMemoryAggregate(ctx context.Context, pool *EnginePool, req mcpgo.Call
 // it uses bigramJaccard similarity + Claude review for near-duplicate merging.
 func handleMemoryConsolidate(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -1029,7 +1214,10 @@ func handleMemoryConsolidate(ctx context.Context, pool *EnginePool, req mcpgo.Ca
 // cfg is passed so the handler can read OllamaURL for the LLM second pass.
 func handleMemorySleep(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	minSim := getFloat(args, "min_similarity", 0.7)
 	limit := getInt(args, "limit", 500)
 	if limit < 1 || limit > 5000 {
@@ -1068,7 +1256,10 @@ func handleMemorySleep(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 // handleMemoryVerify checks integrity of the memory store.
 func handleMemoryVerify(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -1081,9 +1272,15 @@ func handleMemoryVerify(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 }
 
 // handleMemoryMigrateEmbedder re-embeds all chunks using a new Ollama model.
-func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+// Performs a dimension pre-flight before nulling existing embeddings: if the
+// new model outputs a different vector width than the current stored dimension,
+// migration is refused to prevent silent pgvector corruption (#251).
+func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -1092,6 +1289,25 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 	if newModel == "" {
 		return nil, fmt.Errorf("new_model is required")
 	}
+
+	// Dimension pre-flight (#251): compare stored dims against the new model's output.
+	// Avoids nulling all embeddings only to discover a dimension mismatch at INSERT.
+	if storedDimsStr, ok, metaErr := h.Engine.Backend().GetMeta(ctx, project, "embedder_dimensions"); metaErr == nil && ok && storedDimsStr != "" {
+		probeClient, probeErr := embed.NewOllamaClient(ctx, cfg.OllamaURL, newModel)
+		if probeErr == nil {
+			newDims := probeClient.Dimensions()
+			var storedDims int
+			if _, scanErr := fmt.Sscanf(storedDimsStr, "%d", &storedDims); scanErr == nil && storedDims > 0 {
+				if newDims != storedDims {
+					return nil, fmt.Errorf(
+						"dimension mismatch: current model stores %d-dim vectors, new model %q produces %d-dim vectors — pgvector column must be rebuilt first",
+						storedDims, newModel, newDims,
+					)
+				}
+			}
+		}
+	}
+
 	result, err := h.Engine.MigrateEmbedder(ctx, newModel)
 	if err != nil {
 		return nil, err
@@ -1105,7 +1321,10 @@ func handleMemoryExportAll(ctx context.Context, pool *EnginePool, req mcpgo.Call
 		return nil, fmt.Errorf("file operations require --data-dir / ENGRAM_DATA_DIR to be set")
 	}
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -1131,7 +1350,10 @@ func handleMemoryImportClaudeMD(ctx context.Context, pool *EnginePool, req mcpgo
 		return nil, fmt.Errorf("file operations require --data-dir / ENGRAM_DATA_DIR to be set")
 	}
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -1170,7 +1392,10 @@ func handleMemoryIngest(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		return nil, fmt.Errorf("file operations require --data-dir / ENGRAM_DATA_DIR to be set")
 	}
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
@@ -1217,7 +1442,10 @@ func handleMemoryIngest(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 // handleMemoryEpisodeStart creates a new episode for a project.
 func handleMemoryEpisodeStart(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	description := getString(args, "description", "")
 	h, err := pool.Get(ctx, project)
 	if err != nil {
@@ -1233,7 +1461,10 @@ func handleMemoryEpisodeStart(ctx context.Context, pool *EnginePool, req mcpgo.C
 // handleMemoryEpisodeEnd marks an episode as ended with an optional summary.
 func handleMemoryEpisodeEnd(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	id := getString(args, "episode_id", "")
 	summary := getString(args, "summary", "")
 	if id == "" {
@@ -1252,7 +1483,10 @@ func handleMemoryEpisodeEnd(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 // handleMemoryEpisodeList returns recent episodes for a project.
 func handleMemoryEpisodeList(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	limit := getInt(args, "limit", 20)
 	h, err := pool.Get(ctx, project)
 	if err != nil {
@@ -1272,7 +1506,10 @@ func handleMemoryEpisodeList(ctx context.Context, pool *EnginePool, req mcpgo.Ca
 // chronological order.
 func handleMemoryEpisodeRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	episodeID := getString(args, "episode_id", "")
 	if episodeID == "" {
 		return mcpgo.NewToolResultError("episode_id is required"), nil
@@ -1321,7 +1558,10 @@ func buildEvidenceMap(ctx context.Context, backend interface {
 // synthesizing an answer — useful for inspecting conflicts before reasoning.
 func handleMemoryDiagnose(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	question := getString(args, "question", "")
 	topK := getInt(args, "top_k", 10)
 	detail := getString(args, "detail", "full")
@@ -1355,7 +1595,10 @@ func handleMemoryDiagnose(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 // synthesize a grounded, conflict-aware answer.
 func handleMemoryReason(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	question := getString(args, "question", "")
 	topK := getInt(args, "top_k", 10)
 	if topK < 1 {
@@ -1489,7 +1732,7 @@ func parseExploreScope(args map[string]any) claude.ExploreScope {
 		return claude.ExploreScope{}
 	}
 	var scope claude.ExploreScope
-	scope.Tags = toStringSlice(scopeMap["tags"])
+	scope.Tags, _ = toStringSlice(scopeMap["tags"]) // ignore control-char error in optional scope
 	scope.EpisodeID = getString(scopeMap, "episode_id", "")
 	if since := getString(scopeMap, "since", ""); since != "" {
 		if t, err := time.Parse(time.RFC3339, since); err == nil {
@@ -1507,7 +1750,10 @@ func parseExploreScope(args map[string]any) claude.ExploreScope {
 // handleMemoryExplore runs the iterative recall+score+synthesis loop (A3).
 func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	question := getString(args, "question", "")
 	if question == "" {
 		return mcpgo.NewToolResultError("question is required"), nil
@@ -1578,7 +1824,10 @@ func handleMemoryAsk(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRe
 	if question == "" {
 		return mcpgo.NewToolResultError("question: required"), nil
 	}
-	project := getString(args, "project", "")
+	project, err := getProject(args, "")
+	if err != nil {
+		return mcpgo.NewToolResultError("project: " + err.Error()), nil
+	}
 	if project == "" {
 		return mcpgo.NewToolResultError("project: required"), nil
 	}
@@ -1694,7 +1943,10 @@ func handleMemoryQuery(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 func handleMemoryExpand(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
 
-	project := getString(args, "project", "default")
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
 	memoryID := getString(args, "memory_id", "")
 	if memoryID == "" {
 		return nil, fmt.Errorf("memory_id is required")

--- a/internal/mcp/validation_test.go
+++ b/internal/mcp/validation_test.go
@@ -1,0 +1,223 @@
+package mcp
+
+// Tests for input validation helpers added by the security sprint:
+//   - validateProjectName (Fix #249: bidi/homoglyph rejection + NFC normalization)
+//   - toStringSlice (Fix #252: control character rejection in tags)
+//   - validateContent (Fix #253: C0/C1 control character rejection in content)
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── validateProjectName ──────────────────────────────────────────────────────
+
+func TestValidateProjectName_AcceptsNormal(t *testing.T) {
+	cases := []string{
+		"default",
+		"clearwatch",
+		"my-project-123",
+		"project with spaces",
+		"日本語プロジェクト",
+		"café",        // NFC normalizable
+		"a",           // minimum length
+		"project_v2",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			require.NoError(t, validateProjectName(c))
+		})
+	}
+}
+
+func TestValidateProjectName_RejectsEmpty(t *testing.T) {
+	err := validateProjectName("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestValidateProjectName_RejectsWhitespaceOnly(t *testing.T) {
+	err := validateProjectName("   ")
+	require.Error(t, err)
+}
+
+func TestValidateProjectName_RejectsTooLong(t *testing.T) {
+	long := make([]byte, maxProjectNameLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	err := validateProjectName(string(long))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max length")
+}
+
+func TestValidateProjectName_RejectsBidiControlChars(t *testing.T) {
+	bidiCases := []struct {
+		name    string
+		codepoint rune
+	}{
+		{"zero-width space U+200B", 0x200B},
+		{"ZWNJ U+200C", 0x200C},
+		{"ZWJ U+200D", 0x200D},
+		{"LRM U+200E", 0x200E},
+		{"RLM U+200F", 0x200F},
+		{"LRE U+202A", 0x202A},
+		{"RLE U+202B", 0x202B},
+		{"PDF U+202C", 0x202C},
+		{"LRO U+202D", 0x202D},
+		{"RLO U+202E", 0x202E},
+		{"word joiner U+2060", 0x2060},
+		{"FSI U+2068", 0x2068},
+		{"PDI U+2069", 0x2069},
+		{"BOM U+FEFF", 0xFEFF},
+		{"Arabic letter mark U+061C", 0x061C},
+	}
+	for _, tc := range bidiCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Embed the codepoint in an otherwise valid project name.
+			s := "proj" + string([]rune{tc.codepoint}) + "ect"
+			err := validateProjectName(s)
+			require.Error(t, err, "expected error for codepoint U+%04X", tc.codepoint)
+			assert.Contains(t, err.Error(), "disallowed codepoint")
+		})
+	}
+}
+
+// ── toStringSlice ────────────────────────────────────────────────────────────
+
+func TestToStringSlice_AcceptsNormal(t *testing.T) {
+	input := []any{"go", "tdd", "engram", "tag with spaces"}
+	got, err := toStringSlice(input)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"go", "tdd", "engram", "tag with spaces"}, got)
+}
+
+func TestToStringSlice_AcceptsTabLFCR(t *testing.T) {
+	// HT (0x09), LF (0x0A), CR (0x0D) are explicitly allowed.
+	input := []any{"tag\twith\ttabs", "tag\nwith\nnewline", "tag\rwith\rCR"}
+	got, err := toStringSlice(input)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+}
+
+func TestToStringSlice_RejectsNUL(t *testing.T) {
+	input := []any{"valid", "bad\x00tag"}
+	_, err := toStringSlice(input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disallowed control character")
+}
+
+func TestToStringSlice_RejectsC0ControlChars(t *testing.T) {
+	controlCases := []byte{0x01, 0x07, 0x08, 0x0B, 0x0C, 0x0E, 0x1F}
+	for _, b := range controlCases {
+		t.Run(string(rune(b)), func(t *testing.T) {
+			input := []any{"good", "bad" + string([]byte{b}) + "tag"}
+			_, err := toStringSlice(input)
+			require.Error(t, err, "expected error for byte 0x%02X", b)
+		})
+	}
+}
+
+func TestToStringSlice_RejectsDEL(t *testing.T) {
+	input := []any{"tag\x7fwith-del"}
+	_, err := toStringSlice(input)
+	require.Error(t, err)
+}
+
+func TestToStringSlice_NilInput(t *testing.T) {
+	got, err := toStringSlice(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestToStringSlice_RespectsMaxTagCount(t *testing.T) {
+	var input []any
+	for i := 0; i < maxTagCount+10; i++ {
+		input = append(input, "tag")
+	}
+	got, err := toStringSlice(input)
+	require.NoError(t, err)
+	assert.Len(t, got, maxTagCount)
+}
+
+// ── validateContent ──────────────────────────────────────────────────────────
+
+func TestValidateContent_AcceptsNormal(t *testing.T) {
+	cases := []string{
+		"Hello, world!",
+		"Multi\nline\ncontent",
+		"Tab\tseparated",
+		"CR\rLF\ncombined",
+		"Unicode: 日本語 café 🚀",
+	}
+	for _, c := range cases {
+		t.Run(c[:min(len(c), 20)], func(t *testing.T) {
+			require.NoError(t, validateContent(c))
+		})
+	}
+}
+
+func TestValidateContent_RejectsNUL(t *testing.T) {
+	err := validateContent("content with \x00 null")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "U+0000")
+}
+
+func TestValidateContent_RejectsC0ControlChars(t *testing.T) {
+	// 0x01-0x08, 0x0B, 0x0C, 0x0E-0x1F
+	cases := []struct {
+		name string
+		b    byte
+	}{
+		{"SOH 0x01", 0x01},
+		{"BEL 0x07", 0x07},
+		{"BS 0x08", 0x08},
+		{"VT 0x0B", 0x0B},
+		{"FF 0x0C", 0x0C},
+		{"SO 0x0E", 0x0E},
+		{"US 0x1F", 0x1F},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateContent("bad" + string([]byte{tc.b}) + "content")
+			require.Error(t, err, "expected error for byte 0x%02X", tc.b)
+		})
+	}
+}
+
+func TestValidateContent_RejectsDEL(t *testing.T) {
+	err := validateContent("del\x7fchar")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "U+007F")
+}
+
+func TestValidateContent_RejectsC1ControlChars(t *testing.T) {
+	// U+0080 to U+009F as UTF-8 two-byte sequences
+	for r := rune(0x80); r <= 0x9F; r++ {
+		r := r
+		t.Run("C1", func(t *testing.T) {
+			err := validateContent("c1" + string(r))
+			require.Error(t, err, "expected error for codepoint U+%04X", r)
+		})
+	}
+}
+
+func TestValidateContent_AllowsHTLFCR(t *testing.T) {
+	require.NoError(t, validateContent("tab\there"))
+	require.NoError(t, validateContent("newline\nhere"))
+	require.NoError(t, validateContent("cr\rhere"))
+}
+
+func TestValidateContent_Empty(t *testing.T) {
+	require.NoError(t, validateContent(""))
+}
+
+// min is a small helper for Go <1.21 compatibility in tests.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/netutil/private_ip.go
+++ b/internal/netutil/private_ip.go
@@ -1,0 +1,55 @@
+// Package netutil provides network-level security utilities for Engram.
+package netutil
+
+import (
+	"net"
+)
+
+// privateRanges lists IP ranges that must not be dialed by user-supplied URLs.
+// Initialized once at startup via init(); safe for concurrent reads.
+var privateRanges []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		"0.0.0.0/8",      // "this" network (RFC 1122)
+		"10.0.0.0/8",     // RFC1918
+		"100.64.0.0/10",  // Carrier-grade NAT (RFC 6598)
+		"127.0.0.0/8",    // IPv4 loopback
+		"169.254.0.0/16", // link-local / AWS metadata endpoint
+		"172.16.0.0/12",  // RFC1918
+		"192.168.0.0/16", // RFC1918
+		"198.18.0.0/15",  // benchmark testing (RFC 2544)
+		"240.0.0.0/4",    // reserved (RFC 1112)
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 ULA
+		"fe80::/10",      // IPv6 link-local
+	}
+	for _, cidr := range cidrs {
+		_, ipNet, _ := net.ParseCIDR(cidr)
+		privateRanges = append(privateRanges, ipNet)
+	}
+}
+
+// IsPrivateIP reports whether ipStr is an IP address that falls within a
+// private, loopback, link-local, or reserved range. Only literal IP addresses
+// are checked; hostnames must be resolved before calling this function.
+//
+// IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) are normalized to their IPv4
+// form before the range check, preventing bypass via alternate notation.
+func IsPrivateIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	// Normalize IPv4-mapped IPv6 addresses to their IPv4 form so they are
+	// checked against the same IPv4 private ranges.
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+	for _, r := range privateRanges {
+		if r.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/netutil/private_ip_test.go
+++ b/internal/netutil/private_ip_test.go
@@ -1,0 +1,79 @@
+package netutil
+
+import (
+	"testing"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		// IPv4 loopback
+		{"ipv4 loopback 127.0.0.1", "127.0.0.1", true},
+		{"ipv4 loopback 127.255.255.255", "127.255.255.255", true},
+
+		// RFC1918
+		{"rfc1918 10.0.0.1", "10.0.0.1", true},
+		{"rfc1918 10.255.255.255", "10.255.255.255", true},
+		{"rfc1918 172.16.0.1", "172.16.0.1", true},
+		{"rfc1918 172.31.255.255", "172.31.255.255", true},
+		{"rfc1918 192.168.1.1", "192.168.1.1", true},
+		{"rfc1918 192.168.255.255", "192.168.255.255", true},
+
+		// Link-local
+		{"link-local ipv4 169.254.1.1", "169.254.1.1", true},
+
+		// Carrier-grade NAT
+		{"cgnat 100.64.0.1", "100.64.0.1", true},
+
+		// Benchmark range (RFC 2544)
+		{"benchmark 198.18.0.1", "198.18.0.1", true},
+
+		// Reserved
+		{"reserved 240.0.0.1", "240.0.0.1", true},
+
+		// "This" network
+		{"this-network 0.0.0.1", "0.0.0.1", true},
+
+		// Public IPv4 — must be false
+		{"public 8.8.8.8", "8.8.8.8", false},
+		{"public 1.1.1.1", "1.1.1.1", false},
+		{"public 203.0.113.1", "203.0.113.1", false},
+
+		// IPv6 loopback
+		{"ipv6 loopback ::1", "::1", true},
+
+		// IPv6 link-local
+		{"ipv6 link-local fe80::1", "fe80::1", true},
+		{"ipv6 link-local fe80::dead:beef", "fe80::dead:beef", true},
+
+		// IPv6 ULA
+		{"ipv6 ULA fc00::1", "fc00::1", true},
+		{"ipv6 ULA fd00::1", "fd00::1", true},
+
+		// Public IPv6 — must be false
+		{"public ipv6 2001:db8::1", "2001:db8::1", false},
+		{"public ipv6 2606:4700::1", "2606:4700::1", false},
+
+		// IPv4-mapped IPv6 — must match their IPv4 classification
+		{"ipv4-mapped loopback ::ffff:127.0.0.1", "::ffff:127.0.0.1", true},
+		{"ipv4-mapped rfc1918 ::ffff:192.168.1.1", "::ffff:192.168.1.1", true},
+		{"ipv4-mapped public ::ffff:8.8.8.8", "::ffff:8.8.8.8", false},
+
+		// Invalid / non-IP input
+		{"empty string", "", false},
+		{"hostname", "example.com", false},
+		{"garbage", "not-an-ip", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsPrivateIP(tc.ip)
+			if got != tc.want {
+				t.Errorf("IsPrivateIP(%q) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes all 16 findings from the adversarial audit campaign `qa-army-2026-04`.

- Closes #241 — docker-compose: required POSTGRES_PASSWORD, 127.0.0.1 bind, resource limits, healthcheck
- Closes #242 — SSRF: DNS rebinding fix in Ollama HTTP client via post-resolve IP check
- Closes #243 — setup-token: dedicated rate limiter (3 req/5min) + WARN logging
- Closes #244 — cmd/starter + cmd/engram-setup: full unit test coverage (36 tests)
- Closes #245 — SSE sessions: HMAC fingerprint binding, session injection → 403
- Closes #246 — migration 012: safe batched content_hash backfill (1000-row cursor)
- Closes #247 — entity/worker: safeProcessBatch with defer recover() + ERROR logging
- Closes #248 — ILIKE filter: escapeLike() handles `\`, `%`, `_` in correct order
- Closes #249 — project names: validateProjectName() with NFC normalization + bidi rejection
- Closes #250 — cmd/engram: DATABASE_URL unset after read; misleading /proc comment fixed
- Closes #251 — memory_migrate_embedder: embedding dimension pre-flight check
- Closes #252 — tags: toStringSlice() rejects NUL/C0 control chars with descriptive error
- Closes #253 — content: validateContent() rejects C0/C1 control chars (allow \t \n \r)
- Closes #254 — retrieval_events: migration 013 + daily retention worker (90-day TTL)
- Closes #255 — rate limiter: ENGRAM_TRUST_PROXY_HEADERS=1 for X-Forwarded-For support
- Closes #256 — resummarize: verified already soft-delete (UPDATE not DELETE)

## Architecture changes

- New package `internal/netutil` — `IsPrivateIP()` shared by cmd/engram and embed/ollama
- New files: `internal/db/cleanup.go`, `cmd/starter/main_test.go`, `cmd/engram-setup/main_test.go`, `internal/mcp/server_test.go`, `internal/mcp/validation_test.go`, `internal/netutil/private_ip_test.go`
- Two new migrations: 012 (safe backfill), 013 (retention index + cleanup function)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — 21/21 packages pass
- [x] Rickover gate passed (all 6 criteria, including tests for #243 rate limiter and #245 session fingerprint)
- [ ] Integration test: `POSTGRES_PASSWORD=x docker compose up -d` — expected to start cleanly
- [ ] Integration test: `docker compose up` (no POSTGRES_PASSWORD) — expected to fail with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)