### PR TITLE
fix(infra): replace personal hostnames with example.invalid (refs #711)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # Services:
 #   postgres                — persistent storage
 #   engram-go               — MCP server (port 8788) — NO direct embed calls at recall time
-#   engram-reembed-7900xt   — reembed worker → leviathan RX 7900 XT (REEMBED_7900XT_URL)
+#   engram-reembed-7900xt   — reembed worker → e.g. RX 7900 XT (set REEMBED_7900XT_URL in .env)
 #   engram-reembed-w6800    — reembed worker → precision W6800 (REEMBED_W6800_URL)
 #   engram-reembed-oblivion — reembed worker → oblivion GB10 (REEMBED_OBLIVION_URL)
 #
@@ -130,7 +130,8 @@ services:
       - LITELLM_URL=${LITELLM_URL:-http://olla:40114/olla/openai}
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       # Embedding service — Infinity/bge-m3 on oblivion (2026-05-08: switched from vLLM/jina-v5, 14x throughput)
-      - ENGRAM_EMBED_URL=${ENGRAM_EMBED_URL:-http://oblivion.petersimmons.com:8003}
+      # #668: default placeholder — set ENGRAM_EMBED_URL in .env to your real embed endpoint
+      - ENGRAM_EMBED_URL=${ENGRAM_EMBED_URL:-http://example.invalid:8003}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-1024}
       - ENGRAM_SUMMARIZE_MODEL=${ENGRAM_SUMMARIZE_MODEL:-llama3.2:3b}
@@ -175,7 +176,7 @@ services:
   engram-reembed-7900xt:
     <<: *reembed-base
     container_name: engram-reembed-7900xt
-    # RX 7900 XT on leviathan — 896 GB/s, ~15,600 chunks/min
+    # E.g. RX 7900 XT — 896 GB/s, ~15,600 chunks/min on the operator's hardware
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
       - LITELLM_URL=${REEMBED_7900XT_URL:-http://172.23.0.1:8004}
@@ -200,7 +201,8 @@ services:
     # Default 32 (not 100) — W6800 OOMs with sub_batch=100 at concurrency≥4.
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
-      - LITELLM_URL=${REEMBED_W6800_URL:-http://precision.petersimmons.com:8005}
+      # #668: default placeholder — set REEMBED_W6800_URL in .env to your real W6800 host
+      - LITELLM_URL=${REEMBED_W6800_URL:-http://example.invalid:8005}
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-1024}
@@ -221,7 +223,8 @@ services:
     # Lower MAX vs 7900xt — bandwidth-limited despite TFLOPS advantage
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
-      - LITELLM_URL=${REEMBED_OBLIVION_URL:-http://oblivion.petersimmons.com:8003}
+      # #668: default placeholder — set REEMBED_OBLIVION_URL in .env to your real Oblivion host
+      - LITELLM_URL=${REEMBED_OBLIVION_URL:-http://example.invalid:8003}
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-1024}


### PR DESCRIPTION
QA sweep follow-up — closes the last serious-tier issue that wasn't addressed in the main waves.

## Closes

- **#668** Personal hostnames (`oblivion.petersimmons.com`, `precision.petersimmons.com`) removed from `docker-compose.yml` defaults; replaced with `http://example.invalid:<port>` (RFC 2606 reserved).

A fresh clone now fails fast with NXDOMAIN instead of silently attempting to reach the founder's homelab.

## Verification

```
$ go test ./... -count=1 -race -timeout 300s
# 42 packages ok, 0 FAIL

$ docker compose config | grep "URL:"
# All three URLs resolve to example.invalid when .env doesn't override.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)