### PR TITLE
fix(health): detect Infinity GPU thread hang via queue-depth probe (#649)

### DIFF
--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -368,3 +368,71 @@ func (c *LiteLLMClient) Probe(ctx context.Context) (ok bool, reason string) {
 	}
 	return false, fmt.Sprintf("embed_probe: %v", err)
 }
+
+// InfinityModelStats holds per-model GPU queue statistics from the Infinity
+// /v1/models response. These fields are Infinity-specific and absent from
+// standard OpenAI-compatible servers (zero value is safe: QueueAbsolute == 0
+// means the hung-state guard never fires on non-Infinity responses).
+type InfinityModelStats struct {
+	QueueFraction  float64 `json:"queue_fraction"`
+	QueueAbsolute  int     `json:"queue_absolute"`
+	ResultsPending int     `json:"results_pending"`
+	BatchSize      int     `json:"batch_size"`
+}
+
+// infinityModelsResponse is the JSON shape of GET /v1/models from Infinity.
+type infinityModelsResponse struct {
+	Data []struct {
+		ID    string             `json:"id"`
+		Stats InfinityModelStats `json:"stats"`
+	} `json:"data"`
+}
+
+// InfinityQueueCheck probes GET /v1/models at baseURL and detects the Infinity
+// GPU thread deadlock signature:
+//
+//	queue_fraction > 1.0  — queue is over capacity
+//	results_pending == 0  — GPU inference thread has stopped processing
+//	queue_absolute > 0    — work is enqueued (guards against zero-value structs)
+//
+// Returns (false, reason) when the hung state is detected.
+// Returns (true, "") for healthy queues and for non-Infinity servers that return
+// a standard OpenAI /v1/models payload without the Infinity "stats" field.
+func InfinityQueueCheck(ctx context.Context, httpClient *http.Client, baseURL string) (ok bool, reason string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/v1/models", nil)
+	if err != nil {
+		return false, fmt.Sprintf("infinity_queue_check: build request: %v", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Sprintf("infinity_queue_check: request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Sprintf("infinity_queue_check: HTTP %d", resp.StatusCode)
+	}
+
+	var modelsResp infinityModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		// Non-Infinity server or unexpected body — treat as healthy.
+		return true, ""
+	}
+
+	for _, m := range modelsResp.Data {
+		s := m.Stats
+		// All three conditions required to avoid false positives:
+		// - QueueFraction > 1 alone can occur during normal burst load
+		// - ResultsPending == 0 with QueueFraction > 1 is the definitive hang
+		// - QueueAbsolute > 0 guards against zero-value structs (non-Infinity servers)
+		if s.QueueFraction > 1.0 && s.ResultsPending == 0 && s.QueueAbsolute > 0 {
+			return false, fmt.Sprintf(
+				"infinity_queue_check: GPU thread hung (model=%s queue_fraction=%.4f results_pending=%d queue_absolute=%d)",
+				m.ID, s.QueueFraction, s.ResultsPending, s.QueueAbsolute,
+			)
+		}
+	}
+
+	return true, ""
+}

--- a/internal/embed/litellm_test.go
+++ b/internal/embed/litellm_test.go
@@ -396,3 +396,105 @@ func encodeEmbeddingResponse(w http.ResponseWriter, embedding []float32) {
 	}
 	json.NewEncoder(w).Encode(resp) // nolint:errcheck
 }
