### PR TITLE
feat(lme): LME benchmark backend + Nemotron config fixes

### DIFF
--- a/cmd/longmemeval/all.go
+++ b/cmd/longmemeval/all.go
@@ -1,0 +1,21 @@
+package main
+
+import "log"
+
+func runAll(cfg *Config) {
+	if cfg.RunID == "" {
+		cfg.RunID = newRunID()
+	}
+	log.Printf("all: run-id=%s data=%s workers=%d", cfg.RunID, cfg.DataFile, cfg.Workers)
+
+	log.Println("--- Stage 1: ingest ---")
+	runIngest(cfg)
+
+	log.Println("--- Stage 2: run ---")
+	runRun(cfg)
+
+	log.Println("--- Stage 3: score ---")
+	runScore(cfg)
+
+	log.Printf("all: complete (run-id=%s)", cfg.RunID)
+}

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -56,26 +56,17 @@ func runIngest(cfg *Config) {
 
 func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
 	ctx := context.Background()
-	mcpClient, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
-	if err != nil {
-		log.Printf("WARN ingest worker: connect failed: %v", err)
-		for item := range work {
-			out <- longmemeval.IngestEntry{QuestionID: item.QuestionID, Status: "error", Error: err.Error()}
-		}
-		return
-	}
-
+	restClient := longmemeval.NewRestClient(cfg.ServerURL, cfg.APIKey)
 	for item := range work {
-		entry := ingestOne(ctx, cfg, mcpClient, item)
+		entry := ingestOne(ctx, cfg, restClient, item)
 		out <- entry
 		log.Printf("ingest [%s] project=%s sessions=%d status=%s",
 			item.QuestionID, entry.Project, entry.SessionCount, entry.Status)
 	}
 }
 
-const ingestBatchSize = 100
 
-func ingestOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, item longmemeval.Item) (entry longmemeval.IngestEntry) {
+func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestClient, item longmemeval.Item) (entry longmemeval.IngestEntry) {
 	defer func() {
 		if r := recover(); r != nil {
 			entry = longmemeval.IngestEntry{
@@ -103,35 +94,30 @@ func ingestOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, 
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
+		// Prepend session date so the model can anchor relative-time questions.
+		tags := []string{"lme", "sid:" + sessionID}
+		if i < len(item.HaystackDates) && item.HaystackDates[i] != "" {
+			content = "Session date: " + item.HaystackDates[i] + "\n" + content
+			tags = append(tags, "date:"+item.HaystackDates[i])
+		}
 		sessions = append(sessions, sessionEntry{
 			sessionID: sessionID,
-			item:      longmemeval.BatchItem{Content: content, Tags: []string{"lme", "sid:" + sessionID}},
+			item:      longmemeval.BatchItem{Content: content, Tags: tags},
 		})
 	}
 
 	memoryMap := make(map[string]string, len(sessions))
-	for start := 0; start < len(sessions); start += ingestBatchSize {
-		end := start + ingestBatchSize
-		if end > len(sessions) {
-			end = len(sessions)
-		}
-		batch := sessions[start:end]
-		batchItems := make([]longmemeval.BatchItem, len(batch))
-		for i, s := range batch {
-			batchItems[i] = s.item
-		}
-		ids, err := mcpClient.StoreBatch(ctx, project, batchItems)
+	for i, s := range sessions {
+		id, err := restClient.QuickStore(ctx, project, s.item.Content, s.item.Tags)
 		if err != nil {
 			return longmemeval.IngestEntry{
 				QuestionID: item.QuestionID,
 				Project:    project,
 				Status:     "error",
-				Error:      fmt.Sprintf("store_batch offset %d: %v", start, err),
+				Error:      fmt.Sprintf("quick-store offset %d: %v", i, err),
 			}
 		}
-		for i, id := range ids {
-			memoryMap[id] = batch[i].sessionID
-		}
+		memoryMap[id] = s.sessionID
 	}
 
 	return longmemeval.IngestEntry{

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -60,8 +60,7 @@ func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmeme
 	for item := range work {
 		entry := ingestOne(ctx, cfg, restClient, item)
 		out <- entry
-		log.Printf("ingest [%s] project=%s sessions=%d status=%s",
-			item.QuestionID, entry.Project, entry.SessionCount, entry.Status)
+		log.Printf("ingest [%s] project=%s sessions=%d status=%s error=%q", item.QuestionID, entry.Project, entry.SessionCount, entry.Status, entry.Error)
 	}
 }
 

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -73,6 +73,8 @@ func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmeme
 	}
 }
 
+const ingestBatchSize = 100
+
 func ingestOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, item longmemeval.Item) (entry longmemeval.IngestEntry) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -85,8 +87,13 @@ func ingestOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, 
 	}()
 
 	project := projectName(cfg.RunID, item.QuestionID)
-	memoryMap := make(map[string]string, len(item.HaystackSessions))
 
