### PR TITLE
fix(compose): retarget engram-go at olla, retire LiteLLM container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,11 +65,11 @@ services:
         required: true
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
-      # LiteLLM endpoint (external). Required. Example: http://your-host:4000
-      - LITELLM_URL=http://litellm:4000
+      # OpenAI-compatible upstream (olla load balancer; LiteLLM container retired 2026-05-05)
+      - LITELLM_URL=${LITELLM_URL:-http://olla:40114/olla/openai}
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
-      # Embedding service (usually LiteLLM, but can be any OpenAI-compatible endpoint)
-      - ENGRAM_EMBED_URL=${ENGRAM_EMBED_URL:-http://litellm:4000}
+      # Embedding service — same olla endpoint by default
+      - ENGRAM_EMBED_URL=${ENGRAM_EMBED_URL:-http://olla:40114/olla/openai}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-qwen3-embedding:8b}
       - ENGRAM_SUMMARIZE_MODEL=${ENGRAM_SUMMARIZE_MODEL:-llama3.2:3b}
       # IMPORTANT: MCP server does NOT run the reembed worker — that lives in the
@@ -117,7 +117,7 @@ services:
         required: false
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
-      - LITELLM_URL=${ENGRAM_EMBED_URL:-http://litellm:4000}
+      - LITELLM_URL=${ENGRAM_EMBED_URL:-http://olla:40114/olla/openai}
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-qwen3-embedding:8b}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-0}


### PR DESCRIPTION
Compose-only change. Default `LITELLM_URL` and `ENGRAM_EMBED_URL` env values now point at the olla load balancer instead of the litellm container.

## Why
The LiteLLM container saturated under load on 2026-05-05 (HTTP 503 / queue exhaustion in <100ms). Engram's SSE handshake to MCP tools broke because every embed call failed instantly, and CC's runtime synthesized 'user rejected' denials when the calls timed out. Operator switched to olla fronting Ollama directly.

## Change
```
LITELLM_URL=http://litellm:4000             →  ${LITELLM_URL:-http://olla:40114/olla/openai}
ENGRAM_EMBED_URL=...:-http://litellm:4000   →  ${ENGRAM_EMBED_URL:-http://olla:40114/olla/openai}
```

Same change applied to `engram-reembed`.

## Backward compatibility
Operators with `LITELLM_URL=...` already set in their `.env` see no change. Fresh deployments no longer require the `litellm_default` external Docker network to start engram (the network reference remains in the compose file under `networks:` for now; removing it is a follow-up since some deployments may still need it).

## Companion changes (already merged today)
- #606 — per-upstream circuit breaker in embed client (handles persistent backend failure even if the upstream fix is incomplete)
- olla config (operator side, separate repo): `load_balancer: priority` + `retry.on_status_codes: [502,503,504]`

## Test plan
- [ ] `docker compose config` parses cleanly
- [ ] On a host with `.env` empty, `docker compose up -d engram-go` resolves `LITELLM_URL=http://olla:40114/olla/openai`
- [ ] Existing host with `LITELLM_URL=...` set in `.env` keeps that value (no override)