+
+// ---------------------------------------------------------------------------
+// InfinityQueueCheck tests (#649)
+// ---------------------------------------------------------------------------
+
+// encodeModelsResponse writes an Infinity-style /v1/models JSON payload.
+func encodeModelsResponse(w http.ResponseWriter, modelID string, queueFraction float64, queueAbsolute, resultsPending int) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+		"data": []map[string]any{{
+			"id": modelID,
+			"stats": map[string]any{
+				"queue_fraction":  queueFraction,
+				"queue_absolute":  queueAbsolute,
+				"results_pending": resultsPending,
+				"batch_size":      64,
+			},
+		}},
+	})
+}
+
+// TestInfinityQueueCheck_HealthyQueue verifies that queue_fraction < 1.0
+// with non-zero results_pending returns ok=true.
+func TestInfinityQueueCheck_HealthyQueue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			encodeModelsResponse(w, "BAAI/bge-m3", 0.42, 27, 5)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if !ok {
+		t.Errorf("expected ok=true for healthy queue, got ok=false reason=%q", reason)
+	}
+}
+
+// TestInfinityQueueCheck_HungQueue verifies that the deadlock signature
+// (queue_fraction > 1.0, results_pending == 0, queue_absolute > 0) returns
+// ok=false with a reason string that identifies the model.
+func TestInfinityQueueCheck_HungQueue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			encodeModelsResponse(w, "BAAI/bge-m3", 1.00059375, 32019, 0)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if ok {
+		t.Fatal("expected ok=false for hung queue, got ok=true")
+	}
+	if !strings.Contains(reason, "BAAI/bge-m3") {
+		t.Errorf("expected reason to contain model ID, got %q", reason)
+	}
+	if !strings.Contains(reason, "GPU thread hung") {
+		t.Errorf("expected reason to contain 'GPU thread hung', got %q", reason)
+	}
+}
+
+// TestInfinityQueueCheck_NonInfinityServer verifies that a standard OpenAI
+// /v1/models response (no "stats" field) is treated as healthy.
+func TestInfinityQueueCheck_NonInfinityServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"object": "list",
+				"data":   []map[string]any{{"id": "gpt-4", "object": "model"}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if !ok {
+		t.Errorf("expected ok=true for non-Infinity server (no stats field), got ok=false reason=%q", reason)
+	}
+}
+
+// TestInfinityQueueCheck_ServerError verifies that a 500 from /v1/models
+// returns ok=false.
+func TestInfinityQueueCheck_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if ok {
+		t.Fatal("expected ok=false for 500 response, got ok=true")
+	}
+	if !strings.Contains(reason, "500") {
+		t.Errorf("expected reason to mention HTTP 500, got %q", reason)
+	}
+}

--- a/internal/embed/litellm_test.go
+++ b/internal/embed/litellm_test.go
@@ -498,3 +498,23 @@ func TestInfinityQueueCheck_ServerError(t *testing.T) {
 		t.Errorf("expected reason to mention HTTP 500, got %q", reason)
 	}
 }
+
+// TestInfinityQueueCheck_HighLoadNotHung verifies that queue_fraction > 1.0
+// with non-zero results_pending is NOT flagged as hung — the GPU is still
+// processing, just under burst load. This is the false-positive guard for the
+// three-condition detection logic.
+func TestInfinityQueueCheck_HighLoadNotHung(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			encodeModelsResponse(w, "BAAI/bge-m3", 1.25, 800, 12) // over capacity but still processing
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if !ok {
+		t.Errorf("expected ok=true for high-load-but-processing queue, got ok=false reason=%q", reason)
+	}
+}

--- a/internal/mcp/health_test.go
+++ b/internal/mcp/health_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -41,10 +40,21 @@ func newHealthServer(ollamaURL string) *Server {
 // Postgres: PgPool is nil — the handler skips the probe and reports ok.
 // Ollama: a test HTTP server returns 200 HEAD /api/tags.
 func TestHealth_BothDepsUp(t *testing.T) {
-	// Fake Ollama that accepts HEAD /api/tags.
+	// Fake Infinity server: responds to GET /v1/models with healthy queue stats.
 	ollamaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/api/tags") {
-			w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  0.10,
+						"queue_absolute":  6,
+						"results_pending": 2,
+						"batch_size":      64,
+					},
+				}},
+			})
 			return
 		}
 		http.NotFound(w, r)