+	// Collect non-empty sessions with their IDs.
+	type sessionEntry struct {
+		sessionID string
+		item      longmemeval.BatchItem
+	}
+	var sessions []sessionEntry
 	for i, session := range item.HaystackSessions {
 		if i >= len(item.HaystackSessionIDs) {
 			break
@@ -96,17 +103,35 @@ func ingestOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, 
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
-		tags := []string{"lme", "sid:" + sessionID}
-		memID, err := mcpClient.Store(ctx, project, content, tags)
+		sessions = append(sessions, sessionEntry{
+			sessionID: sessionID,
+			item:      longmemeval.BatchItem{Content: content, Tags: []string{"lme", "sid:" + sessionID}},
+		})
+	}
+
+	memoryMap := make(map[string]string, len(sessions))
+	for start := 0; start < len(sessions); start += ingestBatchSize {
+		end := start + ingestBatchSize
+		if end > len(sessions) {
+			end = len(sessions)
+		}
+		batch := sessions[start:end]
+		batchItems := make([]longmemeval.BatchItem, len(batch))
+		for i, s := range batch {
+			batchItems[i] = s.item
+		}
+		ids, err := mcpClient.StoreBatch(ctx, project, batchItems)
 		if err != nil {
 			return longmemeval.IngestEntry{
 				QuestionID: item.QuestionID,
 				Project:    project,
 				Status:     "error",
-				Error:      fmt.Sprintf("store session %s: %v", sessionID, err),
+				Error:      fmt.Sprintf("store_batch offset %d: %v", start, err),
 			}
 		}
-		memoryMap[memID] = sessionID
+		for i, id := range ids {
+			memoryMap[id] = batch[i].sessionID
+		}
 	}
 
 	return longmemeval.IngestEntry{

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+func runIngest(cfg *Config) {
+	items := loadItems(cfg.DataFile)
+	ckptPath := filepath.Join(cfg.OutDir, "checkpoint-ingest.jsonl")
+
+	skip, err := longmemeval.ReadSkipSet(ckptPath)
+	if err != nil {
+		log.Fatalf("read ingest checkpoint: %v", err)
+	}
+	log.Printf("ingest: %d items loaded, %d already done", len(items), len(skip))
+
+	ckptCh := make(chan longmemeval.IngestEntry, cfg.Workers*2)
+	var wgWriter sync.WaitGroup
+	wgWriter.Add(1)
+	go func() {
+		defer wgWriter.Done()
+		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+	}()
+
+	work := make(chan longmemeval.Item, len(items))
+	for _, item := range items {
+		if !skip[item.QuestionID] {
+			work <- item
+		}
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	for i := 0; i < cfg.Workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ingestWorker(cfg, work, ckptCh)
+		}()
+	}
+	wg.Wait()
+	close(ckptCh)
+	wgWriter.Wait()
+
+	log.Printf("ingest: complete")
+}
+
+func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
+	ctx := context.Background()
+	mcpClient, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
+	if err != nil {
+		log.Printf("WARN ingest worker: connect failed: %v", err)
+		for item := range work {
+			out <- longmemeval.IngestEntry{QuestionID: item.QuestionID, Status: "error", Error: err.Error()}
+		}
+		return
+	}
+
+	for item := range work {
+		entry := ingestOne(ctx, cfg, mcpClient, item)
+		out <- entry
+		log.Printf("ingest [%s] project=%s sessions=%d status=%s",
+			item.QuestionID, entry.Project, entry.SessionCount, entry.Status)
+	}
+}
+
+func ingestOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, item longmemeval.Item) (entry longmemeval.IngestEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			entry = longmemeval.IngestEntry{
+				QuestionID: item.QuestionID,
+				Status:     "error",
+				Error:      fmt.Sprintf("panic: %v", r),
+			}
+		}
+	}()
+
+	project := projectName(cfg.RunID, item.QuestionID)
+	memoryMap := make(map[string]string, len(item.HaystackSessions))
+
+	for i, session := range item.HaystackSessions {
+		if i >= len(item.HaystackSessionIDs) {
+			break
+		}
+		sessionID := item.HaystackSessionIDs[i]
+		content := longmemeval.SessionContent(session)
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		tags := []string{"lme", "sid:" + sessionID}
+		memID, err := mcpClient.Store(ctx, project, content, tags)
+		if err != nil {
+			return longmemeval.IngestEntry{
+				QuestionID: item.QuestionID,
+				Project:    project,
+				Status:     "error",
+				Error:      fmt.Sprintf("store session %s: %v", sessionID, err),
+			}
+		}
+		memoryMap[memID] = sessionID
+	}
+
+	return longmemeval.IngestEntry{
+		QuestionID:   item.QuestionID,
+		Project:      project,
+		SessionCount: len(memoryMap),
+		MemoryMap:    memoryMap,
+		Status:       "done",
+	}
+}
+
+// loadItems parses the LongMemEval JSON file.
+func loadItems(path string) []longmemeval.Item {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("read data file %q: %v", path, err)
+	}
+	var items []longmemeval.Item
+	if err := json.Unmarshal(data, &items); err != nil {
+		log.Fatalf("parse data file: %v", err)
+	}
+	if len(items) == 0 {
+		log.Fatal("data file is empty")
+	}
+	return items
+}

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -5,10 +5,12 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 // Config holds flags shared across all subcommands.
@@ -35,8 +37,9 @@ func main() {
 	fs.StringVar(&cfg.DataFile, "data", "", "Path to longmemeval_m_cleaned.json (required)")
 	fs.IntVar(&cfg.Workers, "workers", 4, "Number of parallel workers")
 	fs.StringVar(&cfg.RunID, "run-id", "", "Run ID (hex); auto-generated if empty")
-	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", "http://localhost:8788"), "Engram server URL")
-	fs.StringVar(&cfg.APIKey, "api-key", os.Getenv("ENGRAM_API_KEY"), "Engram API key")
+	defaultURL, defaultKey := mcpDefaults()
+	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", defaultURL), "Engram server URL")
+	fs.StringVar(&cfg.APIKey, "api-key", envOr("ENGRAM_API_KEY", defaultKey), "Engram API key")
 	fs.BoolVar(&cfg.NoCleanup, "no-cleanup", false, "Skip Engram project deletion after run stage")
 	fs.IntVar(&cfg.Retries, "retries", 1, "Retry count for claude --print and Engram calls")
 	fs.StringVar(&cfg.OutDir, "out", ".", "Output directory for checkpoint and result files")
@@ -79,6 +82,47 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// mcpDefaults reads the engram URL and Bearer token from ~/.claude/mcp_servers.json,
+// which is kept current by the session-start hook. Falls back to localhost defaults.
+func mcpDefaults() (url, token string) {
+	url = "http://localhost:8788"
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return url, ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "mcp_servers.json"))
+	if err != nil {
+		return url, ""
+	}
+	var cfg struct {
+		McpServers map[string]struct {
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return url, ""
+	}
+	for name, srv := range cfg.McpServers {
+		if name != "engram" {
+			continue
+		}
+		// Strip /sse suffix — the benchmark appends it in Connect().
+		srvURL := srv.URL
+		if len(srvURL) > 4 && srvURL[len(srvURL)-4:] == "/sse" {
+			srvURL = srvURL[:len(srvURL)-4]
+		}
+		if srvURL != "" {
+			url = srvURL
+		}
+		if auth := srv.Headers["Authorization"]; len(auth) > 7 {
+			token = auth[7:] // strip "Bearer "
+		}
+		return url, token
+	}
+	return url, token
 }
 
 func projectName(runID, questionID string) string {

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -17,14 +17,16 @@ import (
 
 // Config holds flags shared across all subcommands.
 type Config struct {
-	DataFile  string
-	Workers   int
-	RunID     string
-	ServerURL string
-	APIKey    string
-	NoCleanup bool
-	Retries   int
-	OutDir    string
+	DataFile   string
+	Workers    int
+	RunID      string
+	ServerURL  string
+	APIKey     string
+	NoCleanup  bool
+	Retries    int
+	OutDir     string
+	LLMBaseURL string // OpenAI-compatible base URL; bypasses claude CLI when set
+	LLMModel   string // model name for LLMBaseURL endpoint
 }
 
 func main() {
@@ -43,8 +45,10 @@ func main() {
 	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", defaultURL), "Engram server URL")
 	fs.StringVar(&cfg.APIKey, "api-key", envOr("ENGRAM_API_KEY", defaultKey), "Engram API key")
 	fs.BoolVar(&cfg.NoCleanup, "no-cleanup", false, "Skip Engram project deletion after run stage")
-	fs.IntVar(&cfg.Retries, "retries", 1, "Retry count for claude --print and Engram calls")
+	fs.IntVar(&cfg.Retries, "retries", 1, "Retry count for generation and Engram calls")
 	fs.StringVar(&cfg.OutDir, "out", ".", "Output directory for checkpoint and result files")
+	fs.StringVar(&cfg.LLMBaseURL, "llm-url", envOr("LME_LLM_URL", ""), "OpenAI-compatible base URL (e.g. http://oblivion:8000/v1); bypasses claude CLI when set")
+	fs.StringVar(&cfg.LLMModel, "llm-model", envOr("LME_LLM_MODEL", ""), "Model name for --llm-url endpoint")
 
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		log.Fatal(err)

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -1,0 +1,86 @@
+// longmemeval runs the LongMemEval benchmark against a live engram-go MCP server.
+// Usage: longmemeval <ingest|run|score|all> [flags]
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+// Config holds flags shared across all subcommands.
+type Config struct {
+	DataFile  string
+	Workers   int
+	RunID     string
+	ServerURL string
+	APIKey    string
+	NoCleanup bool
+	Retries   int
+	OutDir    string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: longmemeval <ingest|run|score|all> [flags]")
+		os.Exit(1)
+	}
+	subcommand := os.Args[1]
+
+	fs := flag.NewFlagSet(subcommand, flag.ExitOnError)
+	cfg := &Config{}
+	fs.StringVar(&cfg.DataFile, "data", "", "Path to longmemeval_m_cleaned.json (required)")
+	fs.IntVar(&cfg.Workers, "workers", 4, "Number of parallel workers")
+	fs.StringVar(&cfg.RunID, "run-id", "", "Run ID (hex); auto-generated if empty")
+	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", "http://localhost:8788"), "Engram server URL")
+	fs.StringVar(&cfg.APIKey, "api-key", os.Getenv("ENGRAM_API_KEY"), "Engram API key")
+	fs.BoolVar(&cfg.NoCleanup, "no-cleanup", false, "Skip Engram project deletion after run stage")
+	fs.IntVar(&cfg.Retries, "retries", 1, "Retry count for claude --print and Engram calls")
+	fs.StringVar(&cfg.OutDir, "out", ".", "Output directory for checkpoint and result files")
+
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		log.Fatal(err)
+	}
+
+	if cfg.DataFile == "" && subcommand != "help" {
+		log.Fatal("--data is required")
+	}
+
+	if cfg.RunID == "" {
+		cfg.RunID = newRunID()
+	}
+
+	switch subcommand {
+	case "ingest":
+		runIngest(cfg)
+	case "run":
+		runRun(cfg)
+	case "score":
+		runScore(cfg)
+	case "all":
+		runAll(cfg)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", subcommand)
+		os.Exit(1)
+	}
+}
+
+func newRunID() string {
+	b := make([]byte, 3)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func projectName(runID, questionID string) string {
+	return fmt.Sprintf("lme-%s-%s", runID, questionID)
+}

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -9,8 +9,10 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	neturl "net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Config holds flags shared across all subcommands.
@@ -109,10 +111,13 @@ func mcpDefaults() (url, token string) {
 		if name != "engram" {
 			continue
 		}
-		// Strip /sse suffix — the benchmark appends it in Connect().
+		// Strip /sse path component — the benchmark appends it in Connect().
+		// Parse properly so query params don't break the suffix check.
 		srvURL := srv.URL
-		if len(srvURL) > 4 && srvURL[len(srvURL)-4:] == "/sse" {
-			srvURL = srvURL[:len(srvURL)-4]
+		if u, err := neturl.Parse(srvURL); err == nil {
+			u.Path = strings.TrimSuffix(u.Path, "/sse")
+			u.RawQuery = ""
+			srvURL = u.String()
 		}
 		if srvURL != "" {
 			url = srvURL

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -80,22 +80,21 @@ func runRun(cfg *Config) {
 }
 
 func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry) {
-	ctx := context.Background()
-	mcpClient, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
-	if err != nil {
-		log.Printf("WARN run worker: connect failed: %v", err)
-		for e := range work {
-			out <- longmemeval.RunEntry{QuestionID: e.QuestionID, Status: "error", Error: err.Error()}
-		}
-		return
-	}
-
 	for ingestEntry := range work {
+		ctx := context.Background()
 		item, ok := itemMap[ingestEntry.QuestionID]
 		if !ok {
 			out <- longmemeval.RunEntry{QuestionID: ingestEntry.QuestionID, Status: "error", Error: "item not found in data file"}
 			continue
 		}
+
+		// Fresh connection per item — SSE sessions expire under long runs.
+		mcpClient, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
+		if err != nil {
+			out <- longmemeval.RunEntry{QuestionID: ingestEntry.QuestionID, Status: "error", Error: fmt.Sprintf("connect: %v", err)}
+			continue
+		}
+
 		entry := runOne(ctx, cfg, mcpClient, item, ingestEntry)
 		out <- entry
 		log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -21,7 +21,7 @@ var temporalInterrogativeRe = regexp.MustCompile(
 )
 
 const recallTopK = 100
-const contextTopK = 20
+const contextTopK = 40
 
 func runRun(cfg *Config) {
 	items := loadItems(cfg.DataFile)
@@ -97,11 +97,17 @@ func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan lon
 
 		entry := runOne(ctx, cfg, mcpClient, item, ingestEntry)
 		out <- entry
-		log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))
+		if entry.Status == "error" {
+			log.Printf("run [%s] status=%s hypothesis_len=%d error=%q", item.QuestionID, entry.Status, len(entry.Hypothesis), entry.Error)
+		} else {
+			log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))
+		}
 
 		if !cfg.NoCleanup {
 			if err := mcpClient.DeleteProject(ctx, ingestEntry.Project); err != nil {
-				log.Printf("WARN run [%s] cleanup failed: %v", item.QuestionID, err)
+				if !longmemeval.IsStaleSessionError(err) {
+					log.Printf("WARN run [%s] cleanup failed: %v", item.QuestionID, err)
+				}
 			}
 		}
 	}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -154,7 +154,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 
 	prompt := longmemeval.GenerationPrompt(item.Question, item.QuestionDate, contextBlocks)
-	hypothesis, err := longmemeval.Generate(ctx, prompt, cfg.Retries)
+	var hypothesis string
+	if cfg.LLMBaseURL != "" {
+		hypothesis, err = longmemeval.GenerateOAI(ctx, prompt, cfg.LLMBaseURL, cfg.LLMModel, cfg.Retries)
+	} else {
+		hypothesis, err = longmemeval.Generate(ctx, prompt, cfg.Retries)
+	}
 	if err != nil {
 		return longmemeval.RunEntry{
 			QuestionID:   item.QuestionID,

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -21,7 +21,7 @@ var temporalInterrogativeRe = regexp.MustCompile(
 )
 
 const recallTopK = 100
-const contextTopK = 40
+const contextTopK = 8 // 40 blocks x 10KB avg = 104K tokens; 8 blocks ~21K tokens - 5x faster
 
 func runRun(cfg *Config) {
 	items := loadItems(cfg.DataFile)

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -5,13 +5,23 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"regexp"
 	"sync"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
 
-const recallTopK = 50
-const contextTopK = 10
+// temporalInterrogativeRe strips leading relative-time interrogatives so the
+// recall query matches event noun-phrases rather than the question scaffolding.
+var temporalInterrogativeRe = regexp.MustCompile(
+	`(?i)^(how many (days?|weeks?|months?|years?) (ago |before |after )?(did|have|has|was|were|do|does|is|are) ` +
+		`|when did |which (event|thing|one) happened (first|last|earlier|later|more recently) ` +
+		`|what (was|is|were|are) the (date|time|day|week|month|year) ` +
+		`|on what (date|day) )`,
+)
+
+const recallTopK = 100
+const contextTopK = 20
 
 func runRun(cfg *Config) {
 	items := loadItems(cfg.DataFile)
@@ -109,7 +119,16 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		}
 	}()
 
-	retrievedIDs, err := mcpClient.Recall(ctx, ingest.Project, item.Question, recallTopK)
+	// Strip leading interrogative phrases for temporal questions so the recall
+	// query matches event noun-phrases rather than "how many weeks ago did...".
+	recallQuery := item.Question
+	if item.QuestionType == "temporal-reasoning" {
+		recallQuery = temporalInterrogativeRe.ReplaceAllString(recallQuery, "")
+		if recallQuery == "" {
+			recallQuery = item.Question
+		}
+	}
+	retrievedIDs, err := mcpClient.Recall(ctx, ingest.Project, recallQuery, recallTopK)
 	if err != nil {
 		return longmemeval.RunEntry{
 			QuestionID: item.QuestionID,

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"sync"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+const recallTopK = 50
+const contextTopK = 10
+
+func runRun(cfg *Config) {
+	items := loadItems(cfg.DataFile)
+	itemMap := make(map[string]longmemeval.Item, len(items))
+	for _, item := range items {
+		itemMap[item.QuestionID] = item
+	}
+
+	ingestEntries, err := longmemeval.ReadAllIngest(filepath.Join(cfg.OutDir, "checkpoint-ingest.jsonl"))
+	if err != nil {
+		log.Fatalf("read ingest checkpoint: %v", err)
+	}
+	ingestMap := make(map[string]longmemeval.IngestEntry, len(ingestEntries))
+	for _, e := range ingestEntries {
+		if e.Status == "done" {
+			ingestMap[e.QuestionID] = e
+		}
+	}
+
+	ckptPath := filepath.Join(cfg.OutDir, "checkpoint-run.jsonl")
+	skip, err := longmemeval.ReadSkipSet(ckptPath)
+	if err != nil {
+		log.Fatalf("read run checkpoint: %v", err)
+	}
+	log.Printf("run: %d ingest entries loaded, %d already done", len(ingestMap), len(skip))
+
+	ckptCh := make(chan longmemeval.RunEntry, cfg.Workers*2)
+	var wgWriter sync.WaitGroup
+	wgWriter.Add(1)
+	go func() {
+		defer wgWriter.Done()
+		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+	}()
+
+	work := make(chan longmemeval.IngestEntry, len(ingestEntries))
+	for _, e := range ingestEntries {
+		if e.Status == "done" && !skip[e.QuestionID] {
+			work <- e
+		}
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	for i := 0; i < cfg.Workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runWorker(cfg, itemMap, work, ckptCh)
+		}()
+	}
+	wg.Wait()
+	close(ckptCh)
+	wgWriter.Wait()
+
+	log.Printf("run: complete")
+}
+
+func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry) {
+	ctx := context.Background()
+	mcpClient, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
+	if err != nil {
+		log.Printf("WARN run worker: connect failed: %v", err)
+		for e := range work {
+			out <- longmemeval.RunEntry{QuestionID: e.QuestionID, Status: "error", Error: err.Error()}
+		}
+		return
+	}
+
+	for ingestEntry := range work {
+		item, ok := itemMap[ingestEntry.QuestionID]
+		if !ok {
+			out <- longmemeval.RunEntry{QuestionID: ingestEntry.QuestionID, Status: "error", Error: "item not found in data file"}
+			continue
+		}
+		entry := runOne(ctx, cfg, mcpClient, item, ingestEntry)
+		out <- entry
+		log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))
+
+		if !cfg.NoCleanup {
+			if err := mcpClient.DeleteProject(ctx, ingestEntry.Project); err != nil {
+				log.Printf("WARN run [%s] cleanup failed: %v", item.QuestionID, err)
+			}
+		}
+	}
+}
+
+func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, item longmemeval.Item, ingest longmemeval.IngestEntry) (entry longmemeval.RunEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			entry = longmemeval.RunEntry{
+				QuestionID: item.QuestionID,
+				Status:     "error",
+				Error:      fmt.Sprintf("panic: %v", r),
+			}
+		}
+	}()
+
+	retrievedIDs, err := mcpClient.Recall(ctx, ingest.Project, item.Question, recallTopK)
+	if err != nil {
+		return longmemeval.RunEntry{
+			QuestionID: item.QuestionID,
+			Status:     "error",
+			Error:      fmt.Sprintf("recall: %v", err),
+		}
+	}
+
+	// Fetch content for top contextTopK memories.
+	contextLimit := contextTopK
+	if contextLimit > len(retrievedIDs) {
+		contextLimit = len(retrievedIDs)
+	}
+	contextBlocks := make([]string, 0, contextLimit)
+	for _, id := range retrievedIDs[:contextLimit] {
+		content, err := mcpClient.FetchContent(ctx, id)
+		if err != nil {
+			log.Printf("WARN run [%s] fetch %s: %v", item.QuestionID, id, err)
+			continue
+		}
+		if content != "" {
+			contextBlocks = append(contextBlocks, content)
+		}
+	}
+
+	prompt := longmemeval.GenerationPrompt(item.Question, item.QuestionDate, contextBlocks)
+	hypothesis, err := longmemeval.Generate(ctx, prompt, cfg.Retries)
+	if err != nil {
+		return longmemeval.RunEntry{
+			QuestionID:   item.QuestionID,
+			RetrievedIDs: retrievedIDs,
+			Status:       "error",
+			Error:        fmt.Sprintf("generate: %v", err),
+		}
+	}
+
+	return longmemeval.RunEntry{
+		QuestionID:   item.QuestionID,
+		Hypothesis:   hypothesis,
+		RetrievedIDs: retrievedIDs,
+		Status:       "done",
+	}
+}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -125,7 +125,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 	contextBlocks := make([]string, 0, contextLimit)
 	for _, id := range retrievedIDs[:contextLimit] {
-		content, err := mcpClient.FetchContent(ctx, id)
+		content, err := mcpClient.FetchContent(ctx, ingest.Project, id)
 		if err != nil {
 			log.Printf("WARN run [%s] fetch %s: %v", item.QuestionID, id, err)
 			continue

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -110,7 +110,7 @@ func scoreOne(ctx context.Context, cfg *Config, item longmemeval.Item, run longm
 		}
 	}()
 
-	result, err := longmemeval.Score(ctx, item.Question, item.Answer, run.Hypothesis, cfg.Retries)
+	result, err := longmemeval.Score(ctx, item.Question, string(item.Answer), run.Hypothesis, cfg.Retries)
 	if err != nil {
 		return longmemeval.ScoreEntry{
 			QuestionID:   item.QuestionID,

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+func runScore(cfg *Config) {
+	items := loadItems(cfg.DataFile)
+	itemMap := make(map[string]longmemeval.Item, len(items))
+	for _, item := range items {
+		itemMap[item.QuestionID] = item
+	}
+
+	ingestEntries, err := longmemeval.ReadAllIngest(filepath.Join(cfg.OutDir, "checkpoint-ingest.jsonl"))
+	if err != nil {
+		log.Fatalf("read ingest checkpoint: %v", err)
+	}
+	ingestMap := make(map[string]longmemeval.IngestEntry, len(ingestEntries))
+	for _, e := range ingestEntries {
+		if e.Status == "done" {
+			ingestMap[e.QuestionID] = e
+		}
+	}
+
+	runEntries, err := longmemeval.ReadAllRun(filepath.Join(cfg.OutDir, "checkpoint-run.jsonl"))
+	if err != nil {
+		log.Fatalf("read run checkpoint: %v", err)
+	}
+
+	ckptPath := filepath.Join(cfg.OutDir, "checkpoint-score.jsonl")
+	skip, err := longmemeval.ReadSkipSet(ckptPath)
+	if err != nil {
+		log.Fatalf("read score checkpoint: %v", err)
+	}
+	log.Printf("score: %d run entries loaded, %d already done", len(runEntries), len(skip))
+
+	ckptCh := make(chan longmemeval.ScoreEntry, cfg.Workers*2)
+	var wgWriter sync.WaitGroup
+	wgWriter.Add(1)
+	go func() {
+		defer wgWriter.Done()
+		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+	}()
+
+	work := make(chan longmemeval.RunEntry, len(runEntries))
+	for _, e := range runEntries {
+		if e.Status == "done" && !skip[e.QuestionID] {
+			work <- e
+		}
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	for i := 0; i < cfg.Workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			scoreWorker(cfg, itemMap, work, ckptCh)
+		}()
+	}
+	wg.Wait()
+	close(ckptCh)
+	wgWriter.Wait()
+
+	// Load all score entries and write output files.
+	allScores, err := longmemeval.ReadAllScore(ckptPath)
+	if err != nil {
+		log.Fatalf("read final scores: %v", err)
+	}
+	writeOutputs(cfg, itemMap, ingestMap, allScores)
+	log.Printf("score: complete")
+}
+
+func scoreWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.RunEntry, out chan<- longmemeval.ScoreEntry) {
+	ctx := context.Background()
+	for runEntry := range work {
+		item, ok := itemMap[runEntry.QuestionID]
+		if !ok {
+			out <- longmemeval.ScoreEntry{QuestionID: runEntry.QuestionID, Status: "error", Error: "item not in data file"}
+			continue
+		}
+		entry := scoreOne(ctx, cfg, item, runEntry)
+		out <- entry
+		log.Printf("score [%s] label=%s", runEntry.QuestionID, entry.ScoreLabel)
+	}
+}
+
+func scoreOne(ctx context.Context, cfg *Config, item longmemeval.Item, run longmemeval.RunEntry) (entry longmemeval.ScoreEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			entry = longmemeval.ScoreEntry{
+				QuestionID: item.QuestionID,
+				Status:     "error",
+				Error:      fmt.Sprintf("panic: %v", r),
+			}
+		}
+	}()
+
+	result, err := longmemeval.Score(ctx, item.Question, item.Answer, run.Hypothesis, cfg.Retries)
+	if err != nil {
+		return longmemeval.ScoreEntry{
+			QuestionID:   item.QuestionID,
+			QuestionType: item.QuestionType,
+			Hypothesis:   run.Hypothesis,
+			ScoreLabel:   result.Label,
+			Explanation:  result.Explanation,
+			Status:       "error",
+			Error:        err.Error(),
+		}
+	}
+	return longmemeval.ScoreEntry{
+		QuestionID:   item.QuestionID,
+		QuestionType: item.QuestionType,
+		Hypothesis:   run.Hypothesis,
+		ScoreLabel:   result.Label,
+		Explanation:  result.Explanation,
+		Status:       "done",
+	}
+}
+
+func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, scores []longmemeval.ScoreEntry) {
+	writeHypotheses(cfg, scores)
+	writeRetrievalLog(cfg, itemMap, ingestMap, scores)
+	writeScoreReport(cfg, scores)
+}
+
+func writeHypotheses(cfg *Config, scores []longmemeval.ScoreEntry) {
+	f, err := os.Create(filepath.Join(cfg.OutDir, "hypotheses.jsonl"))
+	if err != nil {
+		log.Printf("WARN write hypotheses.jsonl: %v", err)
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, s := range scores {
+		_ = enc.Encode(longmemeval.HypothesisLine{QuestionID: s.QuestionID, Hypothesis: s.Hypothesis})
+	}
+	log.Printf("wrote %s", filepath.Join(cfg.OutDir, "hypotheses.jsonl"))
+}
+
+func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, scores []longmemeval.ScoreEntry) {
+	// Build a run-entry map from the run checkpoint for retrieved IDs.
+	runEntries, _ := longmemeval.ReadAllRun(filepath.Join(cfg.OutDir, "checkpoint-run.jsonl"))
+	runMap := make(map[string]longmemeval.RunEntry, len(runEntries))
+	for _, r := range runEntries {
+		runMap[r.QuestionID] = r
+	}
+
+	f, err := os.Create(filepath.Join(cfg.OutDir, "retrieval_log.jsonl"))
+	if err != nil {
+		log.Printf("WARN write retrieval_log.jsonl: %v", err)
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+
+	for _, s := range scores {
+		item, ok := itemMap[s.QuestionID]
+		if !ok {
+			continue
+		}
+		// Skip abstention questions per LongMemEval convention.
+		if strings.Contains(s.QuestionID, "_abs") {
+			continue
+		}
+		ingest, ok := ingestMap[s.QuestionID]
+		if !ok {
+			continue
+		}
+		run, ok := runMap[s.QuestionID]
+		if !ok {
+			continue
+		}
+		sessionIDs := longmemeval.SessionIDs(run.RetrievedIDs, ingest.MemoryMap)
+		metrics := longmemeval.BuildRetrievalMetrics(sessionIDs, item.AnswerSessionIDs)
+
+		var entry longmemeval.RetrievalLogEntry
+		entry.QuestionID = s.QuestionID
+		entry.RetrievalResults.Metrics.Session = metrics
+		_ = enc.Encode(entry)
+	}
+	log.Printf("wrote %s", filepath.Join(cfg.OutDir, "retrieval_log.jsonl"))
+}
+
+func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
+	type byType struct {
+		Correct          int `json:"correct"`
+		PartiallyCorrect int `json:"partially_correct"`
+		Incorrect        int `json:"incorrect"`
+		Total            int `json:"total"`
+	}
+	overall := &byType{}
+	byQType := make(map[string]*byType)
+
+	for _, s := range scores {
+		if s.Status != "done" {
+			continue
+		}
+		qbt := byQType[s.QuestionType]
+		if qbt == nil {
+			qbt = &byType{}
+			byQType[s.QuestionType] = qbt
+		}
+		for _, bt := range []*byType{overall, qbt} {
+			bt.Total++
+			switch s.ScoreLabel {
+			case "CORRECT":
+				bt.Correct++
+			case "PARTIALLY_CORRECT":
+				bt.PartiallyCorrect++
+			default:
+				bt.Incorrect++
+			}
+		}
+	}
+
+	report := map[string]any{
+		"overall":      overall,
+		"by_type":      byQType,
+		"run_id":       cfg.RunID,
+		"total_scored": len(scores),
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		log.Printf("WARN marshal score report: %v", err)
+		return
+	}
+	path := filepath.Join(cfg.OutDir, "score_report.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		log.Printf("WARN write score_report.json: %v", err)
+		return
+	}
+	log.Printf("wrote %s", path)
+
+	// Print summary.
+	if overall.Total > 0 {
+		pct := func(n int) float64 { return float64(n) / float64(overall.Total) * 100 }
+		fmt.Printf("\n--- Score Report (run-id: %s) ---\n", cfg.RunID)
+		fmt.Printf("Total scored:       %d\n", overall.Total)
+		fmt.Printf("Correct:            %d (%.1f%%)\n", overall.Correct, pct(overall.Correct))
+		fmt.Printf("Partially correct:  %d (%.1f%%)\n", overall.PartiallyCorrect, pct(overall.PartiallyCorrect))
+		fmt.Printf("Incorrect:          %d (%.1f%%)\n", overall.Incorrect, pct(overall.Incorrect))
+	}
+}

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -110,7 +110,13 @@ func scoreOne(ctx context.Context, cfg *Config, item longmemeval.Item, run longm
 		}
 	}()
 
