### PR TITLE
fix: security hardening — hook consent, secret redaction, .env hygiene, CI permissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 # =============================================================
+# WARNING: Never commit this file with real values.
+# Canonical credential source: Infisical at https://infisical.petersimmons.com
+# Run 'make init' to generate POSTGRES_PASSWORD and ENGRAM_API_KEY locally.
+# =============================================================
+
+# =============================================================
 # Required
 # =============================================================
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,9 @@ on:
       - "models/candidates.yaml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate manifest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BUILD_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
-.PHONY: help up down down-safe restart logs build build-postgres go-build test setup setup-dry-run init test-explore-soak
+.PHONY: help up down down-safe restart logs build build-postgres go-build test setup setup-dry-run init check-env test-explore-soak
 
 ## Show available make targets
 help:
@@ -72,6 +72,16 @@ init:
 	    touch .env.machine-identity; \
 	    echo "✓ Created .env.machine-identity (empty — add Infisical credentials here if using secret management)"; \
 	fi
+
+## Verify .env contains no placeholder values before deploying.
+check-env:
+	@if grep -qsE '^(POSTGRES_PASSWORD|ENGRAM_API_KEY)=change_me' .env 2>/dev/null; then \
+	    echo "ERROR: .env still contains placeholder credentials. Run 'make init'."; exit 1; \
+	fi
+	@if [ ! -f .env ] || ! grep -qs '^POSTGRES_PASSWORD=' .env || ! grep -qs '^ENGRAM_API_KEY=' .env; then \
+	    echo "ERROR: .env missing required credentials. Run 'make init'."; exit 1; \
+	fi
+	@echo "✓ .env credentials look set"
 
 ## Configure MCP client — fetches current bearer token and writes mcpServers.engram in ~/.claude.json
 ## Run this after: first install, container restart (if key changed), or key rotation.

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -8,6 +8,27 @@ HOOKS_SRC="$REPO_DIR/hooks"
 HOOKS_DEST="$HOME/.claude/hooks"
 SETTINGS="$HOME/.claude/settings.json"
 
+cat <<'DISCLOSURE'
+
+DATA COLLECTION NOTICE
+----------------------
+The instinct hooks observe Claude Code tool activity. On every Edit, Write, Bash,
+Task, Agent, or MCP write call, the hook captures:
+
+  - Tool name and a hash of the tool input (no raw input is stored)
+  - The first 200 characters of the tool response, with secrets redacted
+  - Session ID and a hashed project identifier
+
+This data is written to ~/.local/state/instinct/buffer.jsonl (mode 0600) and
+periodically sent to Anthropic's API by the consolidator (instinct.run).
+
+To opt out at any time without uninstalling, set INSTINCT_ENABLED=0 in your
+environment (e.g., export INSTINCT_ENABLED=0 in ~/.bashrc).
+
+Press ENTER to accept and continue, or Ctrl-C to abort.
+DISCLOSURE
+read -r
+
 echo "Installing instinct hooks..."
 
 # 1. Copy hook scripts

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -12,6 +12,9 @@ CONSOLIDATOR="$HOME/projects/instinct/consolidator/.venv/bin/python"
 CONSOLIDATOR_MODULE="$HOME/projects/instinct/consolidator"
 
 mkdir -p "$BUFFER_DIR"
+chmod 700 "$BUFFER_DIR"
+touch "$BUFFER_FILE"
+chmod 600 "$BUFFER_FILE"
 
 # Read stdin — contains the tool call JSON
 raw_input=$(cat)
@@ -54,7 +57,22 @@ tool_input_hash = hashlib.sha256(raw.encode()).hexdigest()[:12]
 resp = d.get("tool_response") or ""
 if isinstance(resp, dict):
     resp = resp.get("text") or resp.get("content") or str(resp)
