### PR TITLE
fix(consolidator): harden _get_config() and log skipped malformed lines (#266, #267)

### DIFF
--- a/consolidator/instinct/engram_client.py
+++ b/consolidator/instinct/engram_client.py
@@ -20,9 +20,23 @@ class EngramClient:
 
     def _get_config(self) -> tuple[str, str]:
         """Read SSE URL and Bearer token from mcp_servers.json."""
-        cfg = json.loads(Path(self._config_path).read_text())
-        engram = cfg["mcpServers"]["engram"]
-        return engram["url"], engram["headers"]["Authorization"]
+        config_path = Path(self._config_path)
+        if not config_path.exists():
+            raise RuntimeError(
+                f"Engram MCP config not found at {config_path}. "
+                "Run `claude mcp add engram` or create the file manually."
+            )
+        try:
+            cfg = json.loads(config_path.read_text())
+            engram = cfg["mcpServers"]["engram"]
+            url = engram["url"]
+            auth = engram["headers"]["Authorization"]
+        except (KeyError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"Engram MCP server not configured in {config_path}. "
+                "Expected: mcpServers.engram.url and mcpServers.engram.headers.Authorization"
+            ) from exc
+        return url, auth
 
     async def __aenter__(self):
         from contextlib import AsyncExitStack

--- a/consolidator/instinct/run.py
+++ b/consolidator/instinct/run.py
@@ -32,11 +32,15 @@ def load_and_rotate_buffer(buffer_path: Path) -> list[dict]:
         return []
 
     events = []
+    skipped = 0
     for line in raw_lines:
         try:
             events.append(json.loads(line))
         except json.JSONDecodeError:
-            continue
+            skipped += 1
+
+    if skipped:
+        print(f"instinct: WARN — {skipped} malformed line(s) skipped in {buffer_path.name}")
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     dest = buffer_path.parent / f"buffer.jsonl.{ts}.processed"

--- a/consolidator/tests/test_engram_client.py
+++ b/consolidator/tests/test_engram_client.py
@@ -1,4 +1,6 @@
+import json
 import pytest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from instinct.engram_client import EngramClient
 
@@ -85,3 +87,36 @@ async def test_update_confidence_calls_memory_correct(mock_session):
     kwargs = call_args.args[1]
     assert kwargs["memory_id"] == "mem-001"
     assert kwargs["importance"] == 0.5
+
+
+def test_get_config_missing_file_raises_friendly_error(tmp_path):
+    client = EngramClient.__new__(EngramClient)
+    client._config_path = str(tmp_path / "nonexistent.json")
+    with pytest.raises(RuntimeError, match="Engram MCP config not found"):
+        client._get_config()
+
+
+def test_get_config_missing_key_raises_friendly_error(tmp_path):
+    cfg = tmp_path / "mcp_servers.json"
+    cfg.write_text(json.dumps({"mcpServers": {}}))
+    client = EngramClient.__new__(EngramClient)
+    client._config_path = str(cfg)
+    with pytest.raises(RuntimeError, match="Engram MCP server not configured"):
+        client._get_config()
+
+
+def test_get_config_returns_url_and_auth(tmp_path):
+    cfg = tmp_path / "mcp_servers.json"
+    cfg.write_text(json.dumps({
+        "mcpServers": {
+            "engram": {
+                "url": "http://localhost:8788/sse",
+                "headers": {"Authorization": "Bearer secret"}
+            }
+        }
+    }))
+    client = EngramClient.__new__(EngramClient)
+    client._config_path = str(cfg)
+    url, auth = client._get_config()
+    assert url == "http://localhost:8788/sse"
+    assert auth == "Bearer secret"

--- a/consolidator/tests/test_run.py
+++ b/consolidator/tests/test_run.py
@@ -50,6 +50,20 @@ def test_load_and_rotate_rotates_buffer_when_20_plus_events(tmp_path):
     assert len(processed) == 1
 
 
+def test_load_and_rotate_logs_skipped_malformed_lines(tmp_path, capsys):
+    buffer = tmp_path / "buffer.jsonl"
+    good = make_events(19)
+    with buffer.open("w") as f:
+        for e in good:
+            f.write(json.dumps(e) + "\n")
+        f.write("this is not json\n")  # 1 malformed line → 20 total lines
+    events = load_and_rotate_buffer(buffer)
+    assert len(events) == 19
+    assert not buffer.exists()  # still rotated
+    out = capsys.readouterr().out
+    assert "1 malformed" in out
+
+
 def test_group_by_session_splits_correctly():
     events = make_events(3, session_id="s1") + make_events(2, session_id="s2")
     groups = group_by_session(events)


### PR DESCRIPTION
## Summary

- `_get_config()`: wraps bare `KeyError` in `RuntimeError` with actionable message pointing to setup steps (closes #266)
- `load_and_rotate_buffer()`: counts and logs malformed JSONL lines skipped during rotation (closes #267)
- 4 new tests (3 for `_get_config`, 1 for skip logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)