### PR TITLE
ci: fix lint action version and postgres password (#264, #265)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: engram
-          POSTGRES_PASSWORD: engram
+          POSTGRES_PASSWORD: ci_test_secret
           POSTGRES_DB: engram_test
         ports:
           - 5432:5432
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test with coverage
         env:
-          TEST_DATABASE_URL: postgres://engram:engram@localhost:5432/engram_test?sslmode=disable
+          TEST_DATABASE_URL: postgres://engram:ci_test_secret@localhost:5432/engram_test?sslmode=disable
         run: go test -coverprofile=coverage.out ./...
 
       - name: Coverage gate (60% minimum)
@@ -63,6 +63,6 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4


### PR DESCRIPTION
## Summary

- Upgrade `golangci-lint-action@v6` → `@v7` — v6 doesn't support lint v2.x (closes #264)
- Change CI postgres password from `engram` to `ci_test_secret` — security guard in `internal/db/postgres.go` blocks startup with default password (closes #265)

## Test plan
- [ ] CI passes (lint + test jobs both green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)