### PR TITLE
fix(metrics): restore ChunksPendingReembed gauge in GlobalReembedder

### DIFF
--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -77,6 +77,18 @@ func (g *GlobalReembedder) run(ctx context.Context) {
 	for {
 		metrics.WorkerTicks.WithLabelValues("global_reembed").Inc()
 		if g.pool != nil && g.embedder != nil {
+			// Update the pending-reembed gauge before each batch so dashboards and
+			// alerts remain live. The per-project Worker used to do this; GlobalReembedder
+			// now owns the reembed path and must carry the responsibility.
+			countCtx, countCancel := context.WithTimeout(ctx, 5*time.Second)
+			var pending int
+			if err := g.pool.QueryRow(countCtx,
+				"SELECT COUNT(*) FROM chunks WHERE embedding IS NULL",
+			).Scan(&pending); err == nil {
+				metrics.ChunksPendingReembed.Set(float64(pending))
+			}
+			countCancel()
+
 			iterCtx, cancel := context.WithTimeout(ctx, globalBatchTimeout)
 			if err := g.runBatch(iterCtx); err != nil && ctx.Err() == nil {
 				slog.Warn("global reembedder batch error", "err", err)


### PR DESCRIPTION
Fixes the `ChunksPendingReembed` gauge that was left frozen after PR #366 moved all re-embedding to the GlobalReembedder.

The per-project `reembed.Worker` used to update this gauge before each batch. GlobalReembedder took over the reembed path but never transferred this responsibility, leaving the gauge stuck at its last value — breaking dashboards and alerts that watch for embedding backlog.

This PR is a rebased cherry-pick of `ff78dcc` from PR #372, which diverged from main before PR #366 was squash-merged. PR #372 is closed in favour of this clean branch.

## Change

`internal/reembed/global_worker.go`: before each batch, run `SELECT COUNT(*) FROM chunks WHERE embedding IS NULL` with a 5s deadline and call `metrics.ChunksPendingReembed.Set()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)