-tool_output_summary = str(resp)[:200].replace("\n", " ")
+
+import re
+_REDACT = [
+    # Most specific first — full var names before generic keyword match
+    re.compile(r"(?i)(INFISICAL_CLIENT_(?:ID|SECRET)|ENGRAM_API_KEY|POSTGRES_PASSWORD)\s*=\s*\S+"),
+    re.compile(r"(?i)postgres://[^@\s]+@\S+"),
+    re.compile(r"(?i)(password|passwd|secret|api[_-]?key|token|bearer|auth)\s*[=:]\s*\S+"),
+    re.compile(r"[A-Za-z0-9+/]{40,}={0,2}"),
+    re.compile(r"[0-9a-f]{48,}"),
+]
+def _redact(text):
+    for pat in _REDACT:
+        text = pat.sub("[REDACTED]", text)
+    return text
+
+tool_output_summary = _redact(str(resp)[:200].replace("\n", " "))
 
 event = {
     "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -63,16 +63,24 @@ _REDACT = [
     # Most specific first — full var names before generic keyword match
     re.compile(r"(?i)(INFISICAL_CLIENT_(?:ID|SECRET)|ENGRAM_API_KEY|POSTGRES_PASSWORD)\s*=\s*\S+"),
     re.compile(r"(?i)postgres://[^@\s]+@\S+"),
-    re.compile(r"(?i)(password|passwd|secret|api[_-]?key|token|bearer|auth)\s*[=:]\s*\S+"),
-    re.compile(r"[A-Za-z0-9+/]{40,}={0,2}"),
-    re.compile(r"[0-9a-f]{48,}"),
+    # Shell KEY=VALUE and HTTP header KEY: VALUE forms
+    re.compile(r"(?i)\b(password|passwd|secret|api[_-]?key|token|bearer|auth\w*)\s*[=:]\s*\S+"),
+    # JSON "key": "value" form
+    re.compile(r'(?i)"(password|passwd|secret|api[_-]?key|token|bearer|auth\w*)"\s*:\s*"[^"]*"'),
+    # JWTs: three base64url segments separated by dots
+    re.compile(r"[A-Za-z0-9\-_]{20,}\.[A-Za-z0-9\-_]{20,}\.[A-Za-z0-9\-_]{20,}"),
+    # Standard base64 and URL-safe base64 (GitHub PATs, Anthropic keys, etc.)
+    re.compile(r"[A-Za-z0-9+/\-_]{40,}={0,2}"),
+    # Uppercase or lowercase hex blobs ≥48 chars
+    re.compile(r"[0-9a-fA-F]{48,}"),
 ]
 def _redact(text):
     for pat in _REDACT:
         text = pat.sub("[REDACTED]", text)
     return text
 
-tool_output_summary = _redact(str(resp)[:200].replace("\n", " "))
+# Redact before truncating — a secret straddling char 200 would evade patterns if truncated first
+tool_output_summary = _redact(str(resp).replace("\n", " "))[:200]
 
 event = {
     "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),


### PR DESCRIPTION
## Summary

- **hooks/install.sh**: Explicit data-collection consent prompt before hook installation — describes what is captured (first 200 chars of tool responses, hashed), where it is written, and how to opt out (`INSTINCT_ENABLED=0`). Closes #286 requirement (a).
- **hooks/post-tool-use.sh**: Secret redaction pass before writing `tool_output_summary` — matches named keys (`POSTGRES_PASSWORD=`, `ENGRAM_API_KEY=`, Infisical vars), DSN patterns, then generic keyword-value pairs, then long hex/base64 tokens. Buffer dir enforced to 0700, `buffer.jsonl` to 0600. Closes #286 requirements (b) and (c).
- **.env.example**: Warning banner directing users to Infisical as canonical credential source. Relates to #273.
- **Makefile**: `make check-env` target — fails if `.env` contains placeholder values or missing required keys. Relates to #273.
- **.github/workflows/benchmark.yml**: `permissions: contents: read` added — locks down GITHUB_TOKEN scope. Closes SAST alert #2.

> **Note — #273 credential rotation:** The `.env` and `.env.machine-identity` files were never committed (verified via `git log --all --full-history -- .env .env.machine-identity`). The operational rotation step (regenerate `POSTGRES_PASSWORD`/`ENGRAM_API_KEY` via `make init`, revoke + recreate the Infisical machine identity) must be completed before declaring #273 closed.

## Test plan

- [ ] `go test ./... -count=1 -race` — all pass (verified pre-commit)
- [ ] `echo '{"tool_name":"Bash","tool_response":"POSTGRES_PASSWORD=secret123"}' | bash hooks/post-tool-use.sh` — `buffer.jsonl` contains `[REDACTED]`, not the value
- [ ] `stat -c "%a" ~/.local/state/instinct/buffer.jsonl` — returns `600`
- [ ] `make check-env` with placeholder `.env` — exits non-zero
- [ ] Push branch → GitHub Actions → SAST alert #2 auto-closes
- [ ] Adversarial review (Rickover, Spruance, zero-context) per CLAUDE.md AI-generated PR policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)