### PR TITLE
test(mcp): add regression guards for memory_store_batch Immutable forwarding

### DIFF
--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -375,7 +375,10 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 	}
 	var importance *int
 	if v, ok := args["importance"].(float64); ok {
-		n := types.ValidateImportance(int(v))
+		n := int(v)
+		if n < minImportanceValue || n > maxImportanceValue {
+			return mcpgo.NewToolResultError(fmt.Sprintf("importance must be %d–%d, got %d", minImportanceValue, maxImportanceValue, n)), nil
+		}
 		importance = &n
 	}
 	var patternConfidence *float64

--- a/internal/mcp/tools_store_test.go
+++ b/internal/mcp/tools_store_test.go
@@ -12,6 +12,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -83,6 +84,81 @@ func TestMemoryStoreBatch_PersistsImmutable(t *testing.T) {
 	require.True(t, cap.stored[0].Immutable, "Immutable must be true — see issue #764")
 }
 
+// ── #782: memory_store_batch Immutable does not reach DB column ───────────────
+
+// TestMemoryStoreBatch_ImmutableForwardedToDBAll verifies that when ALL items in
+// a batch have immutable=true, every stored memory reaches the capturing-backend
+// layer (i.e., StoreMemoryTx) with Immutable=true — regression guard for #782.
+// This is the "bulk-store path forwards Immutable to the DB column" check.
+func TestMemoryStoreBatch_ImmutableForwardedToDBAll(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"memories": []any{
+			map[string]any{
+				"content":   "immutable item alpha",
+				"immutable": true,
+			},
+			map[string]any{
+				"content":   "immutable item beta",
+				"immutable": true,
+			},
+		},
+	}
+
+	res, err := handleMemoryStoreBatch(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Len(t, cap.stored, 2, "exactly 2 memories must be stored")
+	require.True(t, cap.stored[0].Immutable,
+		"item 0: Immutable must reach DB layer as true — see issue #782")
+	require.True(t, cap.stored[1].Immutable,
+		"item 1: Immutable must reach DB layer as true — see issue #782")
+}
+
+// TestMemoryStoreBatch_ImmutableMixedNoCrossContamination verifies that when a
+// batch has a mix of immutable and mutable items, only the items with
+// immutable=true arrive at the DB layer as Immutable=true, and mutable items
+// are not promoted — regression guard for #764 and #782.
+func TestMemoryStoreBatch_ImmutableMixedNoCrossContamination(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"memories": []any{
+			map[string]any{
+				"content":   "mutable item",
+				"immutable": false,
+			},
+			map[string]any{
+				"content":   "immutable item",
+				"immutable": true,
+			},
+			map[string]any{
+				"content": "default-mutable item (no flag)",
+			},
+		},
+	}
+
+	res, err := handleMemoryStoreBatch(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Len(t, cap.stored, 3, "exactly 3 memories must be stored")
+	require.False(t, cap.stored[0].Immutable,
+		"item 0 (immutable=false): must not be marked immutable at DB layer")
+	require.True(t, cap.stored[1].Immutable,
+		"item 1 (immutable=true): must be marked immutable at DB layer — see issue #764/#782")
+	require.False(t, cap.stored[2].Immutable,
+		"item 2 (no flag): must default to mutable at DB layer — no cross-contamination from item 1")
+}
+
 // ── #763: memory_store_document drops valid_from and episode_id ───────────────
 
 // documentCapturingBackend extends storeCapableBackend to record the memory
@@ -144,6 +220,36 @@ func TestMemoryStoreDocument_PersistsValidFromAndEpisode(t *testing.T) {
 		"ValidFrom must equal 2024-03-20 UTC, got %s", m.ValidFrom)
 
 	require.Equal(t, episodeID, m.EpisodeID, "EpisodeID must be propagated — see issue #763")
+}
+
+// ── #789: handleMemoryCorrect silently clamps importance; should validate ────────
+
+// TestHandleMemoryCorrect_RejectsOutOfRangeImportance is the regression guard
+// for issue #789. handleMemoryCorrect was silently clamping importance values
+// outside [0, 4] instead of returning an error. It must now mirror the store
+// path and reject them with a descriptive MCP error.
+func TestHandleMemoryCorrect_RejectsOutOfRangeImportance(t *testing.T) {
+	back := &validFromCorrectBackend{}
+	pool := newValidFromCorrectPool(t, back)
+
+	for _, imp := range []float64{-1, 5, 10, 100} {
+		t.Run(fmt.Sprintf("importance=%.0f", imp), func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{
+				"project":    "test",
+				"memory_id":  "mem-abc123",
+				"importance": imp,
+			}
+
+			res, err := handleMemoryCorrect(context.Background(), pool, req)
+			require.NoError(t, err, "handler must not return a Go error for invalid importance")
+			require.NotNil(t, res, "handler must return a result")
+			require.True(t, res.IsError,
+				"importance=%.0f is out of range — handler must return an MCP error, not silently clamp", imp)
+			require.False(t, back.called,
+				"UpdateMemory must not be called when importance is out of range")
+		})
+	}
 }
 
 // ── #765: memory_correct does not recalc valid_from on tag change ─────────────


### PR DESCRIPTION
## Summary

- Adds `TestMemoryStoreBatch_ImmutableForwardedToDBAll`: verifies that when all batch items have `immutable=true`, every stored `types.Memory` reaches `StoreMemoryTx` (the DB layer) with `Immutable=true` — regression guard for #782
- Adds `TestMemoryStoreBatch_ImmutableMixedNoCrossContamination`: verifies per-item immutable flags are independently forwarded with no cross-contamination between mutable and immutable items in the same batch — regression guard for #764 and #782
- The code fix (line 309, `Immutable: getBool(mmap, "immutable", false)`) was already present in `main`; these tests lock in the verified behavior end-to-end through the capturing backend (equivalent to the DB column write path)

Also included: #789 fix — `handleMemoryCorrect` now rejects out-of-range importance values (was silently clamping).

Closes #782
Closes #764

## Test plan

- [x] `TestMemoryStoreBatch_ImmutableForwardedToDBAll` — PASS
- [x] `TestMemoryStoreBatch_ImmutableMixedNoCrossContamination` — PASS
- [x] `TestMemoryStoreBatch_PersistsImmutable` (pre-existing #764 guard) — PASS
- [x] `go test ./internal/mcp/ -count=1 -race` — PASS
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)