### PR TITLE
fix: warn at startup when ENGRAM_TRUST_PROXY_HEADERS is enabled (#261)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -91,6 +91,8 @@ For Claude Code, `make setup` configures the token automatically. For other clie
 
 **`ENGRAM_TRUST_PROXY_HEADERS`:** When Engram is behind a reverse proxy (nginx, Traefik, Caddy), set `ENGRAM_TRUST_PROXY_HEADERS=1` in `.env`. This enables the server to read the real client IP from `X-Forwarded-For` / `X-Real-IP` headers for rate limiting and `/setup-token` locality checks. Default is `false` — leave it off unless you have a trusted proxy in front.
 
+> **Security note:** Enabling this flag without a trusted L7 proxy in front allows any client with the Bearer token to supply an arbitrary `X-Forwarded-For` header, bypassing per-IP rate limiting. The Bearer token requirement still applies — this is not an authentication bypass.
+
 ---
 
 ## Data Portability

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -118,6 +118,7 @@ func NewServer(pool *EnginePool, cfg Config) *Server {
 	trustProxy := false
 	if v := os.Getenv("ENGRAM_TRUST_PROXY_HEADERS"); v == "1" || strings.EqualFold(v, "true") {
 		trustProxy = true
+		slog.Warn("ENGRAM_TRUST_PROXY_HEADERS is enabled — ensure a trusted reverse proxy terminates all inbound connections; direct clients can spoof X-Forwarded-For to bypass rate limiting")
 	}
 	s := &Server{pool: pool, cfg: cfg, uploads: make(map[string]*uploadSession), trustProxy: trustProxy}
 	mcpServer := server.NewMCPServer("engram", "1.0.0",


### PR DESCRIPTION
## Summary

- Add `slog.Warn` in `NewServer()` when `ENGRAM_TRUST_PROXY_HEADERS` is enabled — warns operators that direct clients can spoof `X-Forwarded-For` to bypass rate limiting
- Add security note to `docs/operations.md` clarifying this is rate-limit bypass only, not auth bypass

Closes #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)