### PR TITLE
docs+refactor(mcp): memory_correct semantics + importance constant rename (#779, #790)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -258,6 +258,8 @@ memory_correct(
 | `tags` | array of strings | no | Replacement tag set; see tag-and-valid_from rules below |
 | `importance` | integer 0–4 | no | Replacement importance value; must be 0–4. Out-of-range returns a tool-result error (`isError: true`) with message `importance must be 0-4`. Symmetric with `memory_store` validation. |
 
+> **Only-promote-never-nullify rule (issue #779):** `memory_correct` can set or recalculate `valid_from` via `date:` tags, but it can never clear it except through an explicit empty tag list. Sending no `tags` argument at all leaves `valid_from` untouched — it is never nullified by a field you did not send. In practice: omit `tags` to update only `content` or `importance` without disturbing `valid_from`. This asymmetry is intentional; it prevents accidental date-erasure when the caller only cares about the content. The sole exception is `tags: []` (empty array), which explicitly clears `valid_from` — see issue #765 for the recalculation logic.
+
 **Tag and valid_from rules (issue #765):**
 
 `valid_from` is derived from `date:YYYY-MM-DD` tags. On every `memory_correct` call that includes a `tags` argument, `valid_from` is recalculated from the supplied tag set:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -111,6 +111,8 @@ memory_store(
 | Low | 3 | 0.67× | Never |
 | Trivial | 4 | 0.33× | After 30 days |
 
+> **Two scales, do not confuse them.** `importance` itself is an integer 0–4 (5 discrete levels). The **multiplier** column above shows the runtime scoring effect (~0.33× to ~1.67×, derived as `max(0.1, (5 - importance) / 3)`). If you have seen a range like "5-100" or "0.33–1.67" referenced elsewhere, that is the multiplier or its percent form, not the input you pass to `memory_store`. The only other numeric memory field, `pattern_confidence`, is a float 0.0–1.0.
+
 Set `importance=0` (Critical) sparingly. A constraint that must never be violated — never use raw SQL outside the repository layer, never store tokens in localStorage — belongs here. Most decisions belong at High or Medium. If everything is Critical, nothing is.
 
 ---

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1263,7 +1263,7 @@ func (s *Server) registerTools() {
 		{"memory_expand", "Explore the relationship graph neighbourhood of a known memory.",
 			noConfig(handleMemoryExpand)},
 		// Mutations
-		{"memory_correct", "Update content, tags, importance, or pattern_confidence (float 0.0–1.0) on an existing memory. Omit pattern_confidence to leave it unchanged.",
+		{"memory_correct", "Update content, tags, importance, or pattern_confidence (float 0.0–1.0) on an existing memory. Omit pattern_confidence to leave it unchanged. Only-promote-never-nullify rule: omit 'tags' entirely to preserve the existing valid_from; sending tags=[...] recalculates valid_from from date: tags; sending tags=[] clears valid_from to null. See docs/tools.md#memory_correct and issue #765.",
 			noConfig(handleMemoryCorrect)},
 		{"memory_forget", "Soft-delete a memory (sets valid_to, preserves history, respects immutability)",
 			noConfig(handleMemoryForget)},

--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -378,8 +378,8 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 	var importance *int
 	if v, ok := args["importance"].(float64); ok {
 		n := int(v)
-		if n < minImportanceValue || n > maxImportanceValue {
-			return mcpgo.NewToolResultError(fmt.Sprintf("importance must be %d–%d, got %d", minImportanceValue, maxImportanceValue, n)), nil
+		if n < highestImportanceLevel || n > lowestImportanceLevel {
+			return mcpgo.NewToolResultError(fmt.Sprintf("importance must be %d–%d, got %d", highestImportanceLevel, lowestImportanceLevel, n)), nil
 		}
 		importance = &n
 	}
@@ -446,12 +446,16 @@ const maxQuickStoreTags = 64
 // maxQuickStoreTagLength is the maximum length of a single tag.
 const maxQuickStoreTagLength = 256
 
-// maxImportanceValue is the maximum allowed importance value.
+// lowestImportanceLevel is the highest numeric value on the 0–4 importance
+// scale (= least important / lowest retention priority). The scale is inverted:
+// 0 = Critical (highest priority), 4 = Low (lowest priority). "Lowest" here
+// refers to retention importance, not the numeric value.
 // Must match the 0–4 range enforced by handleMemoryStore.
-const maxImportanceValue = 4
+const lowestImportanceLevel = 4
 
-// minImportanceValue is the minimum allowed importance value.
-const minImportanceValue = 0
+// highestImportanceLevel is the lowest numeric value on the 0–4 importance
+// scale (= most important / highest retention priority). 0 = Critical.
+const highestImportanceLevel = 0
 
 // projectNamePattern validates project names: ^[a-z0-9_-]{1,64}$.
 var projectNamePattern = regexp.MustCompile(`^[a-z0-9_-]{1,64}$`)
@@ -476,8 +480,8 @@ func validateQuickStoreInput(content string, project string, tags []string, impo
 			return fmt.Errorf("tag %d exceeds max length %d chars", i, maxQuickStoreTagLength)
 		}
 	}
-	if importance < minImportanceValue || importance > maxImportanceValue {
-		return fmt.Errorf("importance must be %d–%d, got %d", minImportanceValue, maxImportanceValue, importance)
+	if importance < highestImportanceLevel || importance > lowestImportanceLevel {
+		return fmt.Errorf("importance must be %d–%d, got %d", highestImportanceLevel, lowestImportanceLevel, importance)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **Closes #779**: Adds only-promote-never-nullify callout to `docs/tools.md` and the `memory_correct` MCP tool description. Clarifies that omitting `tags` entirely preserves the existing `valid_from` (never nullified); `tags=[...]` recalculates from `date:` tags; `tags=[]` explicitly clears `valid_from`. Links to issue #765 as the exception that established the rule.
- **Closes #790**: Renames `maxImportanceValue`/`minImportanceValue` constants to `lowestImportanceLevel`/`highestImportanceLevel`. The prior names were semantically inverted — `max=4` is the least important (lowest retention priority) and `min=0` is Critical (highest retention priority). New names express semantic meaning; comments clarify the numeric inversion explicitly.

No logic changes. Pure documentation + mechanical rename.

## Test plan

- [x] `go test -race ./internal/mcp/... ./internal/db/...` — both pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./internal/mcp/...` — 0 issues
- [x] All importance-validation tests (`TestHandleMemoryCorrect_RejectsOutOfRangeImportance`, `TestQuickStore_*`) serve as rename regression guard — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)