### PR TITLE
refactor: import/type hygiene (#780, #781, #799)

### DIFF
--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/petersimmons1972/engram/internal/parse"
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
@@ -212,7 +213,7 @@ func (b *PostgresBackend) UpdateMemory(
 		// tags are provided. ParseDateTag returns nil when no date: tag exists, which
 		// clears valid_from to NULL. To preserve an existing valid_from, omit the tags
 		// argument entirely (see docs/tools.md#memory_correct).
-		m.ValidFrom = types.ParseDateTag(tags)
+		m.ValidFrom = parse.ParseDateTag(tags)
 	}
 	if importance != nil {
 		m.Importance = *importance

--- a/internal/mcp/date_tag_test.go
+++ b/internal/mcp/date_tag_test.go
@@ -3,11 +3,13 @@ package mcp
 import (
 	"testing"
 	"time"
+
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 func TestParseDateTag_Valid(t *testing.T) {
 	tags := []string{"lme", "sid:abc123", "date:2023-06-15"}
-	got := parseDateTag(tags)
+	got := types.ParseDateTag(tags)
 	if got == nil {
 		t.Fatal("parseDateTag returned nil, want 2023-06-15")
 	}
@@ -19,30 +21,30 @@ func TestParseDateTag_Valid(t *testing.T) {
 
 func TestParseDateTag_Invalid(t *testing.T) {
 	tags := []string{"lme", "date:not-a-date"}
-	got := parseDateTag(tags)
+	got := types.ParseDateTag(tags)
 	if got != nil {
-		t.Errorf("parseDateTag(%q) = %v, want nil for invalid date", tags, got)
+		t.Errorf("types.ParseDateTag(%q) = %v, want nil for invalid date", tags, got)
 	}
 }
 
 func TestParseDateTag_NonePresent(t *testing.T) {
 	tags := []string{"lme", "sid:abc", "project:foo"}
-	got := parseDateTag(tags)
+	got := types.ParseDateTag(tags)
 	if got != nil {
 		t.Errorf("parseDateTag with no date: tag = %v, want nil", got)
 	}
 }
 
 func TestParseDateTag_EmptyTags(t *testing.T) {
-	got := parseDateTag(nil)
+	got := types.ParseDateTag(nil)
 	if got != nil {
-		t.Errorf("parseDateTag(nil) = %v, want nil", got)
+		t.Errorf("types.ParseDateTag(nil) = %v, want nil", got)
 	}
 }
 
 func TestParseDateTag_FirstWins(t *testing.T) {
 	tags := []string{"date:2022-01-01", "date:2024-12-31"}
-	got := parseDateTag(tags)
+	got := types.ParseDateTag(tags)
 	if got == nil {
 		t.Fatal("parseDateTag returned nil")
 	}
@@ -65,13 +67,13 @@ func TestParseDateTag_LongMemEvalFormat(t *testing.T) {
 		{"date:2024/01/01 (Mon) 09:00", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 	}
 	for _, tc := range cases {
-		got := parseDateTag([]string{tc.tag})
+		got := types.ParseDateTag([]string{tc.tag})
 		if got == nil {
-			t.Errorf("parseDateTag(%q) = nil, want %v", tc.tag, tc.want)
+			t.Errorf("types.ParseDateTag(%q) = nil, want %v", tc.tag, tc.want)
 			continue
 		}
 		if !got.Equal(tc.want) {
-			t.Errorf("parseDateTag(%q) = %v, want %v", tc.tag, *got, tc.want)
+			t.Errorf("types.ParseDateTag(%q) = %v, want %v", tc.tag, *got, tc.want)
 		}
 	}
 }

--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -12,6 +12,7 @@ import (
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/parse"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 )
@@ -90,7 +91,7 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		Immutable:         getBool(args, "immutable", false),
 		StorageMode:       "focused",
 		EpisodeID:         episodeID,
-		ValidFrom:         types.ParseDateTag(tags),
+		ValidFrom:         parse.ParseDateTag(tags),
 		PatternConfidence: patternConfidence,
 	}
 	storeCtx, storeCancel := context.WithTimeout(ctx, storeTimeout)
@@ -191,7 +192,7 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 		Tags:       docTags,
 		Immutable:  getBool(args, "immutable", false),
 		EpisodeID:  episodeIDFromContextOrArgs(ctx, args),
-		ValidFrom:  types.ParseDateTag(docTags),
+		ValidFrom:  parse.ParseDateTag(docTags),
 	}
 	engine := h.Engine
 	deps := storeDocumentDeps{
@@ -310,7 +311,7 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 			Immutable:         getBool(mmap, "immutable", false),
 			StorageMode:       "focused",
 			EpisodeID:         itemEpisodeID,
-			ValidFrom:         types.ParseDateTag(itemTags),
+			ValidFrom:         parse.ParseDateTag(itemTags),
 			PatternConfidence: itemPatternConfidence,
 		})
 	}

--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -90,7 +90,7 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		Immutable:         getBool(args, "immutable", false),
 		StorageMode:       "focused",
 		EpisodeID:         episodeID,
-		ValidFrom:         parseDateTag(tags),
+		ValidFrom:         types.ParseDateTag(tags),
 		PatternConfidence: patternConfidence,
 	}
 	storeCtx, storeCancel := context.WithTimeout(ctx, storeTimeout)
@@ -191,7 +191,7 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 		Tags:       docTags,
 		Immutable:  getBool(args, "immutable", false),
 		EpisodeID:  episodeIDFromContextOrArgs(ctx, args),
-		ValidFrom:  parseDateTag(docTags),
+		ValidFrom:  types.ParseDateTag(docTags),
 	}
 	engine := h.Engine
 	deps := storeDocumentDeps{
@@ -310,7 +310,7 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 			Immutable:         getBool(mmap, "immutable", false),
 			StorageMode:       "focused",
 			EpisodeID:         itemEpisodeID,
-			ValidFrom:         parseDateTag(itemTags),
+			ValidFrom:         types.ParseDateTag(itemTags),
 			PatternConfidence: itemPatternConfidence,
 		})
 	}
