### PR TITLE
feat(mcp): memory_ingest_export tool — Slack zip + ChatGPT/Claude.ai JSON (#262)

### DIFF
--- a/internal/ingest/router/router.go
+++ b/internal/ingest/router/router.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/petersimmons1972/engram/internal/ingest/chatgpt"
@@ -22,6 +23,7 @@ const (
 	FormatUnknown  Format = "unknown"
 	FormatClaudeAI Format = "claudeai"
 	FormatChatGPT  Format = "chatgpt"
+	FormatSlack    Format = "slack"
 )
 
 // peekSize is the number of bytes we read when sniffing a stream. 4 KiB is
@@ -125,4 +127,27 @@ func ParseAuto(r io.Reader) (Format, []*types.Memory, error) {
 		// Defensive: new Format values not handled above.
 		return FormatUnknown, nil, nil
 	}
+}
+
+var zipMagic = []byte{0x50, 0x4B, 0x03, 0x04}
+
+// DetectFromPath opens the file at path, reads the first peekSize bytes, and
+// returns the detected format. ZIP files (magic bytes PK\x03\x04) are
+// classified as FormatSlack; all others fall back to Detect.
+func DetectFromPath(path string) Format {
+	f, err := os.Open(path)
+	if err != nil {
+		return FormatUnknown
+	}
+	defer f.Close()
+	buf := make([]byte, peekSize)
+	n, _ := f.Read(buf)
+	if n < 4 {
+		return FormatUnknown
+	}
+	peek := buf[:n]
+	if bytes.HasPrefix(peek, zipMagic) {
+		return FormatSlack
+	}
+	return Detect(peek)
 }

--- a/internal/ingest/router/router_test.go
+++ b/internal/ingest/router/router_test.go
@@ -4,6 +4,7 @@ package router_test
 // so each can be run independently in the red state.
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -157,4 +158,42 @@ func TestParseAuto_DetectMismatch(t *testing.T) {
 	require.Equal(t, router.FormatClaudeAI, format)
 	require.Nil(t, memories)
 	require.Error(t, err, "a malformed body on a detected format must return an error")
+}
+
+// ── DetectFromPath ────────────────────────────────────────────────────────────
+
+func TestDetectFromPath_ZipMagicBytes(t *testing.T) {
+	f, _ := os.CreateTemp(t.TempDir(), "export*.zip")
+	f.Write([]byte{0x50, 0x4B, 0x03, 0x04, 0x00})
+	f.Close()
+	if got := router.DetectFromPath(f.Name()); got != router.FormatSlack {
+		t.Errorf("want FormatSlack, got %q", got)
+	}
+}
+
+func TestDetectFromPath_ZipMagicNoExtension(t *testing.T) {
+	f, _ := os.CreateTemp(t.TempDir(), "export")
+	f.Write([]byte{0x50, 0x4B, 0x03, 0x04, 0x00})
+	f.Close()
+	if got := router.DetectFromPath(f.Name()); got != router.FormatSlack {
+		t.Errorf("want FormatSlack for zip magic, got %q", got)
+	}
+}
+
+func TestDetectFromPath_ClaudeAIJSON(t *testing.T) {
+	f, _ := os.CreateTemp(t.TempDir(), "claude*.json")
+	f.WriteString(`[{"chat_messages":[]}]`)
+	f.Close()
+	if got := router.DetectFromPath(f.Name()); got != router.FormatClaudeAI {
+		t.Errorf("want FormatClaudeAI, got %q", got)
+	}
+}
+
+func TestDetectFromPath_UnknownFile(t *testing.T) {
+	f, _ := os.CreateTemp(t.TempDir(), "random*.txt")
+	f.WriteString("hello world")
+	f.Close()
+	if got := router.DetectFromPath(f.Name()); got != router.FormatUnknown {
+		t.Errorf("want FormatUnknown, got %q", got)
+	}
 }

--- a/internal/mcp/ingest_export.go
+++ b/internal/mcp/ingest_export.go
@@ -1,0 +1,65 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/ingest/router"
+	"github.com/petersimmons1972/engram/internal/ingest/slack"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+func handleMemoryIngestExport(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+
+	project, err := getProject(args, "default")
+	if err != nil {
+		return nil, err
+	}
+
+	path := getString(args, "path", "")
+	if path == "" {
+		return mcpgo.NewToolResultError("path is required"), nil
+	}
+
+	safePath, err := SafePath(cfg.DataDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path: %w", err)
+	}
+
+	format := router.DetectFromPath(safePath)
+	if format == router.FormatUnknown {
+		return nil, fmt.Errorf("memory_ingest_export: unrecognised format for %q — supported: slack (.zip), claudeai, chatgpt", path)
+	}
+
+	var memories []*types.Memory
+	switch format {
+	case router.FormatSlack:
+		memories, err = slack.ParseFile(safePath)
+		if err != nil {
+			return nil, fmt.Errorf("memory_ingest_export: slack parse: %w", err)
+		}
+	default:
+		f, openErr := os.Open(safePath)
+		if openErr != nil {
+			return nil, fmt.Errorf("memory_ingest_export: open: %w", openErr)
+		}
+		defer f.Close()
+		_, memories, err = router.ParseAuto(f)
+		if err != nil {
+			return nil, fmt.Errorf("memory_ingest_export: parse: %w", err)
+		}
+	}
+
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	deps := storeDocumentDeps{
+		engine:  engineStorerAdapter{store: h.Engine.StoreWithRawBody},
+		backend: backendDocumentAdapter{b: h.Engine.Backend()},
+	}
+	return runExportFanout(ctx, deps, project, format, memories)
+}

