### PR TITLE
fix(oobe): durable token backup + embed config validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,17 @@ init:
 	@if grep -qs '^ENGRAM_API_KEY=' .env 2>/dev/null; then \
 	    echo "ENGRAM_API_KEY already set in .env — skipping"; \
 	else \
-	    KEY=$$(openssl rand -hex 32); \
-	    echo "ENGRAM_API_KEY=$$KEY" >> .env; \
-	    echo "✓ Generated ENGRAM_API_KEY in .env"; \
+	    BACKUP=$$HOME/.config/engram/api_key; \
+	    if [ -f "$$BACKUP" ] && [ -s "$$BACKUP" ]; then \
+	        KEY=$$(cat "$$BACKUP" | tr -d '[:space:]'); \
+	        echo "ENGRAM_API_KEY=$$KEY" >> .env; \
+	        echo "✓ Restored ENGRAM_API_KEY from $$BACKUP (key unchanged)"; \
+	    else \
+	        KEY=$$(openssl rand -hex 32); \
+	        echo "ENGRAM_API_KEY=$$KEY" >> .env; \
+	        mkdir -p "$$HOME/.config/engram" && echo "$$KEY" > "$$BACKUP" && chmod 0600 "$$BACKUP"; \
+	        echo "✓ Generated ENGRAM_API_KEY in .env and backed up to $$BACKUP"; \
+	    fi; \
 	fi
 	@if [ ! -f .env.machine-identity ]; then \
 	    touch .env.machine-identity; \

--- a/cmd/engram-setup/main.go
+++ b/cmd/engram-setup/main.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -109,6 +110,15 @@ func run() error {
 
 	if len(updated) == 0 {
 		return fmt.Errorf("failed to update any config file")
+	}
+
+	// Also write the key to a durable backup outside the repo. (#377)
+	// If .env is deleted and make init is re-run, the backup is consulted first
+	// so the same key is restored rather than generating a new random one.
+	if keyPath, err := defaultKeyBackupPath(); err == nil {
+		if writeErr := writeKeyBackup(setup.Token, keyPath); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "engram-setup: warning: could not write key backup to %s: %v\n", keyPath, writeErr)
+		}
 	}
 
 	fmt.Printf("engram configured.\n")
