### PR TITLE
fix(W6): repo hygiene + pprof gating + template security

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -29,9 +29,6 @@ import (
 	"github.com/petersimmons1972/engram/internal/summarize"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/petersimmons1972/engram/internal/weight"
-
-	// Register pprof HTTP handlers at /debug/pprof/ (localhost only).
-	_ "net/http/pprof"
 )
 
 // Version is injected at build time via -ldflags "-X main.Version=$(git describe --tags --always)".

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -120,5 +123,31 @@ func TestIsPrivateIP_ViaNetutil(t *testing.T) {
 		if got != tc.private {
 			t.Errorf("netutil.IsPrivateIP(%q) = %v, want %v", tc.ip, got, tc.private)
 		}
+	}
+}
+
+// TestPprofNotRegisteredByDefault verifies that pprof HTTP handlers are NOT
+// registered by default (requires -tags=pprof). This is the complement of the
+// pprof_enabled.go build tag — pprof should only be available in opt-in builds.
+func TestPprofNotRegisteredByDefault(t *testing.T) {
+	// In the default build (without -tags=pprof), the pprof import should not
+	// be active, so no handlers should be registered on http.DefaultServeMux.
+	//
+	// We test this by iterating the mux and checking that no pattern contains
+	// the "debug/pprof" string that pprof handlers are registered under.
+	defaultMux := http.DefaultServeMux
+	defaultMux.Handle("/test-marker", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Path: "/debug/pprof/"},
+		Host:   "localhost",
+	}
+	handler, pattern := defaultMux.Handler(req)
+	if pattern != "" && strings.Contains(pattern, "debug/pprof") {
+		t.Errorf("pprof should not be registered by default; found pattern %q", pattern)
+	}
+	if handler != nil && strings.Contains(fmt.Sprint(handler), "pprof") {
+		t.Errorf("pprof handler should not be registered by default")
 	}
 }

--- a/cmd/engram/pprof_enabled.go
+++ b/cmd/engram/pprof_enabled.go
@@ -1,0 +1,10 @@
+//go:build pprof
+// +build pprof
+
+// Conditional pprof support: register HTTP handlers only when built with -tags=pprof.
+package main
+
+import (
+	// Register pprof HTTP handlers at /debug/pprof/ when the pprof build tag is active.
+	_ "net/http/pprof"
+)

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -221,6 +221,7 @@ func (b *PostgresBackend) runMigrations(ctx context.Context) error {
 			lockTimeoutMs = rem
 		}
 	}
+	// integer-only — DO NOT change to %s; SET LOCAL cannot use parameter binding
 	if _, err := conn.Exec(ctx,
 		fmt.Sprintf("SET LOCAL lock_timeout = '%dms'", lockTimeoutMs),
 	); err != nil {

--- a/internal/db/postgres_chunk.go
+++ b/internal/db/postgres_chunk.go
@@ -256,6 +256,7 @@ func (b *PostgresBackend) VectorSearch(ctx context.Context, project string, quer
 		}
 		defer func() { _ = tx.Rollback(ctx) }() // read-only — rollback == commit here
 		efSearch := efSearchForLimit(limit)
+		// integer-only — DO NOT change to %s; SET LOCAL cannot use parameter binding
 		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)); err != nil {
 			return nil, fmt.Errorf("set hnsw.ef_search: %w", err)
 		}

--- a/internal/mcp/safepath.go
+++ b/internal/mcp/safepath.go
@@ -29,9 +29,19 @@ func SafePath(baseDir, target string) (string, error) {
 		return "", fmt.Errorf("resolving real base dir: %w", err)
 	}
 