-	result, err := longmemeval.Score(ctx, item.Question, string(item.Answer), run.Hypothesis, cfg.Retries)
+	var result longmemeval.ScoreResult
+	var err error
+	if cfg.LLMBaseURL != "" {
+		result, err = longmemeval.ScoreOAI(ctx, item.Question, string(item.Answer), run.Hypothesis, cfg.LLMBaseURL, cfg.LLMModel, cfg.Retries)
+	} else {
+		result, err = longmemeval.Score(ctx, item.Question, string(item.Answer), run.Hypothesis, cfg.Retries)
+	}
 	if err != nil {
 		return longmemeval.ScoreEntry{
 			QuestionID:   item.QuestionID,

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -35,6 +35,10 @@ func runScore(cfg *Config) {
 	if err != nil {
 		log.Fatalf("read run checkpoint: %v", err)
 	}
+	runMap := make(map[string]longmemeval.RunEntry, len(runEntries))
+	for _, r := range runEntries {
+		runMap[r.QuestionID] = r
+	}
 
 	ckptPath := filepath.Join(cfg.OutDir, "checkpoint-score.jsonl")
 	skip, err := longmemeval.ReadSkipSet(ckptPath)
@@ -51,6 +55,7 @@ func runScore(cfg *Config) {
 		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
 	}()
 
+	// Buffer sized to full input so pre-load before workers start cannot block.
 	work := make(chan longmemeval.RunEntry, len(runEntries))
 	for _, e := range runEntries {
 		if e.Status == "done" && !skip[e.QuestionID] {
@@ -76,7 +81,7 @@ func runScore(cfg *Config) {
 	if err != nil {
 		log.Fatalf("read final scores: %v", err)
 	}
-	writeOutputs(cfg, itemMap, ingestMap, allScores)
+	writeOutputs(cfg, itemMap, ingestMap, runMap, allScores)
 	log.Printf("score: complete")
 }
 
@@ -111,8 +116,6 @@ func scoreOne(ctx context.Context, cfg *Config, item longmemeval.Item, run longm
 			QuestionID:   item.QuestionID,
 			QuestionType: item.QuestionType,
 			Hypothesis:   run.Hypothesis,
-			ScoreLabel:   result.Label,
-			Explanation:  result.Explanation,
 			Status:       "error",
 			Error:        err.Error(),
 		}
@@ -127,9 +130,9 @@ func scoreOne(ctx context.Context, cfg *Config, item longmemeval.Item, run longm
 	}
 }
 
-func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, scores []longmemeval.ScoreEntry) {
+func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, runMap map[string]longmemeval.RunEntry, scores []longmemeval.ScoreEntry) {
 	writeHypotheses(cfg, scores)
-	writeRetrievalLog(cfg, itemMap, ingestMap, scores)
+	writeRetrievalLog(cfg, itemMap, ingestMap, runMap, scores)
 	writeScoreReport(cfg, scores)
 }
 
@@ -142,19 +145,15 @@ func writeHypotheses(cfg *Config, scores []longmemeval.ScoreEntry) {
 	defer f.Close()
 	enc := json.NewEncoder(f)
 	for _, s := range scores {
-		_ = enc.Encode(longmemeval.HypothesisLine{QuestionID: s.QuestionID, Hypothesis: s.Hypothesis})
+		if err := enc.Encode(longmemeval.HypothesisLine{QuestionID: s.QuestionID, Hypothesis: s.Hypothesis}); err != nil {
+			log.Printf("WARN writeHypotheses encode [%s]: %v", s.QuestionID, err)
+			break
+		}
 	}
 	log.Printf("wrote %s", filepath.Join(cfg.OutDir, "hypotheses.jsonl"))
 }
 
-func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, scores []longmemeval.ScoreEntry) {
-	// Build a run-entry map from the run checkpoint for retrieved IDs.
-	runEntries, _ := longmemeval.ReadAllRun(filepath.Join(cfg.OutDir, "checkpoint-run.jsonl"))
-	runMap := make(map[string]longmemeval.RunEntry, len(runEntries))
-	for _, r := range runEntries {
-		runMap[r.QuestionID] = r
-	}
-
+func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, runMap map[string]longmemeval.RunEntry, scores []longmemeval.ScoreEntry) {
 	f, err := os.Create(filepath.Join(cfg.OutDir, "retrieval_log.jsonl"))
 	if err != nil {
 		log.Printf("WARN write retrieval_log.jsonl: %v", err)
@@ -169,7 +168,7 @@ func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestM
 			continue
 		}
 		// Skip abstention questions per LongMemEval convention.
-		if strings.Contains(s.QuestionID, "_abs") {
+		if strings.HasSuffix(s.QuestionID, "_abs") {
 			continue
 		}
 		ingest, ok := ingestMap[s.QuestionID]
@@ -186,7 +185,10 @@ func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestM
 		var entry longmemeval.RetrievalLogEntry
 		entry.QuestionID = s.QuestionID
 		entry.RetrievalResults.Metrics.Session = metrics
-		_ = enc.Encode(entry)
+		if err := enc.Encode(entry); err != nil {
+			log.Printf("WARN writeRetrievalLog encode [%s]: %v", entry.QuestionID, err)
+			break
+		}
 	}
 	log.Printf("wrote %s", filepath.Join(cfg.OutDir, "retrieval_log.jsonl"))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,15 @@
 module github.com/petersimmons1972/engram
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.36.0
 	golang.org/x/time v0.15.0
 )
 
@@ -26,6 +27,5 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -55,6 +55,10 @@ type Backend interface {
 	// force=true bypasses the immutability check (rollback path only).
 	// Prefer SoftDeleteMemory for all caller-initiated deletes.
 	DeleteMemoryAtomic(ctx context.Context, project, id string, force bool) (bool, error)
+	// DeleteProject hard-deletes all memories and associated data for a project
+	// in a single transaction. Returns the number of memories deleted.
+	// Used by the eval harness to clean up per-question isolation projects.
+	DeleteProject(ctx context.Context, project string) (int64, error)
 	// MergeMemoriesAtomic updates winnerID content (if newContent non-empty) and
 	// deletes loserID in a single transaction. Prevents partial-merge state on crash.
 	MergeMemoriesAtomic(ctx context.Context, project, winnerID, loserID, newContent string) error

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -624,4 +625,18 @@ func rowToChunk(row pgx.CollectableRow) (*types.Chunk, error) {
 		ChunkType:      chunkType,
 		LastMatched:    r.LastMatched,
 	}, nil
+}
+
+// isUndefinedTable returns true when err is a PostgreSQL "undefined_table"
+// error (SQLSTATE 42P01). Used by DeleteProject to gracefully skip optional
+// tables that may not be present in all schema versions.
+func isUndefinedTable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if ok := errors.As(err, &pgErr); ok {
+		return pgErr.Code == "42P01"
+	}
+	return false
 }

--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -650,3 +650,70 @@ func (b *PostgresBackend) ClearSummaries(ctx context.Context, project string) (i
 	}
 	return int(result.RowsAffected()), nil
 }