@@ -192,5 +202,89 @@ func TestApplyMiddleware_SetsRequestID(t *testing.T) {
 	}
 	if len(capturedID) < 8 {
 		t.Errorf("request_id seems too short: %q", capturedID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Infinity hung-state detection tests (#649)
+// ---------------------------------------------------------------------------
+
+// TestHealth_InfinityHung verifies that when /v1/models reports the GPU thread
+// deadlock signature, handleHealth returns 503 with ollama="error".
+func TestHealth_InfinityHung(t *testing.T) {
+	infinityServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  1.00059375,
+						"queue_absolute":  32019,
+						"results_pending": 0,
+						"batch_size":      64,
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer infinityServer.Close()
+
+	s := newHealthServer(infinityServer.URL)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for hung Infinity, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Ollama != "error" {
+		t.Errorf("expected ollama=error for hung GPU thread, got %q", resp.Ollama)
+	}
+}
+
+// TestHealth_InfinityHealthyStats verifies that a healthy Infinity queue
+// (queue_fraction < 1.0, results_pending > 0) returns 200 with ollama="ok".
+func TestHealth_InfinityHealthyStats(t *testing.T) {
+	infinityServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  0.42,
+						"queue_absolute":  27,
+						"results_pending": 5,
+						"batch_size":      64,
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer infinityServer.Close()
+
+	s := newHealthServer(infinityServer.URL)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for healthy Infinity, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Ollama != "ok" {
+		t.Errorf("expected ollama=ok for healthy queue, got %q", resp.Ollama)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1415,30 +1415,19 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		pgStatus = "ok"
 	}
 
-	// Probe LiteLLM via GET /v1/models (OpenAI-compatible, available on all deployments).
+	// Probe LiteLLM via InfinityQueueCheck: GETs /v1/models and parses Infinity
+	// queue stats to detect GPU thread deadlock (queue_fraction > 1.0,
+	// results_pending == 0). Subsumes the former status-code-only check (#649).
 	embedLiveOK := false
 	if s.cfg.LiteLLMURL != "" {
 		embedCtx, embedCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer embedCancel()
-		modelsURL := strings.TrimRight(s.cfg.LiteLLMURL, "/") + "/v1/models"
-		req, err := http.NewRequestWithContext(embedCtx, http.MethodGet, modelsURL, nil)
-		if err == nil {
-			resp, herr := http.DefaultClient.Do(req)
-			if herr != nil {
-				ollamaStatus = "error" //nolint:ineffassign // overwritten if EmbedDegraded
-				slog.Warn("health: litellm probe failed", "err", herr)
-			} else {
-				_ = resp.Body.Close()
-				if resp.StatusCode >= 500 {
-					ollamaStatus = "error" //nolint:ineffassign // overwritten if EmbedDegraded
-					slog.Warn("health: litellm returned server error", "status", resp.StatusCode)
-				} else {
-					embedLiveOK = true
-				}
-			}
-		} else {
+		probeOK, probeReason := embed.InfinityQueueCheck(embedCtx, http.DefaultClient, s.cfg.LiteLLMURL)
+		if !probeOK {
 			ollamaStatus = "error" //nolint:ineffassign // overwritten if EmbedDegraded
-			slog.Warn("health: could not build litellm probe request", "err", err)
+			slog.Warn("health: litellm probe failed", "reason", probeReason)
+		} else {
+			embedLiveOK = true
 		}
 
 		// Check the current embedding degradation status. Update the atomic flag


### PR DESCRIPTION
## Summary

- Adds `embed.InfinityQueueCheck(ctx, httpClient, baseURL)` which GETs `/v1/models`, parses Infinity queue stats, and returns unhealthy when `queue_fraction > 1.0` with `results_pending == 0` — the definitive signature of a hung GPU thread
- Replaces the raw GET `/v1/models` status-code-only check in `handleHealth` with the new function, so the hung state surfaces as a **503 within 2 seconds** instead of silently passing for 12+ minutes
- Updates `TestHealth_BothDepsUp` to serve a proper `GET /v1/models` response (the old `HEAD /api/tags` handler reflected the previous probe shape)

## Root cause

The Infinity embedding server's HTTP layer stays alive even when its GPU inference thread deadlocks. The previous `/health` probe only checked the HTTP status code of `GET /v1/models` — it discarded the body. Infinity returns 200 either way. The hung state is only visible in the response payload: `queue_fraction > 1.0` and `results_pending == 0`.

## What this fixes

The 12-minute timeout storm documented in #649: 5 consecutive 120s-per-batch timeouts in the reembed worker while `/health` kept returning 200 and Docker's healthcheck kept the container marked `Up (healthy)`.

After this PR, the hung state surfaces as a 503 on `/health` within the 2-second probe timeout, enabling automatic container restart via Docker's `--health-cmd` or a K8s liveness probe.

## Test plan

- [ ] `go test ./internal/embed/... -run TestInfinityQueueCheck -v -race` — 4 new tests (healthy queue, hung queue, non-Infinity server, 5xx response)
- [ ] `go test ./internal/mcp/... -run "TestHealth_Infinity" -v -race` — 2 new tests (hung → 503, healthy stats → 200)
- [ ] `go test ./... -count=1 -race` — full suite green (verified locally)
- [ ] Post-deploy: confirm `WARN health: litellm probe failed reason="infinity_queue_check: GPU thread hung ..."` appears in slog during next GPU thread hang instead of a silent 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)