### PR TITLE
fix(reembed): recover from stale connection after Postgres restart (#645)

### DIFF
--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -60,7 +60,9 @@ func configureSharedPool(cfg *pgxpool.Config) {
 	cfg.MaxConns = 50
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 3 * time.Minute
-	cfg.HealthCheckPeriod = 30 * time.Second
+	// 15s health-check so the pool detects dead connections within one
+	// GlobalReembedder poll interval after a Postgres restart (#645).
+	cfg.HealthCheckPeriod = 15 * time.Second
 }
 
 // registerTypesAfterConnect registers custom type codecs that every connection

--- a/internal/db/postgres_pool_config_test.go
+++ b/internal/db/postgres_pool_config_test.go
@@ -57,3 +57,49 @@ func TestPoolConfig_LifetimeValues(t *testing.T) {
 		t.Errorf("HealthCheckPeriod: got %v, want %v", got, want)
 	}
 }
+
+// TestSharedPoolConfig_HasLifetimeSettings verifies that configureSharedPool
+// sets all connection lifetime fields to non-zero values. The shared pool is
+// used by the server process (including the GlobalReembedder); a zero
+// HealthCheckPeriod would disable proactive detection of dead connections after
+// a Postgres restart (#645).
+func TestSharedPoolConfig_HasLifetimeSettings(t *testing.T) {
+	cfg, err := pgxpool.ParseConfig("postgres://user:password@localhost:5432/engram")
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	configureSharedPool(cfg)
+
+	if cfg.MaxConns <= 0 {
+		t.Errorf("MaxConns: got %d, want > 0", cfg.MaxConns)
+	}
+	if cfg.MaxConnLifetime == 0 {
+		t.Error("MaxConnLifetime is zero — stale connections will never be evicted")
+	}
+	if cfg.MaxConnIdleTime == 0 {
+		t.Error("MaxConnIdleTime is zero — idle connections will never be reaped")
+	}
+	if cfg.HealthCheckPeriod == 0 {
+		t.Error("HealthCheckPeriod is zero — dead connections will not be detected proactively")
+	}
+}
+
+// TestSharedPoolConfig_HealthCheckPeriod verifies that HealthCheckPeriod is at
+// most 15 seconds for the shared pool. A shorter period means stale connections
+// (from a Postgres restart) are detected within one GlobalReembedder poll
+// interval, preventing the silent-hang described in #645.
+func TestSharedPoolConfig_HealthCheckPeriod(t *testing.T) {
+	cfg, err := pgxpool.ParseConfig("postgres://user:password@localhost:5432/engram")
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	configureSharedPool(cfg)
+
+	const maxAllowed = 15 * time.Second
+	if cfg.HealthCheckPeriod > maxAllowed {
+		t.Errorf("HealthCheckPeriod: got %v, want ≤ %v — too long to detect post-restart stale connections promptly (#645)",
+			cfg.HealthCheckPeriod, maxAllowed)
+	}
+}

