### PR TITLE
chore(compose): tune leviathan ollama KV cache to free VRAM

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -55,13 +55,22 @@ services:
 
   ollama:
     container_name: engram-ollama
-    image: ollama/ollama:latest
+    image: ollama/ollama:rocm
     ports:
       - "127.0.0.1:11434:11434"
     volumes:
       - ollama_storage:/root/.ollama
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
+      # KV-cache tuning (2026-05-07): cut jina VRAM ~8.9 GB → ~4 GB on 7900 XT
+      # to leave more headroom for the display + small utility model.
+      - OLLAMA_NUM_PARALLEL=2          # was 8 — 4× KV slot reduction
+      - OLLAMA_FLASH_ATTENTION=1       # required for KV quantization
+      - OLLAMA_KV_CACHE_TYPE=q8_0      # halves KV bytes per slot vs f16
+      - OLLAMA_KEEP_ALIVE=1h
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
       interval: 5s
@@ -152,7 +161,7 @@ volumes:
     name: engram_pgdata
   ollama_storage:
     external: true
-    name: ollama_storage
+    name: ollama_ollama_storage
   engram-data:
 
 networks:


### PR DESCRIPTION
## Summary

Config-only change to `docker-compose.local.yml` — engram-ollama service env tuning to free VRAM on the 7900 XT (leviathan display card).

## Changes

- `OLLAMA_NUM_PARALLEL`: 8 → **2** (4× fewer KV cache slots)
- Add `OLLAMA_FLASH_ATTENTION=1` (required for KV quantization below)
- Add `OLLAMA_KV_CACHE_TYPE=q8_0` (halves KV bytes per slot vs default f16)
- Add `OLLAMA_KEEP_ALIVE=1h`
- Pin image to `ollama/ollama:rocm` and add `/dev/kfd` + `/dev/dri` device passthrough (matching the actual running container — file previously declared `:latest` with no device block)
- Fix external volume reference to point at the actual volume name `ollama_ollama_storage`

## Verified on leviathan

| | Before | After |
|---|---|---|
| jina VRAM | 8.9 GB | **4.0 GB** (−55%) |
| Embed cold start | 8–10 s | **1.7 s** |
| Total committed (warm) | 16.4 GB | ~10 GB |

## Why

7900 XT drives 4 monitors; large jina footprint left thin headroom for display load and the on-demand `llama3.2:3b` small utility model.

## Test plan

- [x] `docker compose -f docker-compose.local.yml up -d ollama` recreates container with new env
- [x] `docker inspect engram-ollama` confirms NUM_PARALLEL=2, FLASH_ATTENTION=1, KV_CACHE_TYPE=q8_0
- [x] `/api/embed` against jina returns HTTP 200 with sub-2s cold start
- [x] `/api/ps` reports `size_vram` ~4 GB for jina (was 8.9 GB)

## Reviewer notes (per CLAUDE.md AI-PR policy)

This is a config-only change — no code paths, no test coverage impact. Adversarial review dimensions:

- **Correctness:** YAML parses; container starts; env vars take effect (verified)
- **Coverage:** N/A (no Go code)
- **Structural:** comment in compose explains intent + numerical impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)