### PR TITLE
fix(qa): resolve five post-merge issues (#367 #368 #369 #370 #371)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,15 @@ POSTGRES_PASSWORD=change_me_to_a_strong_password
 # full   = return complete memory objects on every recall
 # ENGRAM_RECALL_DEFAULT_MODE=handle
 
+# Maximum results returned by memory_recall — hard cap applied after scoring (default: 500)
+# ENGRAM_RECALL_MAX_TOP_K=500
+
+# GlobalReembedder: chunks to embed per polling iteration (default: 100)
+# ENGRAM_REEMBED_BATCH_SIZE=100
+
+# GlobalReembedder: delay between polling iterations (default: 10s)
+# ENGRAM_REEMBED_INTERVAL=10s
+
 # Maximum bytes returned by memory_fetch with detail=full (default: 65536)
 # ENGRAM_FETCH_MAX_BYTES=65536
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -201,6 +201,9 @@ ENGRAM_CLAUDE_RERANK=false                # Use Claude to rerank results (slower
 | `POSTGRES_DB`              | `engram`             | No       | Database name (rarely needs changing)                 |
 | `POSTGRES_USER`            | `engram`             | No       | Database user (rarely needs changing)                 |
 | `ENGRAM_TRUST_PROXY_HEADERS` | `false`              | No       | Trust `X-Forwarded-For` / `X-Real-IP` for rate limiting. Set to `1` only when a trusted reverse proxy is in front. |
+| `ENGRAM_RECALL_MAX_TOP_K`  | `500`                | No       | Hard cap on results returned by `memory_recall`. Increase for bulk export use cases. |
+| `ENGRAM_REEMBED_BATCH_SIZE`| `100`                | No       | Chunks processed per GlobalReembedder iteration. Increase for faster catch-up after model changes. |
+| `ENGRAM_REEMBED_INTERVAL`  | `10s`                | No       | Delay between GlobalReembedder polling iterations. Accepts Go duration strings (`10s`, `1m`). |
 
 ---
 

--- a/internal/db/cleanup.go
+++ b/internal/db/cleanup.go
@@ -23,9 +23,16 @@ func (b *PostgresBackend) StartRetentionWorker(ctx context.Context) {
 		n, err := b.deleteOldRetrievalEvents(ctx)
 		if err != nil {
 			slog.Error("retention worker: cleanup failed", "err", err)
-			return
+		} else {
+			slog.Info("retention worker: cleanup complete", "rows_deleted", n)
 		}
-		slog.Info("retention worker: cleanup complete", "rows_deleted", n)
+
+		sn, serr := b.deleteOldSessions(ctx)
+		if serr != nil {
+			slog.Error("retention worker: session cleanup failed", "err", serr)
+		} else {
+			slog.Info("retention worker: session cleanup complete", "rows_deleted", sn)
+		}
 	}
 
 	run() // catch-up pass at startup
@@ -49,6 +56,25 @@ func (b *PostgresBackend) deleteOldRetrievalEvents(ctx context.Context) (int64, 
 	const q = `
 DELETE FROM retrieval_events
 WHERE created_at < NOW() - INTERVAL '90 days'`
+
+	tag, err := b.pool.Exec(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+// deleteOldSessions removes mcp_sessions rows that have been inactive for more
+// than 4 hours. The 4-hour window is 2× the 2-hour rehydration window in
+// RehydrateSessions, ensuring sessions that could still be rehydrated are never
+// prematurely deleted (#367).
+func (b *PostgresBackend) deleteOldSessions(ctx context.Context) (int64, error) {
+	if b.pool == nil {
+		return 0, nil
+	}
+	const q = `
+DELETE FROM mcp_sessions
+WHERE last_seen_at < NOW() - INTERVAL '4 hours'`
 
 	tag, err := b.pool.Exec(ctx, q)
 	if err != nil {

--- a/internal/db/cleanup.go
+++ b/internal/db/cleanup.go
@@ -53,6 +53,9 @@ func (b *PostgresBackend) StartRetentionWorker(ctx context.Context) {
 // number of rows removed. Kept private; callers should use StartRetentionWorker
 // or CleanupRetentionEvents.
 func (b *PostgresBackend) deleteOldRetrievalEvents(ctx context.Context) (int64, error) {
+	if b.pool == nil {
+		return 0, nil
+	}
 	const q = `
 DELETE FROM retrieval_events
 WHERE created_at < NOW() - INTERVAL '90 days'`

--- a/internal/db/cleanup_test.go
+++ b/internal/db/cleanup_test.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDeleteOldSessionsNilPool verifies that the nil-pool fast path in
+// deleteOldSessions returns (0, nil) rather than panicking. This matches the
+// documented behaviour: a nil-pool backend is a no-op for cleanup, not an error.
+func TestDeleteOldSessionsNilPool(t *testing.T) {
+	b := &PostgresBackend{pool: nil, project: "default"}
+	n, err := b.deleteOldSessions(context.Background())
+	if err != nil {
+		t.Errorf("deleteOldSessions with nil pool should return nil error, got %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleteOldSessions with nil pool should return 0 rows, got %d", n)
+	}
+}
+
+// TestEfSearchForLimitBoundaries exercises the efSearchForLimit helper for the
+// three behavioural regions: below threshold, above threshold but below cap, and
+// above the cap boundary (#370).
+func TestEfSearchForLimitBoundaries(t *testing.T) {
+	cases := []struct {
+		limit int
+		want  int
+	}{
+		{limit: 1, want: 2},
+		{limit: 64, want: 128},  // at the HNSW default threshold
+		{limit: 100, want: 200}, // above threshold, below cap
+		{limit: 499, want: 998}, // just below the cap boundary (499*2=998 ≤ 1000)
+		{limit: 500, want: 1000}, // exactly at the cap boundary (500*2=1000)
+		{limit: 501, want: 1000}, // one above — cap kicks in (501*2=1002 → 1000)
+		{limit: 10000, want: 1000}, // pathological large limit
+	}
+	for _, tc := range cases {
+		got := efSearchForLimit(tc.limit)
+		if got != tc.want {
+			t.Errorf("efSearchForLimit(%d) = %d, want %d", tc.limit, got, tc.want)
+		}
+	}
+}

--- a/internal/db/postgres_chunk.go
+++ b/internal/db/postgres_chunk.go
@@ -187,11 +187,22 @@ func (b *PostgresBackend) UpdateChunkEmbedding(ctx context.Context, chunkID stri
 	return int(tag.RowsAffected()), err
 }
 
-// hnswDefaultEfSearch is the HNSW index ef_construction value (build-time). The
-// query-time ef_search defaults to the same value. When callers request more
-// candidates than this threshold, we tune ef_search upward so the index can
-// actually return the requested number of rows rather than silently truncating.
+// hnswDefaultEfSearch is the HNSW index default ef_search (query-time candidate
+// set size). When callers request more candidates than this threshold, we tune
+// ef_search upward so the index can actually return the requested number of rows
+// rather than silently truncating.
 const hnswDefaultEfSearch = 64
+
+// efSearchForLimit returns the ef_search value to set for a given query limit.
+// It doubles the limit to overscan, capped at 1000 to prevent pathological
+// HNSW scans on very large limits (#370).
+func efSearchForLimit(limit int) int {
+	v := limit * 2
+	if v > 1000 {
+		v = 1000
+	}
+	return v
+}
 
 func (b *PostgresBackend) VectorSearch(ctx context.Context, project string, queryVec []float32, limit int) ([]VectorHit, error) {
 	// When the requested limit exceeds the HNSW default ef_search, the index
@@ -204,10 +215,7 @@ func (b *PostgresBackend) VectorSearch(ctx context.Context, project string, quer
 			return nil, fmt.Errorf("begin vector search tx: %w", err)
 		}
 		defer func() { _ = tx.Rollback(ctx) }() // read-only — rollback == commit here
-		efSearch := limit * 2
-		if efSearch > 1000 {
-			efSearch = 1000
-		}
+		efSearch := efSearchForLimit(limit)
 		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)); err != nil {
 			return nil, fmt.Errorf("set hnsw.ef_search: %w", err)
 		}

--- a/internal/db/postgres_chunk.go
+++ b/internal/db/postgres_chunk.go
@@ -205,6 +205,9 @@ func (b *PostgresBackend) VectorSearch(ctx context.Context, project string, quer
 		}
 		defer func() { _ = tx.Rollback(ctx) }() // read-only — rollback == commit here
 		efSearch := limit * 2
+		if efSearch > 1000 {
+			efSearch = 1000
+		}
 		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)); err != nil {
 			return nil, fmt.Errorf("set hnsw.ef_search: %w", err)
 		}

--- a/internal/db/postgres_session_test.go
+++ b/internal/db/postgres_session_test.go
@@ -2,20 +2,73 @@ package db
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/petersimmons1972/engram/internal/testutil"
 )
 
 // TestSessionRegistryRoundtrip verifies the four session methods work correctly
 // against a real PostgreSQL database. Requires TEST_DATABASE_URL.
 func TestSessionRegistryRoundtrip(t *testing.T) {
-	dsn := os.Getenv("TEST_DATABASE_URL")
-	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set — skipping integration test")
+	dsn := testutil.DSN(t)
+	ctx := context.Background()
+
+	pool, err := NewSharedPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("NewSharedPool: %v", err)
 	}
-	// TODO: implement with real DB when integration env is available.
-	_ = dsn
+	defer pool.Close()
+
+	b, err := NewPostgresBackendWithPool(ctx, testutil.UniqueProject("sess"), pool)
+	if err != nil {
+		t.Fatalf("NewPostgresBackendWithPool: %v", err)
+	}
+
+	sessionID := fmt.Sprintf("test-session-%d", time.Now().UnixNano())
+	apiKeyHash := "deadbeef"
+
+	// Register
+	if err := b.RegisterSession(ctx, sessionID, apiKeyHash); err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+
+	// List — should appear
+	sessions, err := b.ListActiveSessions(ctx, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("ListActiveSessions: %v", err)
+	}
+	found := false
+	for _, s := range sessions {
+		if s == sessionID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("registered session %q not found in ListActiveSessions", sessionID)
+	}
+
+	// Touch — should not error
+	if err := b.TouchSession(ctx, sessionID); err != nil {
+		t.Errorf("TouchSession: %v", err)
+	}
+
+	// Unregister
+	if err := b.UnregisterSession(ctx, sessionID); err != nil {
+		t.Fatalf("UnregisterSession: %v", err)
+	}
+
+	// List again — should be gone
+	sessions, err = b.ListActiveSessions(ctx, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("ListActiveSessions after unregister: %v", err)
+	}
+	for _, s := range sessions {
+		if s == sessionID {
+			t.Errorf("unregistered session %q still appears in ListActiveSessions", sessionID)
+		}
+	}
 }
 
 // TestRegisterSessionRejectsNilPool verifies that calling RegisterSession on a

--- a/internal/reembed/embed_fail_test.go
+++ b/internal/reembed/embed_fail_test.go
@@ -1,0 +1,77 @@
+package reembed
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/metrics"
+	"github.com/petersimmons1972/engram/internal/testutil"
+)
+
+// failEmbedder is a mock embed.Client that always returns an error.
+type failEmbedder struct{}
+
+func (f *failEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, errors.New("mock embed failure")
+}
+func (f *failEmbedder) Name() string    { return "fail" }
+func (f *failEmbedder) Dimensions() int { return 0 }
+
+var _ embed.Client = (*failEmbedder)(nil)
+
+// TestEmbedFailureCountedInMetrics verifies that when the embedder returns an
+// error for a chunk, WorkerErrors{"global_reembed"} is incremented (#370a).
+// Requires TEST_DATABASE_URL pointing to a live Postgres+pgvector instance with
+// the engram schema already migrated.
+func TestEmbedFailureCountedInMetrics(t *testing.T) {
+	dsn := testutil.DSN(t)
+	ctx := context.Background()
+
+	pool, err := db.NewSharedPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("NewSharedPool: %v", err)
+	}
+	defer pool.Close()
+
+	// Insert a minimal chunk row with a NULL embedding so runBatch has something
+	// to pick up. We use a conflict-safe upsert to re-run the test idempotently.
+	chunkID := "reembed-test-embed-fail-chunk"
+	memID := "reembed-test-embed-fail-mem"
+	_, err = pool.Exec(ctx, `
+		INSERT INTO chunks (id, memory_id, project, chunk_text, chunk_index, embedding)
+		VALUES ($1, $2, 'reembed-test', 'test content', 0, NULL)
+		ON CONFLICT (id) DO UPDATE SET embedding = NULL`,
+		chunkID, memID,
+	)
+	if err != nil {
+		t.Skipf("cannot seed test chunk (schema constraint): %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM chunks WHERE id = $1", chunkID)
+	})
+
+	g := &GlobalReembedder{
+		pool:      pool,
+		embedder:  &failEmbedder{},
+		batchSize: 10,
+		interval:  1 * time.Hour,
+		done:      make(chan struct{}),
+	}
+
+	before := promtest.ToFloat64(metrics.WorkerErrors.WithLabelValues("global_reembed"))
+
+	if err := g.runBatch(ctx); err != nil {
+		t.Fatalf("runBatch returned unexpected error: %v", err)
+	}
+
+	after := promtest.ToFloat64(metrics.WorkerErrors.WithLabelValues("global_reembed"))
+	if after <= before {
+		t.Errorf("WorkerErrors{global_reembed} did not increase after embed failure: before=%.0f after=%.0f", before, after)
+	}
+}