--- a/internal/db/postgres_shared_pool_test.go
+++ b/internal/db/postgres_shared_pool_test.go
@@ -12,6 +12,9 @@ import (
 // TestSharedPoolConfig verifies configureSharedPool sets values tuned for
 // a single pool shared across all project backends: higher MaxConns to handle
 // concurrent projects, lower MinConns to avoid wasting slots on idle instances.
+// HealthCheckPeriod was tightened from 30s to 15s in #645 so the pool detects
+// dead connections within one GlobalReembedder poll interval after a Postgres
+// restart, eliminating the silent-hang regression.
 func TestSharedPoolConfig(t *testing.T) {
 	cfg, err := pgxpool.ParseConfig("postgres://user:password@localhost:5432/engram")
 	if err != nil {
@@ -29,7 +32,9 @@ func TestSharedPoolConfig(t *testing.T) {
 	if got, want := cfg.MaxConnIdleTime, 3*time.Minute; got != want {
 		t.Errorf("MaxConnIdleTime: got %v, want %v", got, want)
 	}
-	if got, want := cfg.HealthCheckPeriod, 30*time.Second; got != want {
+	// 15s: tightened from 30s in #645 so stale connections are detected within
+	// one GlobalReembedder poll interval after a Postgres restart.
+	if got, want := cfg.HealthCheckPeriod, 15*time.Second; got != want {
 		t.Errorf("HealthCheckPeriod: got %v, want %v", got, want)
 	}
 	if cfg.MaxConnLifetime == 0 {

--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -19,18 +20,26 @@ const globalBatchTimeout = 5 * time.Minute
 const globalEmbedTimeout = 15 * time.Second
 const globalConcurrency = 8
 
+// consecutiveErrorThreshold is the number of consecutive batch errors after
+// which the worker calls pool.Reset() to drop stale connections and logs a
+// watchdog warning. This is the primary recovery mechanism for issue #645:
+// after a Postgres restart all pool connections become stale; pool.Reset()
+// forces the pool to establish fresh connections on the next Acquire() call.
+const consecutiveErrorThreshold = 3
+
 // GlobalReembedder processes unembedded chunks across ALL projects from a
 // single goroutine that is lifecycle-independent of any EnginePool entry.
 // It uses FOR UPDATE SKIP LOCKED so multiple server instances can safely
 // run concurrent GlobalReembedders against the same database (#359).
 type GlobalReembedder struct {
-	pool      *pgxpool.Pool
-	embedder  embed.Client
-	batchSize int
-	interval  time.Duration
-	startOnce sync.Once
-	done      chan struct{}
-	notify    chan struct{}
+	pool             *pgxpool.Pool
+	embedder         embed.Client
+	batchSize        int
+	interval         time.Duration
+	startOnce        sync.Once
+	done             chan struct{}
+	notify           chan struct{}
+	consecutiveErrors atomic.Int64 // counts consecutive batch errors; resets on success
 }
 
 // pendingChunk holds the minimal fields needed to embed and update a chunk.
@@ -82,6 +91,13 @@ func (g *GlobalReembedder) Notify() {
 	}
 }
 
+// ConsecutiveErrors returns the current count of consecutive batch errors.
+// It resets to zero after any successful batch (including an empty-queue result).
+// Exposed for integration tests that verify recovery after a Postgres restart.
+func (g *GlobalReembedder) ConsecutiveErrors() int64 {
+	return g.consecutiveErrors.Load()
+}
+
 func (g *GlobalReembedder) run(ctx context.Context) {
 	defer close(g.done)
 	slog.Info("global reembedder started", "batch_size", g.batchSize, "interval", g.interval)
@@ -115,10 +131,26 @@ func (g *GlobalReembedder) run(ctx context.Context) {
 					return
 				}
 				if err != nil {
-					slog.Warn("global reembedder batch error", "err", err)
+					consecutive := g.consecutiveErrors.Add(1)
+					slog.Warn("global reembedder batch error",
+						"err", err,
+						"consecutive_errors", consecutive)
 					metrics.WorkerErrors.WithLabelValues("global_reembed").Inc()
+					// After consecutiveErrorThreshold failures the pool likely
+					// holds only stale connections from before a Postgres restart.
+					// pool.Reset() closes all idle connections and marks checked-out
+					// ones for close-on-return, forcing fresh connections on the
+					// next Acquire() call. This is the primary recovery path for
+					// issue #645 (silent hang after 15s Postgres outage).
+					if consecutive >= consecutiveErrorThreshold {
+						slog.Warn("global reembedder: resetting pool after repeated errors — possible Postgres restart",
+							"consecutive_errors", consecutive)
+						g.pool.Reset()
+					}
 					break
 				}
+				// Successful iteration: reset consecutive-error counter.
+				g.consecutiveErrors.Store(0)
 				if n == 0 {
 					// Queue is empty — back off exponentially.
 					backoff = min(backoff*2, maxBackoff)

--- a/internal/reembed/global_worker_recovery_test.go
+++ b/internal/reembed/global_worker_recovery_test.go
@@ -1,0 +1,155 @@
+package reembed
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/petersimmons1972/engram/internal/testutil"
+)
+
+// TestGlobalReembedder_ConsecutiveErrorCounterResets verifies that the
+// consecutive-error counter increments on error and resets to zero after a
+// successful batch. This counter drives the pool.Reset() call that recovers
+// from stale connections after a Postgres restart (#645).
+func TestGlobalReembedder_ConsecutiveErrorCounterResets(t *testing.T) {
+	g := &GlobalReembedder{
+		pool:      nil,
+		embedder:  nil,
+		batchSize: 10,
+		interval:  time.Hour,
+		done:      make(chan struct{}),
+		notify:    make(chan struct{}, 1),
+	}
+
+	// Simulate manual error increments (what run() does on safeRunBatch failure).
+	for i := 1; i <= 5; i++ {
+		got := g.consecutiveErrors.Add(1)
+		if got != int64(i) {
+			t.Errorf("after %d errors: consecutive_errors = %d, want %d", i, got, i)
+		}
+	}
+	if g.ConsecutiveErrors() != 5 {
+		t.Fatalf("ConsecutiveErrors(): got %d, want 5", g.ConsecutiveErrors())
+	}
+
+	// On success, run() calls Store(0).
+	g.consecutiveErrors.Store(0)
+	if g.ConsecutiveErrors() != 0 {
+		t.Errorf("after reset: ConsecutiveErrors() = %d, want 0", g.ConsecutiveErrors())
+	}
+}
+
+// TestGlobalReembedder_HasPoolResetOnThreshold verifies the source code contains
+// the pool.Reset() call guarded by the threshold, ensuring the recovery path
+// cannot be accidentally deleted without breaking this test (#645).
+func TestGlobalReembedder_HasPoolResetOnThreshold(t *testing.T) {
+	src, err := os.ReadFile("global_worker.go")
+	if err != nil {
+		t.Fatalf("read global_worker.go: %v", err)
+	}
+	text := string(src)
+
+	if !strings.Contains(text, "pool.Reset()") {
+		t.Error("global_worker.go missing pool.Reset() call — Postgres restart recovery path deleted (#645)")
+	}
+	if !strings.Contains(text, "consecutiveErrorThreshold") {
+		t.Error("global_worker.go missing consecutiveErrorThreshold guard — pool.Reset() must be threshold-gated (#645)")
+	}
+}
+
+// countingEmbedder is a fake embed.Client that returns a zero vector.
+type countingEmbedder struct {
+	dims int
+}
+
+func (c *countingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, c.dims), nil
+}
+func (c *countingEmbedder) Name() string    { return fmt.Sprintf("counting") }
+func (c *countingEmbedder) Dimensions() int { return c.dims }
+
+// TestGlobalReembedder_RecoveryIntegration is an integration test that requires
+// a live Postgres instance (TEST_DATABASE_URL). It verifies that after the pool
+// is forcibly reset (simulating a Postgres restart), the GlobalReembedder
+// processes a queued chunk within 25 seconds (#645).
+func TestGlobalReembedder_RecoveryIntegration(t *testing.T) {
+	dsn := testutil.DSN(t) // skips if TEST_DATABASE_URL is unset
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pool, err := db.NewSharedPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("NewSharedPool: %v", err)
+	}
+	defer pool.Close()
+
+	project := testutil.UniqueProject("reembed-recovery")
+	backend, err := db.NewPostgresBackendWithPool(ctx, project, pool)
+	if err != nil {
+		t.Fatalf("NewPostgresBackendWithPool: %v", err)
+	}
+
+	// Seed a memory with a NULL-embedded chunk.
+	mem := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "integration test for #645 recovery",
+		MemoryType:  "context",
+		Project:     project,
+		Importance:  1,
+		StorageMode: "focused",
+	}
+	if err := backend.StoreMemory(ctx, mem); err != nil {
+		t.Fatalf("StoreMemory: %v", err)
+	}
+
+	chunkID := types.NewMemoryID()
+	chunk := &types.Chunk{
+		ID:         chunkID,
+		MemoryID:   mem.ID,
+		Project:    project,
+		ChunkText:  mem.Content,
+		ChunkIndex: 0,
+		// Embedding left nil → stored as NULL → picked up by runBatch.
+	}
+	if err := backend.StoreChunks(ctx, []*types.Chunk{chunk}); err != nil {
+		t.Fatalf("StoreChunks: %v", err)
+	}
+
+	embedder := &countingEmbedder{dims: 768}
+	g := NewGlobalReembedder(pool, embedder, 10, 100*time.Millisecond)
+
+	// Simulate all connections going stale (e.g. Postgres was restarted) by
+	// calling pool.Reset() before starting the worker. The worker must recover
+	// and process the chunk within the test deadline.
+	pool.Reset()
+
+	g.Start(ctx)
+	defer g.Wait()
+
+	// Notify immediately to skip the initial backoff sleep.
+	g.Notify()
+
+	// Poll until the chunk has a non-NULL embedding or the context times out.
+	deadline := time.Now().Add(25 * time.Second)
+	for time.Now().Before(deadline) {
+		var embeddingIsNull bool
+		err := pool.QueryRow(ctx,
+			"SELECT embedding IS NULL FROM chunks WHERE id = $1", chunkID,
+		).Scan(&embeddingIsNull)
+		if err != nil {
+			t.Logf("check embedding: %v (retrying)", err)
+		} else if !embeddingIsNull {
+			return // success
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Errorf("chunk %s still has NULL embedding after 25s — worker did not recover from simulated Postgres restart (#645)", chunkID)
+}

--- a/internal/reembed/global_worker_recovery_test.go
+++ b/internal/reembed/global_worker_recovery_test.go
@@ -2,7 +2,6 @@ package reembed
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -71,7 +70,7 @@ type countingEmbedder struct {
 func (c *countingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, c.dims), nil
 }
-func (c *countingEmbedder) Name() string    { return fmt.Sprintf("counting") }
+func (c *countingEmbedder) Name() string    { return "counting" }
 func (c *countingEmbedder) Dimensions() int { return c.dims }
 
 // TestGlobalReembedder_RecoveryIntegration is an integration test that requires
@@ -122,7 +121,7 @@ func TestGlobalReembedder_RecoveryIntegration(t *testing.T) {
 		t.Fatalf("StoreChunks: %v", err)
 	}
 
-	embedder := &countingEmbedder{dims: 768}
+	embedder := &countingEmbedder{dims: 1024}
 	g := NewGlobalReembedder(pool, embedder, 10, 100*time.Millisecond)
 
 	// Simulate all connections going stale (e.g. Postgres was restarted) by


### PR DESCRIPTION
## Problem

After a Postgres restart (or any outage ≥15 s), all pool connections become stale. `pool.Begin()` fails, `safeRunBatch` returns an error, and the worker backs off — but without calling `pool.Reset()` the pool never drops stale connections. The worker silently stops processing reembed work until the process is restarted.

Closes #645

## Fix

- **Atomic consecutive-error counter**: increments on each `safeRunBatch` failure, resets to 0 on success.
- **`pool.Reset()` on threshold**: after `consecutiveErrorThreshold` (3) failures, `pool.Reset()` is called — closes all idle connections and marks checked-out ones for close-on-return, forcing fresh connections on the next `Acquire()`.
- **`HealthCheckPeriod` tightened**: `configureSharedPool` now sets `HealthCheckPeriod` to 15 s (was 30 s) so the pool self-heals within one poll interval after a Postgres restart.

## Tests added

- `TestGlobalReembedder_ConsecutiveErrorCounterResets` (unit, no DB)
- `TestGlobalReembedder_HasPoolResetOnThreshold` (source guard, no DB)
- `TestGlobalReembedder_RecoveryIntegration` (integration, skips without `TEST_DATABASE_URL`)
- `TestSharedPoolConfig_HasLifetimeSettings` (unit, no DB)
- `TestSharedPoolConfig_HealthCheckPeriod` (unit, no DB — regression guard for 15 s cap)

## Branch note

This is a re-open of the #645 fix on a clean branch. The previous branch (`fix/645-reembed-worker-hang`, PR #792) was closed because it contained a duplicate of the `anthropic.go` transport fix from PR #797 (#772), not the reembed fix. This branch contains only the correct `00337c8` cherry-pick.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>