### PR TITLE
chore: post-campaign cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,16 @@ infisical/infisical-bin
 /instinct-benchmark
 /longmemeval
 /starter
+/audit
 # Compiled binaries in bin/ (built by `go build -o bin/...`)
 /bin/longmemeval
 # Stale sentinel files that have appeared in the past (#699)
 /1.0
 cover.out
+cov.out
+# Backup files
+*.backup
+*.pre-migration-backup
 .claude/
 testdata/longmemeval/*.json
 results/

--- a/docs/proposed-fixes/748-taxonomy-classifier-aggregation-misclassification.md
+++ b/docs/proposed-fixes/748-taxonomy-classifier-aggregation-misclassification.md
@@ -1,0 +1,83 @@
+> **SUPERSEDED** — Implemented in PR #803 (merged 2026-05-20). This document retained for design context only.
+
+# Issue #748 — lme: taxonomy classifier misclassifies aggregation/counting questions as missing_recall
+
+**Severity:** nice-to-have
+**Area:** lme-tooling
+**Status:** Design only — not yet implemented
+
+## Root cause
+
+The failure taxonomy classifier in `results/v9-failure-taxonomy.json` (generated post-run) classifies items by computing word-overlap between the gold answer and the retrieved hypothesis. When the gold answer is a bare digit ("2", "3", "4"), word-overlap is near-zero with any natural-language block. The classifier's branch `"Gold answer is empty or too short to analyze"` fires (threshold: ≤3 chars), assigning `missing_recall`. However, `results/research-notes-failure-patterns.md` §Section 2 (Pattern A) documents that **all 26 affected items have their gold session IDs present in the retrieved set** — the failure is aggregation, not missing data.
+
+The classifier logic is not in a standalone Go file; based on the research notes, it was applied as a post-processing analysis step. The taxonomy JSON labels 26 `multi-session` items as `missing_recall` that should be `aggregation_failure`.
+
+## Repro
+
+```bash
+# Open results/v9-failure-taxonomy.json and filter missing_recall items
+python3 - <<'EOF'
+import json
+with open("results/v9-failure-taxonomy.json") as f:
+    d = json.load(f)
+missing = [i for i in d["items"] if i["class"] == "missing_recall"]
+print(f"missing_recall count: {len(missing)}")
+for m in missing[:5]:
+    print(m["question_id"], repr(m["evidence"]))
+EOF
+# All 26 will show: "Gold answer is empty or too short to analyze."
+# Cross-reference against longmemeval_m_cleaned.json — the gold answer is a
+# single digit (e.g. "4") representing a count across sessions.
+```
+
+## Proposed patch
+
+This is a classifier script fix. The taxonomy generation logic needs a third branch: if the gold answer matches `^\d+$` AND the item's gold `answer_session_ids` are present in the retrieved set, classify as `aggregation_failure` rather than `missing_recall`.
+
+```diff
+--- a/results/taxonomy_classify.py   (hypothetical — logic currently inline)
++++ b/results/taxonomy_classify.py
+@@ -1,0 +1,15 @@
++import re
++
++NUMERIC_RE = re.compile(r'^\d{1,4}$')
++
+ def classify_item(item, retrieved_session_ids, gold_session_ids):
+-    if len(item["gold"]) <= 3:
+-        return "missing_recall", "Gold answer is empty or too short to analyze."
++    if NUMERIC_RE.match(item["gold"].strip()):
++        gold_present = bool(gold_session_ids & retrieved_session_ids)
++        if gold_present:
++            return "aggregation_failure", (
++                "Gold answer is a count/aggregate. Gold sessions retrieved "
++                f"({len(gold_session_ids & retrieved_session_ids)}/{len(gold_session_ids)}) "
++                "but model failed to aggregate across sessions."
++            )
++        else:
++            return "missing_recall", "Numeric gold; gold sessions not in top-K."
+     overlap = word_overlap(item["gold"], item["hypothesis"])
+```
+
+For the existing JSON taxonomy, a one-time re-classification migration is also needed — change the 26 existing `missing_recall` entries with `evidence` matching "empty or too short" to `aggregation_failure` where the gold session IDs were retrieved.
+
+## TDD scenarios
+
+1. **numeric_gold_sessions_retrieved → aggregation_failure** — Given a question with gold "4" and all gold session IDs in the retrieved set, when classify_item is called, then the class is `aggregation_failure` and the evidence mentions "Gold sessions retrieved."
+2. **numeric_gold_sessions_missing → missing_recall** — Given a question with gold "4" and no gold session IDs retrieved, when classify_item is called, then the class remains `missing_recall`.
+3. **non-numeric_short_gold → missing_recall unchanged** — Given a question with gold "yes" (3 chars, non-numeric), when classify_item is called, then the existing short-answer path applies unchanged.
+4. **regression: 26 existing items reclassified** — Given the v9 taxonomy JSON loaded as a fixture, when the re-classification script runs, then exactly 0 items have `missing_recall` + `evidence="Gold answer is empty or too short"` remaining (all should become `aggregation_failure`).
+
+## Risk notes
+
+- Backwards compat: the JSON taxonomy format is unchanged; only the `class` field value changes for the 26 items. Existing scripts that pivot on `missing_recall` counts will see lower numbers — this is correct.
+- The actual Go benchmark pipeline is unaffected; this is a post-processing analysis tool only.
+- The `aggregation_failure` class string matches `types.FailureClass` in `internal/types/types.go:47` — verify before using.
+
+## Rollout
+
+No deploy steps. Re-run taxonomy generator script against `results/v9-failure-taxonomy.json` (or existing run directories) after applying the patch. Update `lme-camp-report.md` with corrected distribution.
+
+## Out of scope (followups)
+
+- H1 prompt fix (arithmetic instruction in generation prompt) — separate concern that addresses the root failure mode that this classifier now correctly identifies. See `results/research-notes-failure-patterns.md` §Section 3, H1.
+- Exp 13 re-run with corrected aggregation prompt.

--- a/docs/proposed-fixes/750-generate-for-model-no-retry-on-invalid-model.md
+++ b/docs/proposed-fixes/750-generate-for-model-no-retry-on-invalid-model.md
@@ -1,0 +1,105 @@
+> **SUPERSEDED** — Implemented in PR #755 (merged 2026-05-20). This document retained for design context only.
+
+# Issue #750 — lme: GenerateForModel retries on invalid-model error instead of short-circuiting
+
+**Severity:** nice-to-have
+**Area:** lme-tooling
+**Status:** Design only — not yet implemented
+
+## Root cause
+
+`internal/longmemeval/claude.go:66-86` — the `generate()` function runs a retry loop with backoffs of 30s, 60s, 120s. `runClaude()` at line 104-106 returns a static validation error `"claude: refusing to invoke with disallowed model %q"` for any model not in `validClaudeModels`. This error is permanent — no amount of retrying will resolve it — but `generate()` does not distinguish it from a transient API error and sleeps the full backoff before each retry.
+
+The test `TestGenerateForModel_InvalidModel_NoRetry` in `internal/longmemeval/claude_additions_test.go` is currently `t.Skip`'d with the comment "subprocess retry blocks 60s timeout; functionality covered by sibling test." The sibling test only validates that the error is returned, not that retries are skipped.
+
+## Repro
+
+```bash
+# With retries=2 and model="gpt-4o" (not in allowlist), the call blocks ~90s
+# before returning: 0s first attempt + 30s sleep + 60s sleep = ~90s wasted
+go test ./internal/longmemeval/ -run TestGenerateForModel_InvalidModel_NoRetry -v -timeout 120s
+# (currently skipped; if unskipped, takes 90s+ before returning the error)
+```
+
+## Proposed patch
+
+```diff
+--- a/internal/longmemeval/claude.go
++++ b/internal/longmemeval/claude.go
+@@ -1,4 +1,11 @@
+ package longmemeval
+ 
++import "errors"
++
++// ErrDisallowedModel is a permanent error returned when the model name is not
++// in the allowlist. The retry loop must not sleep on this error.
++var ErrDisallowedModel = errors.New("disallowed model")
++
+ // generateTimeout is the hard cap for one OAI generation call.
+@@ -66,10 +73,15 @@ func generate(ctx context.Context, prompt, model string, retries int) (string, error) {
+ 	var lastErr error
+ 	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
+ 	for attempt := 0; attempt <= retries; attempt++ {
+ 		out, err := runClaude(ctx, prompt, model)
+ 		if err == nil {
+ 			return out, nil
+ 		}
+ 		lastErr = err
++		// Permanent validation errors must not be retried.
++		if errors.Is(err, ErrDisallowedModel) {
++			break
++		}
+ 		if attempt >= retries {
+ 			break
+ 		}
+@@ -104,7 +116,7 @@ func runClaude(ctx context.Context, prompt, model string) (string, error) {
+ 	if !isValidClaudeModel(model) {
+-		return "", fmt.Errorf("claude: refusing to invoke with disallowed model %q (allowed: opus, sonnet, haiku) (#678)", model)
++		return "", fmt.Errorf("%w: %q (allowed: opus, sonnet, haiku) (#678)", ErrDisallowedModel, model)
+ 	}
+```
+
+Then un-skip the test:
+
+```diff
+--- a/internal/longmemeval/claude_additions_test.go
++++ b/internal/longmemeval/claude_additions_test.go
+@@ -59,7 +59,6 @@ func TestGenerateForModel_InvalidModel(t *testing.T) {
+ func TestGenerateForModel_InvalidModel_NoRetry(t *testing.T) {
+-	t.Skip("subprocess retry blocks 60s timeout; functionality covered by sibling test")
+ 	// Even with retries > 0 the model-rejection error should be returned
+ 	// immediately (no point sleeping and retrying a static validation failure).
+ 	ctx := context.Background()
+```
+
+Note: the test should also add a timing assertion — the call must complete in <1s, not 60s+:
+
+```diff
++	start := time.Now()
+ 	_, err := longmemeval.GenerateForModel(ctx, "prompt", "claude-3-opus-20240229", 2)
++	elapsed := time.Since(start)
++	if elapsed > 5*time.Second {
++		t.Errorf("GenerateForModel with invalid model took %v — retry not short-circuited", elapsed)
++	}
+```
+
+## TDD scenarios
+
+1. **invalid_model_no_retry_immediate** — Given `retries=2` and model `"gpt-4o"` (not in allowlist), when `GenerateForModel` is called, then it returns within 1s with an error wrapping `ErrDisallowedModel`.
+2. **invalid_model_error_message_preserved** — Given an invalid model, when the error is returned, then `errors.Is(err, ErrDisallowedModel)` is true and the error string still contains the model name for diagnostics.
+3. **valid_model_retries_on_transient_error** — Given a valid model `"sonnet"` and a transient error from `runClaude` (simulated), when `generate` is called with `retries=1`, then the retry sleep fires and the second attempt is made (no short-circuit).
+4. **regression: sibling test still passes** — `TestGenerateForModel_InvalidModel` (zero retries) continues to pass and returns `ErrDisallowedModel`-wrapping error.
+
+## Risk notes
+
+- `ErrDisallowedModel` is a new exported sentinel; callers using `errors.Is` will work correctly; callers matching the string may need updating (search for `"disallowed model"`).
+- The OAI path (`GenerateOAI`) does not call `runClaude`; its model validation (if any) is separate. Not affected by this change.
+- The `Generate` function used by `GenerateOpus` calls `generate()` with a valid model — no behavior change for production use.
+
+## Rollout
+
+Rebuild binary. No infra changes. Un-skip the test and add it to CI.
+
+## Out of scope (followups)
+
+- Apply the same permanent-error short-circuit pattern to `ScoreOAI` retries if the scorer URL is unreachable at connection time (connection refused vs. transient timeout).

--- a/docs/proposed-fixes/751-project-cleanup-preserve-flag.md
+++ b/docs/proposed-fixes/751-project-cleanup-preserve-flag.md
@@ -1,0 +1,89 @@
+> **SUPERSEDED** — Implemented in PR #807 (merged 2026-05-20). This document retained for design context only.
+
+# Issue #751 — lme: project auto-cleanup deletes ingested projects before cross-experiment reuse is possible
+
+**Severity:** nice-to-have
+**Area:** lme-tooling
+**Status:** Design only — not yet implemented
+
+## Root cause
+
+`cmd/longmemeval/run.go:170-175` deletes each item's Engram project immediately after the run phase completes, unless `cfg.NoCleanup` is true. The default is `NoCleanup: false` (delete). The existing opt-out flag `--no-cleanup` uses a double-negative name that does not signal the intent "I want to reuse these projects later." Exp 13 planned to reuse Exp 10's ingested projects for a different recall configuration run, but they had been auto-deleted, requiring a full re-ingest.
+
+## Repro
+
+```bash
+# Run experiment, then try to reference the same projects in a follow-up
+./bin/longmemeval run \
+  --data testdata/longmemeval/longmemeval_m_cleaned.json \
+  --out results/exp-10 \
+  --llm-url http://oblivion:8000/v1 --llm-model inference
+# Projects deleted on completion (default behaviour)
+
+# Follow-up experiment expecting same projects — fails because projects are gone
+./bin/longmemeval run \
+  --data testdata/longmemeval/longmemeval_m_cleaned.json \
+  --out results/exp-13 \
+  --llm-url http://oblivion:8000/v1 --llm-model inference
+# Error: project not found for each item
+```
+
+## Proposed patch
+
+**Advisory gate recommendation: Option B** — add `--preserve-projects` as an alias/replacement for `--no-cleanup`. Keep delete as default; do not flip.
+
+```diff
+--- a/cmd/longmemeval/main.go
++++ b/cmd/longmemeval/main.go
+@@ -27,6 +27,7 @@ type Config struct {
+ 	NoCleanup  bool
++	PreserveProjects bool // alias for NoCleanup with clearer semantics
+```
+
+```diff
+@@ -111,6 +112,9 @@ func dispatch(...) int {
+ 	fs.BoolVar(&cfg.NoCleanup, "no-cleanup", false, "Skip Engram project deletion after run stage (deprecated: use --preserve-projects)")
++	fs.BoolVar(&cfg.PreserveProjects, "preserve-projects", false,
++		"Preserve Engram projects after run stage for reuse in follow-up experiments.\n"+
++		"Without this flag, projects are deleted after each item completes.\n"+
++		"Combine with --out <dir> to resume from an existing ingest checkpoint.")
+```
+
+```diff
+--- a/cmd/longmemeval/run.go
++++ b/cmd/longmemeval/run.go
+@@ -170,7 +170,7 @@ func runWorker(...) {
+-			if !cfg.NoCleanup {
++			if !cfg.NoCleanup && !cfg.PreserveProjects {
+ 				if err := mcpClient.DeleteProject(ctx, ingestEntry.Project); err != nil {
+```
+
+Also add a log line when preservation is active so the operator knows cleanup is being skipped intentionally:
+
+```diff
++	if cfg.PreserveProjects || cfg.NoCleanup {
++		log.Printf("run: projects will be preserved after run (--preserve-projects / --no-cleanup)")
++	}
+```
+
+## TDD scenarios
+
+1. **preserve_projects_skips_delete** — Given `--preserve-projects`, when `runWorker` completes an item, then `mcpClient.DeleteProject` is NOT called for that item's project.
+2. **default_deletes_project** — Given neither `--preserve-projects` nor `--no-cleanup`, when `runWorker` completes an item, then `mcpClient.DeleteProject` IS called.
+3. **no_cleanup_still_works** — Given `--no-cleanup` (legacy flag), when `runWorker` completes an item, then `mcpClient.DeleteProject` is NOT called (backwards compat).
+4. **both_flags_safe** — Given both `--preserve-projects` and `--no-cleanup`, when `runWorker` runs, then no panic or double-skip occurs; projects are preserved.
+
+## Risk notes
+
+- `--no-cleanup` is preserved for backwards compat; existing camp pipeline scripts (`results/lme-camp-*/run-pipeline.sh`) continue to work unchanged.
+- The `--preserve-projects` flag does not manage project accumulation. Over many runs, projects will accumulate in the Engram namespace. See issue #754 for the companion scratch-namespace retention design.
+- No schema changes required.
+
+## Rollout
+
+Rebuild binary. Update `results/BENCHMARK-PLAN.md` and `results/lme-camp-report.md` to use `--preserve-projects` in all future experiment commands. No infra changes.
+
+## Out of scope (followups)
+
+- Issue #754 (scratch namespace + TTL) addresses the accumulation problem that `--preserve-projects` creates if used frequently.
+- Consider whether `all` subcommand (ingest → run → score) should default to `--preserve-projects=true` since the user has just invested in ingestion.

--- a/docs/proposed-fixes/752-retrieval-tracking-dim-mismatch.md
+++ b/docs/proposed-fixes/752-retrieval-tracking-dim-mismatch.md
@@ -1,0 +1,99 @@
+> **SUPERSEDED** — Implemented in PR #756 (merged 2026-05-20). This document retained for design context only.
+
+# Issue #752 — test: TestRetrievalTracking_PrecisionUpdated — verify embed-dim fixture alignment
+
+**Severity:** nice-to-have
+**Area:** testing
+**Status:** Design only — not yet implemented
+
+## Root cause
+
+The task brief cited a 1024 vs 768 embed-dim mismatch failure in `TestRetrievalTracking_PrecisionUpdated` (`internal/search/retrieval_precision_test.go:123`). As of the 2026-05-19 investigation the test **passes** (`go test ./internal/search/ -run TestRetrievalTracking_PrecisionUpdated` exits 0). The root cause of the original failure is unconfirmed — likely one of:
+
+1. A live-DB fixture had memories at 1024 dims (from a prior embedder), and a test run against the shared dev DB picked up that mismatch. See `internal/search/engine_test.go:420-440` for an existing dim-mismatch guard at the engine level.
+2. The failure was environment-specific and was resolved by re-embedding or DB reset.
+
+The gap is not the test failure itself but the **absence of a dim-mismatch test at the retrieval-precision layer** — `retrieval_precision_test.go` creates a `newTestEngine` with the default fake client (768 dims) but never exercises the path where a memory stored at one dim is later queried by an engine with a different dim.
+
+## Repro
+
+```bash
+# Current state: test passes
+cd /home/psimmons/projects/engram-go
+go test ./internal/search/ -run TestRetrievalTracking_PrecisionUpdated -v -count=1
+# Output: ok
+
+# To reproduce the hypothetical failure:
+# 1. Store a memory using an engine with 1024-dim embedder
+# 2. Re-open the project with a 768-dim engine
+# 3. Call RecallWithEvent + FeedbackWithEvent
+# 4. Expected: error returned, not silent empty recall + phantom precision score
+```
+
+## Proposed patch
+
+Add a dim-mismatch guard test in `internal/search/retrieval_precision_test.go`:
+
+```diff
+--- a/internal/search/retrieval_precision_test.go
++++ b/internal/search/retrieval_precision_test.go
+@@ -151,0 +152,30 @@
++
++// TestRetrievalTracking_DimMismatch verifies that opening a project with a
++// different embedding dimension than it was stored with returns a clear error
++// from RecallWithEvent rather than silently returning zero results and
++// recording phantom precision data.
++func TestRetrievalTracking_DimMismatch(t *testing.T) {
++	ctx := context.Background()
++	proj := uniqueProject("test-rt-dim-mismatch")
++
++	// Store a memory using a 1024-dim engine.
++	engine1024 := newEngineWithDims(t, proj, 1024)
++	t.Cleanup(func() { engine1024.Close() })
++	m := &types.Memory{
++		Content:     "dim mismatch test memory",
++		MemoryType:  types.MemoryTypeDecision,
++		Project:     proj,
++		Importance:  1,
++		StorageMode: "focused",
++	}
++	require.NoError(t, engine1024.Store(ctx, m))
++
++	// Attempt recall using a 768-dim engine — must fail clearly, not silently.
++	engine768 := newEngineWithDims(t, proj, 768)
++	t.Cleanup(func() { engine768.Close() })
++	_, _, err := engine768.RecallWithEvent(ctx, "dim mismatch test memory", 5, "normal")
++	require.Error(t, err, "RecallWithEvent with dim mismatch must return an error")
++	assert.Contains(t, err.Error(), "dim", "error must mention embedding dimension mismatch")
++}
+```
+
+The `newEngineWithDims` helper:
+
+```go
+func newEngineWithDims(t *testing.T, proj string, dims int) *search.Engine {
+    t.Helper()
+    backend := newTestBackend(t)
+    return search.New(ctx, backend, &fakeClient{dims: dims}, proj, search.DefaultConfig())
+}
+```
+
+## TDD scenarios
+
+1. **dim_match_precision_tracking_works** — Given consistent 768-dim engine across store + recall + feedback, when 5 cycles complete, then `RetrievalPrecision` is non-nil and near 1.0 (existing test, verify still passes).
+2. **dim_mismatch_returns_error** — Given memory stored at 1024 dims, when a 768-dim engine calls `RecallWithEvent`, then an error is returned containing "dim" (or "dimension" or similar) rather than returning empty results silently.
+3. **dim_mismatch_no_phantom_precision** — Given dim mismatch error from RecallWithEvent, when the error path is taken, then `times_retrieved` on the memory is NOT incremented (no phantom tracking data).
+
+## Risk notes
+
+- The proposed `newEngineWithDims` helper already has a structural counterpart in `engine_test.go:420-440`; the pattern is established.
+- If the search engine does not currently return an error on dim mismatch (it may just return empty results), the fix may require a production-code change in `internal/search/engine.go` — this design doc does not prescribe that fix, only the test that would detect it.
+- Blast radius: test-only change unless the production guard is also added.
+
+## Rollout
+
+Test-only change. No schema migrations, no binary rebuild needed beyond running tests.
+
+## Out of scope (followups)
+
+- If dim-mismatch currently silently returns zero results in production, file a separate blocker: `memory_recall` silently returning empty when the DB has a different dim than the current embedder is a production correctness issue.

--- a/docs/proposed-fixes/753-scorer-rubric-error-verification.md
+++ b/docs/proposed-fixes/753-scorer-rubric-error-verification.md
@@ -1,0 +1,108 @@
+> **SUPERSEDED** — Implemented in PR #757 (merged 2026-05-20). This document retained for design context only.
+
+# Issue #753 — lme: scorer rubric error inflated v9 baseline — verify fix completeness
+
+**Severity:** nice-to-have
+**Area:** lme-tooling
+**Status:** Design only — not yet implemented
+
+## Root cause
+
+Prior to commit `423343a`, the scoring LLM was prompted to emit a rationale first and the label second (or sometimes not at all when `max_tokens=256` caused truncation mid-rationale). `ParseScoreLabel` defaulted to `PARTIALLY_CORRECT` when no label was found, inflating that bucket by ~61 items in the v9 baseline.
+
+Commit `423343a` fixed this by:
+1. Restructuring the rubric prompt to emit label FIRST, then rationale.
+2. Setting `DefaultScorerMaxTokens = 2048` to prevent truncation.
+3. Hardening `ParseScoreLabel` to return `SCORE_ERROR` instead of `PARTIALLY_CORRECT` when no label is found.
+
+The fix appears correctly implemented. The gap is **test coverage** — the test suite in `internal/longmemeval/claude_test.go` covers the current (label-first) format but does not cover the pre-fix (rationale-first) failure mode as a regression guard, nor does it verify that `SCORE_ERROR` is correctly propagated in the score pipeline.
+
+## Repro
+
+```bash
+# Verify fix is in place
+grep -n "SCORE_ERROR\|PARTIALLY_CORRECT" internal/longmemeval/claude.go
+# Should see: "SCORE_ERROR" returned in Pass 3 (no label found)
+# Should NOT see: "PARTIALLY_CORRECT" as a default fallback
+
+# Run existing tests
+go test ./internal/longmemeval/ -run TestParseScoreLabel -v
+# All should pass
+```
+
+## Proposed patch
+
+Add three missing test cases to `internal/longmemeval/claude_test.go`:
+
+```diff
+--- a/internal/longmemeval/claude_test.go
++++ b/internal/longmemeval/claude_test.go
+@@ -80,0 +81,55 @@
++
++// TestParseScoreLabel_OldFormatRationale verifies that the pre-fix rubric format
++// (rationale before label, as generated before commit 423343a) is handled by
++// the scan-all-lines pass and does NOT default to PARTIALLY_CORRECT.
++// This is a regression guard against reverting the rubric prompt structure.
++func TestParseScoreLabel_OldFormatRationale(t *testing.T) {
++	// Old format: rationale first, label buried at end — no longer generated
++	// but ParseScoreLabel must handle it gracefully (find the label, not error).
++	old := "The hypothesis closely matches the gold answer in key facts.\nCORRECT"
++	label, _ := longmemeval.ParseScoreLabel(old)
++	if label != "CORRECT" {
++		t.Errorf("ParseScoreLabel(old-format rationale-first) = %q, want CORRECT", label)
++	}
++}
++
++// TestParseScoreLabel_TruncatedNoLabel verifies that when max_tokens is too low
++// and the response is cut off before a label appears, SCORE_ERROR is returned
++// rather than PARTIALLY_CORRECT (pre-fix behaviour).
++func TestParseScoreLabel_TruncatedNoLabel(t *testing.T) {
++	truncated := "The hypothesis matches several facts from the gold answer such as the date"
++	// Note: no label anywhere — simulates truncation before label was emitted
++	label, _ := longmemeval.ParseScoreLabel(truncated)
++	if label != "SCORE_ERROR" {
++		t.Errorf("ParseScoreLabel(truncated, no label) = %q, want SCORE_ERROR", label)
++	}
++}
++
++// TestParseScoreLabel_ScoreErrorPropagation verifies that SCORE_ERROR returned
++// from ParseScoreLabel results in a score entry with status="error" (not
++// silently counted as PARTIALLY_CORRECT in the score report).
++func TestParseScoreLabel_ScoreErrorPropagation(t *testing.T) {
++	// SCORE_ERROR should be treated as an error in writeScoreReport, not as a
++	// valid label. Verify it falls into the "default" / Incorrect bucket.
++	// This test documents the expected pipeline behaviour.
++	//
++	// In writeScoreReport (cmd/longmemeval/score.go), the switch statement:
++	//   case "CORRECT": ...
++	//   case "PARTIALLY_CORRECT": ...
++	//   default: Incorrect++
++	// SCORE_ERROR hits "default" → counted as Incorrect, which is correct
++	// behaviour (conservative: unknown = not correct).
++	//
++	// If this behaviour changes, update this comment and the switch.
++	t.Log("SCORE_ERROR falls into default/Incorrect in writeScoreReport — documented by design")
++}
+```
+
+## TDD scenarios
+
+1. **old_format_rationale_before_label** — Given a response with rationale text on line 1 and a label on the last line (old rubric format), when `ParseScoreLabel` is called, then the label is correctly extracted (not `SCORE_ERROR`) via the scan-all-lines pass.
+2. **truncated_no_label_returns_SCORE_ERROR** — Given a response that ends mid-rationale with no label (simulating `max_tokens` truncation), when `ParseScoreLabel` is called, then `SCORE_ERROR` is returned (not `PARTIALLY_CORRECT`).
+3. **SCORE_ERROR_counted_as_incorrect** — Given a `ScoreEntry` with `ScoreLabel="SCORE_ERROR"`, when `writeScoreReport` processes it, then it increments `Incorrect` (not `PartiallyCorrect` or `Correct`).
+4. **regression: existing ParseScoreLabel tests pass** — All five existing `TestParseScoreLabel_*` tests continue to pass with no changes.
+
+## Risk notes
+
+- No production code changes required if `ParseScoreLabel` is already correct. This is test-only.
+- If the scoring prompt is ever changed to re-emit rationale-first, tests 1 and 2 will catch the regression.
+- `SCORE_ERROR` items in the score report should ideally be flagged separately (not silently counted as incorrect) — this design doc notes that as a nice-to-have but does not prescribe it.
+
+## Rollout
+
+Test-only change. Run `go test ./... -count=1 -race` after adding tests.
+
+## Out of scope (followups)
+
+- Surface `SCORE_ERROR` count in the score report JSON as a distinct field (currently absorbed into `Incorrect`). Low priority but useful for diagnosing scorer reliability.
+- Add a test that the scoring prompt's current format (label-first) is actually what the LLM sees — i.e., a golden snapshot test of `buildScorePrompt()`.

--- a/docs/proposed-fixes/754-lme-scratch-namespace-retention.md
+++ b/docs/proposed-fixes/754-lme-scratch-namespace-retention.md
@@ -1,0 +1,122 @@
+# Issue #754 — lme: no retention policy for benchmark projects — scratch namespace design
+
+**Severity:** nice-to-have
+**Area:** db, lme-tooling
+**Status:** Design only — not yet implemented
+
+## Root cause
+
+LME benchmark projects are named `lme-<question_id>` (set in `cmd/longmemeval/ingest.go`) and stored in the global Engram memory store alongside production memories. There is no namespace separation, no TTL, and no automatic expiry. This has two failure modes: (1) benchmark data pollutes production recall queries that iterate all projects; (2) projects accumulate indefinitely unless the operator manually triggers cleanup. The Exp 13 failure (planning to reuse Exp 10 projects that had been auto-deleted) is the concrete incident.
+
+## Repro
+
+```bash
+# Run two experiments; observe project accumulation with no expiry mechanism
+./bin/longmemeval ingest --out /tmp/exp-10 --data ...
+./bin/longmemeval run --out /tmp/exp-10 --no-cleanup --data ...
+# lme-<question_id> projects now live in the global store indefinitely
+
+# Production recall query touches all projects — benchmark data may interfere
+curl -s http://localhost:8788/mcp -d '{"method":"memory_recall","params":{"query":"test"}}' | jq '.result | length'
+# Returns memories from both production and benchmark namespaces
+```
+
+## Proposed patch
+
+**Advisory gate recommendation: Option A** — `scratch/lme-*` prefix + TTL retention.
+
+### Step 1: Naming convention change (no schema migration)
+
+```diff
+--- a/cmd/longmemeval/ingest.go
++++ b/cmd/longmemeval/ingest.go
+@@ -90,7 +90,13 @@ func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
+ 	restClient := longmemeval.NewRestClient(cfg.ServerURL, cfg.APIKey)
+ 	for item := range work {
+-		projectName := fmt.Sprintf("lme-%s", item.QuestionID)
++		// Use scratch/ prefix so benchmark projects are namespace-isolated from
++		// production memories. TTL-based cleanup (see Issue #754) can target
++		// scratch/* without touching production projects.
++		runSuffix := cfg.RunID
++		if runSuffix == "" {
++			runSuffix = "untagged"
++		}
++		projectName := fmt.Sprintf("scratch/lme-%s-%s", item.QuestionID, runSuffix)
+```
+
+Note: the `scratch/` prefix is a naming convention only. No DB schema change is required for the prefix. Existing projects with the old naming (`lme-<question_id>`) are not migrated — they persist until manually deleted.
+
+### Step 2: TTL retention (schema migration required)
+
+Add a `scratch_expires_at` column to the `projects` table:
+
+```sql
+-- Migration: add scratch_expires_at
+ALTER TABLE projects ADD COLUMN scratch_expires_at TIMESTAMPTZ;
+CREATE INDEX idx_projects_scratch_expires ON projects (scratch_expires_at)
+  WHERE scratch_expires_at IS NOT NULL;
+```
+
+At project creation time, if the project name starts with `scratch/`, set `scratch_expires_at = NOW() + INTERVAL '72 hours'`:
+
+```diff
+--- a/internal/db/projects.go (hypothetical)
++++ b/internal/db/projects.go
+@@ -CreateProject
++	var expiresAt *time.Time
++	if strings.HasPrefix(projectName, "scratch/") {
++		t := time.Now().Add(72 * time.Hour)
++		expiresAt = &t
++	}
+```
+
+Add a purge job (cron or MCP tool `memory_cleanup`):
+
+```sql
+-- Purge expired scratch projects (run daily via pg_cron or external cron)
+DELETE FROM projects WHERE scratch_expires_at < NOW();
+-- Cascade deletes memories, embeddings in those projects.
+```
+
+### Step 3: Recall filter
+
+Ensure production `memory_recall` calls exclude `scratch/*` projects by default. Add an opt-in `include_scratch: true` parameter for benchmark use:
+
+```diff
+--- a/internal/mcp/recall.go
++++ b/internal/mcp/recall.go
+@@ -RecallHandler
++	// Exclude scratch/* projects from production recall by default.
++	if !params.IncludeScratch {
++		query = query.Where("project NOT LIKE 'scratch/%'")
++	}
+```
+
+## TDD scenarios
+
+1. **scratch_prefix_set_on_ingest** — Given a `runRun` invocation with `--run-id abc123`, when ingest creates a project, then the project name is `scratch/lme-<question_id>-abc123`.
+2. **scratch_project_gets_expiry** — Given a project created with `scratch/lme-*` prefix, when `CreateProject` is called, then `scratch_expires_at` is set to approximately `NOW() + 72h`.
+3. **production_project_no_expiry** — Given a project created without `scratch/` prefix, when `CreateProject` is called, then `scratch_expires_at` is NULL.
+4. **production_recall_excludes_scratch** — Given memories in both `scratch/lme-*` and production projects, when `memory_recall` is called without `include_scratch`, then no memories from `scratch/*` appear in results.
+5. **purge_job_removes_expired** — Given a `scratch/lme-*` project with `scratch_expires_at < NOW()`, when the purge SQL runs, then the project and its memories are deleted; non-expired scratch projects and all production projects are unaffected.
+
+## Risk notes
+
+- **Breaking change**: Renaming the project prefix from `lme-<question_id>` to `scratch/lme-<question_id>-<run_id>` means existing ingest checkpoints (`checkpoint-ingest.jsonl`) reference old project names. The `run` stage reads project names from the ingest checkpoint — if ingest is re-run with the new naming, old run checkpoints are incompatible. Migration: either re-ingest, or add a `--legacy-project-prefix` flag that generates old-style names.
+- **Schema migration**: The `scratch_expires_at` column requires a DB migration. Use the existing `internal/db/migrations/` pattern. The column is nullable; existing rows get NULL (no expiry).
+- **Recall filter change**: Excluding `scratch/*` from default recall may break benchmarks that intentionally query benchmark data from the same server. The `include_scratch: true` parameter resolves this.
+- **72h TTL**: Chosen to outlast the longest expected experiment run (~35h per the camp state). Adjust via `LME_SCRATCH_TTL_HOURS` env var.
+
+## Rollout
+
+1. Apply DB migration: `scratch_expires_at` column.
+2. Deploy updated binary with `scratch/` prefix naming.
+3. Add pg_cron job (or external cron) for daily purge: `DELETE FROM projects WHERE scratch_expires_at < NOW()`.
+4. Update `results/BENCHMARK-PLAN.md` to document the new naming convention.
+5. Existing `lme-<question_id>` projects remain until manually cleaned; they are not affected by the TTL purge (they have `scratch_expires_at = NULL`).
+
+## Out of scope (followups)
+
+- Issue #751 (`--preserve-projects` flag): complement to this design — the TTL gives automatic cleanup for abandoned scratch projects, while `--preserve-projects` lets operators extend beyond the TTL for intentional cross-experiment reuse.
+- A `longmemeval projects list` subcommand to show live scratch projects with their expiry times.
+- Configurable TTL per experiment via a `--scratch-ttl` flag.

--- a/docs/proposed-fixes/audit-persistence-2026-05-19.md
+++ b/docs/proposed-fixes/audit-persistence-2026-05-19.md
@@ -1,0 +1,160 @@
+# Persistence Audit — "Parsed but Never Persisted" — 2026-05-19
+
+**SHA audited:** c409c22  
+**Auditor:** Claude Sonnet 4.6 (sub-agent, read-only)  
+**Wall time:** ~40 min  
+**Scope:** `internal/db/*.go`, `internal/mcp/tools_store.go`, `internal/types/types.go`, `internal/search/engine.go`, `internal/db/migrations/*.sql`, `internal/entity/entity.go`
+
+---
+
+## Summary Table
+
+| # | Severity | File:Line | Finding | GH Issue |
+|---|----------|-----------|---------|----------|
+| F1 | **blocker** | `internal/mcp/tools_store.go:300–310` | `memory_store_batch` never calls `parseDateTag` → `ValidFrom` is always `nil` for all batch items | [#762](https://github.com/petersimmons1972/engram-go/issues/762) |
+| F2 | **blocker** | `internal/mcp/tools_store.go:185–192` | `memory_store_document` never calls `parseDateTag` → `ValidFrom` nil; also never calls `episodeIDFromContextOrArgs` → `EpisodeID` always empty | [#763](https://github.com/petersimmons1972/engram-go/issues/763) |
+| F3 | nice-to-have | `internal/mcp/tools_store.go:300–310` | `memory_store_batch` silently drops per-item `immutable=true` flag | [#764](https://github.com/petersimmons1972/engram-go/issues/764) |
+| F4 | nice-to-have | `internal/db/postgres_memory.go:229–237` | `memory_correct` does not recalculate `valid_from` when `date:` tags are updated | [#765](https://github.com/petersimmons1972/engram-go/issues/765) |
+
+---
+
+## Methodology
+
+### Dimension 1 — INSERT vs struct fields
+
+Enumerated every `INSERT INTO <table>` in `internal/db/*.go` and cross-checked against the corresponding `types.*` struct fields and the `rowToMemory` scanner.
+
+**memories INSERT** (`postgres_memory.go:78–88`): 19 columns. Cross-checked against `types.Memory` (24 exported fields). Discrepancies investigated:
+
+- `search_vector`: generated column, not in INSERT. Correct by design.
+- `RawBody`: `json:"-"`, explicitly documented as transient. False positive.
+- `valid_from`: NOW IN INSERT (fix from #747, commit c409c22). ✅
+
+**chunks INSERT** (`postgres_chunk.go:44–46`): 9 columns. `Chunk.LastMatched` is not in INSERT (starts NULL, updated on first vector-search hit). Correct by design — the `UPDATE chunks SET last_matched=NOW()` call in `UpdateChunkLastMatched` is the intended write path.
+
+**memory_versions INSERT** (`postgres_memory.go:434–441`): snapshots `valid_from`, `valid_to`, `change_type`, `change_reason`, `project`. `PatternConfidence` and `DynamicImportance` are NOT snapshotted. This is an intentional scope limitation (version table tracks content/type/tags/importance changes only), not a bug. Confirmed by code comment pattern.
+
+**episodes INSERT** (`postgres_episode.go:20–22`): 4 columns. `EndedAt` and `Summary` are NULL at creation, populated by `EndEpisode`. Correct.
+
+**relationships INSERT** (`postgres_relationship.go:47–54`): all `Relationship` fields persisted. ✅
+
+**retrieval_events INSERT** (`postgres_feedback.go:27–31`): 5 columns. `failure_class`, `feedback_ids`, `feedback_at` are NULL at creation — populated by `RecordFeedbackWithClass`. Correct by design.
+
+**canonical_entities INSERT** (`postgres_entity.go:17–23`): `created_at` uses DB DEFAULT NOW(). `Entity` struct has no `CreatedAt` field — intentional; `updated_at` is in INSERT as `NOW()`. ✅
+
+### Dimension 2 — Default fallbacks masking absence
+
+**`temporalAnchorHours` (`internal/search/engine.go:1030–1034`)** — the archetype from #747. After the #747 fix, `ValidFrom` is correctly persisted by `storeMemoryExec`. However findings F1 and F2 show that two other store paths (`memory_store_batch`, `memory_store_document`) never populate `ValidFrom` before calling into the engine, so those paths still exhibit the pre-#747 silent degradation.
+
+No other `if x == nil { x = time.Now() }` patterns found in hot scoring/recall paths that would mask absent fields.
+
+### Dimension 3 — Migration vs ORM drift
+
+Compared latest migration (021_pattern_confidence.sql) against `types.Memory`:
+
+- `memories` DB columns: `id`, `content`, `memory_type`, `project`, `tags`, `importance`, `access_count`, `last_accessed`, `created_at`, `updated_at`, `search_vector`, `immutable`, `expires_at`, `summary`, `content_hash`, `storage_mode`, `valid_from`, `valid_to`, `invalidation_reason`, `dynamic_importance`, `retrieval_interval_hrs`, `next_review_at`, `times_retrieved`, `times_useful`, `retrieval_precision`, `episode_id`, `document_id`, `pattern_confidence` — **28 columns total**.
+- `rowToMemory` scanner at `postgres.go:631–639` scans 28 positional parameters in migration-documented order. ✅
+- `types.Memory` has 24 exported fields (plus `RawBody json:"-"`). Every DB column maps to a struct field; `search_vector` is scanned into a `[]byte` dummy that is discarded. ✅
+
+No column-without-field or field-without-column drift found.
+
+### Dimension 4 — Tag parsers → struct → INSERT
+
+`parseDateTag` (`tools_store.go:515–531`) returns `*time.Time` parsed from `date:<value>` tags.
+
+Trace:
+- `handleMemoryStore` line 92: `ValidFrom: parseDateTag(tags)` → struct field set → reaches `storeMemoryExec` line 87: `m.ValidFrom` in INSERT position 19. ✅ (after #747 fix)
+- `handleMemoryStoreBatch` lines 300–310: **`parseDateTag` NOT called**. `ValidFrom` field absent from struct literal → `nil` in DB. **F1 (blocker)**
+- `handleMemoryStoreDocument` lines 185–192: **`parseDateTag` NOT called**. Same gap. **F2 (blocker)**
+- `handleMemoryQuickStore` lines 485–504: delegates to `handleMemoryStore` → `parseDateTag` called. ✅
+
+### Dimension 5 — MCP tool inputs vs storage
+
+| Tool | `valid_from` | `episode_id` | `immutable` | `pattern_confidence` |
+|------|-------------|-------------|------------|---------------------|
+| `memory_store` | ✅ via `parseDateTag` | ✅ `episodeIDFromContextOrArgs` | ✅ `getBool` | ✅ validated |
+| `memory_store_batch` (per-item) | ❌ **F1** | ✅ `batchEpisodeID` fallback | ❌ **F3** | ✅ validated |
+| `memory_store_document` | ❌ **F2** | ❌ **F2** | ✅ `getBool` | not applicable |
+| `memory_quick_store` | ✅ delegates to `memory_store` | ✅ same | ✅ same | ✅ same |
+
+---
+
+## Findings Detail
+
+### F1 — BLOCKER: `memory_store_batch` drops `ValidFrom` for all batch items
+
+**File:line:** `internal/mcp/tools_store.go:300–310` (SHA c409c22)
+
+**Evidence:** `handleMemoryStore` calls `parseDateTag(tags)` at line 92 and assigns the result to `ValidFrom`. `handleMemoryStoreBatch` constructs the same `types.Memory` literal but omits this call entirely. The batch path is used by the LongMemEval haystack ingest pipeline (`internal/longmemeval/engram.go` — though the current LME ingest happens to use `QuickStore` which delegates correctly, the MCP-level `memory_store_batch` API is broken for any caller using `date:` tags).
+
+**Scoring impact:** `temporalAnchorHours` at `internal/search/engine.go:1031-1034` uses `ValidFrom` as the primary temporal anchor. With `ValidFrom=nil`, it falls back to `LastAccessed = NOW()` (set in `storeMemoryExec` line 44), making every batch-ingested dated memory appear to have been created at ingest time, destroying recency scoring for historical memories.
+
+**Proposed fix:** Add `ValidFrom: parseDateTag(itemTags)` to the `types.Memory` literal at line 300. One-line change.
+
+**GH:** [#762](https://github.com/petersimmons1972/engram-go/issues/762)
+
+---
+
+### F2 — BLOCKER: `memory_store_document` drops `ValidFrom` and `EpisodeID`
+
+**File:line:** `internal/mcp/tools_store.go:185–192` (SHA c409c22)
+
+**Evidence:** The `types.Memory` struct built at lines 185–192 does not include `ValidFrom` or `EpisodeID`. Compare with `handleMemoryStore` lines 82–94 which populates both.
+
+**`ValidFrom` impact:** Same as F1. Documents stored with date-tagged content will have `nil` ValidFrom, causing recency scorer to use ingest time.
+
+**`EpisodeID` impact:** Documents stored during an active named episode (auto-episode context or explicit `episode_id` arg) will not be linked to that episode. `memory_episode_recall` will silently omit them.
+
+**Proposed fix:**
+```go
+m := &types.Memory{
+    // ... existing fields ...
+    EpisodeID: episodeIDFromContextOrArgs(ctx, args),
+    ValidFrom: parseDateTag(docTags),
+}
+```
+
+**GH:** [#763](https://github.com/petersimmons1972/engram-go/issues/763)
+
+---
+
+### F3 — NICE-TO-HAVE: `memory_store_batch` ignores per-item `immutable` flag
+
+**File:line:** `internal/mcp/tools_store.go:300–310` (SHA c409c22)
+
+**Evidence:** `getBool(mmap, "immutable", false)` is never called in the batch item construction loop. The `Immutable` struct field is always `false`. Tool documentation promises parity with `memory_store`.
+
+**Proposed fix:** Add `Immutable: getBool(mmap, "immutable", false)` to the struct literal.
+
+**GH:** [#764](https://github.com/petersimmons1972/engram-go/issues/764)
+
+---
+
+### F4 — NICE-TO-HAVE: `memory_correct` does not update `valid_from` when tags change
+
+**File:line:** `internal/db/postgres_memory.go:229–237` (SHA c409c22)
+
+**Evidence:** Both UPDATE statements in `UpdateMemory` (one with content, one without) update `content`, `tags`, `importance`, `updated_at`, `pattern_confidence`, optionally `content_hash` — but NOT `valid_from`. A caller who adds `date:2023-01-01` via `memory_correct` will see tags updated in the DB but `valid_from` unchanged (still NULL if not set at creation).
+
+**Assessment:** Borderline intentional vs bug. If `valid_from` is intended to be immutable after store, this should be documented. If it should follow tags, a one-line fix in the UPDATE adds `valid_from = $N`.
+
+**GH:** [#765](https://github.com/petersimmons1972/engram-go/issues/765)
+
+---
+
+## False Positives Investigated
+
+| Candidate | Conclusion |
+|-----------|------------|
+| `chunks.last_matched` not in INSERT | Correct — starts NULL, set on first vector hit by `UpdateChunkLastMatched` |
+| `memory_versions` missing `PatternConfidence` / `DynamicImportance` | Intentional scope limit; version table tracks content/type/tags/importance only |
+| `retrieval_events` missing `failure_class` at INSERT | Correct — populated by `RecordFeedbackWithClass`; starts NULL |
+| `canonical_entities` missing `created_at` in struct | Correct — DB DEFAULT NOW(); no need in Go struct |
+| `Memory.RawBody` never in INSERT | Correct — `json:"-"`, explicitly documented as transient ingest-path field |
+| `StorageMode` default fallback in `rowToMemory` | Correct — backward compat for rows written before `storage_mode` column existed |
+
+---
+
+## Advisory Gate
+
+No advisory-gate consultation was needed. All findings were clear #747-class bugs or intentional design choices confirmable from code comments, with no architecturally divergent paths.


### PR DESCRIPTION
## Summary

- **Deleted** 3 untracked build artifacts: `cov.out`, `audit` (compiled Go binary), `docker-compose.yml.pre-migration-backup` (pre-migration snapshot, superseded by current config)
- **Formalized** `docs/proposed-fixes/` into git (8 files): issue design docs for #748–754 plus the persistence audit from 2026-05-19
- **Annotated** 5 docs with `SUPERSEDED` banners (issues #748, #750, #751, #752, #753 — all closed via PRs #803, #755, #807, #756, #757 respectively); #749 was already annotated; #754 kept clean as issue is still open
- **Updated** `.gitignore`: added `/audit`, `cov.out`, `*.backup`, `*.pre-migration-backup`

## Test plan

- [ ] Confirm `git status` is clean after checkout
- [ ] Confirm `docs/proposed-fixes/` is visible in repo and SUPERSEDED banners render correctly on GitHub
- [ ] Confirm `.gitignore` prevents `cov.out` and `audit` binary from reappearing after `go build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)