### PR TITLE
fix: resolve issues 623-631

### DIFF
--- a/cmd/engram-setup/engram_setup_test.go
+++ b/cmd/engram-setup/engram_setup_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -191,6 +193,40 @@ func TestOfflineFlag(t *testing.T) {
 			t.Errorf("output should contain redacted token indicator")
 		}
 	})
+}
+
+func TestOfflineRequiresDryRun(t *testing.T) {
+	oldArgs := os.Args
+	oldCommandLine := flag.CommandLine
+	defer func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldCommandLine
+	}()
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	claudePath := filepath.Join(tmpHome, ".claude", "mcp_servers.json")
+	legacyPath := filepath.Join(tmpHome, ".claude.json")
+
+	flag.CommandLine = flag.NewFlagSet("engram-setup", flag.ContinueOnError)
+	os.Args = []string{"engram-setup", "--offline"}
+
+	err := run()
+	if err == nil {
+		t.Fatal("expected --offline without --dry-run to fail")
+	}
+	if !strings.Contains(err.Error(), "preview-only") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(claudePath); !os.IsNotExist(statErr) {
+		t.Fatalf("offline failure must not write %s", claudePath)
+	}
+	if _, statErr := os.Stat(legacyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("offline failure must not write %s", legacyPath)
+	}
 }
 
 // TestConfigFormatFlag verifies that the --format flag controls output.

--- a/cmd/engram-setup/main.go
+++ b/cmd/engram-setup/main.go
@@ -53,7 +53,7 @@ func run() error {
 	port := flag.Int("port", 8788, "engram server port")
 	name := flag.String("name", "engram", "MCP server name to write in Claude config files")
 	dryRun := flag.Bool("dry-run", false, "print the MCP config diff without writing any files")
-	offline := flag.Bool("offline", false, "skip /setup-token call (useful when server is rate-limited during setup)")
+	offline := flag.Bool("offline", false, "preview-only: skip /setup-token call and require --dry-run")
 	format := flag.String("format", "text", "output format: text or json")
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
@@ -64,6 +64,10 @@ func run() error {
 	}
 
 	base := fmt.Sprintf("http://127.0.0.1:%d", *port)
+
+	if *offline && !*dryRun {
+		return fmt.Errorf("--offline is preview-only and must be combined with --dry-run")
+	}
 
 	// 1. Verify server is reachable (unless --offline).
 	if !*offline {

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -54,6 +54,8 @@ func run() error {
 	// ENGRAM_LOG_FORMAT=json. Auto-detects container by checking TERM absence.
 	logFormat := os.Getenv("ENGRAM_LOG_FORMAT")
 	logLevel := slog.LevelInfo
+	logLevelVar := &slog.LevelVar{}
+	logLevelVar.Set(logLevel)
 	logLevelErr := error(nil)
 	if lvl := os.Getenv("ENGRAM_LOG_LEVEL"); lvl != "" {
 		if err := logLevel.UnmarshalText([]byte(lvl)); err != nil {
@@ -61,14 +63,15 @@ func run() error {
 			logLevelErr = err
 		}
 	}
+	logLevelVar.Set(logLevel)
 	if logFormat == "json" || (logFormat == "" && os.Getenv("TERM") == "") {
 		slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			AddSource: true,
-			Level:     logLevel,
+			Level:     logLevelVar,
 		})))
 	} else if logLevel != slog.LevelInfo {
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: logLevel,
+			Level: logLevelVar,
 		})))
 	}
 	// Log warning about invalid log level after handler is initialized
