### PR TITLE
fix(mcp): 15s dispatch-layer timeout on all tool handlers (#379)

### DIFF
--- a/internal/mcp/dispatch_timeout_spike_test.go
+++ b/internal/mcp/dispatch_timeout_spike_test.go
@@ -1,0 +1,89 @@
+package mcp
+
+// Context-propagation spike for #379.
+// Proves that context.WithTimeout in a dispatch wrapper correctly cancels
+// the ctx handed to a blocking tool handler — so Option C (per-tool timeout
+// annotation with WithTimeout wrapper) is safe to implement without the
+// goroutine+channel fallback pattern.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// withTimeoutSpike is the proposed dispatch wrapper (Option C from Opus advisor).
+func withTimeoutSpike(d time.Duration, h server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		ctx, cancel := context.WithTimeout(ctx, d)
+		defer cancel()
+		return h(ctx, req)
+	}
+}
+
+// TestDispatchTimeout_ContextPropagation proves that context.WithTimeout in
+// the wrapper correctly cancels the ctx passed to a blocking handler.
+//
+// Verdict: if the test passes, Option C is safe — use context.WithTimeout.
+// If it hangs past 5s (test timeout), Option C fails — use goroutine+channel.
+func TestDispatchTimeout_ContextPropagation(t *testing.T) {
+	var ctxCancelledInHandler atomic.Bool
+
+	blockingHandler := func(ctx context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		<-ctx.Done()
+		ctxCancelledInHandler.Store(true)
+		return &mcpgo.CallToolResult{
+			IsError: true,
+			Content: []mcpgo.Content{
+				mcpgo.TextContent{Type: "text", Text: "tool timed out"},
+			},
+		}, nil
+	}
+
+	mcpServer := server.NewMCPServer("spike-test", "1.0.0",
+		server.WithToolCapabilities(true),
+	)
+	mcpServer.AddTool(
+		mcpgo.NewTool("block_forever"),
+		withTimeoutSpike(300*time.Millisecond, blockingHandler),
+	)
+
+	c, err := mcpclient.NewInProcessClient(mcpServer)
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Close()
+
+	initReq := mcpgo.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcpgo.Implementation{Name: "spike", Version: "1.0.0"}
+	if _, err := c.Initialize(context.Background(), initReq); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	start := time.Now()
+	var callReq mcpgo.CallToolRequest
+	callReq.Params.Name = "block_forever"
+	result, err := c.CallTool(context.Background(), callReq)
+	elapsed := time.Since(start)
+
+	isErr := result != nil && result.IsError
+	t.Logf("elapsed: %v | err: %v | isError: %v", elapsed, err, isErr)
+
+	if !ctxCancelledInHandler.Load() {
+		t.Fatal("SPIKE FAILED: handler ctx was NOT cancelled — context.WithTimeout does not propagate; must use goroutine+channel instead")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("SPIKE FAILED: call took %v — timeout wrapper did not terminate handler in time", elapsed)
+	}
+
+	t.Log("SPIKE PASSED: context.WithTimeout propagates correctly — Option C is safe")
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -705,15 +705,47 @@ func withWarnLog(name string, h toolHandler) toolHandler {
 	}
 }
 
