### PR TITLE
fix(lme): ParseScoreLabel polish (#759, #760, #761)

### DIFF
--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -508,17 +508,24 @@ func ParseScoreLabel(raw string) (label, explanation string) {
 	}
 
 	// Pass 2: scan all lines for first label occurrence.
+	// Note: firstLineIdx != i is always true when the if-block below is entered —
+	// Pass 1 already tried firstLineIdx and found no match, so Pass 2 cannot
+	// match there either. The guard is removed to reduce cognitive overhead (#760).
 	for i, l := range allLines {
 		upper := strings.ToUpper(strings.TrimSpace(l))
 		for _, v := range validLabels {
 			if upper == v {
 				label = v
 				// Explanation is whatever follows on subsequent lines.
+				// When the label is on the last line (rationale-first format like
+				// "rationale\nCORRECT"), post is empty and the pre-label text
+				// becomes the explanation instead — this is intentional (#759).
 				if i+1 < len(allLines) {
 					explanation = strings.TrimSpace(strings.Join(allLines[i+1:], "\n"))
 				}
-				// Also capture any pre-label text as part of explanation if first line had content.
-				if firstLineIdx >= 0 && firstLineIdx != i {
+				// Capture any pre-label text as part of explanation.
+				// firstLineIdx != i is guaranteed (Pass 1 eliminated firstLineIdx).
+				if firstLineIdx >= 0 {
 					pre := strings.TrimSpace(strings.Join(allLines[firstLineIdx:i], "\n"))
 					if pre != "" && explanation != "" {
 						explanation = pre + "\n" + explanation

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -443,23 +443,47 @@ func TestParseScoreLabel_TruncatedNoLabel(t *testing.T) {
 	}
 }
 
-// TestParseScoreLabel_ScoreErrorPropagation verifies that SCORE_ERROR returned
-// from ParseScoreLabel results in a score entry with status="error" (not
-// silently counted as PARTIALLY_CORRECT in the score report).
+// TestParseScoreLabel_LabelLastLine verifies explanation semantics when the label
+// is on the last line (rationale-first / old format like "rationale\nCORRECT").
+// When no post-label lines exist, ParseScoreLabel uses the pre-label text as the
+// explanation — this is intentional: the preamble IS the rationale. (#759)
+func TestParseScoreLabel_LabelLastLine(t *testing.T) {
+	raw := "The answer matches the gold facts exactly.\nCORRECT"
+	label, expl := longmemeval.ParseScoreLabel(raw)
+	if label != "CORRECT" {
+		t.Errorf("label = %q, want CORRECT", label)
+	}
+	// Pre-label rationale becomes the explanation in last-line-label format.
+	if expl == "" {
+		t.Errorf("explanation is empty; want pre-label rationale as explanation (#759)")
+	}
+	if !strings.Contains(expl, "matches") {
+		t.Errorf("explanation = %q; want pre-label rationale text (#759)", expl)
+	}
+}
+
+// TestParseScoreLabel_ScoreErrorPropagation verifies that ParseScoreLabel returns
+// SCORE_ERROR (not CORRECT or PARTIALLY_CORRECT) when no valid label is found.
+// Guards the pipeline contract: SCORE_ERROR hits the default/Incorrect bucket in
+// writeScoreReport (cmd/longmemeval/score.go) — never silently inflates scores. (#761)
 func TestParseScoreLabel_ScoreErrorPropagation(t *testing.T) {
-	// SCORE_ERROR should be treated as an error in writeScoreReport, not as a
-	// valid label. Verify it falls into the "default" / Incorrect bucket.
-	// This test documents the expected pipeline behaviour.
-	//
-	// In writeScoreReport (cmd/longmemeval/score.go), the switch statement:
-	//   case "CORRECT": ...
-	//   case "PARTIALLY_CORRECT": ...
-	//   default: Incorrect++
-	// SCORE_ERROR hits "default" → counted as Incorrect, which is correct
-	// behaviour (conservative: unknown = not correct).
-	//
-	// If this behaviour changes, update this comment and the switch.
-	t.Log("SCORE_ERROR falls into default/Incorrect in writeScoreReport — documented by design")
+	inputs := []string{
+		// Truncated response — context window ran out before label was emitted.
+		"The hypothesis mentions the correct city but the explanation was cut",
+		// Garbled output — label-like text embedded inside a longer word.
+		"The result is INCORRECTLY stated in the hypothesis.",
+		// Empty string — no content at all.
+		"",
+	}
+	for _, raw := range inputs {
+		label, _ := longmemeval.ParseScoreLabel(raw)
+		if label == "CORRECT" || label == "PARTIALLY_CORRECT" {
+			t.Errorf("ParseScoreLabel(%q) = %q; want SCORE_ERROR, not a valid label — would silently inflate score counts (#761)", raw, label)
+		}
+		if label != "SCORE_ERROR" {
+			t.Errorf("ParseScoreLabel(%q) = %q, want SCORE_ERROR (#761)", raw, label)
+		}
+	}
 }
 
 func TestPreferenceRecallQuery_TransformsLiteralQuestion(t *testing.T) {


### PR DESCRIPTION
## Summary

Three `severity/nice-to-have` polish items from adversarial review of PR #757.

- **#759** — Document last-line label explanation semantics with a test. When the label is on the last line (old rationale-first format like `"rationale\nCORRECT"`), no post-label lines exist so `ParseScoreLabel` falls back to the pre-label text as the explanation. Added `TestParseScoreLabel_LabelLastLine` with assertions to document and guard this behaviour.

- **#760** — Remove unreachable `firstLineIdx != i` guard in Pass 2. Pass 1 and Pass 2 use identical comparison logic; if Pass 1 found no match at `firstLineIdx`, Pass 2 cannot match there either — the condition was always `true` when the if-block was entered. Removed the dead branch and replaced with an explanatory comment.

- **#761** — Replace the `t.Log`-only `TestParseScoreLabel_ScoreErrorPropagation` with real assertions. Three inputs that should yield `SCORE_ERROR` (truncated text, label embedded in a word, empty string) are now asserted — catches any regression where the parser incorrectly promotes an error input to a valid label and silently inflates score counts.

## Files changed

- `internal/longmemeval/claude.go` — #760 guard removed, #759 comment added (+9/−7 lines)
- `internal/longmemeval/claude_test.go` — `TestParseScoreLabel_LabelLastLine` added, `TestParseScoreLabel_ScoreErrorPropagation` replaced (+42/−11 lines)

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/longmemeval/... -count=1 -race` — all pass (10/10 ParseScoreLabel tests, full suite ok)
- [x] New tests `TestParseScoreLabel_LabelLastLine` and `TestParseScoreLabel_ScoreErrorPropagation` pass

## Not included

#758 (`newEngineWithDims` cleanup) — deferred until #767 merges per coordinator brief.

Closes #759, #760, #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)