@@ -202,6 +212,37 @@ type setupResponse struct {
 	Token    string `json:"token"`
 	Endpoint string `json:"endpoint"`
 	Name     string `json:"name"`
+}
+
+// defaultKeyBackupPath returns the path where the API key is durably stored
+// outside the repository. Survives .env deletion and container rebuilds. (#377)
+func defaultKeyBackupPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "engram", "api_key"), nil
+}
+
+// writeKeyBackup writes token to path with mode 0600, creating parent dirs.
+// This backs up the ENGRAM_API_KEY outside the repo so it survives .env deletion.
+func writeKeyBackup(token, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create backup dir: %w", err)
+	}
+	return os.WriteFile(path, []byte(token+"\n"), 0600)
+}
+
+// readKeyBackup reads the backup key file. Returns ("", nil) if file is absent.
+func readKeyBackup(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(raw)), nil
 }
 
 func healthCheck(base string) error {

--- a/cmd/engram-setup/main_test.go
+++ b/cmd/engram-setup/main_test.go
@@ -377,3 +377,99 @@ func TestUpdateMCPConfig(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// writeKeyBackup / readKeyBackup — durable token outside .env (#377)
+// ---------------------------------------------------------------------------
+
+func TestWriteKeyBackup(t *testing.T) {
+	const token = "abcdef1234567890abcdef1234567890"
+
+	t.Run("creates file with token and newline", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "api_key")
+
+		if err := writeKeyBackup(token, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("file not created: %v", err)
+		}
+		got := strings.TrimSpace(string(raw))
+		if got != token {
+			t.Errorf("key: got %q, want %q", got, token)
+		}
+	})
+
+	t.Run("file permissions are 0600", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "api_key")
+
+		if err := writeKeyBackup(token, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat failed: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Errorf("permissions: got %o, want 0600", perm)
+		}
+	})
+
+	t.Run("creates parent directories", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "engram", "nested", "api_key")
+
+		if err := writeKeyBackup(token, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("file should exist after creating parent dirs: %v", err)
+		}
+	})
+}
+
+func TestReadKeyBackup(t *testing.T) {
+	const token = "abcdef1234567890abcdef1234567890"
+
+	t.Run("returns token from existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "api_key")
+		os.WriteFile(path, []byte(token+"\n"), 0600)
+
+		got, err := readKeyBackup(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != token {
+			t.Errorf("got %q, want %q", got, token)
+		}
+	})
+
+	t.Run("returns empty string when file absent", func(t *testing.T) {
+		got, err := readKeyBackup("/nonexistent/path/api_key")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
+
+	t.Run("strips whitespace", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "api_key")
+		os.WriteFile(path, []byte("  "+token+"  \n"), 0600)
+
+		got, err := readKeyBackup(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != token {
+			t.Errorf("got %q, want %q", got, token)
+		}
+	})
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -133,6 +133,11 @@ func run() error {
 		return fmt.Errorf("ENGRAM_API_KEY environment variable is required (--api-key flag intentionally omitted — see issue #136)")
 	}
 
+	// Warn on inconsistent embed config before spending time connecting to Ollama. (#380)
+	if warn := validateEmbedConfig(*embedModel, *embedDims); warn != "" {
+		slog.Warn("embed config warning", "detail", warn)
+	}
+
 	// Unset secrets from the process environment after reading (#139, #141, #250).
 	// Reduces the exposure window for credentials in /proc/self/environ.
 	_ = os.Unsetenv("ENGRAM_API_KEY")
@@ -438,6 +443,30 @@ func (a *entityDBAdapter) UpsertEntity(ctx context.Context, e *entity.Entity) (s
 // auditRecallerAdapter adapts the engine pool to the audit.Recaller interface.
 type auditRecallerAdapter struct {
 	pool *internalmcp.EnginePool
+}
+
+// validateEmbedConfig checks that the embedding model and dimensions are
+// consistent. Returns a non-empty warning string when misconfigured. (#380)
+//
+// qwen3-embedding:8b natively outputs 1536 dims; set ENGRAM_EMBED_DIMENSIONS=1024
+// to enable MRL truncation so vectors fit in the existing vector(1024) column.
+// mxbai-embed-large does not support MRL; ENGRAM_EMBED_DIMENSIONS must be 0.
+func validateEmbedConfig(model string, dims int) string {
+	switch model {
+	case "qwen3-embedding:8b":
+		if dims == 1024 {
+			return ""
+		}
+		return "qwen3-embedding:8b requires ENGRAM_EMBED_DIMENSIONS=1024 for MRL truncation " +
+			"to fit the vector(1024) column; current value (" + fmt.Sprintf("%d", dims) + ") will cause dimension mismatch errors"
+	case "mxbai-embed-large", "mxbai-embed-large:latest":
+		if dims == 0 {
+			return ""
+		}
+		return "mxbai-embed-large does not support MRL truncation; set ENGRAM_EMBED_DIMENSIONS=0 " +
+			"(current value: " + fmt.Sprintf("%d", dims) + ")"
+	}
+	return ""
 }
 
 func (a *auditRecallerAdapter) Recall(ctx context.Context, project, query string, topK int) ([]string, error) {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/netutil"
@@ -33,6 +34,44 @@ func TestRecallDefaultModeDefault(t *testing.T) {
 // delegates correctly to netutil.IsPrivateIP. The comprehensive range coverage
 // is in internal/netutil/private_ip_test.go; this test covers the cases that
 // were exercised by the old inline isPrivateIP function (#55, #68, #242).
+// ---------------------------------------------------------------------------
+// validateEmbedConfig — embed config consistency guard (#380)
+// ---------------------------------------------------------------------------
+
+func TestValidateEmbedConfig(t *testing.T) {
+	cases := []struct {
+		model   string
+		dims    int
+		wantWarn bool
+		warnContains string
+	}{
+		// qwen3-embedding:8b requires dims=1024 for MRL truncation to fit vector(1024)
+		{"qwen3-embedding:8b", 0, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
+		{"qwen3-embedding:8b", 1536, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
+		{"qwen3-embedding:8b", 1024, false, ""},
+		// mxbai-embed-large does not support MRL — dims must be 0
+		{"mxbai-embed-large", 1024, true, "ENGRAM_EMBED_DIMENSIONS=0"},
+		{"mxbai-embed-large", 512, true, "ENGRAM_EMBED_DIMENSIONS=0"},
+		{"mxbai-embed-large", 0, false, ""},
+		// unknown models: no opinion
+		{"nomic-embed-text", 0, false, ""},
+		{"nomic-embed-text", 768, false, ""},
+	}
+
+	for _, tc := range cases {
+		warn := validateEmbedConfig(tc.model, tc.dims)
+		if tc.wantWarn && warn == "" {
+			t.Errorf("validateEmbedConfig(%q, %d): want warning, got empty", tc.model, tc.dims)
+		}
+		if !tc.wantWarn && warn != "" {
+			t.Errorf("validateEmbedConfig(%q, %d): want no warning, got %q", tc.model, tc.dims, warn)
+		}
+		if tc.warnContains != "" && !strings.Contains(warn, tc.warnContains) {
+			t.Errorf("validateEmbedConfig(%q, %d): warning %q should contain %q", tc.model, tc.dims, warn, tc.warnContains)
+		}
+	}
+}
+
 func TestIsPrivateIP_ViaNetutil(t *testing.T) {
 	cases := []struct {
 		ip      string


### PR DESCRIPTION
## Summary

- **Durable ENGRAM_API_KEY backup** (`~/.config/engram/api_key`): `make init` restores the existing key from the backup file before generating a new random one — container rebuilds and `.env` deletion no longer rotate the token and break MCP auth (#377)
- **`engram-setup` writes backup**: every `make setup` run keeps `~/.config/engram/api_key` current so it always reflects the live server token
- **Embed config validation at startup**: `validateEmbedConfig()` warns when model/dims are inconsistent — prevents the silent `ENGRAM_EMBED_DIMENSIONS=1536` misconfiguration that caused the global reembedder to fail silently for days (#380)

## Root cause addressed

The circular recovery sequence (`container rebuild → make setup → /mcp`) was triggered because the token could silently change. With this PR:
- Normal container restart: token unchanged, no user action needed
- `.env` deleted + `make init`: same key restored from `~/.config/engram/api_key`
- Embed misconfiguration: warned at startup before any damage occurs

## Test plan

- [ ] `go test ./cmd/engram-setup/... ./cmd/engram/... -v` — all pass
- [ ] `go test ./... -count=1 -race` — no races, no failures
- [ ] `make setup` on running server → `~/.config/engram/api_key` contains current token
- [ ] Delete `.env`, re-run `make init` → same key restored, server starts without reconnect
- [ ] `ENGRAM_EMBED_DIMENSIONS=1536` with `qwen3-embedding:8b` → startup WARN logged
- [ ] Adversarial review: Rickover, Spruance, zero-context (required per CLAUDE.md policy)

## Files

| File | Change |
|------|--------|
| `Makefile` | `init` reads `~/.config/engram/api_key` before generating |
| `cmd/engram-setup/main.go` | `writeKeyBackup`, `readKeyBackup`, backup write in `run()` |
| `cmd/engram-setup/main_test.go` | 6 new tests for backup functions |
| `cmd/engram/main.go` | `validateEmbedConfig` + startup call |
| `cmd/engram/main_test.go` | 8-case table test for validation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)