--- a/internal/mcp/ingest_export_helpers_test.go
+++ b/internal/mcp/ingest_export_helpers_test.go
@@ -1,0 +1,101 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/search"
+)
+
+// IngestExportResult is the parsed JSON result of memory_ingest_export.
+type IngestExportResult struct {
+	Format         string   `json:"format"`
+	MemoriesStored int      `json:"memories_stored"`
+	MemoryIDs      []string `json:"memory_ids"`
+}
+
+// newToolRequest builds a mcpgo.CallToolRequest with the given arguments.
+func newToolRequest(args map[string]any) mcpgo.CallToolRequest {
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = args
+	return req
+}
+
+// extractTextContent returns the text body of the first TextContent item in
+// a tool result. Returns an empty string if there is no content or the first
+// item is not a TextContent.
+func extractTextContent(result *mcpgo.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	tc, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok {
+		return ""
+	}
+	return tc.Text
+}
+
+// storeableNoopBackend embeds noopBackend but overrides Begin to return a
+// real (no-op) Tx so SearchEngine.StoreWithRawBody can complete without
+// panicking on tx.Commit. Uses the noopTx already defined in simple_tools_test.go.
+type storeableNoopBackend struct{ noopBackend }
+
+func (storeableNoopBackend) Begin(_ context.Context) (db.Tx, error) {
+	return noopTx{}, nil
+}
+
+// storeableNoopEmbedder is a deterministic embedder for store tests.
+type storeableNoopEmbedder struct{}
+
+func (storeableNoopEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, 384), nil
+}
+func (storeableNoopEmbedder) Name() string    { return "noop-store" }
+func (storeableNoopEmbedder) Dimensions() int { return 384 }
+
+var _ embed.Client = storeableNoopEmbedder{}
+
+// NewTestStorePool builds an EnginePool where the backing engine can complete
+// StoreWithRawBody calls without a live database or Ollama instance.
+// Exported so mcp_test package tests can use it directly.
+func NewTestStorePool(t *testing.T) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, storeableNoopBackend{}, storeableNoopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+// CallHandleMemoryIngestExport is a test helper that invokes handleMemoryIngestExport.
+func CallHandleMemoryIngestExport(
+	ctx context.Context,
+	t *testing.T,
+	pool *EnginePool,
+	project string,
+	cfg Config,
+	path string,
+) (IngestExportResult, error) {
+	t.Helper()
+	req := newToolRequest(map[string]any{
+		"path":    path,
+		"project": project,
+	})
+	result, err := handleMemoryIngestExport(ctx, pool, req, cfg)
+	if err != nil {
+		return IngestExportResult{}, err
+	}
+	if result.IsError {
+		return IngestExportResult{}, fmt.Errorf("tool error: %s", extractTextContent(result))
+	}
+	var out IngestExportResult
+	json.Unmarshal([]byte(extractTextContent(result)), &out)
+	return out, nil
+}

