### PR TITLE
fix(search): revert RRF fusion, tune preference boost and recency for LME v8

### DIFF
--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -613,12 +613,6 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		}
 	}
 
-	// Build vector rank map (1-based, ordered by cosine similarity best-first).
-	vectorRankMap := make(map[string]int, len(uniqueIDs))
-	for i, id := range uniqueIDs {
-		vectorRankMap[id] = i + 1
-	}
-
 	// Batch-fetch memory records for vector hits.
 	batchMems, err := e.backend.GetMemoriesByIDs(ctx, e.project, uniqueIDs)
 	if err != nil {
@@ -641,14 +635,12 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	}
 	ftsScores := make(map[string]float64)
 	maxBM25 := 0.0
-	bm25RankMap := make(map[string]int, len(ftsRes.results))
-	for i, r := range ftsRes.results {
+	for _, r := range ftsRes.results {
 		ftsScores[r.Memory.ID] = r.Score
 		if r.Score > maxBM25 {
 			maxBM25 = r.Score
 		}
 		memories[r.Memory.ID] = r.Memory
-		bm25RankMap[r.Memory.ID] = i + 1
 	}
 
 	// Detect query type once before the scoring loop.
@@ -704,8 +696,7 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			MemoryType:         m.MemoryType,
 			IsPreferenceQuery:  prefQuery,
 		}
-		rrfBase := RRFScore(vectorRankMap[id], bm25RankMap[id], 60)
-		score := CompositeScoreRRF(input, baseWeights, rrfBase)
+		score := CompositeScoreWithWeights(input, baseWeights)
 
 		result := types.SearchResult{
 			Memory:     m,
@@ -715,7 +706,6 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 				bd := map[string]float64{
 					"cosine":        hit.cosine,
 					"bm25":          bm25,
-					"rrf_base":      rrfBase,
 					"recency":       RecencyDecay(input.HoursSince),
 					"episode_boost": 1.0,
 				}

--- a/internal/search/preference_test.go
+++ b/internal/search/preference_test.go
@@ -297,7 +297,7 @@ func TestPreferenceBoostNotAppliedForNeutralQuery(t *testing.T) {
 	}
 }
 
-// TestPreferenceBoostMagnitude verifies the boost multiplier is exactly 1.8×.
+// TestPreferenceBoostMagnitude verifies the boost multiplier is exactly 1.35×.
 func TestPreferenceBoostMagnitude(t *testing.T) {
 	base := ScoreInput{
 		Cosine: 0.8, BM25: 0.5, HoursSince: 1, Importance: 2,
@@ -315,7 +315,7 @@ func TestPreferenceBoostMagnitude(t *testing.T) {
 		t.Skip("base score is zero — cannot verify multiplier")
 	}
 	ratio := scorePreference / scoreContext
-	const want = 1.8
+	const want = 1.35
 	const eps = 0.001
 	if ratio < want-eps || ratio > want+eps {
 		t.Errorf("preference boost ratio = %.4f, want %.4f ± %.4f", ratio, want, eps)

--- a/internal/search/score.go
+++ b/internal/search/score.go
@@ -28,7 +28,7 @@ const (
 	// completely discarding semantic relevance.
 	kuWeightVector    = 0.38
 	kuWeightBM25      = 0.27
-	kuWeightRecency   = 0.35 // raised from 0.22 — after RRF fusion, recency dominance improves knowledge-update recall
+	kuWeightRecency   = 0.25 // moderate value: better than 0.22 baseline, avoids over-weighting recency without RRF
 	kuWeightPrecision = 0.13
 )
 
@@ -249,12 +249,8 @@ func CompositeScoreWithWeights(in ScoreInput, w Weights) float64 {
 	// Preference queries ("what does the user prefer?") don't always vector-match
 	// well against preference-expressing memories ("I really like X"), so a
 	// type-aware boost compensates for the embedding space gap.
-	// Raised from 1.35× to 1.8× — with better ingest-time tagging via the expanded
-	// keyword set and PatternPreferenceExtractor, the boost now fires on correctly-typed
-	// memories. The larger multiplier overcomes the embedding space gap between
-	// preference queries and preference-expressing memories.
 	if in.IsPreferenceQuery && in.MemoryType == "preference" {
-		raw *= 1.8
+		raw *= 1.35
 	}
 	return raw * boost
 }


### PR DESCRIPTION
## Summary

Option A from the LME v7 handoff plan. v7's RRF changes improved knowledge-update (+8.4pp) and temporal-reasoning (+3.3pp) but caused multi-session collapse (-12pp) and preference collapse (-8.8pp). This reverts the regression-causing changes while keeping the context window gains for a clean v8 baseline run.

- Replaces `CompositeScoreRRF` call in `engine.go` with `CompositeScoreWithWeights`; removes `vectorRankMap`, `bm25RankMap`, and `rrfBase` intermediaries
- `kuWeightRecency` 0.35 → 0.25 (moderate, not full revert to 0.22 baseline)
- Preference boost 1.8× → 1.35× in `CompositeScoreWithWeights`
- `RRFScore` and `CompositeScoreRRF` functions retained in `score.go` for Option C
- `TestPreferenceBoostMagnitude` updated to expect 1.35×

Closes #640

## Test plan

- [ ] `go test ./internal/search/... -count=1 -race` passes (verified locally)
- [ ] Run LME v8 benchmark on Oblivion (Nemotron-120B-NVFP4, contextTopK=40, 131k window) — expected: overall ~52%, multi-session and preference recover to v6 baseline
- [ ] Confirm v8 vs v7 delta confirms RRF as the regression source before exploring Option C

🤖 Generated with [Claude Code](https://claude.com/claude-code)