### PR TITLE
fix(mcp): SSE endpoint event is relative — fixes localhost/127.0.0.1 mismatch (#406)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -448,7 +448,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 		advertised = fmt.Sprintf("http://%s", addr)
 	}
 	slog.Info("SSE base URL", "url", advertised)
-	sse := server.NewSSEServer(s.mcp, server.WithBaseURL(advertised))
+	sse := buildSSEServer(s.mcp, advertised)
 
 	s.registerSessionHooks(apiKey)
 

--- a/internal/mcp/sse_origin.go
+++ b/internal/mcp/sse_origin.go
@@ -1,0 +1,23 @@
+package mcp
+
+import "github.com/mark3labs/mcp-go/server"
+
+// buildSSEServer wires the mcp-go SSE server with engram's transport policy.
+//
+// Why WithUseFullURLForMessageEndpoint(false): the mcp-go default is to emit
+// the `endpoint` SSE event as a fully-qualified URL built from baseURL. The
+// SSE client then enforces endpoint.Host == c.baseURL.Host. When the server
+// is configured for one loopback alias (e.g. 127.0.0.1) and the client
+// connects via another (e.g. localhost), the hosts differ verbatim even
+// though both resolve to the loopback interface, so the client silently
+// drops every endpoint event with "Endpoint origin does not match
+// connection origin" (#406). Emitting a path-only endpoint sidesteps the
+// check entirely — the client resolves it against its own connection URL,
+// so loopback aliases are interchangeable.
+func buildSSEServer(mcp *server.MCPServer, baseURL string) *server.SSEServer {
+	return server.NewSSEServer(
+		mcp,
+		server.WithBaseURL(baseURL),
+		server.WithUseFullURLForMessageEndpoint(false),
+	)
+}

--- a/internal/mcp/sse_origin_test.go
+++ b/internal/mcp/sse_origin_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildSSEServer_EndpointEventIsRelative is the regression guard for
+// #406. The SSE client (mark3labs/mcp-go transport/sse.go) rejects any
+// `endpoint` event whose Host differs from the URL the client connected
+// with. When the server's configured baseURL uses one loopback alias
+// (e.g. 127.0.0.1) and the client uses another (e.g. localhost), an
+// absolute endpoint URL fails that check despite both being loopback.
+//
+// buildSSEServer must emit a path-only endpoint URL so the client resolves
+// it against whatever Host header it used to connect.
+func TestBuildSSEServer_EndpointEventIsRelative(t *testing.T) {
+	mcp := server.NewMCPServer("test", "0.0.0", server.WithToolCapabilities(false))
+	// Reproduce #406's mismatch: server configured with 127.0.0.1, client
+	// will connect via the httptest URL (also 127.0.0.1, but the assertion
+	// is on the *shape* of the emitted endpoint, not the host strings).
+	sse := buildSSEServer(mcp, "http://127.0.0.1:8788")
+
+	ts := httptest.NewServer(sse.SSEHandler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	endpoint := readEndpointEvent(t, resp.Body)
+
+	require.Falsef(t, strings.HasPrefix(endpoint, "http://"),
+		"endpoint event must be relative (#406); got absolute %q", endpoint)
+	require.Falsef(t, strings.HasPrefix(endpoint, "https://"),
+		"endpoint event must be relative (#406); got absolute %q", endpoint)
+	require.Truef(t, strings.HasPrefix(endpoint, "/"),
+		"endpoint event must be a path-only URL; got %q", endpoint)
+}
+
+// readEndpointEvent reads SSE frames until it captures the `endpoint`
+// event's data line, then returns it.
+func readEndpointEvent(t *testing.T, body interface{ Read(p []byte) (int, error) }) string {
+	t.Helper()
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	var sawEndpointEvent bool
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "event: endpoint" {
+			sawEndpointEvent = true
+			continue
+		}
+		if sawEndpointEvent {
+			if data, ok := strings.CutPrefix(line, "data: "); ok {
+				return strings.TrimSpace(data)
+			}
+		}
+	}
+	t.Fatalf("never saw endpoint event; scanner err: %v", sc.Err())
+	return ""
+}


### PR DESCRIPTION
## Summary
The mcp-go SSE server's default behavior is to advertise its message endpoint as a fully-qualified URL using the configured \`baseURL\`. The SSE client then enforces \`endpoint.Host == c.baseURL.Host\`. When engram-go is configured for one loopback alias (e.g. \`127.0.0.1\`) and a client connects via another (e.g. \`localhost\`), the host strings differ verbatim and every endpoint event is silently rejected.

Fix: pass \`server.WithUseFullURLForMessageEndpoint(false)\` so the endpoint event is path-only (\`/message?sessionId=...\`). The client resolves it against the URL it actually connected with — loopback aliases, and any other configured/connected URL skew, now interop transparently.

Refactored the SSE construction call site into a one-liner helper (\`buildSSEServer\`) so the transport policy is documented in one place and unit-testable without spinning up the full engram backend.

## TDD
\`internal/mcp/sse_origin_test.go::TestBuildSSEServer_EndpointEventIsRelative\` reads the actual SSE \`endpoint\` frame off an \`httptest\` server and asserts the emitted URL is path-only.

**Confirmed failure before the fix:**
\`\`\`
endpoint event must be relative (#406); got absolute "http://127.0.0.1:8788/message?sessionId=..."
\`\`\`
**After the fix:** test passes, race-clean.

## Verification
\`\`\`
go test -race ./internal/mcp/ -run TestBuildSSEServer -count=1     # PASS
go test ./internal/mcp/ -count=1                                   # PASS (10.8s)
\`\`\`

## Test plan
- [ ] CI lint + tests green
- [ ] Manual: \`ENGRAM_BASE_URL=http://127.0.0.1:8788\` + client \`--url http://localhost:8788\` — SSE worker connects without origin error

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)