+
+// DeleteProject hard-deletes all memories and associated data for a project
+// in a single transaction. Returns the number of memories deleted.
+// Used by the eval harness to clean up per-question isolation projects.
+func (b *PostgresBackend) DeleteProject(ctx context.Context, project string) (int64, error) {
+	tx, err := b.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// Delete per-memory dependent rows first (FK constraints on memories.id).
+	memoryDeps := []string{
+		"DELETE FROM chunks WHERE memory_id IN (SELECT id FROM memories WHERE project=$1)",
+		"DELETE FROM relationships WHERE source_id IN (SELECT id FROM memories WHERE project=$1) OR target_id IN (SELECT id FROM memories WHERE project=$1)",
+		"DELETE FROM memory_versions WHERE project=$1",
+	}
+	for _, q := range memoryDeps {
+		if _, err := tx.Exec(ctx, q, project); err != nil {
+			return 0, fmt.Errorf("DeleteProject dep cleanup: %w", err)
+		}
+	}
+
+	// Count and delete the memories themselves.
+	tag, err := tx.Exec(ctx, "DELETE FROM memories WHERE project=$1", project)
+	if err != nil {
+		return 0, fmt.Errorf("DeleteProject memories: %w", err)
+	}
+	deleted := tag.RowsAffected()
+
+	// Delete project-scoped rows from remaining tables.
+	// Tables that may or may not exist in all deployments use IF EXISTS guards
+	// via DO $$ blocks to avoid errors on older schemas.
+	projectScoped := []string{
+		"DELETE FROM project_meta WHERE project=$1",
+		"DELETE FROM weight_config WHERE project=$1",
+		"DELETE FROM weight_history WHERE project=$1",
+		"DELETE FROM retrieval_events WHERE project=$1",
+		"DELETE FROM audit_canonical_queries WHERE project=$1",
+		"DELETE FROM audit_snapshots WHERE project=$1",
+		"DELETE FROM episodes WHERE project=$1",
+	}
+	for _, q := range projectScoped {
+		if _, err := tx.Exec(ctx, q, project); err != nil {
+			return 0, fmt.Errorf("DeleteProject project cleanup: %w", err)
+		}
+	}
+
+	// Optional tables (present only when entity-extraction migration has run).
+	optionalScoped := []string{
+		"DELETE FROM canonical_entities WHERE project=$1",
+		"DELETE FROM entity_extraction_jobs WHERE project=$1",
+	}
+	for _, q := range optionalScoped {
+		if _, err := tx.Exec(ctx, q, project); err != nil {
+			// Ignore "relation does not exist" — table simply not migrated yet.
+			if !isUndefinedTable(err) {
+				return 0, fmt.Errorf("DeleteProject optional cleanup: %w", err)
+			}
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return deleted, nil
+}

--- a/internal/db/postgres_memory_delete_project_test.go
+++ b/internal/db/postgres_memory_delete_project_test.go
@@ -1,0 +1,78 @@
+package db_test
+
+// NOTE: This is an integration test requiring a running Postgres instance.
+// Run with: go test ./internal/db/... -run TestDeleteProject -v
+// The test is skipped automatically when ENGRAM_TEST_DSN is unset.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+func TestDeleteProject(t *testing.T) {
+	dsn := os.Getenv("ENGRAM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("ENGRAM_TEST_DSN not set")
+	}
+	ctx := context.Background()
+	project := "test-delete-project-" + t.Name()
+
+	b, err := db.NewPostgresBackend(ctx, project, dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresBackend: %v", err)
+	}
+	defer b.Close()
+
+	// Store two memories.
+	m1 := &types.Memory{Project: project, Content: "hello world", Tags: []string{"a"}}
+	m2 := &types.Memory{Project: project, Content: "second memory", Tags: []string{"b"}}
+	if err := b.StoreMemory(ctx, m1); err != nil {
+		t.Fatalf("StoreMemory m1: %v", err)
+	}
+	if err := b.StoreMemory(ctx, m2); err != nil {
+		t.Fatalf("StoreMemory m2: %v", err)
+	}
+
+	// Delete the project.
+	n, err := b.DeleteProject(ctx, project)
+	if err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("DeleteProject returned %d, want 2", n)
+	}
+
+	// Verify memories are gone.
+	got, err := b.GetMemory(ctx, m1.ID)
+	if err != nil {
+		t.Fatalf("GetMemory after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("memory %s still exists after DeleteProject", m1.ID)
+	}
+}
+
+func TestDeleteProject_Empty(t *testing.T) {
+	dsn := os.Getenv("ENGRAM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("ENGRAM_TEST_DSN not set")
+	}
+	ctx := context.Background()
+	b, err := db.NewPostgresBackend(ctx, "test-dp-empty", dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresBackend: %v", err)
+	}
+	defer b.Close()
+
+	n, err := b.DeleteProject(ctx, "nonexistent-project-xyz")
+	if err != nil {
+		t.Fatalf("DeleteProject on empty project: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 deletions, got %d", n)
+	}
+}

--- a/internal/longmemeval/checkpoint.go
+++ b/internal/longmemeval/checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"log"
 	"os"
 )
 
@@ -12,6 +13,7 @@ import (
 func WriteCheckpoint[T any](path string, ch <-chan T) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
+		log.Printf("WARN WriteCheckpoint: open %s: %v — all entries will be lost", path, err)
 		for range ch {
 		}
 		return

--- a/internal/longmemeval/checkpoint.go
+++ b/internal/longmemeval/checkpoint.go
@@ -1,0 +1,92 @@
+package longmemeval
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+// WriteCheckpoint reads entries from ch and appends each as a JSON line to path.
+// Runs until ch is closed. Designed to run in a dedicated goroutine.
+func WriteCheckpoint[T any](path string, ch <-chan T) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		for range ch {
+		}
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for entry := range ch {
+		_ = enc.Encode(entry)
+	}
+}
+
+// ReadSkipSet reads a checkpoint file and returns a set of question IDs with
+// status == "done". Returns an empty set (not an error) if the file does not exist.
+func ReadSkipSet(path string) (map[string]bool, error) {
+	skip := make(map[string]bool)
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return skip, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		var entry struct {
+			QuestionID string `json:"question_id"`
+			Status     string `json:"status"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Status == "done" {
+			skip[entry.QuestionID] = true
+		}
+	}
+	return skip, scanner.Err()
+}
+
+// ReadAllIngest reads all entries from a checkpoint-ingest.jsonl file.
+func ReadAllIngest(path string) ([]IngestEntry, error) {
+	return readAll[IngestEntry](path)
+}
+
+// ReadAllRun reads all entries from a checkpoint-run.jsonl file.
+func ReadAllRun(path string) ([]RunEntry, error) {
+	return readAll[RunEntry](path)
+}
+
+// ReadAllScore reads all entries from a checkpoint-score.jsonl file.
+func ReadAllScore(path string) ([]ScoreEntry, error) {
+	return readAll[ScoreEntry](path)
+}
+
+func readAll[T any](path string) ([]T, error) {
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []T
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		var entry T
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out, scanner.Err()
+}

--- a/internal/longmemeval/checkpoint_test.go
+++ b/internal/longmemeval/checkpoint_test.go
@@ -1,0 +1,69 @@
+package longmemeval_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+func TestCheckpointRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	ch := make(chan longmemeval.IngestEntry, 4)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		longmemeval.WriteCheckpoint(path, ch)
+	}()
+
+	ch <- longmemeval.IngestEntry{QuestionID: "q001", Status: "done", SessionCount: 3}
+	ch <- longmemeval.IngestEntry{QuestionID: "q002", Status: "error", Error: "timeout"}
+	close(ch)
+	<-done
+
+	skip, err := longmemeval.ReadSkipSet(path)
+	if err != nil {
+		t.Fatalf("ReadSkipSet: %v", err)
+	}
+	if !skip["q001"] {
+		t.Error("q001 (done) should be in skip set")
+	}
+	if skip["q002"] {
+		t.Error("q002 (error) should NOT be in skip set")
+	}
+}
+
+func TestReadSkipSet_Missing(t *testing.T) {
+	skip, err := longmemeval.ReadSkipSet("/tmp/nonexistent-ckpt-xyz.jsonl")
+	if err != nil {
+		t.Fatalf("ReadSkipSet on missing file: %v", err)
+	}
+	if len(skip) != 0 {
+		t.Errorf("expected empty skip set, got %d entries", len(skip))
+	}
+}
+
+func TestReadAllIngest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ingest.jsonl")
+
+	ch := make(chan longmemeval.IngestEntry, 2)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		longmemeval.WriteCheckpoint(path, ch)
+	}()
+	ch <- longmemeval.IngestEntry{QuestionID: "q001", Status: "done", Project: "lme-x-q001", MemoryMap: map[string]string{"m1": "s1"}}
+	close(ch)
+	<-done
+
+	entries, err := longmemeval.ReadAllIngest(path)
+	if err != nil {
+		t.Fatalf("ReadAllIngest: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Project != "lme-x-q001" {
+		t.Errorf("unexpected entries: %+v", entries)
+	}
+}

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -14,7 +14,7 @@ import (
 // claudePrintTimeout is the hard cap for one claude --print call.
 
 // generateTimeout is the hard cap for one OAI generation call. 1200s needed for 120B vLLM on 40-block contexts.
-const generateTimeout = 1200 * time.Second
+const generateTimeout = 600 * time.Second
 
 // GenerateForType generates an answer using Sonnet for all question types.
 func GenerateForType(ctx context.Context, prompt, questionType string, retries int) (string, error) {
@@ -126,22 +126,34 @@ func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error)
 	tctx, cancel := context.WithTimeout(ctx, generateTimeout)
 	defer cancel()
 
+	// oaiMessage omits Reasoning — sending it (even empty) causes HTTP 400 on
+	// vLLM's Nemotron v3 reasoning parser (vLLM GH#39103).
 	type oaiMessage struct {
-		Role      string `json:"role"`
-		Content   string `json:"content"`
-		Reasoning string `json:"reasoning"`
+		Role    string `json:"role"`
+		Content string `json:"content"`
 	}
 	reqBody, err := json.Marshal(struct {
-		Model     string       `json:"model"`
-		Messages  []oaiMessage `json:"messages"`
-		MaxTokens int          `json:"max_tokens"`
+		Model              string         `json:"model"`
+		Messages           []oaiMessage   `json:"messages"`
+		MaxTokens          int            `json:"max_tokens"`
+		Temperature        float64        `json:"temperature"`
+		TopP               float64        `json:"top_p"`
+		ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 	}{
 		Model: model,
 		Messages: []oaiMessage{
-			{Role: "system", Content: "You are a helpful assistant. Answer the question directly and concisely. Do not show your reasoning or thinking process. Give only the final answer."},
+			{
+				Role:    "system",
+				Content: "You are a precise QA assistant. Answer concisely using only the provided memory context.",
+			},
 			{Role: "user", Content: prompt},
 		},
-		MaxTokens: 1024,
+		MaxTokens:   2048, // with enable_thinking=false, answers are short QA; 20480 overflowed 131k context limit
+		Temperature: 0.2,   // instruct/deterministic mode per NVIDIA model card
+		TopP:        0.95,
+		ChatTemplateKwargs: map[string]any{
+			"enable_thinking": false, // disable reasoning chain; answer goes to content not reasoning_content
+		},
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal OAI request: %w", err)
@@ -167,9 +179,15 @@ func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error)
 		return "", fmt.Errorf("OAI request: status %d", resp.StatusCode)
 	}
 
+	// Response struct reads reasoning_content (vLLM GH#39103: Nemotron v3 puts answer
+	// there when reasoning parser is active), falling back to content then reasoning.
 	var oaiResp struct {
 		Choices []struct {
-			Message oaiMessage `json:"message"`
+			Message struct {
+				Content          string `json:"content"`
+				Reasoning        string `json:"reasoning"`
+				ReasoningContent string `json:"reasoning_content"`
+			} `json:"message"`
 		} `json:"choices"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&oaiResp); err != nil {
@@ -178,12 +196,16 @@ func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error)
 	if len(oaiResp.Choices) == 0 {
 		return "", fmt.Errorf("OAI response: no choices returned")
 	}
-	content := strings.TrimSpace(oaiResp.Choices[0].Message.Content)
+	msg := oaiResp.Choices[0].Message
+	content := strings.TrimSpace(msg.ReasoningContent)
 	if content == "" {
-		content = strings.TrimSpace(oaiResp.Choices[0].Message.Reasoning)
+		content = strings.TrimSpace(msg.Content)
 	}
 	if content == "" {
-		return "", fmt.Errorf("OAI response: both content and reasoning fields are empty")
+		content = strings.TrimSpace(msg.Reasoning)
+	}
+	if content == "" {
+		return "", fmt.Errorf("OAI response: content, reasoning_content, and reasoning are all empty")
 	}
 	// Strip <think>...</think> reasoning block if present; keep only the final answer.
 	if idx := strings.LastIndex(content, "</think>"); idx != -1 {
@@ -215,7 +237,7 @@ Relevant memory context:
 
 Question (asked on %s): %s
 
-Answer in one sentence using only the facts directly required by the question. Do not restate the question. Do not add context the user did not ask for. If the answer is a number, date, name, or short phrase, return only that value with minimal framing. If the answer cannot be determined from the provided context, respond with exactly: I don't know.`, questionDate, ctx, questionDate, question)
+Answer in one sentence using only the facts directly required by the question. Do not restate the question. Do not add context the user did not ask for. If the answer is a number, date, name, or short phrase, return only that value with minimal framing. If the answer is not explicitly present, provide your best inference from the strongest matching context.`, questionDate, ctx, questionDate, question)
 }
 
 // ScoringPrompt builds the judge prompt for answer scoring.

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -17,10 +17,20 @@ const generateTimeout = 180 * time.Second
 // On failure a backoff sleep (30s, 60s, 120s) is inserted between attempts
 // so transient API rate limits have a chance to clear before retrying.
 func Generate(ctx context.Context, prompt string, retries int) (string, error) {
+	return generate(ctx, prompt, "opus", retries)
+}
+
+// GenerateSonnet is like Generate but uses Sonnet — cheaper and higher rate
+// limits, suitable for judge/scoring tasks that don't require Opus reasoning.
+func GenerateSonnet(ctx context.Context, prompt string, retries int) (string, error) {
+	return generate(ctx, prompt, "sonnet", retries)
+}
+
+func generate(ctx context.Context, prompt, model string, retries int) (string, error) {
 	var lastErr error
 	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
 	for attempt := 0; attempt <= retries; attempt++ {
-		out, err := runClaude(ctx, prompt)
+		out, err := runClaude(ctx, prompt, model)
 		if err == nil {
 			return out, nil
 		}
@@ -38,13 +48,13 @@ func Generate(ctx context.Context, prompt string, retries int) (string, error) {
 	return "", lastErr
 }
 
-func runClaude(ctx context.Context, prompt string) (string, error) {
+func runClaude(ctx context.Context, prompt, model string) (string, error) {
 	tctx, cancel := context.WithTimeout(ctx, generateTimeout)
 	defer cancel()
 	// Pass the prompt via stdin rather than argv so we don't blow past
 	// the OS argv limit (E2BIG / "argument list too long") on large
 	// retrieved contexts (~10 sessions × ~7 KB = ~70 KB prompts).
-	cmd := exec.CommandContext(tctx, "claude", "--print", "--model", "opus")
+	cmd := exec.CommandContext(tctx, "claude", "--print", "--model", model)
 	cmd.Stdin = strings.NewReader(prompt)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -113,9 +123,10 @@ type ScoreResult struct {
 }
 
 // Score calls claude --print with the judge prompt and parses the result.
+// Uses Sonnet — the judge task (classify correct/incorrect) doesn't need Opus.
 func Score(ctx context.Context, question, referenceAnswer, hypothesis string, retries int) (ScoreResult, error) {
 	prompt := ScoringPrompt(question, referenceAnswer, hypothesis)
-	out, err := Generate(ctx, prompt, retries)
+	out, err := GenerateSonnet(ctx, prompt, retries)
 	if err != nil {
 		return ScoreResult{Label: "PARTIALLY_CORRECT"}, err
 	}

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -1,0 +1,104 @@
+package longmemeval
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const generateTimeout = 90 * time.Second
+
+// Generate calls `claude --print prompt` and returns trimmed stdout.
+// retries is the number of additional attempts on failure (0 = try once).
+func Generate(ctx context.Context, prompt string, retries int) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt <= retries; attempt++ {
+		out, err := runClaude(ctx, prompt)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+	}
+	return "", lastErr
+}
+
+func runClaude(ctx context.Context, prompt string) (string, error) {
+	tctx, cancel := context.WithTimeout(ctx, generateTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(tctx, "claude", "--print", prompt)
+	raw, err := cmd.Output()
+	if err != nil {
+		if tctx.Err() != nil {
+			return "", fmt.Errorf("claude --print timed out after %s", generateTimeout)
+		}
+		return "", fmt.Errorf("claude --print: %w", err)
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+// GenerationPrompt builds the prompt for answer generation.
+func GenerationPrompt(question, questionDate string, contextBlocks []string) string {
+	ctx := strings.Join(contextBlocks, "\n\n---\n\n")
+	return fmt.Sprintf(`You are answering questions about a person's conversation history.
+
+Relevant memory context:
+%s
+
+Question (asked on %s): %s
+
+Answer the question based only on the provided context. If the answer cannot be determined from the context, respond with exactly: I don't know.`, ctx, questionDate, question)
+}
+
+// ScoringPrompt builds the judge prompt for answer scoring.
+func ScoringPrompt(question, referenceAnswer, hypothesis string) string {
+	return fmt.Sprintf(`You are judging whether a generated answer correctly answers a question about conversation history.
+
+Question: %s
+
+Reference answer: %s
+
+Generated answer: %s
+
+Is the generated answer correct? Reply with exactly one of these labels on the first line:
+CORRECT
+PARTIALLY_CORRECT
+INCORRECT
+
+Then on the second line, briefly explain why (one sentence).`, question, referenceAnswer, hypothesis)
+}
+
+// ScoreResult holds the parsed output of the judge prompt.
+type ScoreResult struct {
+	Label       string
+	Explanation string
+}
+
+// Score calls claude --print with the judge prompt and parses the result.
+func Score(ctx context.Context, question, referenceAnswer, hypothesis string, retries int) (ScoreResult, error) {
+	prompt := ScoringPrompt(question, referenceAnswer, hypothesis)
+	out, err := Generate(ctx, prompt, retries)
+	if err != nil {
+		return ScoreResult{Label: "PARTIALLY_CORRECT"}, err
+	}
+	label, explanation := ParseScoreLabel(out)
+	return ScoreResult{Label: label, Explanation: explanation}, nil
+}
+
+// ParseScoreLabel extracts the label and explanation from raw judge output.
+// Returns PARTIALLY_CORRECT as default if the label is unrecognised.
+func ParseScoreLabel(raw string) (label, explanation string) {
+	lines := strings.SplitN(strings.TrimSpace(raw), "\n", 2)
+	first := strings.ToUpper(strings.TrimSpace(lines[0]))
+	switch first {
+	case "CORRECT", "PARTIALLY_CORRECT", "INCORRECT":
+		label = first
+	default:
+		label = "PARTIALLY_CORRECT"
+	}
+	if len(lines) > 1 {
+		explanation = strings.TrimSpace(lines[1])
+	}
+	return label, explanation
+}

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -14,14 +14,26 @@ const generateTimeout = 90 * time.Second
 
 // Generate calls `claude --print prompt` and returns trimmed stdout.
 // retries is the number of additional attempts on failure (0 = try once).
+// On failure a backoff sleep (30s, 60s, 120s) is inserted between attempts
+// so transient API rate limits have a chance to clear before retrying.
 func Generate(ctx context.Context, prompt string, retries int) (string, error) {
 	var lastErr error
+	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
 	for attempt := 0; attempt <= retries; attempt++ {
 		out, err := runClaude(ctx, prompt)
 		if err == nil {
 			return out, nil
 		}
 		lastErr = err
+		if attempt >= retries {
+			break
+		}
+		wait := backoffs[attempt%len(backoffs)]
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(wait):
+		}
 	}
 	return "", lastErr
 }
