### PR TITLE
fix(lme): cleanup-policy enum with auto default — preserve cross-experiment projects (#751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to engram-go are documented here.
 
 ## [Unreleased] — v3.3.0
 
+### Bug Fix — lme cleanup-policy (#751)
+
+- **`--cleanup-policy` enum (default: `auto`):** The `lme run` stage now ships a three-value cleanup policy instead of the old unconditional delete. `auto` (new default) deletes only projects whose name matches the `lme-{runID}-*` prefix created by the current invocation; externally ingested or cache-reused projects are preserved. `always` restores the pre-fix unconditional-delete behavior. `never` preserves everything (useful for cross-experiment reuse such as Exp 10 → Exp 13).
+- **`--no-cleanup` deprecated:** The old boolean flag remains registered for backward compatibility and is silently coerced to `--cleanup-policy=never`. A `WARN: --no-cleanup is deprecated` message is emitted to stderr on use.
+- **Migration note:** Existing camp pipeline scripts that relied on `--no-cleanup` continue to work unchanged. Scripts that want the old unconditional-delete behavior must pass `--cleanup-policy=always` explicitly going forward.
+
+---
+
+## [Unreleased] — v3.3.0
+
 ### Reliability (PR #611-fix2)
 
 - **Async embed on store (architecturally enforced):** `memory_store` and `memory_store_batch` return after the DB write completes (~10ms), regardless of embed pool state. Chunks are stored with NULL embeddings and the existing reembed worker backfills them asynchronously. New Prometheus counter `engram_store_embed_async_total` tracks call volume on the async path. Rollback: set `ENGRAM_STORE_EMBED_MODE=sync` to restore inline embedding without redeploying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ All notable changes to engram-go are documented here.
 
 ## [Unreleased] — v3.3.0
 
-### Bug Fix — lme cleanup-policy (#751)
+### Bug Fix — lme cleanup-policy (#751, PR #807)
 
 - **`--cleanup-policy` enum (default: `auto`):** The `lme run` stage now ships a three-value cleanup policy instead of the old unconditional delete. `auto` (new default) deletes only projects whose name matches the `lme-{runID}-*` prefix created by the current invocation; externally ingested or cache-reused projects are preserved. `always` restores the pre-fix unconditional-delete behavior. `never` preserves everything (useful for cross-experiment reuse such as Exp 10 → Exp 13).
 - **`--no-cleanup` deprecated:** The old boolean flag remains registered for backward compatibility and is silently coerced to `--cleanup-policy=never`. A `WARN: --no-cleanup is deprecated` message is emitted to stderr on use.
 - **Migration note:** Existing camp pipeline scripts that relied on `--no-cleanup` continue to work unchanged. Scripts that want the old unconditional-delete behavior must pass `--cleanup-policy=always` explicitly going forward.
+- **`--cleanup-policy=<invalid>` now rejected (PR #807 R2-B2):** Unrecognised values (e.g. `ALWAYS`, `Never`, empty string) exit 1 with `invalid --cleanup-policy` in stderr instead of silently falling through to `auto`.
+- **`--no-cleanup` + `--cleanup-policy` conflict error (PR #807 R2-B3):** Passing both flags now produces a clear conflict error and exits 1.
+- **RunID expanded to 64-bit entropy (PR #807 S7):** `newRunID()` now generates 8 random bytes (16 hex chars) instead of 3 (6 hex chars), reducing prefix-match collision risk from 1-in-16M to ~1-in-18-quintillion on shared infrastructure.
+- **Cleanup preserve log collapsed to single end-of-run summary (PR #807 S9):** Per-question "preserved" log lines replaced by one `cleanup-summary` line at the end of the run. Grep token: `cleanup-summary`.
 
 ---
-
-## [Unreleased] — v3.3.0
 
 ### Reliability (PR #611-fix2)
 
@@ -24,7 +26,7 @@ All notable changes to engram-go are documented here.
 
 ---
 
-## [Unreleased] — v3.2.0
+## [v3.2.0]
 
 ### Security (PR #594)
 - **Bearer auth on `/setup-token` and `/metrics`:** Added Authorization header requirement to prevent token enumeration and metrics exposure from unauthenticated clients.

--- a/cmd/audit/report.go
+++ b/cmd/audit/report.go
@@ -76,7 +76,7 @@ func envOr(key, fallback string) string {
 // errNoEngram is returned when no Engram credentials can be resolved from
 // flags, environment variables, or the developer config file.
 var errNoEngram = errors.New(
-	"Engram credentials not found: set ENGRAM_URL and ENGRAM_TOKEN env vars, " +
+	"engram credentials not found: set ENGRAM_URL and ENGRAM_TOKEN env vars, " +
 		"or pass -engram and -token flags",
 )
 // resolveEngram returns the Engram base URL and bearer token to use.

--- a/cmd/longmemeval/cleanup_policy.go
+++ b/cmd/longmemeval/cleanup_policy.go
@@ -1,0 +1,40 @@
+package main
+
+import "strings"
+
+// CleanupPolicy controls whether Engram projects are deleted after the run stage.
+type CleanupPolicy string
+
+const (
+	// CleanupPolicyAuto (default) deletes only projects created by this run
+	// invocation — identified by the lme-{runID}-* name prefix. Externally
+	// supplied or cache-reused projects are preserved.
+	CleanupPolicyAuto CleanupPolicy = "auto"
+
+	// CleanupPolicyAlways unconditionally deletes every project touched by
+	// the run stage, matching the pre-v0 behavior.
+	CleanupPolicyAlways CleanupPolicy = "always"
+
+	// CleanupPolicyNever preserves all projects regardless of provenance.
+	// Equivalent to the deprecated --no-cleanup flag.
+	CleanupPolicyNever CleanupPolicy = "never"
+)
+
+// shouldCleanupProject returns true when the configured cleanup policy
+// requires project to be deleted after the run stage.
+//
+// Policy semantics:
+//   - auto:   delete iff project name matches lme-{cfg.RunID}-* (created by this run)
+//   - always: always delete
+//   - never:  never delete
+func shouldCleanupProject(cfg *Config, project string) bool {
+	switch cfg.CleanupPolicy {
+	case CleanupPolicyAlways:
+		return true
+	case CleanupPolicyNever:
+		return false
+	default: // CleanupPolicyAuto
+		prefix := "lme-" + cfg.RunID + "-"
+		return strings.HasPrefix(project, prefix)
+	}
+}

--- a/cmd/longmemeval/cleanup_policy_test.go
+++ b/cmd/longmemeval/cleanup_policy_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// CleanupPolicy enum — #751
+// ---------------------------------------------------------------------------
+
+// TestCleanupPolicy_AutoPreservesExternalProject verifies that when
+// --cleanup-policy=auto, a project whose name does NOT match the current
+// run's lme-{runID}-* prefix is preserved (not deleted).
+func TestCleanupPolicy_AutoPreservesExternalProject(t *testing.T) {
+	// External project: ingested by a *different* run (runID "abc111")
+	cfg := &Config{
+		RunID:         "abc222",
+		CleanupPolicy: CleanupPolicyAuto,
+	}
+	project := "lme-abc111-q001" // different runID in name
+	if shouldCleanupProject(cfg, project) {
+		t.Errorf("auto policy: expected external project %q to be preserved, but shouldCleanupProject returned true", project)
+	}
+}
+
+// TestCleanupPolicy_AutoDeletesIngestedProject verifies that when
+// --cleanup-policy=auto, a project whose name matches the current run's
+// lme-{runID}-* prefix IS deleted.
+func TestCleanupPolicy_AutoDeletesIngestedProject(t *testing.T) {
+	cfg := &Config{
+		RunID:         "abc222",
+		CleanupPolicy: CleanupPolicyAuto,
+	}
+	project := "lme-abc222-q001" // matches this run's runID
+	if !shouldCleanupProject(cfg, project) {
+		t.Errorf("auto policy: expected ingested project %q to be cleaned up, but shouldCleanupProject returned false", project)
+	}
+}
+
+// TestCleanupPolicy_AlwaysDeletes verifies that --cleanup-policy=always
+// deletes every project regardless of provenance.
+func TestCleanupPolicy_AlwaysDeletes(t *testing.T) {
+	cfg := &Config{
+		RunID:         "abc222",
+		CleanupPolicy: CleanupPolicyAlways,
+	}
+	cases := []string{
+		"lme-abc222-q001", // own project
+		"lme-abc111-q001", // external project
+		"my-custom-project", // non-lme project
+	}
+	for _, project := range cases {
+		if !shouldCleanupProject(cfg, project) {
+			t.Errorf("always policy: expected project %q to be deleted, but shouldCleanupProject returned false", project)
+		}
+	}
+}
+
+// TestCleanupPolicy_NeverPreserves verifies that --cleanup-policy=never
+// preserves every project regardless of provenance.
+func TestCleanupPolicy_NeverPreserves(t *testing.T) {
+	cfg := &Config{
+		RunID:         "abc222",
+		CleanupPolicy: CleanupPolicyNever,
+	}
+	cases := []string{
+		"lme-abc222-q001",
+		"lme-abc111-q001",
+		"my-custom-project",
+	}
+	for _, project := range cases {
+		if shouldCleanupProject(cfg, project) {
+			t.Errorf("never policy: expected project %q to be preserved, but shouldCleanupProject returned true", project)
+		}
+	}
+}
+
+// TestNoCleanupFlag_DeprecatedAliasForNever verifies that --no-cleanup is
+// parsed as CleanupPolicyNever (backward-compat) and emits a deprecation
+// warning to stderr.
+func TestNoCleanupFlag_DeprecatedAliasForNever(t *testing.T) {
+	// Structural: verify the flag registration wires NoCleanup to CleanupPolicyNever
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+	// The flag must still be registered for backward compat
+	if !strings.Contains(text, `"no-cleanup"`) {
+		t.Error("main.go: --no-cleanup flag must remain registered for backward compatibility (#751)")
+	}
+	// A deprecation notice must be emitted
+	if !strings.Contains(text, "deprecated") && !strings.Contains(text, "DEPRECATED") {
+		t.Error("main.go: --no-cleanup must emit a deprecation warning (#751)")
+	}
+}
+
+// TestCleanupPolicyFlag_DefaultIsAuto verifies that CleanupPolicy defaults to
+// "auto" in the flag registration so existing runs that don't set any flag
+// switch to the safe default (preserve external projects).
+func TestCleanupPolicyFlag_DefaultIsAuto(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, `"cleanup-policy"`) {
+		t.Error("main.go: --cleanup-policy flag must be registered (#751)")
+	}
+	if !strings.Contains(text, `CleanupPolicyAuto`) {
+		t.Error("main.go: --cleanup-policy default must be CleanupPolicyAuto (#751)")
+	}
+}
+
+// TestCleanupPolicyStructuralGuard verifies run.go uses shouldCleanupProject
+// instead of the old cfg.NoCleanup boolean check.
+func TestCleanupPolicyStructuralGuard(t *testing.T) {
+	src, err := os.ReadFile("run.go")
+	if err != nil {
+		t.Fatalf("read run.go: %v", err)
+	}
+	text := string(src)
+	if strings.Contains(text, "cfg.NoCleanup") {
+		t.Error("run.go: cfg.NoCleanup still referenced; must be replaced by shouldCleanupProject() (#751)")
+	}
+	if !strings.Contains(text, "shouldCleanupProject") {
+		t.Error("run.go: must call shouldCleanupProject() for cleanup decision (#751)")
+	}
+}

--- a/cmd/longmemeval/cleanup_policy_test.go
+++ b/cmd/longmemeval/cleanup_policy_test.go
@@ -141,7 +141,7 @@ func TestCleanupPolicyStructuralGuard(t *testing.T) {
 // ingest (avoids log.Fatalf in loadItems). The cleanup-policy check must fire
 // before the --data required check.
 func TestCleanupPolicy_UnknownValueRejected(t *testing.T) {
-	cases := []string{"ALWAYS", "Never", "sometimes", "1"}
+	cases := []string{"ALWAYS", "Never", "sometimes", "1", ""}
 	for _, val := range cases {
 		t.Run("policy="+val, func(t *testing.T) {
 			var stdout, stderr strings.Builder

--- a/cmd/longmemeval/cleanup_policy_test.go
+++ b/cmd/longmemeval/cleanup_policy_test.go
@@ -129,3 +129,99 @@ func TestCleanupPolicyStructuralGuard(t *testing.T) {
 		t.Error("run.go: must call shouldCleanupProject() for cleanup decision (#751)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// B2: unknown --cleanup-policy value must be rejected — Round 2 QA
+// ---------------------------------------------------------------------------
+
+// TestCleanupPolicy_UnknownValueRejected verifies that an unrecognised
+// --cleanup-policy value causes dispatch to exit non-zero with a descriptive
+// error message rather than silently falling through to auto. (B2)
+// Note: --data is intentionally omitted so dispatch returns before running
+// ingest (avoids log.Fatalf in loadItems). The cleanup-policy check must fire
+// before the --data required check.
+func TestCleanupPolicy_UnknownValueRejected(t *testing.T) {
+	cases := []string{"ALWAYS", "Never", "sometimes", "1"}
+	for _, val := range cases {
+		t.Run("policy="+val, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			args := []string{"longmemeval", "ingest", "--cleanup-policy", val}
+			exit := dispatch(args, &stdout, &stderr)
+			if exit == 0 {
+				t.Errorf("dispatch with --cleanup-policy=%q exited 0; want non-zero (invalid value must be rejected)", val)
+			}
+			combined := stderr.String() + stdout.String()
+			if !strings.Contains(combined, "invalid --cleanup-policy") {
+				t.Errorf("expected 'invalid --cleanup-policy' in output; got stderr=%q stdout=%q", stderr.String(), stdout.String())
+			}
+		})
+	}
+}
+
+// TestCleanupPolicy_ValidValuesAccepted ensures the three valid values are not
+// rejected by the enum guard (they may fail later due to missing --data, but
+// must not fail with the cleanup-policy error). (B2 regression guard)
+func TestCleanupPolicy_ValidValuesAccepted(t *testing.T) {
+	for _, val := range []string{"auto", "always", "never"} {
+		t.Run("policy="+val, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			args := []string{"longmemeval", "ingest", "--cleanup-policy", val}
+			exit := dispatch(args, &stdout, &stderr)
+			combined := stderr.String() + stdout.String()
+			if strings.Contains(combined, "invalid --cleanup-policy") {
+				t.Errorf("valid --cleanup-policy=%q was rejected: %s", val, combined)
+			}
+			// exit may be non-zero (e.g. missing --data) but must not be due to policy
+			_ = exit
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B3: --no-cleanup + explicit --cleanup-policy must conflict — Round 2 QA
+// ---------------------------------------------------------------------------
+
+// TestNoCleanup_ConflictsWithExplicitPolicy verifies that combining the
+// deprecated --no-cleanup flag with an explicit (non-default) --cleanup-policy
+// value causes an error rather than silently overwriting the policy. (B3)
+// Note: --data omitted intentionally — conflict check must fire before data check.
+func TestNoCleanup_ConflictsWithExplicitPolicy(t *testing.T) {
+	// "auto" is the default value; --no-cleanup + explicit auto cannot be
+	// distinguished from --no-cleanup alone, so only non-auto values conflict.
+	conflicts := []string{"always", "never"}
+	for _, policy := range conflicts {
+		t.Run("policy="+policy, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			args := []string{
+				"longmemeval", "ingest",
+				"--no-cleanup",
+				"--cleanup-policy", policy,
+			}
+			exit := dispatch(args, &stdout, &stderr)
+			if exit == 0 {
+				t.Errorf("--no-cleanup --cleanup-policy=%s exited 0; want non-zero (conflict must be detected)", policy)
+			}
+			combined := stderr.String() + stdout.String()
+			if !strings.Contains(combined, "conflicting flags") {
+				t.Errorf("expected 'conflicting flags' in output; got stderr=%q stdout=%q", stderr.String(), stdout.String())
+			}
+		})
+	}
+}
+
+// TestNoCleanup_AloneCoercesToNever verifies that --no-cleanup alone (without
+// an explicit --cleanup-policy) silently coerces to never without error. (B3 regression guard)
+func TestNoCleanup_AloneCoercesToNever(t *testing.T) {
+	var stdout, stderr strings.Builder
+	// --data is missing so dispatch will return an error, but it must NOT be
+	// a conflict error — the conflict check only fires when policy is explicit.
+	args := []string{"longmemeval", "ingest", "--no-cleanup"}
+	_ = dispatch(args, &stdout, &stderr)
+	combined := stderr.String() + stdout.String()
+	if strings.Contains(combined, "conflicting flags") {
+		t.Errorf("--no-cleanup alone must not trigger conflict error; got: %s", combined)
+	}
+	if strings.Contains(combined, "invalid --cleanup-policy") {
+		t.Errorf("--no-cleanup alone must not trigger policy-validation error; got: %s", combined)
+	}
+}

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -201,8 +201,27 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	// #751: --no-cleanup is deprecated; coerce to CleanupPolicyNever and warn.
+	// B2 (#807): validate --cleanup-policy against the known enum set.
+	// Must fire before any other validation so the error is clearly attributable.
+	switch cfg.CleanupPolicy {
+	case CleanupPolicyAuto, CleanupPolicyAlways, CleanupPolicyNever:
+		// valid
+	default:
+		_, _ = fmt.Fprintf(stderr, "invalid --cleanup-policy %q: must be one of auto|always|never\n", cfg.CleanupPolicy)
+		return 1
+	}
+
+	// B3 (#807): --no-cleanup is deprecated; coerce to CleanupPolicyNever and warn.
+	// If user explicitly set a non-default policy alongside --no-cleanup, reject
+	// the combination — silently overwriting would hide intent bugs.
 	if cfg.NoCleanup {
+		if cfg.CleanupPolicy != CleanupPolicyAuto {
+			// User passed both --no-cleanup and an explicit --cleanup-policy.
+			_, _ = fmt.Fprintf(stderr,
+				"conflicting flags: --no-cleanup is deprecated alias for --cleanup-policy=never; cannot combine with --cleanup-policy=%s\n",
+				cfg.CleanupPolicy)
+			return 1
+		}
 		_, _ = fmt.Fprintln(stderr, "WARN: --no-cleanup is deprecated; use --cleanup-policy=never instead")
 		cfg.CleanupPolicy = CleanupPolicyNever
 	}
@@ -248,7 +267,10 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 }
 
 func newRunID() string {
-	b := make([]byte, 3)
+	// S7 (#807): 8 bytes = 16 hex chars = 64 bits; reduces prefix-match collision
+	// risk on shared infra from 1/16M (24-bit) to ~1/18E (64-bit). Callers treat
+	// RunID as an opaque string so length change is backward-compatible.
+	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
 }

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -25,7 +25,8 @@ type Config struct {
 	RunID      string
 	ServerURL  string
 	APIKey     string
-	NoCleanup  bool
+	NoCleanup     bool          // Deprecated: use CleanupPolicy=never
+	CleanupPolicy CleanupPolicy // "auto" | "always" | "never" (default: auto)
 	Retries    int
 	OutDir     string
 	LLMBaseURL string // OpenAI-compatible base URL; bypasses claude CLI when set
@@ -89,7 +90,11 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  --out <dir>             Output directory for checkpoints (default .)")
 	_, _ = fmt.Fprintln(w, "  --run-id <hex>          Run identifier (auto-generated if empty)")
 	_, _ = fmt.Fprintln(w, "  --retries <n>           Retry count for generation + Engram calls (default 1)")
-	_, _ = fmt.Fprintln(w, "  --no-cleanup            Skip project deletion after run stage")
+	_, _ = fmt.Fprintln(w, "  --cleanup-policy <val>  Project cleanup after run: auto (default), always, never")
+	_, _ = fmt.Fprintln(w, "                          auto: delete only projects created by this run invocation")
+	_, _ = fmt.Fprintln(w, "                          always: unconditional deletion (pre-v0 behavior)")
+	_, _ = fmt.Fprintln(w, "                          never: preserve all projects (use if reusing data in a follow-up experiment)")
+	_, _ = fmt.Fprintln(w, "  --no-cleanup            DEPRECATED: alias for --cleanup-policy=never")
 }
 
 // dispatch parses args and runs the requested subcommand. Returns the process
@@ -117,7 +122,11 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	defaultURL, defaultKey := mcpDefaults()
 	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", defaultURL), "Engram server URL")
 	fs.StringVar(&cfg.APIKey, "api-key", envOr("ENGRAM_API_KEY", defaultKey), "Engram API key")
-	fs.BoolVar(&cfg.NoCleanup, "no-cleanup", false, "Skip Engram project deletion after run stage")
+	// #751: cleanup-policy enum replaces the old boolean --no-cleanup flag.
+	// v0.x: cleanup is now scoped to ephemeral projects only. Pass --cleanup-policy=always to restore prior unconditional deletion.
+	fs.StringVar((*string)(&cfg.CleanupPolicy), "cleanup-policy", string(CleanupPolicyAuto), "Project cleanup after run stage: auto (default, delete only projects created by this run), always (unconditional), never (preserve all)")
+	// Deprecated: --no-cleanup is an alias for --cleanup-policy=never. Emits a deprecation WARN at parse time.
+	fs.BoolVar(&cfg.NoCleanup, "no-cleanup", false, "DEPRECATED: use --cleanup-policy=never instead")
 	fs.IntVar(&cfg.Retries, "retries", 1, "Retry count for generation and Engram calls")
 	fs.StringVar(&cfg.OutDir, "out", ".", "Output directory for checkpoint and result files")
 	fs.StringVar(&cfg.LLMBaseURL, "llm-url", envOr("LME_LLM_URL", ""), "OpenAI-compatible base URL (e.g. http://oblivion:8000/v1); bypasses claude CLI when set")
@@ -190,6 +199,12 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	if err := fs.Parse(args[2:]); err != nil {
 		return 2
+	}
+
+	// #751: --no-cleanup is deprecated; coerce to CleanupPolicyNever and warn.
+	if cfg.NoCleanup {
+		_, _ = fmt.Fprintln(stderr, "WARN: --no-cleanup is deprecated; use --cleanup-policy=never instead")
+		cfg.CleanupPolicy = CleanupPolicyNever
 	}
 
 	if cfg.DataFile == "" {

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -164,12 +164,14 @@ func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan lon
 			log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))
 		}
 
-			if !cfg.NoCleanup {
+			if shouldCleanupProject(cfg, ingestEntry.Project) {
 				if err := mcpClient.DeleteProject(ctx, ingestEntry.Project); err != nil {
 					if !longmemeval.IsStaleSessionError(err) {
 						log.Printf("WARN run [%s] cleanup failed: %v", item.QuestionID, err)
 					}
 				}
+			} else {
+				log.Printf("INFO cleanup-policy=auto: preserving project %s (not created by this run); pass --cleanup-policy=always to override", ingestEntry.Project)
 			}
 		}()
 	}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -88,17 +88,38 @@ func runRun(cfg *Config) int {
 	}
 	close(work)
 
+	// S9 (#807): collect preserved-project names so we can emit one summary line
+	// instead of per-item log noise (~one line per question).
+	preservedCh := make(chan string, cfg.Workers*2)
+
 	var wg sync.WaitGroup
 	for i := 0; i < cfg.Workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runWorker(cfg, itemMap, work, innerCh)
+			runWorker(cfg, itemMap, work, innerCh, preservedCh)
 		}()
 	}
 	wg.Wait()
 	close(innerCh)
+	close(preservedCh)
 	wgWriter.Wait()
+
+	// S9 (#807): emit one summary line for all preserved projects.
+	var preserved []string
+	for name := range preservedCh {
+		preserved = append(preserved, name)
+	}
+	if len(preserved) > 0 {
+		sample := preserved
+		if len(sample) > 5 {
+			sample = sample[:5]
+		}
+		// TODO(#807-S3): migrate to slog once structured logging is wired into
+		// cmd/longmemeval (currently uses stdlib log; slog lives in internal/ only).
+		log.Printf("INFO run: preserved %d project(s) under cleanup-policy=%s (sample: %v); pass --cleanup-policy=always to override",
+			len(preserved), cfg.CleanupPolicy, sample)
+	}
 
 	att := attempted.Load()
 	errs := errors.Load()
@@ -130,7 +151,9 @@ func exitCodeForRunOutcome(attempted, errors int64) int {
 	return 0
 }
 
-func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry) {
+// runWorker processes items from work, writing RunEntry results to out and
+// sending preserved-project names to preservedCh (for S9 summary logging).
+func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry, preservedCh chan<- string) {
 	for ingestEntry := range work {
 		ctx := context.Background()
 		item, ok := itemMap[ingestEntry.QuestionID]
@@ -157,12 +180,12 @@ func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan lon
 				}
 			}()
 			entry := runOne(ctx, cfg, mcpClient, item, ingestEntry)
-		out <- entry
-		if entry.Status == "error" {
-			log.Printf("run [%s] status=%s hypothesis_len=%d error=%q", item.QuestionID, entry.Status, len(entry.Hypothesis), entry.Error)
-		} else {
-			log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))
-		}
+			out <- entry
+			if entry.Status == "error" {
+				log.Printf("run [%s] status=%s hypothesis_len=%d error=%q", item.QuestionID, entry.Status, len(entry.Hypothesis), entry.Error)
+			} else {
+				log.Printf("run [%s] status=%s hypothesis_len=%d", item.QuestionID, entry.Status, len(entry.Hypothesis))
+			}
 
 			if shouldCleanupProject(cfg, ingestEntry.Project) {
 				if err := mcpClient.DeleteProject(ctx, ingestEntry.Project); err != nil {
@@ -171,7 +194,9 @@ func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan lon
 					}
 				}
 			} else {
-				log.Printf("INFO cleanup-policy=auto: preserving project %s (not created by this run); pass --cleanup-policy=always to override", ingestEntry.Project)
+				// S9 (#807): send to preservedCh for batch summary at end of run;
+				// avoids per-question log noise (~N lines for N questions).
+				preservedCh <- ingestEntry.Project
 			}
 		}()
 	}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -15,6 +15,36 @@ import (
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
 
+// preservedLog is a mutex-protected accumulator for project names that were
+// preserved (not cleaned up) during a run. Using a slice rather than a buffered
+// channel avoids the R2-B2 deadlock: a channel blocks senders when full, which
+// causes runWorker goroutines to hang while wg.Wait() waits for them to finish.
+// See R2-B2, #807.
+type preservedLog struct {
+	mu    sync.Mutex
+	items []string
+}
+
+// add appends name to the log. Safe for concurrent use.
+func (pl *preservedLog) add(name string) {
+	pl.mu.Lock()
+	pl.items = append(pl.items, name)
+	pl.mu.Unlock()
+}
+
+// names returns a copy of the collected names. Safe to call after all writers
+// have finished (e.g., after wg.Wait()).
+func (pl *preservedLog) names() []string {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	if len(pl.items) == 0 {
+		return nil
+	}
+	out := make([]string, len(pl.items))
+	copy(out, pl.items)
+	return out
+}
+
 // temporalInterrogativeRe strips leading relative-time interrogatives so the
 // recall query matches event noun-phrases rather than the question scaffolding.
 var temporalInterrogativeRe = regexp.MustCompile(
@@ -88,28 +118,27 @@ func runRun(cfg *Config) int {
 	}
 	close(work)
 
-	// S9 (#807): collect preserved-project names so we can emit one summary line
-	// instead of per-item log noise (~one line per question).
-	preservedCh := make(chan string, cfg.Workers*2)
+	// S9 (#807 R3): collect preserved-project names via a mutex-protected slice.
+	// A buffered channel was used in R2 but deadlocks when the number of
+	// preserved projects exceeds the buffer size (cfg.Workers*2) — workers block
+	// on send while wg.Wait() blocks waiting for workers to finish. The slice
+	// approach has no capacity limit and never blocks. (R2-B2)
+	pl := &preservedLog{}
 
 	var wg sync.WaitGroup
 	for i := 0; i < cfg.Workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runWorker(cfg, itemMap, work, innerCh, preservedCh)
+			runWorker(cfg, itemMap, work, innerCh, pl)
 		}()
 	}
 	wg.Wait()
 	close(innerCh)
-	close(preservedCh)
 	wgWriter.Wait()
 
-	// S9 (#807): emit one summary line for all preserved projects.
-	var preserved []string
-	for name := range preservedCh {
-		preserved = append(preserved, name)
-	}
+	// S9 (#807): emit one end-of-run summary line (token: cleanup-summary).
+	preserved := pl.names()
 	if len(preserved) > 0 {
 		sample := preserved
 		if len(sample) > 5 {
@@ -117,8 +146,8 @@ func runRun(cfg *Config) int {
 		}
 		// TODO(#807-S3): migrate to slog once structured logging is wired into
 		// cmd/longmemeval (currently uses stdlib log; slog lives in internal/ only).
-		log.Printf("INFO run: preserved %d project(s) under cleanup-policy=%s (sample: %v); pass --cleanup-policy=always to override",
-			len(preserved), cfg.CleanupPolicy, sample)
+		log.Printf("cleanup-summary cleanup-policy=auto preserved=%d sample=%v",
+			len(preserved), sample)
 	}
 
 	att := attempted.Load()
@@ -152,8 +181,8 @@ func exitCodeForRunOutcome(attempted, errors int64) int {
 }
 
 // runWorker processes items from work, writing RunEntry results to out and
-// sending preserved-project names to preservedCh (for S9 summary logging).
-func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry, preservedCh chan<- string) {
+// recording preserved-project names in pl (for S9 end-of-run summary logging).
+func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry, pl *preservedLog) {
 	for ingestEntry := range work {
 		ctx := context.Background()
 		item, ok := itemMap[ingestEntry.QuestionID]
@@ -194,9 +223,9 @@ func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan lon
 					}
 				}
 			} else {
-				// S9 (#807): send to preservedCh for batch summary at end of run;
+				// S9 (#807): record in preservedLog for end-of-run summary;
 				// avoids per-question log noise (~N lines for N questions).
-				preservedCh <- ingestEntry.Project
+				pl.add(ingestEntry.Project)
 			}
 		}()
 	}

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
@@ -202,5 +205,81 @@ func TestQueryParaphrasePassesFlag_DefaultZero(t *testing.T) {
 	// The flag registration must use default value 0.
 	if !strings.Contains(string(src), `"query-paraphrase-passes", 0`) {
 		t.Error("main.go: --query-paraphrase-passes default must be 0 (off by default)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R2-B2: preservedLog — deadlock-free collection (mutex-protected slice)
+// ---------------------------------------------------------------------------
+
+// TestPreservedLog_NoDeadlockOnHighCount verifies that N concurrent goroutines
+// can each append a name to a preservedLog without blocking, even when N far
+// exceeds any channel buffer size. This is the regression guard for R2-B2
+// (#807): the old chan-based approach deadlocked when preserved-project count
+// exceeded cfg.Workers*2.
+func TestPreservedLog_NoDeadlockOnHighCount(t *testing.T) {
+	const N = 100
+	pl := &preservedLog{}
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			pl.add(fmt.Sprintf("project-%03d", n))
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("preservedLog.add deadlocked under high concurrency (R2-B2 regression)")
+	}
+
+	names := pl.names()
+	if len(names) != N {
+		t.Errorf("preservedLog collected %d names, want %d", len(names), N)
+	}
+}
+
+// TestPreservedLog_NamesReturnsCopy verifies that mutating the returned slice
+// does not affect the underlying preservedLog state.
+func TestPreservedLog_NamesReturnsCopy(t *testing.T) {
+	pl := &preservedLog{}
+	pl.add("alpha")
+	pl.add("beta")
+
+	got := pl.names()
+	got[0] = "mutated"
+
+	got2 := pl.names()
+	for _, n := range got2 {
+		if n == "mutated" {
+			t.Error("names() returned a slice sharing the backing array — mutations affect internal state")
+		}
+	}
+}
+
+// TestCleanupSummary_TokenIsCleanupSummary verifies the greppable log token
+// used for the end-of-run preserved-project summary is exactly "cleanup-summary"
+// as specified in S9 (#807 Round 3). (Source-level structural guard.)
+func TestCleanupSummary_TokenIsCleanupSummary(t *testing.T) {
+	src, err := os.ReadFile("run.go")
+	if err != nil {
+		t.Fatalf("read run.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "cleanup-summary") {
+		t.Error("run.go missing 'cleanup-summary' log token (S9 #807 Round 3 spec)")
+	}
+	// Ensure the old token is gone.
+	if strings.Contains(text, "INFO run: preserved") {
+		t.Error("run.go still contains old log token 'INFO run: preserved' — should be replaced by 'cleanup-summary'")
 	}
 }


### PR DESCRIPTION
## Summary

- Introduces `--cleanup-policy {auto,always,never}` (default: `auto`) replacing the boolean `--no-cleanup` flag
- `auto` deletes only projects whose name matches the `lme-{runID}-*` prefix created by the current invocation; externally ingested / cross-experiment projects are preserved
- `always` restores pre-fix unconditional-delete behavior; `never` preserves all
- `--no-cleanup` is deprecated but honored as `never`-alias; emits `WARN: --no-cleanup is deprecated` to stderr
- Provenance detection: pure in-memory via `projectName()` prefix (`lme-{runID}-{qid}`) — no checkpoint schema changes required

## Advisory reference

Implemented per opus-advisor Path S recommendation (cleanup-policy enum, auto default, in-memory prefix provenance).

## Test plan

- [ ] `TestCleanupPolicy_AutoPreservesExternalProject` — auto preserves project with mismatched runID prefix
- [ ] `TestCleanupPolicy_AutoDeletesIngestedProject` — auto deletes project matching this run's prefix
- [ ] `TestCleanupPolicy_AlwaysDeletes` — always policy deletes every project
- [ ] `TestCleanupPolicy_NeverPreserves` — never policy preserves every project
- [ ] `TestNoCleanupFlag_DeprecatedAliasForNever` — --no-cleanup registered, deprecation warning present
- [ ] `TestCleanupPolicyFlag_DefaultIsAuto` — --cleanup-policy default is CleanupPolicyAuto
- [ ] `TestCleanupPolicyStructuralGuard` — run.go uses shouldCleanupProject(), not cfg.NoCleanup
- [ ] `go test -race ./cmd/longmemeval/...` passes
- [ ] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)