-// registerTool adds a tool to the MCP server wrapped with Prometheus instrumentation.
-func (s *Server) registerTool(name, desc string, h toolHandler) {
+// defaultToolTimeout is the per-call deadline applied at the MCP dispatch layer.
+// Prevents silent hangs up to the HTTP server WriteTimeout (90s) when a handler
+// blocks on Ollama, a slow DB query, or an unguarded third-party call. (#379)
+//
+// All synchronous handlers return well under 10s in normal operation; 15s gives
+// headroom for transient slowness without ever approaching the 90s HTTP timeout.
+// Tools that trigger background work (migrate_embedder, consolidate) also return
+// quickly — the heavy lifting happens in background goroutines, not the handler.
+const defaultToolTimeout = 15 * time.Second
+
+// registerToolWithTimeout adds a tool to the MCP server with a per-call deadline
+// and Prometheus instrumentation. timeout=0 uses defaultToolTimeout.
+func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeout time.Duration) {
+	if timeout == 0 {
+		timeout = defaultToolTimeout
+	}
 	pool, cfg := s.pool, s.cfg
 	toolName := name
+	toolTimeout := timeout
 	s.mcp.AddTool(mcpgo.NewTool(name, mcpgo.WithDescription(desc)),
 		func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			ctx, cancel := context.WithTimeout(ctx, toolTimeout)
+			defer cancel()
+
 			timer := prometheus.NewTimer(metrics.ToolDuration.WithLabelValues(toolName))
 			defer timer.ObserveDuration()
+
 			result, err := h(ctx, pool, req, cfg)
+			if err != nil && ctx.Err() == context.DeadlineExceeded {
+				slog.Warn("mcp tool timed out", "tool", toolName, "timeout", toolTimeout)
+				metrics.ToolRequests.WithLabelValues(toolName, "timeout").Inc()
+				return &mcpgo.CallToolResult{
+					IsError: true,
+					Content: []mcpgo.Content{
+						mcpgo.TextContent{
+							Type: "text",
+							Text: toolName + " timed out after " + toolTimeout.String() + " — Ollama may be slow or unavailable",
+						},
+					},
+				}, nil
+			}
 			status := "ok"
 			if err != nil || (result != nil && result.IsError) {
 				status = "error"
@@ -721,6 +753,11 @@ func (s *Server) registerTool(name, desc string, h toolHandler) {
 			metrics.ToolRequests.WithLabelValues(toolName, status).Inc()
 			return result, err
 		})
+}
+
+// registerTool adds a tool with the default dispatch timeout.
+func (s *Server) registerTool(name, desc string, h toolHandler) {
+	s.registerToolWithTimeout(name, desc, h, 0)
 }
 
 func (s *Server) registerTools() {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -7,10 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	mcpclient "github.com/mark3labs/mcp-go/client"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // ---------------------------------------------------------------------------
@@ -499,5 +502,68 @@ func TestHealthProbe_IgnoresExpiredRequestContext(t *testing.T) {
 		// Probe reached the fake Ollama — correct.
 	default:
 		t.Fatal("fake Ollama was never contacted — probe may have short-circuited on the dead context")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch-layer timeout (#379)
+// ---------------------------------------------------------------------------
+
+// TestDispatchTimeout_RegisterToolAppliesDeadline verifies that registerTool
+// applies a context deadline so blocking handlers are cancelled within
+// defaultToolTimeout rather than running to the HTTP server WriteTimeout (90s).
+func TestDispatchTimeout_RegisterToolAppliesDeadline(t *testing.T) {
+	var handlerCtxCancelled atomic.Bool
+
+	// noopPoolForTimeout satisfies EnginePool minimally — registerTool only
+	// needs a pool reference; the handler controls its own behaviour.
+	pool := NewEnginePool(func(_ context.Context, _ string) (*EngineHandle, error) {
+		return nil, nil
+	})
+
+	srv := &Server{
+		pool: pool,
+		mcp:  server.NewMCPServer("timeout-test", "1.0.0", server.WithToolCapabilities(true)),
+		cfg:  Config{},
+	}
+
+	blockingHandler := func(ctx context.Context, _ *EnginePool, _ mcpgo.CallToolRequest, _ Config) (*mcpgo.CallToolResult, error) {
+		<-ctx.Done()
+		handlerCtxCancelled.Store(true)
+		return &mcpgo.CallToolResult{IsError: true, Content: []mcpgo.Content{
+			mcpgo.TextContent{Type: "text", Text: "timed out"},
+		}}, nil
+	}
+
+	// Register with a short timeout so the test completes quickly.
+	srv.registerToolWithTimeout("block_test", "blocks until ctx cancelled", blockingHandler, 200*time.Millisecond)
+
+	c, err := mcpclient.NewInProcessClient(srv.mcp)
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Close()
+
+	initReq := mcpgo.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcpgo.Implementation{Name: "test", Version: "1.0.0"}
+	if _, err := c.Initialize(context.Background(), initReq); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	start := time.Now()
+	var callReq mcpgo.CallToolRequest
+	callReq.Params.Name = "block_test"
+	_, _ = c.CallTool(context.Background(), callReq)
+	elapsed := time.Since(start)
+
+	if !handlerCtxCancelled.Load() {
+		t.Error("handler ctx was not cancelled — registerTool did not apply dispatch timeout")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("call took %v — should complete within 2x the 200ms timeout", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `registerToolWithTimeout()` wrapping every tool handler with `context.WithTimeout(ctx, 15s)` at the dispatch layer (#379)
- `registerTool()` now delegates to `registerToolWithTimeout()` with `timeout=0` → `defaultToolTimeout=15s` — no call sites changed
- On timeout: logs WARN, increments a `timeout` Prometheus counter, returns structured MCP `IsError: true` result with actionable message
- Spike test proves `context.WithTimeout` propagates correctly through mcp-go's transport — no goroutine+channel pattern required

## Why 15s

All synchronous handlers return well under 10s normally. Tools that appear heavy (migrate_embedder, consolidate) trigger background goroutines and return quickly. 15s gives transient-slowness headroom without approaching the 90s HTTP WriteTimeout.

## Test plan

- [ ] `go test ./internal/mcp/... -run TestDispatchTimeout -v` — both spike + integration tests pass
- [ ] `go test ./... -count=1 -race` — no races, no failures  
- [ ] Adversarial review: Rickover, Spruance, zero-context (required per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)