@@ -512,13 +512,6 @@ func handleMemoryQuickStore(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 	req2 := req
 	req2.Params.Arguments = merged
 	return handleMemoryStore(ctx, pool, req2, cfg)
-}
-
-// parseDateTag is a package-local shim that delegates to types.ParseDateTag.
-// Kept for call-site compatibility within this file; callers in other packages
-// (e.g., internal/db) import types.ParseDateTag directly.
-func parseDateTag(tags []string) *time.Time {
-	return types.ParseDateTag(tags)
 }
 
 // handleMemoryQuery is a simplified front door for handleMemoryRecall.

--- a/internal/mcp/tools_store_test.go
+++ b/internal/mcp/tools_store_test.go
@@ -20,6 +20,7 @@ import (
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/parse"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/require"
@@ -290,7 +291,7 @@ func (b *validFromCorrectBackend) UpdateMemory(_ context.Context, id string, _ *
 		Content:   "updated",
 		Project:   "test",
 		Tags:      tags,
-		ValidFrom: types.ParseDateTag(tags), // simulate what the real DB impl does
+		ValidFrom: parse.ParseDateTag(tags), // simulate what the real DB impl does
 	}, nil
 }
 
@@ -324,7 +325,7 @@ func (b *validFromCorrectBackendV2) UpdateMemory(_ context.Context, id string, _
 	// date: tags on every UpdateMemory call where tags are provided.
 	var vf *time.Time
 	if tags != nil {
-		vf = types.ParseDateTag(tags)
+		vf = parse.ParseDateTag(tags)
 	} else {
 		vf = b.initialValidFrom
 	}
@@ -386,7 +387,7 @@ func TestMemoryCorrect_RecalculatesValidFromOnTagChange(t *testing.T) {
 	_ = tc
 	// The in-memory simulation sets ValidFrom via ParseDateTag; the simulated
 	// backend returns a memory with the correct value — verify via back state.
-	gotVF := types.ParseDateTag(back.capturedTags)
+	gotVF := parse.ParseDateTag(back.capturedTags)
 	require.NotNil(t, gotVF, "ParseDateTag on updated tags must return non-nil")
 	require.True(t, gotVF.Equal(want), "recalculated ValidFrom must be 2024-12-31, got %s", gotVF)
 }
@@ -447,7 +448,7 @@ func TestMemoryCorrect_DateTag_CorrectUpdatesValidFrom(t *testing.T) {
 	require.False(t, res.IsError)
 
 	require.True(t, back.called, "UpdateMemory must be called")
-	gotVF := types.ParseDateTag(back.capturedTags)
+	gotVF := parse.ParseDateTag(back.capturedTags)
 	require.NotNil(t, gotVF, "ParseDateTag on updated tags must return non-nil")
 	require.True(t, gotVF.Equal(want),
 		"valid_from must be 2024-04-15 after correct with date: tag, got %s", gotVF)
@@ -476,7 +477,7 @@ func TestMemoryCorrect_EmptyTags_ClearsValidFrom(t *testing.T) {
 	require.True(t, back.called, "UpdateMemory must be called")
 	// An empty tags slice means no date: tag → valid_from is recalculated as NULL.
 	// The backend simulation returns nil ValidFrom when tags is non-nil but has no date:.
-	gotVF := types.ParseDateTag(back.capturedTags)
+	gotVF := parse.ParseDateTag(back.capturedTags)
 	require.Nil(t, gotVF,
 		"valid_from must be NULL when tags:[] clears all date: tags")
 }
@@ -607,7 +608,7 @@ func TestMemoryCorrect_MCP_EmptyTagsClearsValidFrom(t *testing.T) {
 	require.Empty(t, back.capturedTags,
 		`"tags":[] must pass empty (not nil) slice, causing valid_from to be cleared (B1)`)
 	// Confirm valid_from would be NULL under the real DB impl.
-	gotVF := types.ParseDateTag(back.capturedTags)
+	gotVF := parse.ParseDateTag(back.capturedTags)
 	require.Nil(t, gotVF,
 		"empty tags must yield nil valid_from (cleared to NULL in Postgres) (B1)")
 }
@@ -627,7 +628,7 @@ func (b *historyTrackingBackend) UpdateMemory(_ context.Context, id string, cont
 	if b.versions == nil {
 		b.versions = make(map[string][]*types.MemoryVersion)
 	}
-	vf := types.ParseDateTag(tags)
+	vf := parse.ParseDateTag(tags)
 	// Snapshot the state of this update as a new version (mirrors versionMemoryTx behaviour).
 	v := &types.MemoryVersion{
 		ID:         fmt.Sprintf("ver-%d", len(b.versions[id])+1),

--- a/internal/parse/date_tag.go
+++ b/internal/parse/date_tag.go
@@ -1,0 +1,39 @@
+// Package parse holds string-parsing utilities that operate on values
+// embedded in higher-level data structures (e.g., memory tags). These are
+// operational helpers, not wire-compatible type definitions — keeping them
+// out of internal/types preserves that package's role as the source of
+// truth for core data shapes.
+package parse
+
+import (
+	"strings"
+	"time"
+)
+
+// ParseDateTag scans tags for a "date:<value>" entry and returns the parsed
+// UTC time (date portion only), or nil if no valid date tag is found.
+// The first matching tag wins. Supported formats:
+//
+//   - "2006-01-02"                — ISO date
+//   - "2006/01/02 (Mon) 15:04"   — LongMemEval haystack date format
+//
+// This function is shared by the MCP store handlers and the DB layer
+// (e.g., UpdateMemory tag recalculation) without a circular import.
+func ParseDateTag(tags []string) *time.Time {
+	layouts := []string{"2006-01-02", "2006/01/02 (Mon) 15:04"}
+	for _, tag := range tags {
+		val, ok := strings.CutPrefix(tag, "date:")
+		if !ok {
+			continue
+		}
+		for _, layout := range layouts {
+			t, err := time.Parse(layout, val)
+			if err != nil {
+				continue
+			}
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+			return &t
+		}
+	}
+	return nil
+}

--- a/internal/parse/date_tag_test.go
+++ b/internal/parse/date_tag_test.go
@@ -1,15 +1,13 @@
-package mcp
+package parse
 
 import (
 	"testing"
 	"time"
-
-	"github.com/petersimmons1972/engram/internal/types"
 )
 
 func TestParseDateTag_Valid(t *testing.T) {
 	tags := []string{"lme", "sid:abc123", "date:2023-06-15"}
-	got := types.ParseDateTag(tags)
+	got := ParseDateTag(tags)
 	if got == nil {
 		t.Fatal("parseDateTag returned nil, want 2023-06-15")
 	}
@@ -21,30 +19,30 @@ func TestParseDateTag_Valid(t *testing.T) {
 
 func TestParseDateTag_Invalid(t *testing.T) {
 	tags := []string{"lme", "date:not-a-date"}
-	got := types.ParseDateTag(tags)
+	got := ParseDateTag(tags)
 	if got != nil {
-		t.Errorf("types.ParseDateTag(%q) = %v, want nil for invalid date", tags, got)
+		t.Errorf("ParseDateTag(%q) = %v, want nil for invalid date", tags, got)
 	}
 }
 
 func TestParseDateTag_NonePresent(t *testing.T) {
 	tags := []string{"lme", "sid:abc", "project:foo"}
-	got := types.ParseDateTag(tags)
+	got := ParseDateTag(tags)
 	if got != nil {
 		t.Errorf("parseDateTag with no date: tag = %v, want nil", got)
 	}
 }
 
 func TestParseDateTag_EmptyTags(t *testing.T) {
-	got := types.ParseDateTag(nil)
+	got := ParseDateTag(nil)
 	if got != nil {
-		t.Errorf("types.ParseDateTag(nil) = %v, want nil", got)
+		t.Errorf("ParseDateTag(nil) = %v, want nil", got)
 	}
 }
 
 func TestParseDateTag_FirstWins(t *testing.T) {
 	tags := []string{"date:2022-01-01", "date:2024-12-31"}
-	got := types.ParseDateTag(tags)
+	got := ParseDateTag(tags)
 	if got == nil {
 		t.Fatal("parseDateTag returned nil")
 	}
@@ -67,13 +65,13 @@ func TestParseDateTag_LongMemEvalFormat(t *testing.T) {
 		{"date:2024/01/01 (Mon) 09:00", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 	}
 	for _, tc := range cases {
-		got := types.ParseDateTag([]string{tc.tag})
+		got := ParseDateTag([]string{tc.tag})
 		if got == nil {
-			t.Errorf("types.ParseDateTag(%q) = nil, want %v", tc.tag, tc.want)
+			t.Errorf("ParseDateTag(%q) = nil, want %v", tc.tag, tc.want)
 			continue
 		}
 		if !got.Equal(tc.want) {
-			t.Errorf("types.ParseDateTag(%q) = %v, want %v", tc.tag, *got, tc.want)
+			t.Errorf("ParseDateTag(%q) = %v, want %v", tc.tag, *got, tc.want)
 		}
 	}
 }

--- a/internal/types/benchmark.go
+++ b/internal/types/benchmark.go
@@ -1,6 +1,0 @@
-// LLM benchmark types (Verdict, RunAttempt, RunResult, Score, ModelResult,
-// Duration) have been moved to internal/benchmark to avoid coupling
-// internal/types consumers to campaign/evaluation tooling.
-//
-// See: https://github.com/petersimmons1972/engram-go/issues/771
-package types

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -6,7 +6,6 @@ package types
 import (
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -406,31 +405,3 @@ type AggregateRow struct {
 	Newest time.Time `json:"newest"`
 }
 
-// ParseDateTag scans tags for a "date:<value>" entry and returns the parsed
-// UTC time (date portion only), or nil if no valid date tag is found.
-// The first matching tag wins. Supported formats:
-//
-//   - "2006-01-02"                — ISO date
-//   - "2006/01/02 (Mon) 15:04"   — LongMemEval haystack date format
-//
-// This is the canonical implementation; the mcp package delegates to it so
-// that the same logic is available to the db layer (e.g., UpdateMemory tag
-// recalculation) without a circular import.
-func ParseDateTag(tags []string) *time.Time {
-	layouts := []string{"2006-01-02", "2006/01/02 (Mon) 15:04"}
-	for _, tag := range tags {
-		val, ok := strings.CutPrefix(tag, "date:")
-		if !ok {
-			continue
-		}
-		for _, layout := range layouts {
-			t, err := time.Parse(layout, val)
-			if err != nil {
-				continue
-			}
-			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
-			return &t
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
Closes #780, Closes #781, Closes #799.

Three sequential cleanups, each a self-contained commit:

1. **#780 — inline parseDateTag shim.** The package-local `parseDateTag` in `internal/mcp/tools_store.go` was a one-line passthrough to `types.ParseDateTag` with no validation or normalization. Decision per the issue's "delete or document" choice: inline at all three call sites, remove the shim, and update `date_tag_test.go` to call the canonical implementation directly.

2. **#781 — move ParseDateTag out of internal/types.** `internal/types` is reserved for wire-compatible core data structures; tag-parsing is operational logic placed there only to dodge a previous import cycle. New `internal/parse` package added (`internal/parse/date_tag.go`), tests moved alongside, call sites in `internal/mcp` and `internal/db` updated, and the now-unused `strings` import removed from `types.go`.

3. **#799 — delete internal/types/benchmark.go stub.** PR #797 migrated benchmark types to `internal/benchmark` but left a comment-only stub file behind. All consumers already import the new location (no remaining `types.ModelResult` / `types.RunResult` / `types.Verdict` references in the tree). Delete the stub so the migration is fully closed.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/{parse,mcp,db,types}/...` — 0 issues
- [x] `go test -race ./internal/{parse,mcp,db,types,scorer,runner,benchmark}/...` — all pass

## Notes
- Commits are sequenced smallest → largest as briefed.
- No advisory-gate invocation needed — no non-obvious branches (no circular import, no diverging package expectations) surfaced.