### PR TITLE
fix(search): wire checkEmbedderMeta guard into RecallWithinMemory (#788)

### DIFF
--- a/cmd/audit/report.go
+++ b/cmd/audit/report.go
@@ -76,7 +76,7 @@ func envOr(key, fallback string) string {
 // errNoEngram is returned when no Engram credentials can be resolved from
 // flags, environment variables, or the developer config file.
 var errNoEngram = errors.New(
-	"Engram credentials not found: set ENGRAM_URL and ENGRAM_TOKEN env vars, " +
+	"engram credentials not found: set ENGRAM_URL and ENGRAM_TOKEN env vars, " +
 		"or pass -engram and -token flags",
 )
 // resolveEngram returns the Engram base URL and bearer token to use.

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -946,6 +946,13 @@ func (e *SearchEngine) RecallWithinMemory(ctx context.Context, query string, mem
 	if topK <= 0 {
 		topK = 10
 	}
+	// Guard: reject calls when the stored embedder name does not match the
+	// current client — same check wired into RecallWithOpts and StoreBatch.
+	// Without this, dimension or model mismatches return garbage silently.
+	if err := e.checkEmbedderMeta(ctx); err != nil {
+		return nil, err
+	}
+
 	// Embed call bounded by embedRecallTimeout, consistent with RecallWithOpts.
 	// RecallWithinMemory has no BM25 fallback (document chunk search is
 	// vector-only), so it returns an error on embed failure.

--- a/internal/search/retrieval_precision_test.go
+++ b/internal/search/retrieval_precision_test.go
@@ -208,3 +208,44 @@ func TestRetrievalTracking_DimMismatch(t *testing.T) {
 		"PermanentError must record the dim mismatch in Stored vs Current (stored=%q current=%q)",
 		permErr.Stored, permErr.Current)
 }
+
+// TestRecallWithinMemory_EmbedderMetaGuard is a regression test for issue #788.
+// It verifies that RecallWithinMemory rejects calls when the current embedder
+// name does not match what was stored — the same guard already wired into
+// RecallWithOpts and StoreBatch via checkEmbedderMeta.
+func TestRecallWithinMemory_EmbedderMetaGuard(t *testing.T) {
+	ctx := context.Background()
+	proj := uniqueProject("test-rwm-embedder-meta")
+
+	// Store a memory using an engine named "fake" (fakeClient.Name() == "fake").
+	engine1 := newTestEngine(t, proj)
+	t.Cleanup(func() { engine1.Close() })
+	m := &types.Memory{
+		Content:     "embedder meta guard test memory",
+		MemoryType:  types.MemoryTypeDecision,
+		Project:     proj,
+		Importance:  1,
+		StorageMode: "focused",
+	}
+	require.NoError(t, engine1.Store(ctx, m))
+
+	// Attempt RecallWithinMemory using a different embedder name — must return
+	// an *embed.PermanentError, not silently return mismatched vectors.
+	otherClient := &fakeClientWithName{dims: 768, name: "other-embedder"}
+	backend2, err := db.NewPostgresBackend(ctx, proj, testDSN(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { backend2.Close() })
+	engine2 := search.New(ctx, backend2, otherClient, proj,
+		"http://ollama:11434", "llama3.2", false, nil, 0)
+	t.Cleanup(func() { engine2.Close() })
+
+	_, err = engine2.RecallWithinMemory(ctx, "embedder meta guard test memory", m.ID, 5, "summary")
+	require.Error(t, err, "RecallWithinMemory must return error when embedder name mismatches stored metadata")
+
+	var permErr *embed.PermanentError
+	require.True(t, errors.As(err, &permErr),
+		"error must be an *embed.PermanentError (got: %v)", err)
+	assert.NotEqual(t, permErr.Stored, permErr.Current,
+		"PermanentError must record the embedder mismatch in Stored vs Current (stored=%q current=%q)",
+		permErr.Stored, permErr.Current)
+}


### PR DESCRIPTION
Closes #788.

## What

Wires the `checkEmbedderMeta` guard into `RecallWithinMemory`, following the same pattern established in #785 for `RecallMemories`. Previously, `RecallWithinMemory` skipped the embedder-metadata validation step, meaning a dimension mismatch or stale embedder config could silently produce incorrect recall results within a scoped search.

## Why

The guard was introduced in #785 to prevent retrieval against a mismatched embedding space. `RecallWithinMemory` shares the same retrieval pipeline and is equally vulnerable to the same class of failure. Omitting it there was an oversight caught during the #789 review cycle.

## Test coverage

Existing search-package tests pass with `-race`. The guard itself was validated as part of #785; this commit is the wiring fix only.

## Notes

- Original commit `2d32a51` was stacked on `fix/issue-789` in a local worktree. It has been safely cherry-picked here; the stacked state has been reset.
- Backup ref `origin/backup/issue-788-wip` retains the original stack context and will be deleted after this PR merges.