--- a/internal/reembed/embed_fail_test.go
+++ b/internal/reembed/embed_fail_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/metrics"
 	"github.com/petersimmons1972/engram/internal/testutil"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 // failEmbedder is a mock embed.Client that always returns an error.
@@ -39,22 +40,37 @@ func TestEmbedFailureCountedInMetrics(t *testing.T) {
 	}
 	defer pool.Close()
 
-	// Insert a minimal chunk row with a NULL embedding so runBatch has something
-	// to pick up. We use a conflict-safe upsert to re-run the test idempotently.
-	chunkID := "reembed-test-embed-fail-chunk"
-	memID := "reembed-test-embed-fail-mem"
-	_, err = pool.Exec(ctx, `
-		INSERT INTO chunks (id, memory_id, project, chunk_text, chunk_index, embedding)
-		VALUES ($1, $2, 'reembed-test', 'test content', 0, NULL)
-		ON CONFLICT (id) DO UPDATE SET embedding = NULL`,
-		chunkID, memID,
-	)
+	project := testutil.UniqueProject("reembed-fail")
+	backend, err := db.NewPostgresBackendWithPool(ctx, project, pool)
 	if err != nil {
-		t.Skipf("cannot seed test chunk (schema constraint): %v", err)
+		t.Fatalf("NewPostgresBackendWithPool: %v", err)
 	}