@@ -34,14 +46,31 @@ func runClaude(ctx context.Context, prompt string) (string, error) {
 	// retrieved contexts (~10 sessions × ~7 KB = ~70 KB prompts).
 	cmd := exec.CommandContext(tctx, "claude", "--print")
 	cmd.Stdin = strings.NewReader(prompt)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
 	raw, err := cmd.Output()
 	if err != nil {
 		if tctx.Err() != nil {
 			return "", fmt.Errorf("claude --print timed out after %s", generateTimeout)
 		}
+		stderrSnippet := strings.TrimSpace(stderr.String())
+		if len(stderrSnippet) > 200 {
+			stderrSnippet = stderrSnippet[:200] + "…"
+		}
+		if stderrSnippet != "" {
+			return "", fmt.Errorf("claude --print: %w: %s", err, stderrSnippet)
+		}
 		return "", fmt.Errorf("claude --print: %w", err)
 	}
-	return strings.TrimSpace(string(raw)), nil
+	// Sometimes claude prints usage/rate-limit messages to stdout instead of
+	// stderr and still exits 0. Treat those as failures so the retry loop
+	// kicks in instead of returning a useless "API Error" string as the
+	// hypothesis.
+	out := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(out, "API Error") {
+		return "", fmt.Errorf("claude --print: %s", out)
+	}
+	return out, nil
 }
 
 // GenerationPrompt builds the prompt for answer generation.

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -44,7 +44,7 @@ func runClaude(ctx context.Context, prompt string) (string, error) {
 	// Pass the prompt via stdin rather than argv so we don't blow past
 	// the OS argv limit (E2BIG / "argument list too long") on large
 	// retrieved contexts (~10 sessions × ~7 KB = ~70 KB prompts).
-	cmd := exec.CommandContext(tctx, "claude", "--print")
+	cmd := exec.CommandContext(tctx, "claude", "--print", "--model", "opus")
 	cmd.Stdin = strings.NewReader(prompt)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -10,7 +10,7 @@ import (
 
 // claudePrintTimeout is the hard cap for one claude --print call.
 
-const generateTimeout = 90 * time.Second
+const generateTimeout = 180 * time.Second
 
 // Generate calls `claude --print prompt` and returns trimmed stdout.
 // retries is the number of additional attempts on failure (0 = try once).
@@ -78,12 +78,14 @@ func GenerationPrompt(question, questionDate string, contextBlocks []string) str
 	ctx := strings.Join(contextBlocks, "\n\n---\n\n")
 	return fmt.Sprintf(`You are answering questions about a person's conversation history.
 
+Each memory block may begin with a "Session date: YYYY-MM-DD" header. Use these dates for any relative-time calculations (e.g. "how many days/weeks ago"). The question was asked on %s — subtract the session date from this to compute elapsed time.
+
 Relevant memory context:
 %s
 
 Question (asked on %s): %s
 
-Answer the question based only on the provided context. If the answer cannot be determined from the context, respond with exactly: I don't know.`, ctx, questionDate, question)
+Answer the question based only on the provided context. Be specific and concise. If the answer cannot be determined from the context, respond with exactly: I don't know.`, questionDate, ctx, questionDate, question)
 }
 
 // ScoringPrompt builds the judge prompt for answer scoring.

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -130,11 +130,13 @@ func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error)
 		Content string `json:"content"`
 	}
 	reqBody, err := json.Marshal(struct {
-		Model    string       `json:"model"`
-		Messages []oaiMessage `json:"messages"`
+		Model     string       `json:"model"`
+		Messages  []oaiMessage `json:"messages"`
+		MaxTokens int          `json:"max_tokens"`
 	}{
-		Model:    model,
-		Messages: []oaiMessage{{Role: "user", Content: prompt}},
+		Model:     model,
+		Messages:  []oaiMessage{{Role: "user", Content: prompt}},
+		MaxTokens: 256,
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal OAI request: %w", err)

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -1,8 +1,11 @@
 package longmemeval
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os/exec"
 	"strings"
 	"time"
@@ -91,6 +94,95 @@ func runClaude(ctx context.Context, prompt, model string) (string, error) {
 		return "", fmt.Errorf("claude --print: %s", out)
 	}
 	return out, nil
+}
+
+// GenerateOAI calls an OpenAI-compatible chat completions endpoint instead of
+// the claude CLI. baseURL is the API root (e.g. "http://oblivion:8000/v1").
+// Retry/backoff behaviour mirrors generate().
+func GenerateOAI(ctx context.Context, prompt, baseURL, model string, retries int) (string, error) {
+	var lastErr error
+	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
+	for attempt := 0; attempt <= retries; attempt++ {
+		out, err := callOAI(ctx, prompt, baseURL, model)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		if attempt >= retries {
+			break
+		}
+		wait := backoffs[attempt%len(backoffs)]
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return "", lastErr
+}
+
+func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error) {
+	tctx, cancel := context.WithTimeout(ctx, generateTimeout)
+	defer cancel()
+
+	type oaiMessage struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	reqBody, err := json.Marshal(struct {
+		Model    string       `json:"model"`
+		Messages []oaiMessage `json:"messages"`
+	}{
+		Model:    model,
+		Messages: []oaiMessage{{Role: "user", Content: prompt}},
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal OAI request: %w", err)
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(tctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("create OAI request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if tctx.Err() != nil {
+			return "", fmt.Errorf("OAI request timed out after %s", generateTimeout)
+		}
+		return "", fmt.Errorf("OAI request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OAI request: status %d", resp.StatusCode)
+	}
+
+	var oaiResp struct {
+		Choices []struct {
+			Message oaiMessage `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&oaiResp); err != nil {
+		return "", fmt.Errorf("decode OAI response: %w", err)
+	}
+	if len(oaiResp.Choices) == 0 {
+		return "", fmt.Errorf("OAI response: no choices returned")
+	}
+	return strings.TrimSpace(oaiResp.Choices[0].Message.Content), nil
+}
+
+// ScoreOAI is like Score but uses the OpenAI-compatible endpoint.
+func ScoreOAI(ctx context.Context, question, referenceAnswer, hypothesis, baseURL, model string, retries int) (ScoreResult, error) {
+	prompt := ScoringPrompt(question, referenceAnswer, hypothesis)
+	out, err := GenerateOAI(ctx, prompt, baseURL, model, retries)
+	if err != nil {
+		return ScoreResult{Label: "PARTIALLY_CORRECT"}, err
+	}
+	label, explanation := ParseScoreLabel(out)
+	return ScoreResult{Label: label, Explanation: explanation}, nil
 }
 
 // GenerationPrompt builds the prompt for answer generation.

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -13,7 +13,8 @@ import (
 
 // claudePrintTimeout is the hard cap for one claude --print call.
 
-const generateTimeout = 180 * time.Second
+// generateTimeout is the hard cap for one OAI generation call. 1200s needed for 120B vLLM on 40-block contexts.
+const generateTimeout = 1200 * time.Second
 
 // GenerateForType generates an answer using Sonnet for all question types.
 func GenerateForType(ctx context.Context, prompt, questionType string, retries int) (string, error) {
@@ -126,17 +127,21 @@ func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error)
 	defer cancel()
 
 	type oaiMessage struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
+		Role      string `json:"role"`
+		Content   string `json:"content"`
+		Reasoning string `json:"reasoning"`
 	}
 	reqBody, err := json.Marshal(struct {
 		Model     string       `json:"model"`
 		Messages  []oaiMessage `json:"messages"`
 		MaxTokens int          `json:"max_tokens"`
 	}{
-		Model:     model,
-		Messages:  []oaiMessage{{Role: "user", Content: prompt}},
-		MaxTokens: 256,
+		Model: model,
+		Messages: []oaiMessage{
+			{Role: "system", Content: "You are a helpful assistant. Answer the question directly and concisely. Do not show your reasoning or thinking process. Give only the final answer."},
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens: 1024,
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal OAI request: %w", err)
@@ -173,7 +178,18 @@ func callOAI(ctx context.Context, prompt, baseURL, model string) (string, error)
 	if len(oaiResp.Choices) == 0 {
 		return "", fmt.Errorf("OAI response: no choices returned")
 	}
-	return strings.TrimSpace(oaiResp.Choices[0].Message.Content), nil
+	content := strings.TrimSpace(oaiResp.Choices[0].Message.Content)
+	if content == "" {
+		content = strings.TrimSpace(oaiResp.Choices[0].Message.Reasoning)
+	}
+	if content == "" {
+		return "", fmt.Errorf("OAI response: both content and reasoning fields are empty")
+	}
+	// Strip <think>...</think> reasoning block if present; keep only the final answer.
+	if idx := strings.LastIndex(content, "</think>"); idx != -1 {
+		content = strings.TrimSpace(content[idx+len("</think>"):])
+	}
+	return content, nil
 }
 
 // ScoreOAI is like Score but uses the OpenAI-compatible endpoint.

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+// claudePrintTimeout is the hard cap for one claude --print call.
+
 const generateTimeout = 90 * time.Second
 
 // Generate calls `claude --print prompt` and returns trimmed stdout.
@@ -27,7 +29,11 @@ func Generate(ctx context.Context, prompt string, retries int) (string, error) {
 func runClaude(ctx context.Context, prompt string) (string, error) {
 	tctx, cancel := context.WithTimeout(ctx, generateTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(tctx, "claude", "--print", prompt)
+	// Pass the prompt via stdin rather than argv so we don't blow past
+	// the OS argv limit (E2BIG / "argument list too long") on large
+	// retrieved contexts (~10 sessions × ~7 KB = ~70 KB prompts).
+	cmd := exec.CommandContext(tctx, "claude", "--print")
+	cmd.Stdin = strings.NewReader(prompt)
 	raw, err := cmd.Output()
 	if err != nil {
 		if tctx.Err() != nil {

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -12,7 +12,12 @@ import (
 
 const generateTimeout = 180 * time.Second
 
-// Generate calls `claude --print prompt` and returns trimmed stdout.
+// GenerateForType generates an answer using Sonnet for all question types.
+func GenerateForType(ctx context.Context, prompt, questionType string, retries int) (string, error) {
+	return generate(ctx, prompt, "sonnet", retries)
+}
+
+// Generate calls `claude --print prompt` using Opus and returns trimmed stdout.
 // retries is the number of additional attempts on failure (0 = try once).
 // On failure a backoff sleep (30s, 60s, 120s) is inserted between attempts
 // so transient API rate limits have a chance to clear before retrying.
@@ -20,10 +25,15 @@ func Generate(ctx context.Context, prompt string, retries int) (string, error) {
 	return generate(ctx, prompt, "opus", retries)
 }
 
-// GenerateSonnet is like Generate but uses Sonnet — cheaper and higher rate
-// limits, suitable for judge/scoring tasks that don't require Opus reasoning.
+// GenerateSonnet is like Generate but uses Sonnet.
 func GenerateSonnet(ctx context.Context, prompt string, retries int) (string, error) {
 	return generate(ctx, prompt, "sonnet", retries)
+}
+
+// GenerateHaiku is like Generate but uses Haiku — suitable for simple
+// classification tasks like scoring where reasoning depth doesn't matter.
+func GenerateHaiku(ctx context.Context, prompt string, retries int) (string, error) {
+	return generate(ctx, prompt, "haiku", retries)
 }
 
 func generate(ctx context.Context, prompt, model string, retries int) (string, error) {
@@ -95,7 +105,7 @@ Relevant memory context:
 
 Question (asked on %s): %s
 
-Answer the question based only on the provided context. Be specific and concise. If the answer cannot be determined from the context, respond with exactly: I don't know.`, questionDate, ctx, questionDate, question)
+Answer in one sentence using only the facts directly required by the question. Do not restate the question. Do not add context the user did not ask for. If the answer is a number, date, name, or short phrase, return only that value with minimal framing. If the answer cannot be determined from the provided context, respond with exactly: I don't know.`, questionDate, ctx, questionDate, question)
 }
 
 // ScoringPrompt builds the judge prompt for answer scoring.
@@ -123,10 +133,10 @@ type ScoreResult struct {
 }
 
 // Score calls claude --print with the judge prompt and parses the result.
-// Uses Sonnet — the judge task (classify correct/incorrect) doesn't need Opus.
+// Uses Haiku — classifying CORRECT/INCORRECT is a simple comparison task.
 func Score(ctx context.Context, question, referenceAnswer, hypothesis string, retries int) (ScoreResult, error) {
 	prompt := ScoringPrompt(question, referenceAnswer, hypothesis)
-	out, err := GenerateSonnet(ctx, prompt, retries)
+	out, err := GenerateHaiku(ctx, prompt, retries)
 	if err != nil {
 		return ScoreResult{Label: "PARTIALLY_CORRECT"}, err
 	}

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -1,0 +1,56 @@
+package longmemeval_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+func TestParseScoreLabel_Valid(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"CORRECT\nBecause X.", "CORRECT"},
+		{"PARTIALLY_CORRECT\nSome details missing.", "PARTIALLY_CORRECT"},
+		{"INCORRECT\nWrong answer.", "INCORRECT"},
+		{"  correct  \nexplanation here", "CORRECT"},
+	}
+	for _, c := range cases {
+		got, _ := longmemeval.ParseScoreLabel(c.input)
+		if got != c.want {
+			t.Errorf("ParseScoreLabel(%q) label = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestParseScoreLabel_Invalid(t *testing.T) {
+	label, _ := longmemeval.ParseScoreLabel("I'm not sure about this one.")
+	if label != "PARTIALLY_CORRECT" {
+		t.Errorf("unrecognised label default = %q, want PARTIALLY_CORRECT", label)
+	}
+}
+
+func TestParseScoreLabel_Explanation(t *testing.T) {
+	_, explanation := longmemeval.ParseScoreLabel("CORRECT\nThe answer matches the reference exactly.")
+	if !strings.Contains(explanation, "matches") {
+		t.Errorf("explanation = %q, want it to contain 'matches'", explanation)
+	}
+}
+
+// TestGenerate_RequiresClaude is skipped in short mode.
+func TestGenerate_RequiresClaude(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode")
+	}
+	ctx := context.Background()
+	out, err := longmemeval.Generate(ctx, "Reply with only the word: HELLO", 1)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if out == "" {
+		t.Error("Generate returned empty output")
+	}
+}

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -2,6 +2,9 @@ package longmemeval_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -37,6 +40,105 @@ func TestParseScoreLabel_Explanation(t *testing.T) {
 	_, explanation := longmemeval.ParseScoreLabel("CORRECT\nThe answer matches the reference exactly.")
 	if !strings.Contains(explanation, "matches") {
 		t.Errorf("explanation = %q, want it to contain 'matches'", explanation)
+	}
+}
+
+func TestGenerateOAI_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected Content-Type: %s", r.Header.Get("Content-Type"))
+		}
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"hello world"}}]}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	out, err := longmemeval.GenerateOAI(ctx, "say hello", srv.URL, "test-model", 0)
+	if err != nil {
+		t.Fatalf("GenerateOAI: %v", err)
+	}
+	if out != "hello world" {
+		t.Errorf("output = %q, want %q", out, "hello world")
+	}
+}
+
+func TestGenerateOAI_EmptyChoices(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"choices":[]}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	_, err := longmemeval.GenerateOAI(ctx, "prompt", srv.URL, "test-model", 0)
+	if err == nil {
+		t.Error("expected error for empty choices, got nil")
+	}
+}
+
+func TestGenerateOAI_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	_, err := longmemeval.GenerateOAI(ctx, "prompt", srv.URL, "test-model", 0)
+	if err == nil {
+		t.Error("expected error for HTTP 500, got nil")
+	}
+}
+
+func TestGenerateOAI_TrimsWhitespace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"  trimmed\n"}}]}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	out, err := longmemeval.GenerateOAI(ctx, "prompt", srv.URL, "model", 0)
+	if err != nil {
+		t.Fatalf("GenerateOAI: %v", err)
+	}
+	if out != "trimmed" {
+		t.Errorf("output = %q, want %q", out, "trimmed")
+	}
+}
+
+func TestScoreOAI_ReturnsCorrect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"CORRECT\nMatches reference."}}]}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	result, err := longmemeval.ScoreOAI(ctx, "What is X?", "X is 5", "X is 5", srv.URL, "test-model", 0)
+	if err != nil {
+		t.Fatalf("ScoreOAI: %v", err)
+	}
+	if result.Label != "CORRECT" {
+		t.Errorf("label = %q, want CORRECT", result.Label)
+	}
+	if !strings.Contains(result.Explanation, "Matches") {
+		t.Errorf("explanation = %q, want it to contain 'Matches'", result.Explanation)
+	}
+}
+
+func TestScoreOAI_HTTPError_ReturnsPartiallyCorrect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	result, err := longmemeval.ScoreOAI(ctx, "Q", "A", "B", srv.URL, "model", 0)
+	if err == nil {
+		t.Error("expected error for HTTP 503, got nil")
+	}
+	if result.Label != "PARTIALLY_CORRECT" {
+		t.Errorf("label = %q, want PARTIALLY_CORRECT as default on error", result.Label)
 	}
 }
 

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -164,11 +164,20 @@ func (c *Client) storeBatch(ctx context.Context, project string, items []BatchIt
 		return nil, fmt.Errorf("unexpected content type from memory_store_batch: %T", result.Content[0])
 	}
 	var resp struct {
-		IDs   []string `json:"ids"`
-		Count int      `json:"count"`
+		IDs    []string `json:"ids"`
+		Count  int      `json:"count"`
+		Errors []string `json:"errors"`
 	}
 	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
 		return nil, fmt.Errorf("parse store_batch response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		// Server validated items and rejected them; surface up to 3 messages.
+		sample := resp.Errors
+		if len(sample) > 3 {
+			sample = sample[:3]
+		}
+		return nil, fmt.Errorf("memory_store_batch rejected %d items: %s", len(resp.Errors), strings.Join(sample, "; "))
 	}
 	if len(resp.IDs) != len(items) {
 		return nil, fmt.Errorf("memory_store_batch returned %d ids for %d items", len(resp.IDs), len(items))
@@ -303,6 +312,11 @@ func (c *Client) Close() error {
 // user questions from assistant responses. Dropping assistant turns would
 // make single-session-assistant questions unanswerable (the gold content
 // lives in the assistant's reply).
+//
+// C0/C1 control characters (except \t, \n, \r) are stripped — the server's
+// validateContent rejects them and, because memory_store_batch is all-or-
+// nothing, one offender tanks an entire 100-item batch. See LongMemEval
+// session 158 of question 7e00a6cb for a real-world offender (\x0B).
 func SessionContent(turns []Turn) string {
 	var sb strings.Builder
 	for _, t := range turns {
@@ -318,7 +332,25 @@ func SessionContent(turns []Turn) string {
 		}
 		sb.WriteString(role)
 		sb.WriteString(": ")
-		sb.WriteString(t.Content)
+		sb.WriteString(sanitizeControlChars(t.Content))
+	}
+	return sb.String()
+}
+
+// sanitizeControlChars removes C0 (0x00-0x1F except \t \n \r) and C1 (0x7F-0x9F)
+// control characters from s.
+func sanitizeControlChars(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s))
+	for _, r := range s {
+		if r == '\t' || r == '\n' || r == '\r' {
+			sb.WriteRune(r)
+			continue
+		}
+		if r < 0x20 || (r >= 0x7F && r <= 0x9F) {
+			continue
+		}
+		sb.WriteRune(r)
 	}
 	return sb.String()
 }

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -250,14 +250,18 @@ func (c *Client) recall(ctx context.Context, project, query string, topK int) ([
 	return ids, nil
 }
 
-// FetchContent fetches the full content of a memory by ID.
-func (c *Client) FetchContent(ctx context.Context, id string) (string, error) {
+// FetchContent fetches the full content of a memory by ID within a project.
+// The project argument is required: the server-side memory_fetch handler
+// scopes by project (default "default") and will return "not found" if the
+// memory lives in a different project than the one the call targets.
+func (c *Client) FetchContent(ctx context.Context, project, id string) (string, error) {
 	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "memory_fetch",
 			Arguments: map[string]any{
-				"id":     id,
-				"detail": "full",
+				"project": project,
+				"id":      id,
+				"detail":  "full",
 			},
 		},
 	})

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -506,3 +506,13 @@ func sanitizeControlChars(s string) string {
 	}
 	return sb.String()
 }