-	absTarget, err := filepath.Abs(target)
-	if err != nil {
-		return "", fmt.Errorf("resolving target path: %w", err)
+	// Resolve target against baseDir if it's a relative path; otherwise use as-is.
+	// This ensures that relative paths are always resolved within baseDir, not
+	// against the process's current working directory.
+	var absTarget string
+	if filepath.IsAbs(target) {
+		var err error
+		absTarget, err = filepath.Abs(target)
+		if err != nil {
+			return "", fmt.Errorf("resolving target path: %w", err)
+		}
+	} else {
+		// Relative path: join with baseDir and clean
+		absTarget = filepath.Join(absBase, target)
 	}
 
 	// First check (traversal): absTarget must sit inside absBase. This blocks

--- a/internal/mcp/safepath_test.go
+++ b/internal/mcp/safepath_test.go
@@ -61,6 +61,22 @@ func TestSafePath_BlocksSymlinkEscape(t *testing.T) {
 	require.Contains(t, err.Error(), "escapes allowed directory")
 }
 
+// TestSafePathRelativeResolvesAgainstBaseDir verifies that relative paths are
+// resolved against baseDir, not the process's current working directory. This
+// ensures that "relative.txt" inside /data is /data/relative.txt, not
+// /cwd/relative.txt.
+func TestSafePathRelativeResolvesAgainstBaseDir(t *testing.T) {
+	base := t.TempDir()
+	// Test with a simple relative path that should resolve within baseDir
+	result, err := internalmcp.SafePath(base, "relative.txt")
+	require.NoError(t, err)
+	// Result should contain baseDir
+	require.Contains(t, result, base)
+	// The result should be baseDir + relative path
+	expected := base + "/relative.txt"
+	require.Equal(t, expected, result, "relative path should resolve to baseDir + relative path")
+}
+
 func TestEnginePool_LRU_EvictsAtCap(t *testing.T) {
 	const poolCap = 50
 	created := make(map[string]int)

--- a/internal/reporter/svg.go
+++ b/internal/reporter/svg.go
@@ -2,8 +2,8 @@ package reporter
 
 import (
 	"fmt"
+	"html/template"
 	"strings"
-	"text/template"
 
 	"github.com/petersimmons1972/engram/internal/types"
 )

--- a/internal/reporter/svg_test.go
+++ b/internal/reporter/svg_test.go
@@ -30,3 +30,27 @@ func TestRenderSVG_ContainsExpected(t *testing.T) {
 		t.Error("SVG should use background colour #0D1117")
 	}
 }
+
+// TestSVGTemplateEscapesHTML verifies that html/template properly escapes
+// potentially dangerous content in model names and other fields. This prevents
+// XSS attacks when SVG content is embedded in HTML.
+func TestSVGTemplateEscapesHTML(t *testing.T) {
+	// Inject an HTML/script payload in the model name to verify escaping
+	results := []types.ModelResult{
+		{Model: `<script>alert(1)</script>`, VRAMGB: 4.5, Tier: "4-6GB", Score: types.Score{
+			Verdict: types.VerdictRecommended, Composite: 7.44,
+			AvgLatency: types.Duration(13 * time.Second),
+		}},
+	}
+	svg, err := reporter.RenderSVG(results)
+	if err != nil {
+		t.Fatalf("RenderSVG: %v", err)
+	}
+	// The script tag should be HTML-escaped
+	if strings.Contains(svg, "<script>") {
+		t.Error("SVG should escape <script> to &lt;script&gt;")
+	}
+	if !strings.Contains(svg, "&lt;script&gt;") {
+		t.Error("SVG should contain escaped &lt;script&gt;")
+	}
+}


### PR DESCRIPTION
## Summary

This PR completes W6 (repo hygiene and housekeeping) of the engram-go QA remediation workstreams. It addresses five security, safety, and code quality issues:

1. **#576 — pprof gating**: Move unconditional pprof registration from main.go to a build-tagged file (pprof_enabled.go). Default builds no longer expose pprof on DefaultServeMux; opt-in via `-tags=pprof`. Test added to verify pprof is not registered by default.

2. **#577 — HTML template escaping**: Switch SVG renderer from text/template to html/template to properly escape model names and prevent XSS injection when SVG output is embedded in HTML. Test added to verify escaping of dangerous characters.

3. **#578 — SafePath relative resolution**: Fix SafePath to resolve relative paths against baseDir (not process cwd). Ensures relative paths like 'data.txt' resolve to baseDir/data.txt, not cwd/data.txt. Test added to verify resolution semantics.

4. **#579 — SQL parameter binding guards**: Add comment guards on fmt.Sprintf SET LOCAL builders in postgres.go and postgres_chunk.go to prevent accidental refactoring to parameter binding (which is unsupported for SET LOCAL statements).

5. **#582 — Binary removal verification**: Verified binary removal was completed in an earlier session.

Additionally, **#489 (consolidator investigation)** concluded that consolidator/ is not referenced by the Go build system and is safe to defer deletion.

## Tests

- All existing tests pass: `go test ./... -count=1 -race`
- New tests added:
  - TestPprofNotRegisteredByDefault: verifies pprof not registered in default build
  - TestSVGTemplateEscapesHTML: verifies HTML escaping in SVG output
  - TestSafePathRelativeResolvesAgainstBaseDir: verifies relative path resolution

## Commits

- a0489ca: fix(pprof): move net/http/pprof to build-tagged file
- 37e8019: fix(reporter): swap text/template to html/template for SVG rendering
- b3da279: fix(safepath): resolve relative paths against baseDir not process cwd
- 418c2a1: docs(sql): add comment guards on fmt.Sprintf SET LOCAL builders

Closes #576 #577 #578 #579

🤖 Generated with Claude Code