-	t.Cleanup(func() {
-		_, _ = pool.Exec(context.Background(), "DELETE FROM chunks WHERE id = $1", chunkID)
-	})
+
+	// Seed a memory + chunk with NULL embedding so runBatch picks it up.
+	mem := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "test content for embed failure",
+		MemoryType:  "context",
+		Project:     project,
+		Importance:  1,
+		StorageMode: "focused",
+	}
+	if err := backend.StoreMemory(ctx, mem); err != nil {
+		t.Fatalf("StoreMemory: %v", err)
+	}
+
+	chunk := &types.Chunk{
+		ID:         types.NewMemoryID(),
+		MemoryID:   mem.ID,
+		Project:    project,
+		ChunkText:  mem.Content,
+		ChunkIndex: 0,
+		// Embedding left nil → stored as NULL → picked up by runBatch's
+		// "WHERE c.embedding IS NULL" query.
+	}
+	if err := backend.StoreChunks(ctx, []*types.Chunk{chunk}); err != nil {
+		t.Fatalf("StoreChunks: %v", err)
+	}
 
 	g := &GlobalReembedder{
 		pool:      pool,

--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -160,6 +160,7 @@ func (g *GlobalReembedder) runBatch(ctx context.Context) error {
 			vec, err := g.embedder.Embed(embedCtx, c.chunkText)
 			if err != nil {
 				slog.Warn("global reembedder: embed failed", "chunk", c.id, "err", err)
+				metrics.WorkerErrors.WithLabelValues("global_reembed").Inc()
 				return nil // non-fatal: skip chunk, retry on next tick
 			}
 			if _, err := g.pool.Exec(egCtx,

--- a/internal/search/preference_test.go
+++ b/internal/search/preference_test.go
@@ -5,16 +5,14 @@ import (
 )
 
 // TestIsPreferenceQueryDetectsSignals verifies that queries containing known
-// preference-signal words are detected correctly.
+// preference-signal words are detected correctly. Only high-signal words that
+// rarely appear in engineering prose are retained (#369).
 func TestIsPreferenceQueryDetectsSignals(t *testing.T) {
 	hits := []string{
 		"what does the user prefer for coffee?",
-		"what does the user like to eat?",
 		"what is the user's favorite music?",
 		"what kind of books does the user enjoy?",
-		"what does the user want for lunch?",
-		"what music does the user love?",
-		"WHAT DOES THE USER PREFER?",  // case-insensitive
+		"WHAT DOES THE USER PREFER?", // case-insensitive
 	}
 	for _, q := range hits {
 		if !isPreferenceQuery(q) {
@@ -24,19 +22,17 @@ func TestIsPreferenceQueryDetectsSignals(t *testing.T) {
 }
 
 // TestIsPreferenceQueryIgnoresNeutralQueries verifies that neutral recall
-// queries are not classified as preference queries, including common substrings
-// that would fire a simple strings.Contains check ("likely" contains "like",
-// "unlikely" also contains "like").
+// queries are not classified as preference queries.
 func TestIsPreferenceQueryIgnoresNeutralQueries(t *testing.T) {
 	misses := []string{
 		"what is the project deadline?",
 		"when was the last meeting?",
 		"summarize the architecture decisions",
 		"find all error patterns",
-		"what is the deployment likely to fail on?", // "likely" must not match "like"
-		"it looks unlike the previous regression",   // "unlike" must not match "like"
-		"the build is unwanted overhead",            // "unwanted" must not match "want"
-		"it warrants further investigation",         // "warrants" must not match "want"
+		// "like", "want", "love" removed from signals — must not fire (#369)
+		"what does the user like to eat?",
+		"what does the user want for lunch?",
+		"what music does the user love?",
 	}
 	for _, q := range misses {
 		if isPreferenceQuery(q) {

--- a/internal/search/query_signal.go
+++ b/internal/search/query_signal.go
@@ -5,11 +5,15 @@ import (
 	"unicode"
 )
 
-// preferenceSignals are words that indicate preference-related text.
-// All lowercase; matched as whole words to avoid false positives from
-// substrings (e.g. "like" in "likely", "want" in "unwanted").
-var preferenceSignals = []string{"prefer", "prefers", "preferred", "like", "likes", "liked",
-	"favorite", "favourite", "enjoy", "enjoys", "enjoyed", "want", "wants", "love", "loves"}
+// preferenceSignals are high-signal words indicating stored user preferences.
+// "like", "want", "love" removed — they appear too frequently in engineering
+// prose ("I'd like to", "we want to", "would love feedback") and cause false
+// positives in auto-tagging and query boosting (#369).
+var preferenceSignals = []string{
+	"prefer", "prefers", "preferred",
+	"favorite", "favourite",
+	"enjoy", "enjoys", "enjoyed",
+}
 
 // preferenceSignalSet is the same list in a map for O(1) lookup after tokenisation.
 var preferenceSignalSet = func() map[string]struct{} {


### PR DESCRIPTION
## Summary

- **#367** — `mcp_sessions` TTL: extend `StartRetentionWorker` to delete sessions inactive for 4 hours (2× the 2-hour rehydration window), preventing unbounded table growth
- **#368** — Document three new env vars: `ENGRAM_RECALL_MAX_TOP_K`, `ENGRAM_REEMBED_BATCH_SIZE`, `ENGRAM_REEMBED_INTERVAL` — added to `.env.example` and `docs/getting-started.md`
- **#369** — Narrow preference auto-tag signals: remove `like/want/love` from `preferenceSignals`, which fired false positives on common engineering phrases (`"I'd like to"`, `"we want to"`)
- **#370a** — Count per-chunk embed failures: add `metrics.WorkerErrors.WithLabelValues("global_reembed").Inc()` inside `GlobalReembedder` errgroup closure so embed failures are visible in Prometheus
- **#370b** — Cap `hnsw.ef_search` at 1000 to prevent runaway HNSW candidate scans on pathological large `top_k` values
- **#371** — Implement `TestSessionRegistryRoundtrip` as a real integration test using `testutil.DSN` + `NewSharedPool` (was a `TODO` stub that gave false confidence)

## Test plan

- [x] `go test ./... -count=1 -race` — all 38 packages pass
- [ ] Rickover correctness audit
- [ ] Spruance coverage audit
- [ ] Zero-context structural review
- [ ] `TestSessionRegistryRoundtrip` passes with `TEST_DATABASE_URL` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)