### PR TITLE
fix: un-skip 3 of 4 deferred integration tests (#429)

### DIFF
--- a/internal/db/postgres_feedback.go
+++ b/internal/db/postgres_feedback.go
@@ -100,15 +100,10 @@ func (b *PostgresBackend) RecordFeedback(ctx context.Context, eventID string, us
 		return fmt.Errorf("update retrieval event: %w", err)
 	}
 
-	// Increment times_retrieved on all result memories.
-	if len(event.ResultIDs) > 0 {
-		if _, err := tx.Exec(ctx, `
-			UPDATE memories SET times_retrieved = COALESCE(times_retrieved, 0) + 1 WHERE id = ANY($1)`,
-			event.ResultIDs,
-		); err != nil {
-			return fmt.Errorf("increment times_retrieved: %w", err)
-		}
-	}
+	// times_retrieved is incremented by SearchEngine.RecallWithEvent at recall
+	// time (so the precision denominator warms up even without feedback). We
+	// must NOT bump it again here or every feedback call double-counts the
+	// denominator and pins precision at half its true value.
 
 	// Increment times_useful on useful memories.
 	if len(usefulIDs) > 0 {
@@ -173,15 +168,8 @@ func (b *PostgresBackend) RecordFeedbackWithClass(ctx context.Context, eventID s
 		return fmt.Errorf("update retrieval event: %w", err)
 	}
 
-	// Increment times_retrieved on all result memories.
-	if len(event.ResultIDs) > 0 {
-		if _, err := tx.Exec(ctx, `
-			UPDATE memories SET times_retrieved = COALESCE(times_retrieved, 0) + 1 WHERE id = ANY($1)`,
-			event.ResultIDs,
-		); err != nil {
-			return fmt.Errorf("increment times_retrieved: %w", err)
-		}
-	}
+	// times_retrieved is incremented by SearchEngine.RecallWithEvent at recall
+	// time. Do NOT bump again here — see RecordFeedback for the full rationale.
 
 	// Increment times_useful on useful memories.
 	if len(usefulIDs) > 0 {

--- a/internal/mcp/conflicts_test.go
+++ b/internal/mcp/conflicts_test.go
@@ -277,7 +277,6 @@ func testRecallDSN(t *testing.T) string {
 // creates a "contradicts" edge between them, recalls the source, and verifies
 // that include_conflicts=true returns the contradicting memory.
 func TestHandleMemoryRecall_IncludeConflicts_Integration(t *testing.T) {
-	t.Skip("pre-existing failure — fakeTestEmbedClient returns identical vectors so both memories rank as primary results, leaving conflicts empty (#429)")
 	dsn := testRecallDSN(t)
 	ctx := context.Background()
 	proj := fmt.Sprintf("test-conflicts-%d", time.Now().UnixNano())
@@ -316,8 +315,17 @@ func TestHandleMemoryRecall_IncludeConflicts_Integration(t *testing.T) {
 	}
 	require.NoError(t, h.Engine.Backend().StoreRelationship(ctx, rel))
 
-	// Recall with include_conflicts=true.
-	out := internalmcp.CallHandleMemoryRecall(ctx, t, pool, proj, "deploy Friday", true)
+	// Production stores chunks with NULL embedding and lets the reembed worker
+	// backfill them asynchronously (#414). Tests don't run that worker, so
+	// flush pending chunks synchronously before recall.
+	internalmcp.FlushPendingEmbeddings(t, ctx, dsn, proj)
+
+	// Recall with top_k=1 so only the strongest BM25/vector match enters the
+	// primary results, leaving the contradicting memory available to the
+	// conflicts-enrichment path. The query uses m1's unique tokens
+	// ("afternoons"/"iteration") to make the disambiguation deterministic.
+	out := internalmcp.CallHandleMemoryRecallFull(ctx, t, pool, proj, "afternoons iteration",
+		map[string]any{"top_k": float64(1), "include_conflicts": true})
 
 	conflicts, ok := out["conflicting_results"]
 	require.True(t, ok, "conflicting_results key must be present when include_conflicts=true")

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -5,23 +5,115 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"math"
+	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	pgvector "github.com/pgvector/pgvector-go"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
+// FlushPendingEmbeddings backfills NULL embeddings on chunks for the given
+// project, mirroring what the reembed worker does in production. Tests use
+// this after Store to make recall deterministic without standing up the
+// reembed worker. The dim must match fakeTestEmbedClient (1024) and the live
+// chunks.embedding column (vector(1024) per migration 018).
+func FlushPendingEmbeddings(t *testing.T, ctx context.Context, dsn, project string) {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("FlushPendingEmbeddings: parse dsn: %v", err)
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("FlushPendingEmbeddings: connect: %v", err)
+	}
+	defer pool.Close()
+
+	rows, err := pool.Query(ctx, `
+		SELECT c.id, c.chunk_text
+		FROM chunks c
+		WHERE c.embedding IS NULL AND c.project = $1`, project)
+	if err != nil {
+		t.Fatalf("FlushPendingEmbeddings: query pending: %v", err)
+	}
+	type row struct{ id, text string }
+	var pending []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.text); err != nil {
+			rows.Close()
+			t.Fatalf("FlushPendingEmbeddings: scan: %v", err)
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+
+	embedder := &fakeTestEmbedClient{dims: 1024}
+	for _, p := range pending {
+		vec, err := embedder.Embed(ctx, p.text)
+		if err != nil {
+			t.Fatalf("FlushPendingEmbeddings: embed: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`UPDATE chunks SET embedding = $1 WHERE id = $2`,
+			pgvector.NewVector(vec), p.id,
+		); err != nil {
+			t.Fatalf("FlushPendingEmbeddings: update: %v", err)
+		}
+	}
+}
+
 // fakeTestEmbedClient is a zero-dependency embedder for tests. It returns a
-// deterministic constant vector so vector-search ranking is predictable.
+// deterministic content-derived vector — strings sharing tokens land in
+// overlapping slots and produce high cosine similarity, while disjoint
+// strings concentrate weight in different slots. This is enough to give
+// integration tests realistic-looking vector ranking without standing up
+// Ollama or LiteLLM, and is the difference between conflicts-enrichment
+// tests being able to distinguish a query from a non-matching memory and
+// returning the same vector for everything (which makes vector search
+// useless and leaves the tests unable to prove anything — see #429).
 type fakeTestEmbedClient struct{ dims int }
 
-func (f *fakeTestEmbedClient) Embed(_ context.Context, _ string) ([]float32, error) {
+func (f *fakeTestEmbedClient) Embed(_ context.Context, text string) ([]float32, error) {
 	vec := make([]float32, f.dims)
-	for i := range vec {
-		vec[i] = float32(i) / float32(f.dims)
+	tokens := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+	span := f.dims / 16 // each token activates 1/16 of the vector
+	if span < 1 {
+		span = 1
+	}
+	for _, tok := range tokens {
+		if len(tok) < 3 {
+			continue
+		}
+		// FNV-1a hash → bucket within [0, dims).
+		h := uint32(2166136261)
+		for i := 0; i < len(tok); i++ {
+			h ^= uint32(tok[i])
+			h *= 16777619
+		}
+		base := int(h % uint32(f.dims))
+		for k := 0; k < span; k++ {
+			vec[(base+k)%f.dims] += 1.0
+		}
+	}
+	// L2 normalize so cosine similarity ranges naturally in [0, 1].
+	var sum float32
+	for _, v := range vec {
+		sum += v * v
+	}
+	if sum > 0 {
+		inv := float32(1.0 / math.Sqrt(float64(sum)))
+		for i := range vec {
+			vec[i] *= inv
+		}
 	}
 	return vec, nil
 }
@@ -95,6 +187,15 @@ func CallHandleMemoryRecallFull(
 	var out map[string]any
 	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
 		t.Fatalf("decode tool result JSON: %v", err)
+	}
+	// Re-hydrate conflicting_results to []types.ConflictingResult if present,
+	// so callers can do typed assertions (mirrors CallHandleMemoryRecall).
+	if raw, ok := out["conflicting_results"]; ok && raw != nil {
+		b, _ := json.Marshal(raw)
+		var cr []types.ConflictingResult
+		if err := json.Unmarshal(b, &cr); err == nil {
+			out["conflicting_results"] = cr
+		}
 	}
 	return out
 }

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -83,7 +83,7 @@ type fakeTestEmbedClient struct{ dims int }
 func (f *fakeTestEmbedClient) Embed(_ context.Context, text string) ([]float32, error) {
 	vec := make([]float32, f.dims)
 	tokens := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
-		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	})
 	span := f.dims / 16 // each token activates 1/16 of the vector
 	if span < 1 {

--- a/internal/mcp/federated_conflicts_test.go
+++ b/internal/mcp/federated_conflicts_test.go
@@ -29,7 +29,7 @@ import (
 // returned immediately without reading include_conflicts, so
 // conflicting_results was never populated.
 func TestFederatedRecall_IncludeConflicts_NotSilentlyDropped(t *testing.T) {
-	t.Skip("pre-existing failure — cross-project relationship setup needs product decision (#429)")
+	t.Skip("blocked on cross-project StoreRelationship + GetMemory product decision — see #430")
 	dsn := testRecallDSN(t) // defined in conflicts_test.go; skips without TEST_DATABASE_URL
 	ctx := context.Background()
 

--- a/internal/search/embed_deadline_test.go
+++ b/internal/search/embed_deadline_test.go
@@ -76,7 +76,6 @@ func TestEmbedDeadline_RecallWithOpts(t *testing.T) {
 // fast (within 3s) when Ollama is unavailable. Document chunk search is
 // vector-only so an error is correct — but it must not hang.
 func TestEmbedDeadline_RecallWithinMemory(t *testing.T) {
-	t.Skip("pre-existing failure — production deadline is 4s, test expects 2s (#429)")
 	proj := uniqueProject("embed-deadline-within")
 	eng := newEngineWithEmbedder(t, proj, &blockingClient{dims: 768, holdFor: 60 * time.Second})
 

--- a/internal/search/retrieval_precision_test.go
+++ b/internal/search/retrieval_precision_test.go
@@ -121,7 +121,6 @@ func TestRetrievalTracking_FeedbackRecordsOutcome(t *testing.T) {
 // TestRetrievalTracking_PrecisionUpdated verifies that after enough feedback
 // cycles, retrieval_precision on a memory reflects the useful/retrieved ratio.
 func TestRetrievalTracking_PrecisionUpdated(t *testing.T) {
-	t.Skip("pre-existing failure — always-useful precision yields 0.5 not ~1.0; algorithm review needed (#429)")
 	engine := newTestEngine(t, uniqueProject("test-rt-precision"))
 	t.Cleanup(func() { engine.Close() })
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
Fixes 3 of the 4 tests that were t.Skip'd as pre-existing failures during the merge of PR #426. Each is a focused, surgical change with TDD evidence (red → green verified locally against \`TEST_DATABASE_URL\`).

## Closes (partial)
- ✅ \`TestEmbedDeadline_RecallWithinMemory\` — already in scope: PR #428's 500 ms embed timeout aligned with the test's \`< 1 s\` budget. Just needed the skip removed.
- ✅ \`TestRetrievalTracking_PrecisionUpdated\` — **real bug fixed.** \`PostgresBackend.RecordFeedback{,WithClass}\` was incrementing \`times_retrieved\` even though \`SearchEngine.RecallWithEvent\` already auto-increments it on recall. Result: precision pinned at half its true value. Removed the duplicate bump in both methods, kept \`times_useful\` and the precision recompute, documented the invariant inline.
- ✅ \`TestHandleMemoryRecall_IncludeConflicts_Integration\` — fixed two related issues at once:
  - \`fakeTestEmbedClient\` returned the same vector for every input → vector ranking was useless. Replaced with a token-bag FNV hash embedder (1024 dims, span 64/token, L2-normalized) so disjoint strings get low cosine and shared-token strings get high cosine.
  - Production stores chunks with NULL embedding and lets the reembed worker backfill them. Tests don't run that worker, so added \`FlushPendingEmbeddings\` test helper that mirrors what the worker does.
  - Switched the test to \`top_k=1\` so the contradicting memory stays out of the primary results and the conflicts-enrichment path can surface it.

## Still skipped (deferred to #430)
- \`TestFederatedRecall_IncludeConflicts_NotSilentlyDropped\` — needs a product decision on cross-project edge support in \`StoreRelationship\` and \`GetMemory\`. See **#430** for the focused write-up with both implementation options and a recommendation.

## Coverage gate
Restoring 55 → 60 is appropriate **after** #430 lands. This PR doesn't change the gate.

## Verification
\`\`\`
TEST_DATABASE_URL=... go test -race ./internal/search/ -run "TestEmbedDeadline_RecallWithinMemory|TestRetrievalTracking_PrecisionUpdated"   # PASS
TEST_DATABASE_URL=... go test -race ./internal/mcp/ -run "TestHandleMemoryRecall_IncludeConflicts_Integration"                              # PASS
\`\`\`

## Test plan
- [ ] CI lint + tests green
- [ ] No regressions in adjacent suites (\`internal/db\`, \`internal/search\`, \`internal/mcp\`)

Refs #429
Refs #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)