### PR TITLE
fix(lme): short-circuit generate() retry on ErrDisallowedModel (#750)

### DIFF
--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -4,12 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os/exec"
 	"strings"
 	"time"
 )
+
+// ErrDisallowedModel is a permanent error returned when the model name is not
+// in the allowlist. The retry loop must not sleep on this error.
+var ErrDisallowedModel = errors.New("disallowed model")
 
 // claudePrintTimeout is the hard cap for one claude --print call.
 
@@ -49,6 +54,10 @@ func generate(ctx context.Context, prompt, model string, retries int) (string, e
 			return out, nil
 		}
 		lastErr = err
+		// Permanent validation errors must not be retried.
+		if errors.Is(err, ErrDisallowedModel) {
+			break
+		}
 		if attempt >= retries {
 			break
 		}
@@ -60,6 +69,14 @@ func generate(ctx context.Context, prompt, model string, retries int) (string, e
 		}
 	}
 	return "", lastErr
+}
+
+// GenerateForModel calls generate with the given model alias. model must be
+// one of the values in validClaudeModels ("opus", "sonnet", "haiku"); an
+// unknown value causes generate → runClaude to return ErrDisallowedModel
+// immediately without retrying.
+func GenerateForModel(ctx context.Context, prompt, model string, retries int) (string, error) {
+	return generate(ctx, prompt, model, retries)
 }
 
 // validClaudeModels is the allowlist for the --model flag passed to
@@ -80,7 +97,7 @@ func isValidClaudeModel(model string) bool {
 
 func runClaude(ctx context.Context, prompt, model string) (string, error) {
 	if !isValidClaudeModel(model) {
-		return "", fmt.Errorf("claude: refusing to invoke with disallowed model %q (allowed: opus, sonnet, haiku) (#678)", model)
+		return "", fmt.Errorf("%w: %q (allowed: opus, sonnet, haiku) (#678)", ErrDisallowedModel, model)
 	}
 	tctx, cancel := context.WithTimeout(ctx, generateTimeout)
 	defer cancel()

--- a/internal/longmemeval/generate_for_model_test.go
+++ b/internal/longmemeval/generate_for_model_test.go
@@ -1,0 +1,79 @@
+package longmemeval_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+// ---------------------------------------------------------------------------
+// GenerateForModel — model validation and no-retry behaviour
+// ---------------------------------------------------------------------------
+
+// TestGenerateForModel_InvalidModel verifies that an unknown model alias
+// returns an error containing "disallowed model" (zero retries).
+func TestGenerateForModel_InvalidModel(t *testing.T) {
+	ctx := context.Background()
+	_, err := longmemeval.GenerateForModel(ctx, "prompt", "gpt-4o", 0)
+	if err == nil {
+		t.Fatal("expected error for invalid model, got nil")
+	}
+	if !strings.Contains(err.Error(), "disallowed model") {
+		t.Errorf("error = %q, want it to contain 'disallowed model'", err.Error())
+	}
+}
+
+// TestGenerateForModel_InvalidModel_NoRetry verifies that with retries=2 and
+// an invalid model name, GenerateForModel returns immediately (< 5s) without
+// sleeping through the retry backoffs (30s + 60s = 90s wasted).
+// Regression guard for the ErrDisallowedModel short-circuit added in #750.
+func TestGenerateForModel_InvalidModel_NoRetry(t *testing.T) {
+	// Even with retries > 0 the model-rejection error should be returned
+	// immediately (no point sleeping and retrying a static validation failure).
+	ctx := context.Background()
+	start := time.Now()
+	_, err := longmemeval.GenerateForModel(ctx, "prompt", "gpt-4o", 2)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error for invalid model, got nil")
+	}
+	if !strings.Contains(err.Error(), "disallowed model") {
+		t.Errorf("error = %q, want 'disallowed model'", err.Error())
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("GenerateForModel with invalid model took %v — retry not short-circuited (want < 5s)", elapsed)
+	}
+}
+
+// TestGenerateForModel_InvalidModel_ErrIs verifies that errors.Is(err, ErrDisallowedModel)
+// returns true, so callers can distinguish permanent model errors from transient ones.
+func TestGenerateForModel_InvalidModel_ErrIs(t *testing.T) {
+	ctx := context.Background()
+	_, err := longmemeval.GenerateForModel(ctx, "prompt", "claude-3-opus-20240229", 0)
+	if err == nil {
+		t.Fatal("expected error for invalid model, got nil")
+	}
+	if !errors.Is(err, longmemeval.ErrDisallowedModel) {
+		t.Errorf("errors.Is(err, ErrDisallowedModel) = false; err = %q", err.Error())
+	}
+	// The error string must still contain the model name for diagnostics.
+	if !strings.Contains(err.Error(), "claude-3-opus-20240229") {
+		t.Errorf("error = %q, want it to contain the model name for diagnostics", err.Error())
+	}
+}
+
+// TestGenerateForModel_ValidModel_NoModelRejection verifies that GenerateForModel
+// with a valid alias ("opus") does NOT return ErrDisallowedModel — it will fail
+// because the claude binary is absent in CI, but not for model-validation reasons.
+func TestGenerateForModel_ValidModel_NoModelRejection(t *testing.T) {
+	ctx := context.Background()
+	_, err := longmemeval.GenerateForModel(ctx, "prompt", "opus", 0)
+	if err != nil && errors.Is(err, longmemeval.ErrDisallowedModel) {
+		t.Errorf("GenerateForModel('opus') must not return ErrDisallowedModel, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ErrDisallowedModel` sentinel to `internal/longmemeval/claude.go` and wraps the `runClaude` validation error with it.
- `generate()` retry loop now breaks immediately on `errors.Is(err, ErrDisallowedModel)`, eliminating ~90s wasted backoff (30s + 60s) on a permanent validation failure.
- Adds `GenerateForModel()` as the exported API entry point (used by the campaign branch; forward-ported to main here).
- Adds `generate_for_model_test.go` with 4 tests including `TestGenerateForModel_InvalidModel_NoRetry` timing regression guard (asserts < 5s for invalid model with retries=2).

Closes #750. Design doc: `docs/proposed-fixes/750-generate-for-model-no-retry-on-invalid-model.md`.

**Deviation from design doc:** The design doc referenced `claude_additions.go` / `claude_additions_test.go` which exist only in the campaign branch, not on `main`. `GenerateForModel` and `ErrDisallowedModel` were added directly to `claude.go` and a new `generate_for_model_test.go` was created. Functionally equivalent to the proposed patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)