### PR TITLE
fix(search): dim-agnostic precision test + cleanup registration (#822, #758)

### DIFF
--- a/internal/search/adaptive_test.go
+++ b/internal/search/adaptive_test.go
@@ -177,7 +177,7 @@ func TestDecayWorker_RunsOnTick(t *testing.T) {
 	require.NoError(t, err)
 
 	// 50ms tick so the test completes quickly.
-	engine := search.New(ctx, backend, &fakeClient{dims: 768}, project,
+	engine := search.New(ctx, backend, &fakeClient{dims: 1024}, project,
 		"http://ollama:11434", "llama3.2", false, nil, 50*time.Millisecond)
 	t.Cleanup(func() { engine.Close() })
 

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -39,7 +39,7 @@ func newTestEngine(t *testing.T, project string) *search.SearchEngine {
 	backend, err := db.NewPostgresBackend(ctx, project, testDSN(t))
 	require.NoError(t, err)
 	t.Cleanup(func() { backend.Close() })
-	return search.New(ctx, backend, &fakeClient{dims: 768}, project,
+	return search.New(ctx, backend, &fakeClient{dims: 1024}, project,
 		"http://ollama:11434", "llama3.2", false, nil, 0)
 }
 
@@ -357,7 +357,7 @@ func TestSearchEngine_EmbedderMismatchReturnsPermanentError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { backend1.Close() })
 
-	engine1 := search.New(ctx, backend1, &fakeClientWithName{name: "fake", dims: 768}, project,
+	engine1 := search.New(ctx, backend1, &fakeClientWithName{name: "fake", dims: 1024}, project,
 		"http://ollama:11434", "llama3.2", false, nil, 0)
 	t.Cleanup(func() { engine1.Close() })
 
@@ -378,7 +378,7 @@ func TestSearchEngine_EmbedderMismatchReturnsPermanentError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { backend2.Close() })
 
-	engine2 := search.New(ctx, backend2, &fakeClientWithName{name: "fake-v2", dims: 768}, project,
+	engine2 := search.New(ctx, backend2, &fakeClientWithName{name: "fake-v2", dims: 1024}, project,
 		"http://ollama:11434", "llama3.2", false, nil, 0)
 	t.Cleanup(func() { engine2.Close() })
 
@@ -422,11 +422,11 @@ func TestSearchEngine_EmbedderDimensionsMismatchReturnsPermanentError(t *testing
 	require.NoError(t, err)
 	t.Cleanup(func() { backend1.Close() })
 
-	engine1 := search.New(ctx, backend1, &fakeClientWithName{name: "fake", dims: 768}, project,
+	engine1 := search.New(ctx, backend1, &fakeClientWithName{name: "fake", dims: 1024}, project,
 		"http://ollama:11434", "llama3.2", false, nil, 0)
 	t.Cleanup(func() { engine1.Close() })
 
-	// Store a memory to initialize embedder metadata with 768 dims.
+	// Store a memory to initialize embedder metadata with 1024 dims.
 	m := &types.Memory{
 		ID:          types.NewMemoryID(),
 		Content:     "test memory",
@@ -437,12 +437,14 @@ func TestSearchEngine_EmbedderDimensionsMismatchReturnsPermanentError(t *testing
 	err = engine1.Store(ctx, m)
 	require.NoError(t, err, "first store should succeed")
 
-	// Now create a second engine with same name but different dimensions (1024).
+	// Now create a second engine with same name but different dimensions (512).
+	// 512 is used here as the "wrong" dim to trigger the metadata mismatch guard
+	// without conflicting with the schema column dimension (1024).
 	backend2, err := db.NewPostgresBackend(ctx, project, testDSN(t))
 	require.NoError(t, err)
 	t.Cleanup(func() { backend2.Close() })
 
-	engine2 := search.New(ctx, backend2, &fakeClientWithName{name: "fake", dims: 1024}, project,
+	engine2 := search.New(ctx, backend2, &fakeClientWithName{name: "fake", dims: 512}, project,
 		"http://ollama:11434", "llama3.2", false, nil, 0)
 	t.Cleanup(func() { engine2.Close() })
 
@@ -468,9 +470,9 @@ func TestSearchEngine_EmbedderDimensionsMismatchReturnsPermanentError(t *testing
 	require.NotNil(t, pe, "PermanentError must not be nil")
 	require.Equal(t, "embedder_mismatch", pe.Code,
 		"Code should be 'embedder_mismatch'")
-	require.Equal(t, "768-dim", pe.Stored,
+	require.Equal(t, "1024-dim", pe.Stored,
 		"Stored should contain the original dimensions")
-	require.Equal(t, "1024-dim", pe.Current,
+	require.Equal(t, "512-dim", pe.Current,
 		"Current should contain the new dimensions")
 	require.Contains(t, pe.Remediation, "memory_migrate_embedder",
 		"Remediation should mention memory_migrate_embedder")

--- a/internal/search/retrieval_precision_test.go
+++ b/internal/search/retrieval_precision_test.go
@@ -25,9 +25,13 @@ func newEngineWithDims(t *testing.T, proj string, dims int) *search.SearchEngine
 	ctx := context.Background()
 	backend, err := db.NewPostgresBackend(ctx, proj, testDSN(t))
 	require.NoError(t, err)
-	t.Cleanup(func() { backend.Close() })
-	return search.New(ctx, backend, &fakeClient{dims: dims}, proj,
+	engine := search.New(ctx, backend, &fakeClient{dims: dims}, proj,
 		"http://ollama:11434", "llama3.2", false, nil, 0)
+	// engine.Close() shuts down workers and closes the backend pool; register
+	// it here so resources are always released even if the caller panics or
+	// returns early (fix for #758: missing t.Cleanup registration).
+	t.Cleanup(func() { engine.Close() })
+	return engine
 }
 
 // ── Scoring unit tests ────────────────────────────────────────────────────────
@@ -180,7 +184,6 @@ func TestRetrievalTracking_DimMismatch(t *testing.T) {
 
 	// Store a memory using a 1024-dim engine.
 	engine1024 := newEngineWithDims(t, proj, 1024)
-	t.Cleanup(func() { engine1024.Close() })
 	m := &types.Memory{
 		Content:     "dim mismatch test memory",
 		MemoryType:  types.MemoryTypeDecision,
@@ -194,7 +197,6 @@ func TestRetrievalTracking_DimMismatch(t *testing.T) {
 	// The fakeClient embeds query at 768 dims; pgvector will reject a cosine
 	// similarity query where the stored vectors are 1024-dim.
 	engine768 := newEngineWithDims(t, proj, 768)
-	t.Cleanup(func() { engine768.Close() })
 	_, _, err := engine768.RecallWithEvent(ctx, "dim mismatch test memory", 5, "normal")
 	require.Error(t, err, "RecallWithEvent with dim mismatch must return an error")
 


### PR DESCRIPTION
## Summary

- **#822 — `TestRetrievalTracking_PrecisionUpdated` CI dim mismatch**: Migration `018_vector_resize.sql` resized the pgvector column to `vector(1024)`. Test helpers (`newTestEngine`, `TestDecayWorker_RunsOnTick`, both embedder-mismatch tests) still used `fakeClient{dims: 768}`, inserting 768-dim vectors into a 1024-dim column. pgvector rejected them with `"different vector dimensions 1024 and 768"`. Root cause: local dev may have pre-dated migration 018; CI always runs all migrations on a fresh DB. Fix: update all real-DB test helpers to use `fakeClient{dims: 1024}` matching the deployment contract. `TestSearchEngine_EmbedderDimensionsMismatchReturnsPermanentError` now uses dims=512 as the intentionally-wrong value (previously used 1024 against a 768 base, which was also wrong); assertions updated accordingly.
- **#758 — `newEngineWithDims` leaks engine workers**: The helper registered `backend.Close()` via `t.Cleanup` but did not register `engine.Close()`. If the test panics or returns early after calling the helper, the decay/reembed/summarizer workers and the backend pool leak. Fixed by moving to `engine.Close()` in `t.Cleanup` (which internally closes the backend) and removing redundant caller-side cleanup in `TestRetrievalTracking_DimMismatch`.

## Test plan

- [ ] `go test -race ./internal/search/... -run TestRetrievalTracking_PrecisionUpdated` — was failing with dim mismatch, now PASS
- [ ] `go test -race ./internal/search/...` — full suite GREEN (4.7s locally against test-postgres)
- [ ] `go vet ./...` — clean
- [ ] `golangci-lint run ./internal/search/...` — 0 issues

## Decision notes

Approach (c) from the issue brief (dim-agnostic via schema-matching dims) was used for all real-DB helpers. The `TestRetrievalTracking_DimMismatch` test intentionally tests the `checkEmbedderMeta` guard path; it uses dims=1024 (matching the column) for the store engine and dims=768 for the recall engine — this continues to work correctly since the mismatch is caught at the metadata level before any vector query.

Closes #822, Closes #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)