### PR TITLE
fix(mcp): narrow importance bounds to 0-4 (#768)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ The `/quick-store` and `/quick-recall` REST endpoints enforce per-field limits:
 - **Content Size:** max 1 MiB (quick-store only)
 - **Project Name:** must match `^[a-z0-9_-]{1,64}$` (alphanumeric, underscore, hyphen; no spaces, uppercase, or path traversal)
 - **Tags:** max 64 total; each max 256 characters
-- **Importance:** 0–100 (not 0–4 like memory_type)
+- **Importance:** 0–4 (matches the handler range; 0=Critical, 4=Low)
 - **Query:** must be non-empty
 
 Validation failures return HTTP 400 with structured error message.

--- a/internal/mcp/quick_store_handler_test.go
+++ b/internal/mcp/quick_store_handler_test.go
@@ -182,9 +182,11 @@ func TestQuickStoreHandler_TagTooLong(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestQuickStoreHandler_InvalidImportance verifies that importance outside [0,100] is rejected with 400.
+// TestQuickStoreHandler_InvalidImportance verifies that importance outside [0,4] is rejected with 400.
+// The range was previously documented as 0–100 but the handler (handleMemoryStore) always enforced
+// 0–4. This test was updated as part of fix #768 to match the narrowed validator.
 func TestQuickStoreHandler_InvalidImportance(t *testing.T) {
-	tests := []int{-1, 101}
+	tests := []int{-1, 5}
 	for _, imp := range tests {
 		t.Run(fmt.Sprintf("importance=%d", imp), func(t *testing.T) {
 			s := newQuickStoreServer(t)
@@ -201,6 +203,19 @@ func TestQuickStoreHandler_InvalidImportance(t *testing.T) {
 			s.handleQuickStore(w, req)
 
 			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// TestValidateQuickStoreInput_RejectsImportanceAbove4 is the regression test for #768.
+// Values in the formerly-accepted range (5–100) must now be rejected by the validator
+// before they reach handleMemoryStore, giving callers an early, descriptive error.
+func TestValidateQuickStoreInput_RejectsImportanceAbove4(t *testing.T) {
+	for _, imp := range []int{5, 10, 50, 100} {
+		t.Run(fmt.Sprintf("importance=%d", imp), func(t *testing.T) {
+			err := validateQuickStoreInput("some content", "global", nil, imp)
+			require.Error(t, err, "importance=%d should be rejected — was accepted by the buggy 0-100 validator", imp)
+			require.Contains(t, err.Error(), "importance must be", "error message should describe the valid range")
 		})
 	}
 }

--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -441,7 +441,8 @@ const maxQuickStoreTags = 64
 const maxQuickStoreTagLength = 256
 
 // maxImportanceValue is the maximum allowed importance value.
-const maxImportanceValue = 100
+// Must match the 0–4 range enforced by handleMemoryStore.
+const maxImportanceValue = 4
 
 // minImportanceValue is the minimum allowed importance value.
 const minImportanceValue = 0
@@ -453,7 +454,7 @@ var projectNamePattern = regexp.MustCompile(`^[a-z0-9_-]{1,64}$`)
 // - content: required, max 1 MiB
 // - project: must match ^[a-z0-9_-]{1,64}$
 // - tags: max 64, each max 256 chars
-// - importance: 0–100.
+// - importance: 0–4.
 func validateQuickStoreInput(content string, project string, tags []string, importance int) error {
 	if len(content) > maxQuickStoreContentSize {
 		return fmt.Errorf("content exceeds max size %d bytes", maxQuickStoreContentSize)


### PR DESCRIPTION
## Summary

Fixes #768 — importance bounds inconsistency between `validateQuickStoreInput` and `handleMemoryStore`.

**Decision:** Narrow the REST validator to 0-4 (match the handler), not widen the handler. The handler is the source of truth on semantic meaning; widening it would silently invalidate existing stored data.

## What changed

| File | Change |
|------|--------|
| `internal/mcp/tools_store.go` | `maxImportanceValue`: 100 to 4; constant comment and `validateQuickStoreInput` docstring updated to say 0-4 |
| `internal/mcp/quick_store_handler_test.go` | `TestQuickStoreHandler_InvalidImportance` boundary values updated from `{-1,101}` to `{-1,5}` (old values encoded the bug); added `TestValidateQuickStoreInput_RejectsImportanceAbove4` regression test covering values 5, 10, 50, 100 |
| `docs/architecture.md` | Corrected "Importance: 0-100" bullet to "0-4 (matches the handler range)" |

## Test plan

- [x] `go build ./internal/mcp/...` — clean
- [x] `go vet ./...` — clean (pre-existing build failures in internal/cache, internal/runner, internal/reporter are unrelated to this change)
- [x] `go test ./internal/mcp/... -count=1 -race` — all pass (15s)
- [x] `TestValidateQuickStoreInput_RejectsImportanceAbove4` — new regression test, covers 5/10/50/100
- [x] `TestQuickStoreHandler_InvalidImportance` — updated to reflect correct 0-4 boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)