@@ -374,6 +377,7 @@ func run() error {
 		RateLimitDisable:         *rateLimitDisable,
 		SessionRehydrateWindow:   sessionRehydrateWindow,
 		EmbedRatePerSecond:       *embedRatePerSecond,
+		LogLevelVar:              logLevelVar,
 	}
 	// Default EpisodeTTL to 24 h; set ENGRAM_EPISODE_TTL=0 to disable the sweeper.
 	if cfg.EpisodeTTL == 0 {

--- a/cmd/instinct/main.go
+++ b/cmd/instinct/main.go
@@ -161,10 +161,22 @@ func envInt(key string, def int) int {
 
 // loadAndRotate reads the buffer JSONL. Returns empty if file missing or
 // line count < minEvents. On success renames to .processed and returns events + new path.
-func loadAndRotate(bufferPath string, minEvents int) ([]Event, string) {
+type bufferLoadOutcome int
+
+const (
+	bufferLoadMissing bufferLoadOutcome = iota
+	bufferLoadBelowThreshold
+	bufferLoadProcessed
+	bufferLoadRejected
+)
+
+func loadAndRotate(bufferPath string, minEvents int) ([]Event, string, bufferLoadOutcome, error) {
 	data, err := os.ReadFile(bufferPath)
 	if err != nil {
-		return nil, ""
+		if os.IsNotExist(err) {
+			return nil, "", bufferLoadMissing, nil
+		}
+		return nil, "", bufferLoadMissing, err
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
@@ -176,14 +188,16 @@ func loadAndRotate(bufferPath string, minEvents int) ([]Event, string) {
 	}
 
 	if len(valid) < minEvents {
-		return nil, ""
+		return nil, "", bufferLoadBelowThreshold, nil
 	}
 
 	var events []Event
+	malformedCount := 0
 	for _, l := range valid {
 		var e Event
 		if err := json.Unmarshal([]byte(l), &e); err != nil {
 			slog.Warn("instinct: skipping malformed line", "err", err)
+			malformedCount++
 			continue
 		}
 		events = append(events, e)
@@ -192,13 +206,23 @@ func loadAndRotate(bufferPath string, minEvents int) ([]Event, string) {
 	ts := time.Now().UTC().Format("20060102T150405Z")
 	dir := filepath.Dir(bufferPath)
 	base := filepath.Base(bufferPath)
-	processedPath := filepath.Join(dir, base+"."+ts+".processed")
+	suffix := ".processed"
+	outcome := bufferLoadProcessed
+	if len(events) == 0 {
+		suffix = ".rejected"
+		outcome = bufferLoadRejected
+	}
+	processedPath := filepath.Join(dir, base+"."+ts+suffix)
 	if err := os.Rename(bufferPath, processedPath); err != nil {
 		slog.Error("instinct: failed to rotate buffer", "err", err)
-		return nil, ""
+		return nil, "", bufferLoadMissing, err
 	}
 
-	return events, processedPath
+	if outcome == bufferLoadRejected {
+		slog.Error("instinct: rejecting malformed buffer", "path", processedPath, "lines", len(valid), "malformed", malformedCount)
+		return nil, processedPath, outcome, fmt.Errorf("instinct: rejected malformed buffer %q: %d malformed lines and 0 decoded events", processedPath, malformedCount)
+	}
+	return events, processedPath, outcome, nil
 }
 
 // groupBySession partitions events into buckets keyed by (sessionID, projectID).
@@ -716,8 +740,14 @@ func main() {
 // run is the top-level pipeline: load buffer → group by session → write
 // episodes to Engram → detect patterns via Haiku → upsert patterns.
 func run(ctx context.Context, cfg config) error {
-	events, processedPath := loadAndRotate(cfg.bufferPath, cfg.minEvents)
+	events, processedPath, outcome, err := loadAndRotate(cfg.bufferPath, cfg.minEvents)
+	if err != nil {
+		return err
+	}
 	if len(events) == 0 {
+		if outcome == bufferLoadRejected {
+			return fmt.Errorf("instinct: malformed buffer rejected: %s", processedPath)
+		}
 		slog.Info("instinct: noop", "reason", "buffer below min events or missing")
 		return nil
 	}

--- a/cmd/instinct/main_test.go
+++ b/cmd/instinct/main_test.go
@@ -67,9 +67,15 @@ func TestLoadAndRotate_BelowMinEvents(t *testing.T) {
 	lines := strings.Repeat(`{"session_id":"s1","project_id":"p1","tool_name":"Bash","tool_input_hash":"abc","tool_output_summary":"ok","exit_status":0,"schema_version":1,"timestamp":"2026-01-01T00:00:00Z"}`+"\n", 3)
 	os.WriteFile(buf, []byte(lines), 0600)
 
-	events, processedPath := loadAndRotate(buf, 5)
+	events, processedPath, outcome, err := loadAndRotate(buf, 5)
+	if err != nil {
+		t.Fatalf("loadAndRotate() error: %v", err)
+	}
 	if len(events) != 0 {
 		t.Errorf("want 0 events, got %d", len(events))
+	}
+	if outcome != bufferLoadBelowThreshold {
+		t.Errorf("want below-threshold outcome, got %v", outcome)
 	}
 	if processedPath != "" {
 		t.Errorf("want empty processedPath, got %q", processedPath)
@@ -86,9 +92,15 @@ func TestLoadAndRotate_SkipsMalformed(t *testing.T) {
 	content := strings.Repeat(valid+"\n", 4) + "not-json\n" + valid + "\n"
 	os.WriteFile(buf, []byte(content), 0600)
 
-	events, _ := loadAndRotate(buf, 5)
+	events, _, outcome, err := loadAndRotate(buf, 5)
+	if err != nil {
+		t.Fatalf("loadAndRotate() error: %v", err)
+	}
 	if len(events) != 5 {
 		t.Errorf("want 5 valid events, got %d", len(events))
+	}
+	if outcome != bufferLoadProcessed {
+		t.Errorf("want processed outcome, got %v", outcome)
 	}
 }
 
@@ -99,9 +111,15 @@ func TestLoadAndRotate_Rotates(t *testing.T) {
 	content := strings.Repeat(valid+"\n", 5)
 	os.WriteFile(buf, []byte(content), 0600)
 
-	_, processedPath := loadAndRotate(buf, 5)
+	_, processedPath, outcome, err := loadAndRotate(buf, 5)
+	if err != nil {
+		t.Fatalf("loadAndRotate() error: %v", err)
+	}
 	if processedPath == "" {
 		t.Fatal("want non-empty processedPath")
+	}
+	if outcome != bufferLoadProcessed {
+		t.Errorf("want processed outcome, got %v", outcome)
 	}
 	if _, err := os.Stat(buf); !os.IsNotExist(err) {
 		t.Errorf("original buffer should be renamed, stat err: %v", err)
@@ -115,9 +133,39 @@ func TestLoadAndRotate_Rotates(t *testing.T) {
 }
 
 func TestLoadAndRotate_Missing(t *testing.T) {
-	events, path := loadAndRotate("/nonexistent/buffer.jsonl", 20)
+	events, path, outcome, err := loadAndRotate("/nonexistent/buffer.jsonl", 20)
+	if err != nil {
+		t.Fatalf("loadAndRotate() error: %v", err)
+	}
 	if len(events) != 0 || path != "" {
 		t.Errorf("want empty result for missing file, got %d events, path=%q", len(events), path)
+	}
+	if outcome != bufferLoadMissing {
+		t.Errorf("want missing outcome, got %v", outcome)
+	}
+}
+
+func TestLoadAndRotate_AllMalformedRejected(t *testing.T) {
+	dir := t.TempDir()
+	buf := filepath.Join(dir, "buffer.jsonl")
+	content := strings.Repeat("not-json\n", 5)
+	os.WriteFile(buf, []byte(content), 0600)
+
+	events, processedPath, outcome, err := loadAndRotate(buf, 5)
+	if err == nil {
+		t.Fatal("expected malformed buffer to be rejected")
+	}
+	if len(events) != 0 {
+		t.Errorf("want 0 events, got %d", len(events))
+	}
+	if outcome != bufferLoadRejected {
+		t.Errorf("want rejected outcome, got %v", outcome)
+	}
+	if !strings.Contains(processedPath, ".rejected") {
+		t.Fatalf("want rejected path, got %q", processedPath)
+	}
+	if _, statErr := os.Stat(processedPath); statErr != nil {
+		t.Fatalf("rejected file should exist: %v", statErr)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/petersimmons1972/engram
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -284,6 +284,17 @@ type Backend interface {
 	// GetDocument retrieves raw document content by ID. Returns "" if not found.
 	GetDocument(ctx context.Context, id string) (string, error)
 
+	// DeleteDocument removes a document row by ID. Returns true if deleted.
+	DeleteDocument(ctx context.Context, id string) (bool, error)
+
+	// DeleteDocumentTx removes a document row by ID inside an existing transaction.
+	// Returns true if deleted.
+	DeleteDocumentTx(ctx context.Context, tx Tx, id string) (bool, error)
+
+	// DeleteOrphanedDocumentTx removes a document row inside an existing transaction
+	// only when no remaining memories reference it. Returns true if deleted.
+	DeleteOrphanedDocumentTx(ctx context.Context, tx Tx, id string) (bool, error)
+
 	// SetMemoryDocumentID links a memory to a document by setting
 	// memories.document_id = documentID.
 	SetMemoryDocumentID(ctx context.Context, memoryID, documentID string) error

--- a/internal/db/postgres_document.go
+++ b/internal/db/postgres_document.go
@@ -51,6 +51,44 @@ func (b *PostgresBackend) GetDocument(ctx context.Context, id string) (string, e
 	return content, nil
 }
 
+func (b *PostgresBackend) DeleteDocument(ctx context.Context, id string) (bool, error) {
+	tag, err := b.pool.Exec(ctx, `DELETE FROM documents WHERE id = $1`, id)
+	if err != nil {
+		return false, fmt.Errorf("delete document: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (b *PostgresBackend) DeleteDocumentTx(ctx context.Context, tx Tx, id string) (bool, error) {
+	raw, err := unwrapTx(tx)
+	if err != nil {
+		return false, err
+	}
+	tag, err := raw.Exec(ctx, `DELETE FROM documents WHERE id = $1`, id)
+	if err != nil {
+		return false, fmt.Errorf("delete document tx: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (b *PostgresBackend) DeleteOrphanedDocumentTx(ctx context.Context, tx Tx, id string) (bool, error) {
+	raw, err := unwrapTx(tx)
+	if err != nil {
+		return false, err
+	}
+	tag, err := raw.Exec(ctx, `
+		DELETE FROM documents d
+		WHERE d.id = $1
+		  AND NOT EXISTS (
+			SELECT 1 FROM memories m
+			WHERE m.document_id = d.id
+		  )`, id)
+	if err != nil {
+		return false, fmt.Errorf("delete orphaned document tx: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 // SetMemoryDocumentID links a memory to a previously stored document.
 // Separated from StoreMemory so a Tier-2 write can run: StoreDocument →
 // Engine.Store(memory) → SetMemoryDocumentID(link), keeping the existing

--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -256,11 +256,14 @@ func (b *PostgresBackend) DeleteMemoryAtomic(ctx context.Context, project, id st
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	var immutable bool
+	var (
+		immutable  bool
+		documentID *string
+	)
 	err = tx.QueryRow(ctx,
-		"SELECT immutable FROM memories WHERE id=$1 AND project=$2 FOR UPDATE",
+		"SELECT immutable, document_id FROM memories WHERE id=$1 AND project=$2 FOR UPDATE",
 		id, project,
-	).Scan(&immutable)
+	).Scan(&immutable, &documentID)
 	if err == pgx.ErrNoRows {
 		return false, nil
 	}
@@ -284,6 +287,11 @@ func (b *PostgresBackend) DeleteMemoryAtomic(ctx context.Context, project, id st
 	tag, err := tx.Exec(ctx, "DELETE FROM memories WHERE id=$1 AND project=$2", id, project)
 	if err != nil {
 		return false, err
+	}
+	if documentID != nil && *documentID != "" {
+		if _, err := b.DeleteOrphanedDocumentTx(ctx, tx, *documentID); err != nil {
+			return false, err
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -718,6 +726,12 @@ func (b *PostgresBackend) DeleteProject(ctx context.Context, project string) err
 	// Delete memories
 	if _, err := tx.Exec(ctx, "DELETE FROM memories WHERE project = $1", project); err != nil {
 		return fmt.Errorf("delete memories: %w", err)
+	}
+
+	// Delete documents after memories so any orphaned raw bodies are reclaimed
+	// in the same project-cleanup transaction.
+	if _, err := tx.Exec(ctx, "DELETE FROM documents WHERE project = $1", project); err != nil {
+		return fmt.Errorf("delete documents: %w", err)
 	}
 
 	// Delete episodes

--- a/internal/db/postgres_prune.go
+++ b/internal/db/postgres_prune.go
@@ -16,13 +16,19 @@ import (
 // can reconstruct what was pruned from structured logs.
 func (b *PostgresBackend) PruneStaleMemories(ctx context.Context, project string, maxAgeHours float64, maxImportance int) (int, error) {
 	cutoff := time.Now().UTC().Add(-time.Duration(maxAgeHours * float64(time.Hour)))
-	rows, err := b.pool.Query(ctx, `
+	tx, err := b.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	rows, err := tx.Query(ctx, `
 		DELETE FROM memories
 		WHERE project=$1 AND NOT immutable AND (
 			(importance>=$2 AND last_accessed<$3 AND access_count=0)
 			OR (expires_at IS NOT NULL AND expires_at<NOW())
 		)
-		RETURNING id, content_hash, importance`, project, maxImportance, cutoff,
+		RETURNING id, content_hash, importance, document_id`, project, maxImportance, cutoff,
 	)
 	if err != nil {
 		return 0, err
@@ -30,23 +36,42 @@ func (b *PostgresBackend) PruneStaleMemories(ctx context.Context, project string
 	defer rows.Close()
 
 	var count int
+	docIDs := map[string]struct{}{}
 	for rows.Next() {
 		var id, contentHash string
 		var importance int
-		if err := rows.Scan(&id, &contentHash, &importance); err != nil {
+		var documentID *string
+		if err := rows.Scan(&id, &contentHash, &importance, &documentID); err != nil {
 			return count, err
+		}
+		if documentID != nil && *documentID != "" {
+			docIDs[*documentID] = struct{}{}
 		}
 		slog.Info("prune: deleted stale memory",
 			"project", project, "id", id,
 			"importance", importance, "content_hash", contentHash)
 		count++
 	}
-	return count, rows.Err()
+	if err := rows.Err(); err != nil {
+		return count, err
+	}
+	for docID := range docIDs {
+		if _, err := b.DeleteOrphanedDocumentTx(ctx, tx, docID); err != nil {
+			return count, err
+		}
+	}
+	return count, tx.Commit(ctx)
 }
 
 func (b *PostgresBackend) PruneColdDocuments(ctx context.Context, project string, maxAgeHours float64, maxImportance int) (int, error) {
 	cutoff := time.Now().UTC().Add(-time.Duration(maxAgeHours * float64(time.Hour)))
-	tag, err := b.pool.Exec(ctx, `
+	tx, err := b.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	rows, err := tx.Query(ctx, `
 		DELETE FROM memories WHERE id IN (
 			SELECT m.id FROM memories m
 			WHERE m.project=$1 AND m.storage_mode='document'
@@ -55,9 +80,35 @@ func (b *PostgresBackend) PruneColdDocuments(ctx context.Context, project string
 				SELECT 1 FROM chunks c
 				WHERE c.memory_id=m.id AND c.last_matched IS NOT NULL
 			  )
-		)`, project, maxImportance, cutoff,
+		)
+		RETURNING document_id`, project, maxImportance, cutoff,
 	)
-	return int(tag.RowsAffected()), err
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	count := 0
+	docIDs := map[string]struct{}{}
+	for rows.Next() {
+		var documentID *string
+		if err := rows.Scan(&documentID); err != nil {
+			return count, err
+		}
+		if documentID != nil && *documentID != "" {
+			docIDs[*documentID] = struct{}{}
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return count, err
+	}
+	for docID := range docIDs {
+		if _, err := b.DeleteOrphanedDocumentTx(ctx, tx, docID); err != nil {
+			return count, err
+		}
+	}
+	return count, tx.Commit(ctx)
 }
 
 func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.MemoryStats, error) {

--- a/internal/ingest/router/router.go
+++ b/internal/ingest/router/router.go
@@ -16,6 +16,8 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
+const DefaultParseMaxBytes = 50 * 1024 * 1024
+
 // Format identifies the detected export format.
 type Format string
 
@@ -93,9 +95,20 @@ func Detect(peek []byte) Format {
 // Streams are fully buffered in memory (the stream ingest tool already buffers
 // uploads; reusing that buffer is acceptable).
 func ParseAuto(r io.Reader) (Format, []*types.Memory, error) {
-	data, err := io.ReadAll(r)
+	return ParseAutoWithLimit(r, DefaultParseMaxBytes)
+}
+
+func ParseAutoWithLimit(r io.Reader, maxBytes int64) (Format, []*types.Memory, error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultParseMaxBytes
+	}
+	lr := &io.LimitedReader{R: r, N: maxBytes + 1}
+	data, err := io.ReadAll(lr)
 	if err != nil {
-		return FormatUnknown, nil, fmt.Errorf("router.ParseAuto: read: %w", err)
+		return FormatUnknown, nil, fmt.Errorf("router.ParseAutoWithLimit: read: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return FormatUnknown, nil, fmt.Errorf("router.ParseAutoWithLimit: input exceeds maximum size (%d bytes)", maxBytes)
 	}
 
 	// Use up to peekSize bytes for detection.
@@ -112,14 +125,14 @@ func ParseAuto(r io.Reader) (Format, []*types.Memory, error) {
 	case FormatClaudeAI:
 		memories, err := claudeai.Parse(strings.NewReader(string(data)))
 		if err != nil {
-			return FormatClaudeAI, nil, fmt.Errorf("router.ParseAuto: claudeai: %w", err)
+			return FormatClaudeAI, nil, fmt.Errorf("router.ParseAutoWithLimit: claudeai: %w", err)
 		}
 		return FormatClaudeAI, memories, nil
 
 	case FormatChatGPT:
 		memories, err := chatgpt.Parse(strings.NewReader(string(data)))
 		if err != nil {
-			return FormatChatGPT, nil, fmt.Errorf("router.ParseAuto: chatgpt: %w", err)
+			return FormatChatGPT, nil, fmt.Errorf("router.ParseAutoWithLimit: chatgpt: %w", err)
 		}
 		return FormatChatGPT, memories, nil
 

--- a/internal/ingest/slack/slack.go
+++ b/internal/ingest/slack/slack.go
@@ -28,6 +28,11 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
+const (
+	DefaultMaxEntryBytes    int64 = 25 * 1024 * 1024
+	DefaultMaxExpandedBytes int64 = 100 * 1024 * 1024
+)
+
 // ---------------------------------------------------------------------------
 // JSON shape types
 // ---------------------------------------------------------------------------
@@ -73,6 +78,10 @@ type parsedMessage struct {
 // Returns one types.Memory per channel that has at least one non-skipped message.
 // Memories are returned in alphabetical channel-name order.
 func Parse(r io.ReaderAt, size int64) ([]*types.Memory, error) {
+	return ParseWithLimits(r, size, DefaultMaxEntryBytes, DefaultMaxExpandedBytes)
+}
+
+func ParseWithLimits(r io.ReaderAt, size, maxEntryBytes, maxExpandedBytes int64) ([]*types.Memory, error) {
 	zr, err := zip.NewReader(r, size)
 	if err != nil {
 		return nil, fmt.Errorf("slack.Parse: open zip: %w", err)
@@ -80,7 +89,15 @@ func Parse(r io.ReaderAt, size int64) ([]*types.Memory, error) {
 
 	// Build a lookup from zip entry name → *zip.File for O(1) access.
 	fileMap := make(map[string]*zip.File, len(zr.File))
+	var expandedTotal int64
 	for _, f := range zr.File {
+		if maxEntryBytes > 0 && int64(f.UncompressedSize64) > maxEntryBytes {
+			return nil, fmt.Errorf("slack.Parse: entry %q exceeds maximum expanded size (%d bytes)", f.Name, maxEntryBytes)
+		}
+		expandedTotal += int64(f.UncompressedSize64)
+		if maxExpandedBytes > 0 && expandedTotal > maxExpandedBytes {
+			return nil, fmt.Errorf("slack.Parse: archive exceeds maximum expanded size (%d bytes)", maxExpandedBytes)
+		}
 		fileMap[f.Name] = f
 	}
 
@@ -129,6 +146,10 @@ func Parse(r io.ReaderAt, size int64) ([]*types.Memory, error) {
 
 // ParseFile is a convenience wrapper that opens the .zip file at path and calls Parse.
 func ParseFile(path string) ([]*types.Memory, error) {
+	return ParseFileWithLimits(path, DefaultMaxEntryBytes, DefaultMaxExpandedBytes)
+}
+
+func ParseFileWithLimits(path string, maxEntryBytes, maxExpandedBytes int64) ([]*types.Memory, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("slack.ParseFile: %w", err)
@@ -139,7 +160,7 @@ func ParseFile(path string) ([]*types.Memory, error) {
 	if err != nil {
 		return nil, fmt.Errorf("slack.ParseFile: stat: %w", err)
 	}
-	return Parse(f, info.Size())
+	return ParseWithLimits(f, info.Size(), maxEntryBytes, maxExpandedBytes)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestComplete_SuccessAndAuthHeader(t *testing.T) {
+	var auth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"  hello world  "}}]}`))
+	}))
+	defer ts.Close()
+
+	got, err := Complete(context.Background(), ts.URL+"/", "secret", "model", "prompt")
+	if err != nil {
+		t.Fatalf("Complete returned error: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("got %q, want trimmed response", got)
+	}
+	if auth != "Bearer secret" {
+		t.Fatalf("unexpected auth header: %q", auth)
+	}
+}
+
+func TestComplete_Non200SurfacesBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	_, err := Complete(context.Background(), ts.URL, "", "model", "prompt")
+	if err == nil || !strings.Contains(err.Error(), "upstream exploded") {
+		t.Fatalf("expected body in error, got %v", err)
+	}
+}
+
+func TestComplete_MalformedJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[`))
+	}))
+	defer ts.Close()
+
+	_, err := Complete(context.Background(), ts.URL, "", "model", "prompt")
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestComplete_EmptyChoices(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer ts.Close()
+
+	_, err := Complete(context.Background(), ts.URL, "", "model", "prompt")
+	if err == nil || !strings.Contains(err.Error(), "empty response") {
+		t.Fatalf("expected empty response error, got %v", err)
+	}
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -198,6 +198,13 @@ func (noopBackend) SearchChunksWithinMemory(_ context.Context, _ []float32, _ st
 	return nil, nil
 }
 func (noopBackend) StoreDocument(_ context.Context, _, _ string) (string, error) { return "", nil }
+func (noopBackend) DeleteDocument(_ context.Context, _ string) (bool, error)      { return false, nil }
+func (noopBackend) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (noopBackend) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
 func (noopBackend) GetDocument(_ context.Context, _ string) (string, error)      { return "", nil }
 func (noopBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error     { return nil }
 

--- a/internal/mcp/ingest_document.go
+++ b/internal/mcp/ingest_document.go
@@ -130,6 +130,7 @@ func buildSynopsis(content string) string {
 // full PostgresBackend.
 type documentStorer interface {
 	StoreDocument(ctx context.Context, project, content string) (string, error)
+	DeleteDocument(ctx context.Context, id string) (bool, error)
 	SetMemoryDocumentID(ctx context.Context, memoryID, documentID string) error
 }
 
@@ -206,6 +207,10 @@ func execStoreDocument(ctx context.Context, deps storeDocumentDeps, m *types.Mem
 		m.StorageMode = "document"
 		m.DocumentID = docID
 		if err := deps.engine.StoreWithRawBody(ctx, m, ""); err != nil {
+			if _, rollbackErr := deps.backend.DeleteDocument(ctx, docID); rollbackErr != nil {
+				slog.Warn("execStoreDocument: failed to rollback raw document after memory store failure",
+					"project", m.Project, "document_id", docID, "err", rollbackErr)
+			}
 			return nil, fmt.Errorf("store synopsis memory: %w", err)
 		}
 		return map[string]any{
@@ -251,6 +256,9 @@ type backendDocumentAdapter struct {
 
 func (a backendDocumentAdapter) StoreDocument(ctx context.Context, project, content string) (string, error) {
 	return a.b.StoreDocument(ctx, project, content)
+}
+func (a backendDocumentAdapter) DeleteDocument(ctx context.Context, id string) (bool, error) {
+	return a.b.DeleteDocument(ctx, id)
 }
 func (a backendDocumentAdapter) SetMemoryDocumentID(ctx context.Context, memoryID, documentID string) error {
 	return a.b.SetMemoryDocumentID(ctx, memoryID, documentID)

--- a/internal/mcp/ingest_document_test.go
+++ b/internal/mcp/ingest_document_test.go
@@ -43,6 +43,7 @@ func (s *stubEngine) StoreWithRawBody(_ context.Context, m *types.Memory, rawBod
 type stubDocBackend struct {
 	stored   map[string]string // docID -> content
 	linked   map[string]string // memID -> docID
+	deleted  []string
 	storeErr error
 	linkErr  error
 	nextID   int
@@ -60,6 +61,12 @@ func (s *stubDocBackend) StoreDocument(_ context.Context, _ string, content stri
 	id := fmt.Sprintf("doc-%d", s.nextID)
 	s.stored[id] = content
 	return id, nil
+}
+
+func (s *stubDocBackend) DeleteDocument(_ context.Context, id string) (bool, error) {
+	s.deleted = append(s.deleted, id)
+	delete(s.stored, id)
+	return true, nil
 }
 
 func (s *stubDocBackend) SetMemoryDocumentID(_ context.Context, memID, docID string) error {
@@ -207,6 +214,21 @@ func TestHandleMemoryStoreDocument_Tier2_HugeContent(t *testing.T) {
 	require.Less(t, len(stored.Content), len(content))
 	require.Empty(t, eng.calls[0].rawBody, "Tier-2: raw documents are not chunked inline — rawBody must be empty")
 	require.Equal(t, docID, stored.DocumentID, "Tier-2: memory must carry document_id")
+}
+
+func TestHandleMemoryStoreDocument_Tier2RollbackDeletesDocument(t *testing.T) {
+	const maxDoc = 8 * 1024 * 1024
+	const rawMax = 50 * 1024 * 1024
+
+	eng := &stubEngine{err: fmt.Errorf("downstream store failed")}
+	back := newStubDocBackend()
+	m := &types.Memory{ID: "m-tier2-rollback", Project: "p", MemoryType: types.MemoryTypeContext}
+	content := "# Huge doc\n" + makeContent(9*1024*1024)
+
+	_, err := execStoreDocument(context.Background(), storeDocumentDeps{engine: eng, backend: back}, m, content, maxDoc, rawMax)
+	require.Error(t, err)
+	require.Len(t, back.deleted, 1, "tier-2 rollback must reclaim the staged document row")
+	require.Empty(t, back.stored, "rolled-back document must not remain staged")
 }
 
 func TestHandleMemoryStoreDocument_TooLarge(t *testing.T) {
@@ -470,6 +492,7 @@ type backendStubForAdapter struct {
 	db.Backend
 	storeCalls  int
 	linkCalls   int
+	deleteCalls int
 	lastProject string
 	lastMem     string
 	lastDoc     string
@@ -488,6 +511,12 @@ func (b *backendStubForAdapter) SetMemoryDocumentID(_ context.Context, memID, do
 	return nil
 }
 
+func (b *backendStubForAdapter) DeleteDocument(_ context.Context, id string) (bool, error) {
+	b.deleteCalls++
+	b.lastDoc = id
+	return true, nil
+}
+
 func TestBackendDocumentAdapter(t *testing.T) {
 	bs := &backendStubForAdapter{}
 	a := backendDocumentAdapter{b: bs}
@@ -502,6 +531,11 @@ func TestBackendDocumentAdapter(t *testing.T) {
 	require.Equal(t, 1, bs.linkCalls)
 	require.Equal(t, "mem-1", bs.lastMem)
 	require.Equal(t, "doc-1", bs.lastDoc)
+
+	_, err = a.DeleteDocument(context.Background(), "doc-2")
+	require.NoError(t, err)
+	require.Equal(t, 1, bs.deleteCalls)
+	require.Equal(t, "doc-2", bs.lastDoc)
 }
 
 // TestRunStreamIngest_PoolError exercises runStreamIngest's error path when

--- a/internal/mcp/ingest_export.go
+++ b/internal/mcp/ingest_export.go
@@ -30,6 +30,21 @@ func handleMemoryIngestExport(ctx context.Context, pool *EnginePool, req mcpgo.C
 	if err != nil {
 		return nil, fmt.Errorf("invalid path: %w", err)
 	}
+	info, err := os.Stat(safePath)
+	if err != nil {
+		return nil, fmt.Errorf("memory_ingest_export: stat: %w", err)
+	}
+	importMax := cfg.ImportMaxBytes
+	if importMax <= 0 {
+		importMax = 50 * 1024 * 1024
+	}
+	expandedMax := cfg.ImportExpandedMaxBytes
+	if expandedMax <= 0 {
+		expandedMax = 100 * 1024 * 1024
+	}
+	if info.Size() > int64(importMax) {
+		return nil, fmt.Errorf("memory_ingest_export: file exceeds maximum size (%d bytes > %d)", info.Size(), importMax)
+	}
 
 	format := router.DetectFromPath(safePath)
 	if format == router.FormatUnknown {
@@ -39,7 +54,7 @@ func handleMemoryIngestExport(ctx context.Context, pool *EnginePool, req mcpgo.C
 	var memories []*types.Memory
 	switch format {
 	case router.FormatSlack:
-		memories, err = slack.ParseFile(safePath)
+		memories, err = slack.ParseFileWithLimits(safePath, int64(importMax), int64(expandedMax))
 		if err != nil {
 			return nil, fmt.Errorf("memory_ingest_export: slack parse: %w", err)
 		}
@@ -49,7 +64,7 @@ func handleMemoryIngestExport(ctx context.Context, pool *EnginePool, req mcpgo.C
 			return nil, fmt.Errorf("memory_ingest_export: open: %w", openErr)
 		}
 		defer func() { _ = f.Close() }()
-		_, memories, err = router.ParseAuto(f)
+		_, memories, err = router.ParseAutoWithLimit(f, int64(importMax))
 		if err != nil {
 			return nil, fmt.Errorf("memory_ingest_export: parse: %w", err)
 		}

--- a/internal/mcp/ingest_export_test.go
+++ b/internal/mcp/ingest_export_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,6 +85,41 @@ func TestHandleMemoryIngestExport_PathOutsideDataDir(t *testing.T) {
 	_, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, "/etc/passwd")
 	if err == nil {
 		t.Error("want path validation error, got nil")
+	}
+}
+
+func TestHandleMemoryIngestExport_FileSizeRejectedBeforeParse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversize.json")
+	os.WriteFile(path, []byte("[]"), 0o600)
+	pool := internalmcp.NewTestStorePool(t)
+	cfg := internalmcp.Config{DataDir: dir, ImportMaxBytes: 1}
+	_, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, path)
+	if err == nil || !strings.Contains(err.Error(), "file exceeds maximum size") {
+		t.Fatalf("expected pre-parse size rejection, got %v", err)
+	}
+}
+
+func TestHandleMemoryIngestExport_SlackEntryTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversize-slack.zip")
+	f, _ := os.Create(path)
+	w := zip.NewWriter(f)
+	write := func(name, body string) {
+		zf, _ := w.Create(name)
+		_, _ = zf.Write([]byte(body))
+	}
+	write("users.json", `[{"id":"U1","name":"a"}]`)
+	write("channels.json", `[{"id":"C1","name":"general"}]`)
+	write("general/2026-01-01.json", `[`+strings.Repeat(`{"type":"message","user":"U1","text":"hello","ts":"1700000000.000001"},`, 10)+`{"type":"message","user":"U1","text":"hello","ts":"1700000000.000001"}]`)
+	_ = w.Close()
+	_ = f.Close()
+
+	pool := internalmcp.NewTestStorePool(t)
+	cfg := internalmcp.Config{DataDir: dir, ImportMaxBytes: 1024, ImportExpandedMaxBytes: 200}
+	_, err := internalmcp.CallHandleMemoryIngestExport(context.Background(), t, pool, "default", cfg, path)
+	if err == nil || ( !strings.Contains(err.Error(), "entry") && !strings.Contains(err.Error(), "archive exceeds")) {
+		t.Fatalf("expected oversize entry rejection, got %v", err)
 	}
 }
 

--- a/internal/mcp/issue629_handler_test.go
+++ b/internal/mcp/issue629_handler_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type issue629Backend struct {
+	noopBackend
+	stats    *types.MemoryStats
+	projects []string
+	episode  *types.Episode
+	memories []*types.Memory
+}
+
+func (b issue629Backend) GetStats(_ context.Context, _ string) (*types.MemoryStats, error) {
+	return b.stats, nil
+}
+func (b issue629Backend) ListAllProjects(_ context.Context) ([]string, error) {
+	return b.projects, nil
+}
+func (b issue629Backend) StartEpisode(_ context.Context, _, _ string) (*types.Episode, error) {
+	return b.episode, nil
+}
+func (b issue629Backend) ListEpisodes(_ context.Context, _ string, _ int) ([]*types.Episode, error) {
+	return []*types.Episode{b.episode}, nil
+}
+func (b issue629Backend) RecallEpisode(_ context.Context, _ string) ([]*types.Memory, error) {
+	return b.memories, nil
+}
+
+func newIssue629Pool(t *testing.T) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, issue629Backend{
+			stats:    &types.MemoryStats{TotalMemories: 3},
+			projects: []string{"alpha", "beta"},
+			episode:  &types.Episode{ID: "ep-1", Project: project},
+			memories: []*types.Memory{{ID: "m-1", Project: project}},
+		}, noopEmbedder{}, project, "http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+func decodeToolResult(t *testing.T, res *mcpgo.CallToolResult) map[string]any {
+	t.Helper()
+	require.NotNil(t, res)
+	tc, ok := res.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	return out
+}
+
+func TestIssue629_EpisodeHandlersAndAdminHandlers(t *testing.T) {
+	pool := newIssue629Pool(t)
+
+	res, err := handleMemoryEpisodeStart(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
+	require.NoError(t, err)
+	require.Equal(t, "ep-1", decodeToolResult(t, res)["id"])
+
+	res, err = handleMemoryEpisodeEnd(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj", "episode_id": "ep-1"}}})
+	require.NoError(t, err)
+	require.Equal(t, true, decodeToolResult(t, res)["ended"])
+
+	res, err = handleMemoryEpisodeList(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
+	require.NoError(t, err)
+	require.Equal(t, float64(1), decodeToolResult(t, res)["count"])
+
+	res, err = handleMemoryEpisodeRecall(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj", "episode_id": "ep-1"}}})
+	require.NoError(t, err)
+	require.Equal(t, float64(1), decodeToolResult(t, res)["count"])
+
+	res, err = handleMemoryProjects(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
+	require.NoError(t, err)
+	require.Equal(t, float64(2), decodeToolResult(t, res)["count"])
+
+	res, err = handleMemoryStatus(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
+	require.NoError(t, err)
+	require.Equal(t, float64(3), decodeToolResult(t, res)["total_memories"])
+
+	res, err = handleMemoryDiagnose(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj", "question": "what happened?"}}})
+	require.NoError(t, err)
+	require.Equal(t, float64(0), decodeToolResult(t, res)["memories_used"])
+}
+
+var _ db.Backend = issue629Backend{}

--- a/internal/mcp/migrate_embedder_test.go
+++ b/internal/mcp/migrate_embedder_test.go
@@ -29,6 +29,13 @@ func (b dimBackend) GetMeta(_ context.Context, _, key string) (string, bool, err
 	}
 	return "", false, nil
 }
+func (b dimBackend) DeleteDocument(_ context.Context, _ string) (bool, error) { return false, nil }
+func (b dimBackend) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (b dimBackend) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
 
 var _ db.Backend = dimBackend{}
 
@@ -243,7 +250,7 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_PrivateIPBlocked(t *testing.T) {
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "SSRF protection", "private IP in ollama_url must be rejected")
+	require.Contains(t, err.Error(), "private IP", "private IP in ollama_url must be rejected")
 }
 
 // TestHandleMemoryMigrateEmbedder_OllamaURL_LoopbackBlocked verifies that
@@ -261,7 +268,7 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_LoopbackBlocked(t *testing.T) {
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "SSRF protection", "loopback IP in ollama_url must be rejected")
+	require.Contains(t, err.Error(), "private IP", "loopback IP in ollama_url must be rejected")
 }
 
 // TestHandleMemoryMigrateEmbedder_OllamaURL_InvalidURLBlocked verifies that
@@ -282,29 +289,23 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_InvalidURLBlocked(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid ollama_url", "malformed URL must be rejected")
 }
 
-// TestHandleMemoryMigrateEmbedder_OllamaURL_HostnameAllowed verifies that a
-// hostname-based ollama_url (not a raw IP) is accepted and forwarded — matching
-// the startup-time behavior that allows container hostnames like "ollama".
-func TestHandleMemoryMigrateEmbedder_OllamaURL_HostnameAllowed(t *testing.T) {
+// TestHandleMemoryMigrateEmbedder_OllamaURL_HostnameResolvingPrivateBlocked
+// verifies that hostname overrides are rejected when DNS resolves them to
+// private/reserved targets.
+func TestHandleMemoryMigrateEmbedder_OllamaURL_HostnameResolvingPrivateBlocked(t *testing.T) {
 	pool := newDimPool(t, "", 384) // no stored dims — pre-flight skipped
 
 	var req mcpgo.CallToolRequest
 	req.Params.Arguments = map[string]any{
 		"project":    "proj",
 		"new_model":  "some-model",
-		"ollama_url": "http://custom-ollama:11434",
+		"ollama_url": "http://localhost:11434",
 	}
-	cfg := Config{
-		LiteLLMURL: "http://safe-ollama:11434",
-		testHooks: &testHooks{
-			migrateFunc: func(_ context.Context, _ string) (map[string]any, error) {
-				return map[string]any{"nulled": 0, "model": "some-model"}, nil
-			},
-		},
-	}
+	cfg := Config{LiteLLMURL: "http://safe-ollama:11434"}
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
-	require.NoError(t, err, "hostname-based ollama_url must be accepted")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "resolves to private IP")
 }
 
 // TestHandleMemoryMigrateEmbedder_DimsMatch_ProceedToMigrate verifies that when

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -180,11 +180,16 @@ func (p *EnginePool) WarmProjects(ctx context.Context, projects []string, concur
 	}
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
+	stop := false
 	for _, proj := range projects {
 		proj := proj
+		if stop {
+			break
+		}
 		select {
 		case <-ctx.Done():
-			break
+			stop = true
+			continue
 		default:
 		}
 		sem <- struct{}{}

--- a/internal/mcp/ready_test.go
+++ b/internal/mcp/ready_test.go
@@ -24,7 +24,7 @@ import (
 // the warm phase and embedding is healthy, /ready returns 200 with ready:true.
 func TestReady_WarmPhase_Returns200_EmbedOK(t *testing.T) {
 	s := &Server{}
-	s.serverPhase.Store(int32(phaseWarm)) // phaseWarm constant doesn't exist yet
+	s.serverPhase.Store(phaseWarm) // phaseWarm constant doesn't exist yet
 	s.embedDegraded = new(atomic.Bool)
 
 	req := httptest.NewRequest("GET", "/ready", nil)
@@ -44,7 +44,7 @@ func TestReady_WarmPhase_Returns200_EmbedOK(t *testing.T) {
 // starting (pool cold, not yet ready), /ready returns 503 with ready:false.
 func TestReady_StartingPhase_Returns503(t *testing.T) {
 	s := &Server{}
-	s.serverPhase.Store(int32(phaseStarting)) // phaseStarting constant doesn't exist yet
+	s.serverPhase.Store(phaseStarting) // phaseStarting constant doesn't exist yet
 	s.embedDegraded = new(atomic.Bool)
 
 	req := httptest.NewRequest("GET", "/ready", nil)
@@ -61,7 +61,7 @@ func TestReady_StartingPhase_Returns503(t *testing.T) {
 // does not make the server report unready — BM25 is still operational.
 func TestReady_WarmPhase_EmbedDegraded_Returns200(t *testing.T) {
 	s := &Server{}
-	s.serverPhase.Store(int32(phaseWarm))
+	s.serverPhase.Store(phaseWarm)
 	s.embedDegraded = new(atomic.Bool)
 	s.embedDegraded.Store(true)
 
@@ -82,7 +82,7 @@ func TestReady_WarmPhase_EmbedDegraded_Returns200(t *testing.T) {
 // includes transport_hint: "http" so MCP clients know to use HTTP not SSE.
 func TestReady_AlwaysIncludesTransportHint_HTTP(t *testing.T) {
 	s := &Server{}
-	s.serverPhase.Store(int32(phaseWarm))
+	s.serverPhase.Store(phaseWarm)
 	s.embedDegraded = new(atomic.Bool)
 
 	req := httptest.NewRequest("GET", "/ready", nil)
@@ -98,7 +98,7 @@ func TestReady_AlwaysIncludesTransportHint_HTTP(t *testing.T) {
 // (pool init in progress, not yet fully ready), /ready returns 503.
 func TestReady_WarmingPhase_Returns503(t *testing.T) {
 	s := &Server{}
-	s.serverPhase.Store(int32(phaseWarming)) // phaseWarming constant doesn't exist yet
+	s.serverPhase.Store(phaseWarming) // phaseWarming constant doesn't exist yet
 	s.embedDegraded = new(atomic.Bool)
 
 	req := httptest.NewRequest("GET", "/ready", nil)
@@ -116,7 +116,7 @@ func TestReady_WarmingPhase_Returns503(t *testing.T) {
 // response includes transport_hint so clients can log the correct URL.
 func TestReady_Returns503_TransportHintStillPresent(t *testing.T) {
 	s := &Server{}
-	s.serverPhase.Store(int32(phaseStarting))
+	s.serverPhase.Store(phaseStarting)
 	s.embedDegraded = new(atomic.Bool)
 
 	req := httptest.NewRequest("GET", "/ready", nil)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -350,6 +350,7 @@ func NewServer(pool *EnginePool, cfg Config) *Server {
 		}
 	}
 	runtimeCfg.LogLevel.Store(logLevelVal)
+	cfg.RuntimeConfig = runtimeCfg
 
 	s := &Server{
 		pool:              pool,
@@ -384,6 +385,18 @@ func (s *Server) SetClaudeClient(client *claude.Client) {
 func (s *Server) ReloadRuntimeConfig() {
 	if s.runtimeCfg != nil {
 		reloadRuntimeConfig(s.runtimeCfg)
+		if s.cfg.LogLevelVar != nil {
+			switch s.runtimeCfg.LogLevel.Load() {
+			case 0:
+				s.cfg.LogLevelVar.Set(slog.LevelDebug)
+			case 2:
+				s.cfg.LogLevelVar.Set(slog.LevelWarn)
+			case 3:
+				s.cfg.LogLevelVar.Set(slog.LevelError)
+			default:
+				s.cfg.LogLevelVar.Set(slog.LevelInfo)
+			}
+		}
 	}
 }
 
@@ -519,6 +532,9 @@ func (s *Server) registerSessionHooks(apiKey string) {
 	s.mcp.GetHooks().AddOnUnregisterSession(func(_ context.Context, sess server.ClientSession) {
 		sessionID := sess.SessionID()
 		s.sessionFingerprints.Delete(sessionID)
+		s.sessionTouchMu.Lock()
+		delete(s.sessionTouchTimes, sessionID)
+		s.sessionTouchMu.Unlock()
 
 		// Remove from DB on clean disconnect (#362).
 		if s.cfg.SessionDB != nil {

--- a/internal/mcp/sighup_test.go
+++ b/internal/mcp/sighup_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -88,6 +89,22 @@ func TestSIGHUPConfigReload(t *testing.T) {
 	// is called before the next test registers its own handler (#618).
 	cancel()
 	<-goroutineDone
+}
+
+func TestReloadRuntimeConfigUpdatesServerLogLevelVar(t *testing.T) {
+	levelVar := &slog.LevelVar{}
+	levelVar.Set(slog.LevelInfo)
+	s := &Server{
+		cfg:        Config{LogLevelVar: levelVar},
+		runtimeCfg: &RuntimeConfig{},
+	}
+	t.Setenv("ENGRAM_LOG_LEVEL", "debug")
+
+	s.ReloadRuntimeConfig()
+
+	if levelVar.Level() != slog.LevelDebug {
+		t.Fatalf("expected shared LevelVar to update to debug, got %v", levelVar.Level())
+	}
 }
 
 // TestSIGHUPPartialReload verifies that only changed flags are updated and

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"strings"
 	"time"
@@ -27,6 +28,8 @@ type Config struct {
 	ClaudeEnabled            bool // true when a claude client is present
 	ClaudeConsolidateEnabled bool
 	ClaudeRerankEnabled      bool
+	RuntimeConfig            *RuntimeConfig
+	LogLevelVar             *slog.LevelVar
 	// DataDir is the base directory for all file-system operations (export,
 	// import, ingest). Paths provided by callers are validated to stay within
 	// this directory. Must be set; file-operation tools return an error if empty.
@@ -53,6 +56,12 @@ type Config struct {
 	// Above this size, ingestion is refused. Defaults to 50 MiB. Set via
 	// ENGRAM_RAW_DOCUMENT_MAX_BYTES env var.
 	RawDocumentMaxBytes int
+	// ImportMaxBytes caps local import files before any parsing work begins.
+	// Defaults to 50 MiB. Set via ENGRAM_IMPORT_MAX_BYTES env var.
+	ImportMaxBytes int
+	// ImportExpandedMaxBytes caps total expanded bytes parsed from compressed
+	// archives such as Slack exports. Defaults to 100 MiB.
+	ImportExpandedMaxBytes int
 	// RAGMaxTokens caps the context window assembled for memory_ask prompt
 	// synthesis. Defaults to 4096. Set via ENGRAM_RAG_MAX_TOKENS env var.
 	RAGMaxTokens int

--- a/internal/mcp/tools_consolidate.go
+++ b/internal/mcp/tools_consolidate.go
@@ -69,7 +69,11 @@ func handleMemoryConsolidate(ctx context.Context, pool *EnginePool, req mcpgo.Ca
 		return nil, err
 	}
 	var result map[string]any
-	if cfg.ClaudeConsolidateEnabled && cfg.claudeClient != nil {
+	claudeConsolidateEnabled := cfg.ClaudeConsolidateEnabled
+	if cfg.RuntimeConfig != nil {
+		claudeConsolidateEnabled = cfg.RuntimeConfig.ClaudeConsolidate.Load()
+	}
+	if claudeConsolidateEnabled && cfg.claudeClient != nil {
 		result, err = h.Engine.ConsolidateWithClaude(ctx, &claudeMergeAdapter{client: cfg.claudeClient})
 	} else {
 		result, err = h.Engine.Consolidate(ctx)

--- a/internal/mcp/tools_embedder.go
+++ b/internal/mcp/tools_embedder.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"net"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -40,12 +38,8 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 	// because they resolve to container IPs by design and are not attacker-controlled.
 	ollamaURL := cfg.LiteLLMURL
 	if raw := getString(args, "ollama_url", ""); raw != "" {
-		parsed, parseErr := url.ParseRequestURI(raw)
-		if parseErr != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-			return nil, fmt.Errorf("invalid ollama_url %q: must be an http:// or https:// URL", raw)
-		}
-		if host := parsed.Hostname(); net.ParseIP(host) != nil && netutil.IsPrivateIP(host) {
-			return nil, fmt.Errorf("invalid ollama_url: IP %q is in a private/reserved range (SSRF protection)", host)
+		if err := netutil.ValidateUpstreamURL(raw); err != nil {
+			return nil, fmt.Errorf("invalid ollama_url %q: %w", raw, err)
 		}
 		ollamaURL = raw
 	}

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -263,7 +263,11 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	rerank := getBool(args, "rerank", false)
 	var opts search.RecallOpts
 	// Claude reranker is opt-in via rerank=true.
-	if cfg.ClaudeRerankEnabled && rerank && cfg.claudeClient != nil {
+	claudeRerankEnabled := cfg.ClaudeRerankEnabled
+	if cfg.RuntimeConfig != nil {
+		claudeRerankEnabled = cfg.RuntimeConfig.ClaudeRerank.Load()
+	}
+	if claudeRerankEnabled && rerank && cfg.claudeClient != nil {
 		opts.Reranker = &claudeRerankAdapter{client: cfg.claudeClient}
 	}
 	// Inject current session episode for same-session score boosting (Phase 3).

--- a/internal/mcp/touch_session_test.go
+++ b/internal/mcp/touch_session_test.go
@@ -150,3 +150,18 @@ func TestTouchSessionBreaksCoalesceAfter30s(t *testing.T) {
 		t.Errorf("expected 2 TouchSession calls after 30s, got %d", callCount)
 	}
 }
+
+func TestUnregisterSessionClearsTouchTimestamp(t *testing.T) {
+	s := NewServer(nil, Config{})
+	s.registerSessionHooks("test-key")
+	s.sessionTouchTimes["sess-1"] = time.Now()
+
+	s.mcp.GetHooks().UnregisterSession(context.Background(), &fakeClientSession{id: "sess-1"})
+
+	s.sessionTouchMu.Lock()
+	_, ok := s.sessionTouchTimes["sess-1"]
+	s.sessionTouchMu.Unlock()
+	if ok {
+		t.Fatal("expected unregister hook to delete sessionTouchTimes entry")
+	}
+}

--- a/internal/reembed/worker.go
+++ b/internal/reembed/worker.go
@@ -215,9 +215,9 @@ func (w *Worker) runBatch(ctx context.Context) bool {
 			break
 		}
 		eg.Go(func() error {
-			// Independent 15s deadline (E5): isolates each embed call from the
-			// worker context so a slow Ollama cannot stall the entire batch.
-			embedCtx, embedCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			// Independent 15s deadline layered on the worker context so Stop()
+			// cancels blocked embeds promptly while still bounding each call.
+			embedCtx, embedCancel := context.WithTimeout(egCtx, 15*time.Second)
 			defer embedCancel()
 			vec, err := w.embedder.Embed(embedCtx, c.ChunkText)
 			if err != nil {
@@ -237,4 +237,3 @@ func (w *Worker) runBatch(ctx context.Context) bool {
 	}
 	return len(chunks) < batchSize
 }
-

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -239,6 +239,13 @@ func (noopBackend) SearchChunksWithinMemory(_ context.Context, _ []float32, _ st
 	return nil, nil
 }
 func (noopBackend) StoreDocument(_ context.Context, _, _ string) (string, error) { return "", nil }
+func (noopBackend) DeleteDocument(_ context.Context, _ string) (bool, error)      { return false, nil }
+func (noopBackend) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (noopBackend) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
 func (noopBackend) GetDocument(_ context.Context, _ string) (string, error)      { return "", nil }
 func (noopBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error     { return nil }
 func (noopBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error) {
@@ -431,5 +438,49 @@ func TestRunBatch_ConcurrentEmbedding(t *testing.T) {
 	backend.mu.Unlock()
 	if updatedCount != numChunks {
 		t.Errorf("expected %d chunk updates, got %d", numChunks, updatedCount)
+	}
+}
+
+type blockingEmbedder struct {
+	dims      int
+	started   chan struct{}
+	cancelled chan struct{}
+}
+
+func (b *blockingEmbedder) Embed(ctx context.Context, _ string) ([]float32, error) {
+	close(b.started)
+	<-ctx.Done()
+	close(b.cancelled)
+	return nil, ctx.Err()
+}
+func (b *blockingEmbedder) Name() string    { return "blocking" }
+func (b *blockingEmbedder) Dimensions() int { return b.dims }
+
+func TestWorkerStopCancelsBlockedEmbedPromptly(t *testing.T) {
+	chunk := &types.Chunk{ID: "chunk-blocked", ChunkText: "blocked"}
+	backend := &concurrentUpdateBackend{
+		pendingChunks: []*types.Chunk{chunk},
+	}
+	embedder := &blockingEmbedder{
+		dims:      768,
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+	}
+
+	w := reembed.NewWorker(backend, embedder, "proj", true)
+	w.StartWithContext(context.Background())
+
+	select {
+	case <-embedder.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("embed did not start")
+	}
+
+	w.Stop()
+
+	select {
+	case <-embedder.cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not cancel blocked embed promptly")
 	}
 }

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -389,6 +389,13 @@ func (s *stubBackend) ExistsWithContentHash(_ context.Context, _ string, _ strin
 func (s *stubBackend) StoreDocument(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }
+func (s *stubBackend) DeleteDocument(_ context.Context, _ string) (bool, error) { return false, nil }
+func (s *stubBackend) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (s *stubBackend) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
 func (s *stubBackend) GetDocument(_ context.Context, _ string) (string, error) { return "", nil }
 func (s *stubBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error { return nil }
 


### PR DESCRIPTION
## Summary
This PR resolves the fix batch for issues #623 through #631.

## What changed
- reject all-malformed instinct buffers instead of rotating them to `.processed` and silently no-oping
- make `engram-setup --offline` preview-only and require `--dry-run`
- reclaim raw documents on Tier-2 ingest failure, memory deletion, prune paths, and project deletion
- propagate worker cancellation into in-flight reembed calls
- clean up `sessionTouchTimes` on MCP session unregister
- wire SIGHUP reload to live Claude gating and the active shared `slog.LevelVar`
- validate `memory_migrate_embedder` overrides with `netutil.ValidateUpstreamURL`
- add bounded local import parsing and Slack decompression caps for `memory_ingest_export`
- add direct `internal/llm` and MCP handler coverage for the issue-629 boundary gaps

## Verification
- `go test ./internal/llm -cover`
- `go test ./internal/mcp -coverprofile=/tmp/mcp-cover.out`
- `go test -race ./internal/reembed ./internal/mcp ./internal/search -count=1`
- `go test ./... -count=1`
- `go test ./... -count=1 -race`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./cmd/engram ./cmd/engram-setup ./cmd/instinct ./internal/db ./internal/ingest/... ./internal/llm ./internal/mcp ./internal/netutil ./internal/reembed ./internal/search`

## Issues
Closes #623
Closes #624
Closes #625
Closes #626
Closes #627
Closes #628
Closes #629
Closes #630
Closes #631