+
+// IsStaleSessionError returns true when err represents an MCP session that
+// has already expired server-side. The Engram MCP server drops SSE sessions
+// after a timeout; cleanup calls on expired sessions are not an error.
+func IsStaleSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "invalid session id")
+}

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -1,0 +1,223 @@
+package longmemeval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Client wraps the MCP SSE client with retry logic for eval use.
+type Client struct {
+	mcp     *client.Client
+	retries int
+}
+
+// Connect creates an authenticated MCP SSE client connected to serverURL.
+func Connect(ctx context.Context, serverURL, apiKey string) (*Client, error) {
+	sseURL := strings.TrimRight(serverURL, "/") + "/sse"
+	headers := map[string]string{}
+	if apiKey != "" {
+		headers["Authorization"] = "Bearer " + apiKey
+	}
+	c, err := client.NewSSEMCPClient(sseURL, transport.WithHeaders(headers))
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Start(ctx); err != nil {
+		return nil, err
+	}
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: "longmemeval", Version: "1.0.0"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initialize MCP: %w", err)
+	}
+	return &Client{mcp: c, retries: 1}, nil
+}
+
+// Store stores one session as a memory and returns the memory ID.
+func (c *Client) Store(ctx context.Context, project, content string, tags []string) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt <= c.retries; attempt++ {
+		id, err := c.store(ctx, project, content, tags)
+		if err == nil {
+			return id, nil
+		}
+		lastErr = err
+		if attempt < c.retries {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	return "", lastErr
+}
+
+func (c *Client) store(ctx context.Context, project, content string, tags []string) (string, error) {
+	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "memory_store",
+			Arguments: map[string]any{
+				"content": content,
+				"project": project,
+				"tags":    tags,
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if result.IsError {
+		return "", fmt.Errorf("memory_store tool error")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return "", fmt.Errorf("unexpected content type from memory_store")
+	}
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
+		return "", fmt.Errorf("parse store response: %w", err)
+	}
+	return resp.ID, nil
+}
+
+// Recall calls memory_recall and returns ranked memory IDs.
+// The server returns {"results":[{"memory":{"id":"..."},"score":...},...]}
+func (c *Client) Recall(ctx context.Context, project, query string, topK int) ([]string, error) {
+	var lastErr error
+	for attempt := 0; attempt <= c.retries; attempt++ {
+		ids, err := c.recall(ctx, project, query, topK)
+		if err == nil {
+			return ids, nil
+		}
+		lastErr = err
+		if attempt < c.retries {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) recall(ctx context.Context, project, query string, topK int) ([]string, error) {
+	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "memory_recall",
+			Arguments: map[string]any{
+				"query":   query,
+				"project": project,
+				"top_k":   topK,
+				"detail":  "summary",
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(mcp.TextContent); ok {
+				return nil, fmt.Errorf("memory_recall tool error: %s", tc.Text)
+			}
+		}
+		return nil, fmt.Errorf("memory_recall tool error")
+	}
+	if len(result.Content) == 0 {
+		return nil, fmt.Errorf("memory_recall returned no content")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return nil, fmt.Errorf("unexpected content type from memory_recall: %T", result.Content[0])
+	}
+	// Server returns {"results":[{"memory":{"id":"..."},"score":...},...]}
+	var resp struct {
+		Results []struct {
+			Memory struct {
+				ID string `json:"id"`
+			} `json:"memory"`
+			Score float64 `json:"score"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
+		return nil, fmt.Errorf("parse recall response: %w", err)
+	}
+	ids := make([]string, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		ids = append(ids, r.Memory.ID)
+	}
+	return ids, nil
+}
+
+// FetchContent fetches the full content of a memory by ID.
+func (c *Client) FetchContent(ctx context.Context, id string) (string, error) {
+	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "memory_fetch",
+			Arguments: map[string]any{
+				"id":     id,
+				"detail": "full",
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if result.IsError {
+		return "", fmt.Errorf("memory_fetch tool error")
+	}
+	if len(result.Content) == 0 {
+		return "", fmt.Errorf("memory_fetch returned no content")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return "", fmt.Errorf("unexpected content type from memory_fetch: %T", result.Content[0])
+	}
+	var resp struct {
+		Memory struct {
+			Content string `json:"content"`
+		} `json:"memory"`
+	}
+	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
+		return "", fmt.Errorf("parse fetch response: %w", err)
+	}
+	return resp.Memory.Content, nil
+}
+
+// DeleteProject calls memory_delete_project to clean up an isolation project.
+func (c *Client) DeleteProject(ctx context.Context, project string) error {
+	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "memory_delete_project",
+			Arguments: map[string]any{"project": project},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if result.IsError {
+		return fmt.Errorf("memory_delete_project tool error for %q", project)
+	}
+	return nil
+}
+
+// SessionContent concatenates the user-role turns of a session into a single string.
+func SessionContent(turns []Turn) string {
+	var sb strings.Builder
+	for _, t := range turns {
+		if t.Role == "user" {
+			if sb.Len() > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(t.Content)
+		}
+	}
+	return sb.String()
+}

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -378,10 +378,13 @@ func (r *RestClient) QuickStore(ctx context.Context, project, content string, ta
 	data, _ := json.Marshal(body)
 
 	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := 0; attempt < 8; attempt++ {
 		if attempt > 0 {
+			// Exponential backoff: 1s, 2s, 4s, 8s… capped at 16s.
+			// 429s resolve quickly once the token bucket refills.
+			backoff := time.Duration(1<<min(attempt-1, 4)) * time.Second
 			select {
-			case <-time.After(2 * time.Second):
+			case <-time.After(backoff):
 			case <-ctx.Done():
 				return "", ctx.Err()
 			}
@@ -408,6 +411,10 @@ func (r *RestClient) QuickStore(ctx context.Context, project, content string, ta
 		resp.Body.Close()
 		if decodeErr != nil {
 			lastErr = fmt.Errorf("quick-store decode: %w", decodeErr)
+			continue
+		}
+		if resp.StatusCode == 429 {
+			lastErr = fmt.Errorf("quick-store rate limited (status 429)")
 			continue
 		}
 		if resp.StatusCode >= 500 {

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -18,6 +18,15 @@ type Client struct {
 	retries int
 }
 
+func toolErrorMsg(result *mcp.CallToolResult, toolName string) error {
+	if len(result.Content) > 0 {
+		if tc, ok := result.Content[0].(mcp.TextContent); ok {
+			return fmt.Errorf("%s tool error: %s", toolName, tc.Text)
+		}
+	}
+	return fmt.Errorf("%s tool error", toolName)
+}
+
 // Connect creates an authenticated MCP SSE client connected to serverURL.
 func Connect(ctx context.Context, serverURL, apiKey string) (*Client, error) {
 	sseURL := strings.TrimRight(serverURL, "/") + "/sse"
@@ -54,7 +63,11 @@ func (c *Client) Store(ctx context.Context, project, content string, tags []stri
 		}
 		lastErr = err
 		if attempt < c.retries {
-			time.Sleep(5 * time.Second)
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
 		}
 	}
 	return "", lastErr
@@ -75,7 +88,10 @@ func (c *Client) store(ctx context.Context, project, content string, tags []stri
 		return "", err
 	}
 	if result.IsError {
-		return "", fmt.Errorf("memory_store tool error")
+		return "", toolErrorMsg(result, "memory_store")
+	}
+	if len(result.Content) == 0 {
+		return "", fmt.Errorf("memory_store returned no content")
 	}
 	tc, ok := result.Content[0].(mcp.TextContent)
 	if !ok {
@@ -101,7 +117,11 @@ func (c *Client) Recall(ctx context.Context, project, query string, topK int) ([
 		}
 		lastErr = err
 		if attempt < c.retries {
-			time.Sleep(5 * time.Second)
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 		}
 	}
 	return nil, lastErr
@@ -123,12 +143,7 @@ func (c *Client) recall(ctx context.Context, project, query string, topK int) ([
 		return nil, err
 	}
 	if result.IsError {
-		if len(result.Content) > 0 {
-			if tc, ok := result.Content[0].(mcp.TextContent); ok {
-				return nil, fmt.Errorf("memory_recall tool error: %s", tc.Text)
-			}
-		}
-		return nil, fmt.Errorf("memory_recall tool error")
+		return nil, toolErrorMsg(result, "memory_recall")
 	}
 	if len(result.Content) == 0 {
 		return nil, fmt.Errorf("memory_recall returned no content")
@@ -171,7 +186,7 @@ func (c *Client) FetchContent(ctx context.Context, id string) (string, error) {
 		return "", err
 	}
 	if result.IsError {
-		return "", fmt.Errorf("memory_fetch tool error")
+		return "", toolErrorMsg(result, "memory_fetch")
 	}
 	if len(result.Content) == 0 {
 		return "", fmt.Errorf("memory_fetch returned no content")
@@ -203,9 +218,14 @@ func (c *Client) DeleteProject(ctx context.Context, project string) error {
 		return err
 	}
 	if result.IsError {
-		return fmt.Errorf("memory_delete_project tool error for %q", project)
+		return toolErrorMsg(result, "memory_delete_project")
 	}
 	return nil
+}
+
+// Close shuts down the underlying MCP SSE connection.
+func (c *Client) Close() error {
+	return c.mcp.Close()
 }
 
 // SessionContent concatenates the user-role turns of a session into a single string.

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -298,16 +298,27 @@ func (c *Client) Close() error {
 	return c.mcp.Close()
 }
 
-// SessionContent concatenates the user-role turns of a session into a single string.
+// SessionContent concatenates all turns of a session into a single string,
+// preserving role labels so the retriever and generator can distinguish
+// user questions from assistant responses. Dropping assistant turns would
+// make single-session-assistant questions unanswerable (the gold content
+// lives in the assistant's reply).
 func SessionContent(turns []Turn) string {
 	var sb strings.Builder
 	for _, t := range turns {
-		if t.Role == "user" {
-			if sb.Len() > 0 {
-				sb.WriteByte(' ')
-			}
-			sb.WriteString(t.Content)
+		if t.Content == "" {
+			continue
 		}
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		role := t.Role
+		if role == "" {
+			role = "user"
+		}
+		sb.WriteString(role)
+		sb.WriteString(": ")
+		sb.WriteString(t.Content)
 	}
 	return sb.String()
 }

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -1,9 +1,11 @@
 package longmemeval
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -343,6 +345,111 @@ func (c *Client) DeleteProject(ctx context.Context, project string) error {
 // Close shuts down the underlying MCP SSE connection.
 func (c *Client) Close() error {
 	return c.mcp.Close()
+}
+
+// RestClient calls engram's sessionless REST endpoints (/quick-store,
+// /quick-recall) directly over plain HTTP — no MCP SSE session, no 60s
+// transport timeout. Used by the ingest stage for large haystack items.
+type RestClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// NewRestClient constructs a RestClient pointed at baseURL with Bearer auth.
+func NewRestClient(baseURL, token string) *RestClient {
+	return &RestClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// QuickStore stores a single memory via POST /quick-store and returns its ID.
+// Retries once on 5xx (server-side pool init can transiently time out when
+// many projects are created concurrently; a brief pause and retry succeeds
+// because the pool entry is warm on the second attempt).
+func (r *RestClient) QuickStore(ctx context.Context, project, content string, tags []string) (string, error) {
+	body := map[string]any{
+		"content": content,
+		"project": project,
+		"tags":    tags,
+	}
+	data, _ := json.Marshal(body)
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(2 * time.Second):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.baseURL+"/quick-store", bytes.NewReader(data))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+r.token)
+
+		resp, err := r.http.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		var result struct {
+			OK    bool   `json:"ok"`
+			ID    string `json:"id"`
+			Error string `json:"error"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			lastErr = fmt.Errorf("quick-store decode: %w", decodeErr)
+			continue
+		}
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("quick-store server error (status %d): %s", resp.StatusCode, result.Error)
+			continue
+		}
+		if !result.OK || result.ID == "" {
+			return "", fmt.Errorf("quick-store failed: %s (status %d)", result.Error, resp.StatusCode)
+		}
+		return result.ID, nil
+	}
+	return "", lastErr
+}
+
+// QuickRecall calls POST /quick-recall and returns memory IDs ranked by score.
+func (r *RestClient) QuickRecall(ctx context.Context, project, query string, limit int) ([]string, error) {
+	body := map[string]any{
+		"query":   query,
+		"project": project,
+		"limit":   limit,
+	}
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.baseURL+"/quick-recall", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+r.token)
+
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		IDs []string `json:"ids"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("quick-recall decode: %w", err)
+	}
+	return result.IDs, nil
 }
 
 // SessionContent concatenates all turns of a session into a single string,

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -231,7 +232,18 @@ func (c *Client) recall(ctx context.Context, project, query string, topK int) ([
 	if !ok {
 		return nil, fmt.Errorf("unexpected content type from memory_recall: %T", result.Content[0])
 	}
-	// Server returns {"results":[{"memory":{"id":"..."},"score":...},...]}
+	if os.Getenv("LME_DEBUG_RECALL") != "" {
+		preview := tc.Text
+		if len(preview) > 800 {
+			preview = preview[:800] + "…"
+		}
+		fmt.Fprintf(os.Stderr, "DEBUG recall raw: %s\n", preview)
+	}
+	// Server may respond in either of two shapes depending on configured default
+	// mode (ENGRAM_RECALL_DEFAULT_MODE):
+	//   full:   {"results":[{"memory":{"id":"..."},"score":...}, ...]}
+	//   handle: {"handles":[{"id":"...","score":...}, ...]}
+	// Parse both and prefer whichever is populated.
 	var resp struct {
 		Results []struct {
 			Memory struct {
@@ -239,13 +251,24 @@ func (c *Client) recall(ctx context.Context, project, query string, topK int) ([
 			} `json:"memory"`
 			Score float64 `json:"score"`
 		} `json:"results"`
+		Handles []struct {
+			ID    string  `json:"id"`
+			Score float64 `json:"score"`
+		} `json:"handles"`
 	}
 	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
 		return nil, fmt.Errorf("parse recall response: %w", err)
 	}
-	ids := make([]string, 0, len(resp.Results))
+	ids := make([]string, 0, len(resp.Results)+len(resp.Handles))
 	for _, r := range resp.Results {
-		ids = append(ids, r.Memory.ID)
+		if r.Memory.ID != "" {
+			ids = append(ids, r.Memory.ID)
+		}
+	}
+	for _, h := range resp.Handles {
+		if h.ID != "" {
+			ids = append(ids, h.ID)
+		}
 	}
 	return ids, nil
 }
@@ -278,15 +301,26 @@ func (c *Client) FetchContent(ctx context.Context, project, id string) (string, 
 	if !ok {
 		return "", fmt.Errorf("unexpected content type from memory_fetch: %T", result.Content[0])
 	}
+	if os.Getenv("LME_DEBUG_FETCH") != "" {
+		preview := tc.Text
+		if len(preview) > 600 {
+			preview = preview[:600] + "…"
+		}
+		fmt.Fprintf(os.Stderr, "DEBUG fetch raw: %s\n", preview)
+	}
 	var resp struct {
 		Memory struct {
 			Content string `json:"content"`
 		} `json:"memory"`
+		Content string `json:"content"`
 	}
 	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
 		return "", fmt.Errorf("parse fetch response: %w", err)
 	}
-	return resp.Memory.Content, nil
+	if resp.Memory.Content != "" {
+		return resp.Memory.Content, nil
+	}
+	return resp.Content, nil
 }
 
 // DeleteProject calls memory_delete_project to clean up an isolation project.

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -106,6 +106,76 @@ func (c *Client) store(ctx context.Context, project, content string, tags []stri
 	return resp.ID, nil
 }
 
+// BatchItem is one entry for StoreBatch.
+type BatchItem struct {
+	Content string
+	Tags    []string
+}
+
+// StoreBatch stores up to 100 sessions in a single MCP call and returns their IDs
+// in the same order as items. Uses memory_store_batch to reduce HTTP round-trips.
+func (c *Client) StoreBatch(ctx context.Context, project string, items []BatchItem) ([]string, error) {
+	var lastErr error
+	for attempt := 0; attempt <= c.retries; attempt++ {
+		ids, err := c.storeBatch(ctx, project, items)
+		if err == nil {
+			return ids, nil
+		}
+		lastErr = err
+		if attempt < c.retries {
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+	return nil, lastErr
+}
+
+func (c *Client) storeBatch(ctx context.Context, project string, items []BatchItem) ([]string, error) {
+	memories := make([]any, len(items))
+	for i, item := range items {
+		memories[i] = map[string]any{
+			"content": item.Content,
+			"tags":    item.Tags,
+		}
+	}
+	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "memory_store_batch",
+			Arguments: map[string]any{
+				"project":  project,
+				"memories": memories,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, toolErrorMsg(result, "memory_store_batch")
+	}
+	if len(result.Content) == 0 {
+		return nil, fmt.Errorf("memory_store_batch returned no content")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return nil, fmt.Errorf("unexpected content type from memory_store_batch: %T", result.Content[0])
+	}
+	var resp struct {
+		IDs   []string `json:"ids"`
+		Count int      `json:"count"`
+	}
+	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
+		return nil, fmt.Errorf("parse store_batch response: %w", err)
+	}
+	if len(resp.IDs) != len(items) {
+		return nil, fmt.Errorf("memory_store_batch returned %d ids for %d items", len(resp.IDs), len(items))
+	}
+	return resp.IDs, nil
+}
+
 // Recall calls memory_recall and returns ranked memory IDs.
 // The server returns {"results":[{"memory":{"id":"..."},"score":...},...]}
 func (c *Client) Recall(ctx context.Context, project, query string, topK int) ([]string, error) {

--- a/internal/longmemeval/metrics.go
+++ b/internal/longmemeval/metrics.go
@@ -1,0 +1,74 @@
+package longmemeval
+
+import "github.com/petersimmons1972/engram/internal/eval"
+
+// SessionIDs maps a ranked list of memory IDs to session IDs using the
+// memory_id → session_id map built during ingestion. IDs not in the map are omitted.
+func SessionIDs(memoryIDs []string, memoryMap map[string]string) []string {
+	out := make([]string, 0, len(memoryIDs))
+	for _, mid := range memoryIDs {
+		if sid, ok := memoryMap[mid]; ok {
+			out = append(out, sid)
+		}
+	}
+	return out
+}
+
+// RecallAny returns 1.0 if at least one relevant session appears in the top-k
+// retrieved sessions, 0.0 otherwise.
+func RecallAny(retrieved []string, relevant map[string]bool, k int) float64 {
+	if len(retrieved) == 0 || len(relevant) == 0 || k <= 0 {
+		return 0
+	}
+	limit := k
+	if limit > len(retrieved) {
+		limit = len(retrieved)
+	}
+	for i := 0; i < limit; i++ {
+		if relevant[retrieved[i]] {
+			return 1.0
+		}
+	}
+	return 0
+}
+
+// RecallAll returns 1.0 if all relevant sessions appear in the top-k retrieved
+// sessions, 0.0 otherwise.
+func RecallAll(retrieved []string, relevant map[string]bool, k int) float64 {
+	if len(retrieved) == 0 || len(relevant) == 0 || k <= 0 {
+		return 0
+	}
+	limit := k
+	if limit > len(retrieved) {
+		limit = len(retrieved)
+	}
+	inTopK := make(map[string]bool, limit)
+	for i := 0; i < limit; i++ {
+		inTopK[retrieved[i]] = true
+	}
+	for sid := range relevant {
+		if !inTopK[sid] {
+			return 0
+		}
+	}
+	return 1.0
+}
+
+// NDCGAny wraps internal/eval.NDCG treating any relevant session as binary relevant.
+func NDCGAny(retrieved []string, relevant map[string]bool, k int) float64 {
+	return eval.NDCG(retrieved, relevant, k)
+}
+
+// BuildRetrievalMetrics computes the four session-level metrics at k=5 and k=10.
+func BuildRetrievalMetrics(rankedSessionIDs []string, answerSessionIDs []string) RetrievalMetrics {
+	relevant := make(map[string]bool, len(answerSessionIDs))
+	for _, sid := range answerSessionIDs {
+		relevant[sid] = true
+	}
+	return RetrievalMetrics{
+		RecallAll5:  RecallAll(rankedSessionIDs, relevant, 5),
+		NDCGAny5:    NDCGAny(rankedSessionIDs, relevant, 5),
+		RecallAll10: RecallAll(rankedSessionIDs, relevant, 10),
+		NDCGAny10:   NDCGAny(rankedSessionIDs, relevant, 10),
+	}
+}

--- a/internal/longmemeval/metrics_test.go
+++ b/internal/longmemeval/metrics_test.go
@@ -57,3 +57,44 @@ func TestSessionIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestSessionContentIncludesAllRoles(t *testing.T) {
+	turns := []longmemeval.Turn{
+		{Role: "user", Content: "What's the best ramen place?"},
+		{Role: "assistant", Content: "Ippudo in the East Village is excellent."},
+		{Role: "user", Content: "Thanks!"},
+	}
+	got := longmemeval.SessionContent(turns)
+
+	// Must include the assistant turn — single-session-assistant questions
+	// have their gold answers in assistant replies.
+	if !contains(got, "Ippudo") {
+		t.Errorf("SessionContent dropped assistant turn; got %q", got)
+	}
+	if !contains(got, "ramen") {
+		t.Errorf("SessionContent dropped user turn; got %q", got)
+	}
+	if !contains(got, "assistant:") || !contains(got, "user:") {
+		t.Errorf("SessionContent missing role labels; got %q", got)
+	}
+}
+
+func TestSessionContentEmptyTurnsSkipped(t *testing.T) {
+	turns := []longmemeval.Turn{
+		{Role: "user", Content: ""},
+		{Role: "assistant", Content: "hello"},
+	}
+	got := longmemeval.SessionContent(turns)
+	if !contains(got, "hello") {
+		t.Errorf("expected assistant content, got %q", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/longmemeval/metrics_test.go
+++ b/internal/longmemeval/metrics_test.go
@@ -98,3 +98,20 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+func TestSessionContentStripsControlChars(t *testing.T) {
+	turns := []longmemeval.Turn{
+		{Role: "user", Content: "hello\x0Bworld"},              // VT
+		{Role: "assistant", Content: "answer\x00with\x7Fchar"}, // NUL, DEL
+		{Role: "user", Content: "tab\there\nnew"},              // tab/newline preserved
+	}
+	got := longmemeval.SessionContent(turns)
+	for _, bad := range []string{"\x00", "\x0B", "\x7F"} {
+		if contains(got, bad) {
+			t.Errorf("SessionContent leaked control char %q: %q", bad, got)
+		}
+	}
+	if !contains(got, "\t") || !contains(got, "\n") {
+		t.Errorf("SessionContent stripped tab/newline: %q", got)
+	}
+}

--- a/internal/longmemeval/metrics_test.go
+++ b/internal/longmemeval/metrics_test.go
@@ -1,0 +1,59 @@
+package longmemeval_test
+
+import (
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+func TestRecallAny(t *testing.T) {
+	retrieved := []string{"sid-a", "sid-b", "sid-c"}
+	relevant := map[string]bool{"sid-b": true, "sid-z": true}
+
+	if got := longmemeval.RecallAny(retrieved, relevant, 3); got != 1.0 {
+		t.Errorf("RecallAny@3 = %.2f, want 1.0", got)
+	}
+	if got := longmemeval.RecallAny(retrieved, relevant, 2); got != 1.0 {
+		t.Errorf("RecallAny@2 = %.2f, want 1.0", got)
+	}
+	if got := longmemeval.RecallAny(retrieved, relevant, 1); got != 0.0 {
+		t.Errorf("RecallAny@1 = %.2f, want 0.0", got)
+	}
+}
+
+func TestRecallAll(t *testing.T) {
+	retrieved := []string{"sid-a", "sid-b", "sid-c", "sid-d"}
+	relevant := map[string]bool{"sid-b": true, "sid-c": true}
+
+	if got := longmemeval.RecallAll(retrieved, relevant, 4); got != 1.0 {
+		t.Errorf("RecallAll@4 = %.2f, want 1.0", got)
+	}
+	if got := longmemeval.RecallAll(retrieved, relevant, 2); got != 0.0 {
+		t.Errorf("RecallAll@2 = %.2f, want 0.0", got)
+	}
+}
+
+func TestRecallAny_Empty(t *testing.T) {
+	if got := longmemeval.RecallAny(nil, map[string]bool{"x": true}, 5); got != 0.0 {
+		t.Errorf("RecallAny with nil retrieved = %.2f, want 0.0", got)
+	}
+	if got := longmemeval.RecallAny([]string{"a"}, nil, 5); got != 0.0 {
+		t.Errorf("RecallAny with nil relevant = %.2f, want 0.0", got)
+	}
+}
+
+func TestSessionIDs(t *testing.T) {
+	memoryMap := map[string]string{
+		"mem-1": "sid-a",
+		"mem-2": "sid-b",
+		"mem-3": "sid-c",
+	}
+	retrieved := []string{"mem-2", "mem-3", "mem-1"}
+	want := []string{"sid-b", "sid-c", "sid-a"}
+	got := longmemeval.SessionIDs(retrieved, memoryMap)
+	for i, g := range got {
+		if g != want[i] {
+			t.Errorf("SessionIDs[%d] = %q, want %q", i, g, want[i])
+		}
+	}
+}

--- a/internal/longmemeval/types.go
+++ b/internal/longmemeval/types.go
@@ -1,12 +1,35 @@
 // Package longmemeval implements the LongMemEval benchmark harness for engram-go.
 package longmemeval
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// flexString unmarshals JSON strings or numbers as a Go string.
+// LongMemEval has 32/500 questions with numeric answers (e.g. 120).
+type flexString string
+
+func (f *flexString) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*f = flexString(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err == nil {
+		*f = flexString(n.String())
+		return nil
+	}
+	return fmt.Errorf("flexString: cannot unmarshal %s", b)
+}
+
 // Item is one entry from the LongMemEval dataset JSON file.
 type Item struct {
-	QuestionID         string   `json:"question_id"`
-	QuestionType       string   `json:"question_type"`
-	Question           string   `json:"question"`
-	Answer             string   `json:"answer"`
+	QuestionID         string     `json:"question_id"`
+	QuestionType       string     `json:"question_type"`
+	Question           string     `json:"question"`
+	Answer             flexString `json:"answer"`
 	QuestionDate       string   `json:"question_date"`
 	HaystackSessionIDs []string `json:"haystack_session_ids"`
 	HaystackDates      []string `json:"haystack_dates"`

--- a/internal/longmemeval/types.go
+++ b/internal/longmemeval/types.go
@@ -1,0 +1,82 @@
+// Package longmemeval implements the LongMemEval benchmark harness for engram-go.
+package longmemeval
+
+// Item is one entry from the LongMemEval dataset JSON file.
+type Item struct {
+	QuestionID         string   `json:"question_id"`
+	QuestionType       string   `json:"question_type"`
+	Question           string   `json:"question"`
+	Answer             string   `json:"answer"`
+	QuestionDate       string   `json:"question_date"`
+	HaystackSessionIDs []string `json:"haystack_session_ids"`
+	HaystackDates      []string `json:"haystack_dates"`
+	HaystackSessions   [][]Turn `json:"haystack_sessions"`
+	AnswerSessionIDs   []string `json:"answer_session_ids"`
+}
+
+// Turn is one exchange within a haystack session.
+type Turn struct {
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	HasAnswer bool   `json:"has_answer,omitempty"`
+}
+
+// IngestEntry is one line written to checkpoint-ingest.jsonl.
+type IngestEntry struct {
+	QuestionID   string            `json:"question_id"`
+	Project      string            `json:"project"`
+	SessionCount int               `json:"session_count"`
+	MemoryMap    map[string]string `json:"memory_map"` // memory_id → session_id
+	Status       string            `json:"status"`     // "done" | "error"
+	Error        string            `json:"error,omitempty"`
+}
+
+// RunEntry is one line written to checkpoint-run.jsonl.
+type RunEntry struct {
+	QuestionID   string   `json:"question_id"`
+	Hypothesis   string   `json:"hypothesis"`
+	RetrievedIDs []string `json:"retrieved_ids"` // memory IDs in ranked order
+	Status       string   `json:"status"`
+	Error        string   `json:"error,omitempty"`
+}
+
+// ScoreEntry is one line written to checkpoint-score.jsonl.
+type ScoreEntry struct {
+	QuestionID   string `json:"question_id"`
+	QuestionType string `json:"question_type"`
+	Hypothesis   string `json:"hypothesis"`
+	ScoreLabel   string `json:"score_label"` // CORRECT | PARTIALLY_CORRECT | INCORRECT
+	Explanation  string `json:"explanation"`
+	Status       string `json:"status"`
+	Error        string `json:"error,omitempty"`
+}
+
+// HypothesisLine is one line in the LongMemEval-compatible hypotheses.jsonl output.
+type HypothesisLine struct {
+	QuestionID string `json:"question_id"`
+	Hypothesis string `json:"hypothesis"`
+}
+
+// RetrievalMetrics holds session-level retrieval metrics for one question.
+type RetrievalMetrics struct {
+	RecallAll5  float64 `json:"recall_all@5"`
+	NDCGAny5    float64 `json:"ndcg_any@5"`
+	RecallAll10 float64 `json:"recall_all@10"`
+	NDCGAny10   float64 `json:"ndcg_any@10"`
+}
+
+// RetrievalLogSession is the intermediate type for JSON marshaling.
+type RetrievalLogSession struct {
+	Session RetrievalMetrics `json:"session"`
+}
+
+// RetrievalLogMetrics wraps the session metrics for JSON marshaling.
+type RetrievalLogMetrics struct {
+	Metrics RetrievalLogSession `json:"metrics"`
+}
+
+// RetrievalLogEntry is one line in retrieval_log.jsonl (LongMemEval-compatible).
+type RetrievalLogEntry struct {
+	QuestionID       string              `json:"question_id"`
+	RetrievalResults RetrievalLogMetrics `json:"retrieval_results"`
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -47,6 +47,7 @@ func (noopBackend) DeleteMemory(_ context.Context, _ string) (bool, error)      
 func (noopBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error) {
 	return false, nil
 }
+func (noopBackend) DeleteProject(_ context.Context, _ string) (int64, error) { return 0, nil }
 func (noopBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error { return nil }
 func (noopBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {
 	return nil, nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -480,6 +480,10 @@ func (s *Server) registerTools() {
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryForget(ctx, pool, req)
 			}},
+		{"memory_delete_project", "Hard-delete ALL memories and associated data for a project. Irreversible. Intended for eval-harness cleanup.",
+			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+				return handleMemoryDeleteProject(ctx, pool, req)
+			}},
 		{"memory_history", "Return the full version chain for a memory",
 			func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 				return handleMemoryHistory(ctx, pool, req)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1007,6 +1007,30 @@ func handleMemoryForget(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	return toolResult(map[string]any{"deleted": deleted, "memory_id": id})
 }
 
+// handleMemoryDeleteProject hard-deletes all memories and associated data for
+// a project. Intended for eval-harness cleanup; not reversible.
+func handleMemoryDeleteProject(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	args := req.GetArguments()
+	// Check for the project key before calling getProject, which rejects empty
+	// strings as a validation error rather than a caller error.
+	if raw := getString(args, "project", ""); strings.TrimSpace(raw) == "" {
+		return mcpgo.NewToolResultError("project is required"), nil
+	}
+	project, err := getProject(args, "")
+	if err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
+	h, err := pool.Get(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	deleted, err := h.Engine.Backend().DeleteProject(ctx, project)
+	if err != nil {
+		return nil, fmt.Errorf("delete project %q: %w", project, err)
+	}
+	return toolResult(map[string]any{"project": project, "deleted": deleted})
+}
+
 // handleMemoryHistory returns the version chain for a memory.
 func handleMemoryHistory(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()

--- a/internal/mcp/tools_delete_project_test.go
+++ b/internal/mcp/tools_delete_project_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestPool builds an EnginePool backed by a noopBackend + noopEmbedder.
+// It is an alias for newTestNoopPool, named to match the test spec.
+func newTestPool(t *testing.T) *EnginePool {
+	t.Helper()
+	return newTestNoopPool(t)
+}
+
+// resultText returns the text from the first content item of a non-nil result.
+func resultText(t *testing.T, res *mcpgo.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, res)
+	require.NotEmpty(t, res.Content)
+	text, ok := res.Content[0].(mcpgo.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", res.Content[0])
+	return text.Text
+}
+
+func TestHandleMemoryDeleteProject_MissingProject(t *testing.T) {
+	pool := newTestPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+	result, err := handleMemoryDeleteProject(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected error result for missing project")
+}
+
+func TestHandleMemoryDeleteProject_Empty(t *testing.T) {
+	pool := newTestPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"project": "nonexistent-lme-project-xyz"}
+	result, err := handleMemoryDeleteProject(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	text := resultText(t, result)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &out))
+	require.Contains(t, text, `"deleted"`)
+}

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -83,6 +83,7 @@ func (noopBackend) DeleteMemory(_ context.Context, _ string) (bool, error)      
 func (noopBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error) {
 	return false, nil
 }
+func (noopBackend) DeleteProject(_ context.Context, _ string) (int64, error) { return 0, nil }
 func (noopBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error { return nil }
 func (noopBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {
 	return nil, nil

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -182,6 +182,8 @@ func (s *stubBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool)
 	return false, nil
 }
 
+func (s *stubBackend) DeleteProject(_ context.Context, _ string) (int64, error) { return 0, nil }
+
 func (s *stubBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error { return nil }
 
 func (s *stubBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {


### PR DESCRIPTION
## Summary
OpenAI-compatible LLM backend for LongMemEval benchmark, tuned for Nemotron-3-Nano:

- Remove `Reasoning` field from oaiMessage (vLLM GH#39103 — Nemotron v3 parser rejects it)
- `enable_thinking: false` via `chat_template_kwargs` (thinking mode exhausts tokens in `<think>` tags)
- `max_tokens=2048` not 20480 (large prompts + 20480 > max_model_len=131072)
- `contextTopK=8` not 40 (104K token prompts → 8+ hour run; 8 blocks = 21K tokens = 8.6 q/min)
- Temporal interrogative stripping in recall queries
- `--no-cleanup` flag to preserve ingested data across runs

## Results on LME-M (500 questions)
- Nemotron-3-Nano: 36.6% effective overall
- single-session-assistant: 83.9%
- single-session-user: 60.0%
- knowledge-update: 46.2%
- multi-session: 19.5%
- temporal-reasoning: 18.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)