--- a/internal/mcp/ingest_export_test.go
+++ b/internal/mcp/ingest_export_test.go
@@ -1,0 +1,106 @@
+package mcp_test
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
+)
+
+func buildMinimalSlackZip(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "slack-export.zip")
+	f, _ := os.Create(path)
+	w := zip.NewWriter(f)
+	writeFile := func(name, body string) {
+		zf, _ := w.Create(name)
+		zf.Write([]byte(body))
+	}
+	writeFile("users.json", `[{"id":"U001","name":"alice","real_name":"Alice"}]`)
+	writeFile("channels.json", `[{"id":"C001","name":"general"}]`)
+	writeFile("general/2026-01-01.json", `[{"type":"message","user":"U001","text":"Hello","ts":"1700000000.000001"}]`)
+	w.Close()
+	f.Close()
+	return path
+}
+
+func TestHandleMemoryIngestExport_SlackZip(t *testing.T) {
+	zipPath := buildMinimalSlackZip(t)
+	pool := internalmcp.NewTestStorePool(t)
+	cfg := internalmcp.Config{DataDir: filepath.Dir(zipPath)}
+	result, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, zipPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.MemoriesStored == 0 {
+		t.Errorf("want >=1 memory stored, got 0")
+	}
+	if result.Format != "slack" {
+		t.Errorf("want format=slack, got %q", result.Format)
+	}
+}
+
+func TestHandleMemoryIngestExport_ClaudeAIJSON(t *testing.T) {
+	dir := t.TempDir()
+	content := `[{"uuid":"abc","name":"Test","created_at":"2026-01-01T00:00:00.000000Z","updated_at":"2026-01-01T01:00:00.000000Z","chat_messages":[{"uuid":"m1","sender":"human","text":"hello","created_at":"2026-01-01T00:00:00.000000Z"}]}]`
+	jsonPath := filepath.Join(dir, "conversations.json")
+	os.WriteFile(jsonPath, []byte(content), 0o600)
+	pool := internalmcp.NewTestStorePool(t)
+	cfg := internalmcp.Config{DataDir: dir}
+	result, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, jsonPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.MemoriesStored != 1 {
+		t.Errorf("want 1 memory, got %d", result.MemoriesStored)
+	}
+	if result.Format != "claudeai" {
+		t.Errorf("want format=claudeai, got %q", result.Format)
+	}
+}
+
+func TestHandleMemoryIngestExport_UnknownFormat(t *testing.T) {
+	dir := t.TempDir()
+	txtPath := filepath.Join(dir, "random.txt")
+	os.WriteFile(txtPath, []byte("not an export"), 0o600)
+	pool := internalmcp.NewTestStorePool(t)
+	cfg := internalmcp.Config{DataDir: dir}
+	_, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, txtPath)
+	if err == nil {
+		t.Error("want error for unknown format, got nil")
+	}
+}
+
+func TestHandleMemoryIngestExport_PathOutsideDataDir(t *testing.T) {
+	pool := internalmcp.NewTestStorePool(t)
+	cfg := internalmcp.Config{DataDir: t.TempDir()}
+	_, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, "/etc/passwd")
+	if err == nil {
+		t.Error("want path validation error, got nil")
+	}
+}
+
+// Ensure IngestExportResult round-trips through JSON correctly.
+func TestIngestExportResult_JSONRoundtrip(t *testing.T) {
+	r := internalmcp.IngestExportResult{
+		Format:         "slack",
+		MemoriesStored: 3,
+		MemoryIDs:      []string{"id1", "id2", "id3"},
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got internalmcp.IngestExportResult
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Format != r.Format || got.MemoriesStored != r.MemoriesStored || len(got.MemoryIDs) != len(r.MemoryIDs) {
+		t.Errorf("round-trip mismatch: %+v != %+v", got, r)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -559,6 +559,11 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryIngest(ctx, pool, req, cfg)
 			}},
+		{"memory_ingest_export",
+			"Ingest a server-local AI conversation export file (Slack workspace .zip, Claude.ai conversations.json, or ChatGPT conversations.json). Parses the file, auto-detects format, and stores one memory per conversation or channel.",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryIngestExport(ctx, pool, req, cfg)
+			}},
 		// Feature 4: Cross-Project Knowledge Federation
 		{"memory_projects", "List all projects with memory counts",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {


### PR DESCRIPTION
## Summary

Closes #262.

- Extends `internal/ingest/router` with `FormatSlack` and `DetectFromPath` — detects ZIP magic bytes (`PK\x03\x04`) and maps to the Slack parser; falls back to content-sniffing for JSON formats
- New `memory_ingest_export` MCP tool accepts a server-local file path, auto-detects format, and stores one memory per conversation/channel via the existing `runExportFanout` pipeline
- Path validated via `SafePath` before any file I/O

## Formats supported

| File type | Detection | Parser |
|-----------|-----------|--------|
| Slack workspace `.zip` | ZIP magic bytes | `internal/ingest/slack.ParseFile` |
| Claude.ai `conversations.json` | `"chat_messages"` key in first object | `internal/ingest/claudeai` |
| ChatGPT `conversations.json` | `"mapping"` key in first object | `internal/ingest/chatgpt` |

## Tests

- 4 new `TestDetectFromPath_*` in `router_test.go`
- 5 new `TestHandleMemoryIngestExport_*` in `ingest_export_test.go` (Slack zip, Claude.ai JSON, unknown format error, path traversal rejection, JSON roundtrip)

## Test plan
- [x] `go test ./... -count=1` — 34 packages, all pass
- [x] `SafePath` called before any file I/O
- [x] Unknown format returns descriptive error naming tool, path, and supported set

🤖 Generated with [Claude Code](https://claude.com/claude-code)