### PR TITLE
fix(lme): build tag + crypto-random invocation_id in backend_lock (#817, #818)

### DIFF
--- a/cmd/longmemeval/backend_lock.go
+++ b/cmd/longmemeval/backend_lock.go
@@ -1,7 +1,17 @@
+//go:build !windows
+// +build !windows
+// engram-go targets Linux and macOS only. syscall.Flock / LOCK_EX / LOCK_NB /
+// EWOULDBLOCK are POSIX-only and do not exist on Windows. A no-op stub is not
+// provided because engram-go has no Windows CI and a silent no-op would mask
+// contention bugs in future cross-platform work. If Windows support is ever
+// needed, replace this file with two build-tagged variants. (#817)
+
 package main
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/url"
@@ -70,6 +80,19 @@ func defaultLockDir() string {
 		return filepath.Join(xdg, "lme")
 	}
 	return "/tmp/lme"
+}
+
+// newInvocationID generates a 16-hex-char random ID for lock-file records.
+// Uses crypto/rand to avoid predictability from co-tenant processes that share
+// a wall clock. Falls back to a time-based ID with "ns-" prefix rather than
+// panicking if rand.Read fails (should never happen on Linux/macOS) (#818).
+func newInvocationID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: "ns-" prefix distinguishes from the hex path and signals degraded mode.
+		return fmt.Sprintf("ns-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
 }
 
 // normalizeBackendURL lowercases the host, strips trailing slashes from the
@@ -206,7 +229,7 @@ func acquireBackendLock(cfg *BackendLockConfig, rawURL string) (release func(), 
 	flockErr := syscall.Flock(int(fd.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 	if flockErr == nil {
 		// Lock acquired cleanly. Write our PID record.
-		invID := fmt.Sprintf("%d", time.Now().UnixNano())
+		invID := newInvocationID()
 		content := lockFileContent(os.Getpid(), time.Now().Unix(), invID)
 		if err := fd.Truncate(0); err != nil {
 			// Write setup failed — release flock, remove lock file, return error.
@@ -285,7 +308,7 @@ func acquireBackendLock(cfg *BackendLockConfig, rawURL string) (release func(), 
 			_ = os.Remove(lockPath)
 			return nil, fmt.Errorf("backend lock: reclaim truncate %q failed: %w", lockPath, truncErr)
 		}
-		invID2 := fmt.Sprintf("%d", time.Now().UnixNano())
+		invID2 := newInvocationID()
 		content := lockFileContent(os.Getpid(), time.Now().Unix(), invID2)
 		if _, writeErr := fd2.WriteAt(content, 0); writeErr != nil {
 			_ = syscall.Flock(int(fd2.Fd()), syscall.LOCK_UN)

--- a/cmd/longmemeval/backend_lock_test.go
+++ b/cmd/longmemeval/backend_lock_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package main
 
 import (
@@ -446,4 +449,40 @@ func lockHelperMain() {
 		time.Sleep(hold)
 	}
 	os.Exit(0)
+}
+
+// TestNewInvocationID verifies that newInvocationID returns 16 hex chars and
+// that two consecutive calls produce distinct non-time-based values. (#818)
+func TestNewInvocationID(t *testing.T) {
+	id1 := newInvocationID()
+	id2 := newInvocationID()
+
+	// Must be 16 hex characters (8 bytes encoded).
+	for _, id := range []string{id1, id2} {
+		if len(id) != 16 {
+			t.Errorf("newInvocationID() = %q, want 16 hex chars (got %d)", id, len(id))
+		}
+		for _, c := range id {
+			if !strings.ContainsRune("0123456789abcdef", c) {
+				t.Errorf("newInvocationID() = %q contains non-hex char %q", id, c)
+				break
+			}
+		}
+		// Must NOT look like a bare nanosecond timestamp (all decimal digits).
+		allDigits := true
+		for _, c := range id {
+			if c < '0' || c > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			t.Errorf("newInvocationID() = %q looks like a decimal timestamp; want hex", id)
+		}
+	}
+
+	// Two consecutive calls must differ (birthday probability: 1/2^64 negligible).
+	if id1 == id2 {
+		t.Errorf("newInvocationID() returned identical values on consecutive calls: %q", id1)
+	}
 }


### PR DESCRIPTION
## Summary

- **#817**: Add `//go:build !windows` constraint to `backend_lock.go` and `backend_lock_test.go`. `syscall.Flock`/`LOCK_EX`/`LOCK_NB`/`EWOULDBLOCK` are POSIX-only. No Windows stub — engram-go has no Windows CI; a silent no-op would mask contention bugs. Comment in build tag documents the decision.
- **#818**: Replace `fmt.Sprintf("%d", time.Now().UnixNano())` (two call sites) with `newInvocationID()`, which generates 8 bytes via `crypto/rand` (16 hex chars). Mirrors `newRunID()` pattern from `main.go` (#807). Fallback returns `"ns-<nanoseconds>"` on `rand.Read` error rather than panicking.
- New test: `TestNewInvocationID` — asserts 16 hex chars, no all-decimal output, and uniqueness across consecutive calls.

## Test plan

- [ ] `go test -race -count=1 ./cmd/longmemeval/...` — all pass including `TestNewInvocationID`
- [ ] `go vet ./...` — clean
- [ ] `golangci-lint run ./cmd/longmemeval/...` — 0 issues
- [ ] `GOOS=windows go build ./cmd/longmemeval/...` — errors from `run.go` call sites only (build tag correctly excludes `backend_lock.go`; no errors from the file itself)

Closes #817, Closes #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)