### PR TITLE
docs(results): document results/ tracking convention (#769)

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,31 @@
+# results/
+
+This directory is **gitignored by default** (see `.gitignore`).
+
+Campaign log files that should persist as documentation are tracked deliberately
+via `git add -f`. The currently-tracked files are:
+
+- `lme-camp-report.md` — live campaign-log artifact
+- `lme-camp-state.json`, `lme-camp-stratified-100.json` — campaign-state machine data
+- `next-campaign-manifest.md` — next-campaign starting point + post-campaign outcomes block
+- `wisdom/bottleneck-symmetry.md` — durable pattern doc: bottleneck symmetry analysis
+- `wisdom/temporal-reasoning-mechanism-analysis.md` — durable pattern doc: temporal reasoning failure mechanisms
+
+## When to commit a file under `results/`
+
+Track via `git add -f` if **all** apply:
+- The file is durable wisdom or a pinned campaign reference, not transient per-run data
+- It will be read by future contributors looking to orient themselves
+- It is not regeneratable (it documents a one-time analysis or campaign synthesis)
+
+Do **not** track per-run outputs: `checkpoint-*.jsonl`, `score_report.json`, `run.log`,
+intermediate scoring artifacts, ad-hoc benchmarks. Those stay gitignored.
+
+## Conventions
+
+- File names use `lme-camp-*` prefix for LME campaign artifacts, `wisdom/*.md` for
+  durable pattern docs.
+- When adding a new tracked file, add it to the inventory above in this README in
+  the same commit.
+
+Closes #769.


### PR DESCRIPTION
## Summary

- Creates `results/README.md` explaining the gitignored-with-tracked-exceptions pattern
- Documents the 6 currently-tracked files with one-line descriptions
- Codifies the three-criteria gate for when to use `git add -f` on a new file

## Context

The `results/` directory is gitignored for good reason (transient benchmark data), but PRs #766 and #776 deliberately tracked campaign logs and wisdom docs via `git add -f`. Without documentation, future contributors have no way to know what is intentional. This README closes that gap.

Decision: Option (b) from #769 — document the convention. The existing `git add -f` pattern in #766 and #776 is the right behavior; we just needed prose explaining it.

The inventory in the README reflects the actual `git ls-files results/` output (6 files). `lme-camp-final-report.md` and `MORNING-HANDOFF.md` are not currently tracked and were not included.

Closes #769.

## Test plan

- [ ] `git ls-files results/` matches the inventory in `results/README.md`
- [ ] `results/README.md` is itself tracked (forced via `git add -f`)
- [ ] No per-run output files added to tracking

 Generated with [Claude Code](https://claude.com/claude-code)