### PR TITLE
refactor(db): dedupe UpdateMemory SET clauses (#783)

### DIFF
--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -17,6 +17,14 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
+// updateMemory SQL constants — keep both in sync when adding new columns to the
+// memories table. The "with content" variant also refreshes content_hash and
+// clears the summary so the background worker regenerates it.
+const (
+	sqlUpdateMemoryWithContent = "UPDATE memories SET content=$1, tags=$2, importance=$3, updated_at=$4, content_hash=$5, summary=NULL, pattern_confidence=$6, valid_from=$7 WHERE id=$8 AND project=$9"
+	sqlUpdateMemoryNoContent   = "UPDATE memories SET content=$1, tags=$2, importance=$3, updated_at=$4, pattern_confidence=$5, valid_from=$6 WHERE id=$7 AND project=$8"
+)
+
 // ContentHash returns the canonical SHA-256 hex digest for a memory's content.
 // Used by both the storage layer and the ingest dedup path to guarantee
 // identical hash values from the same input string.
@@ -232,13 +240,11 @@ func (b *PostgresBackend) UpdateMemory(
 		hash := ContentHash(m.Content)
 		m.ContentHash = &hash
 		// Clear the summary so the background worker regenerates it with the new content.
-		_, err = tx.Exec(ctx,
-			"UPDATE memories SET content=$1, tags=$2, importance=$3, updated_at=$4, content_hash=$5, summary=NULL, pattern_confidence=$6, valid_from=$7 WHERE id=$8 AND project=$9",
+		_, err = tx.Exec(ctx, sqlUpdateMemoryWithContent,
 			m.Content, tagsJSON, m.Importance, now, hash, m.PatternConfidence, m.ValidFrom, id, b.project,
 		)
 	} else {
-		_, err = tx.Exec(ctx,
-			"UPDATE memories SET content=$1, tags=$2, importance=$3, updated_at=$4, pattern_confidence=$5, valid_from=$6 WHERE id=$7 AND project=$8",
+		_, err = tx.Exec(ctx, sqlUpdateMemoryNoContent,
 			m.Content, tagsJSON, m.Importance, now, m.PatternConfidence, m.ValidFrom, id, b.project,
 		)
 	}


### PR DESCRIPTION
## Summary

- Closes #783
- Extracts the two `UPDATE memories SET ...` query strings in `UpdateMemory` into named constants (`sqlUpdateMemoryWithContent` / `sqlUpdateMemoryNoContent`), defined side-by-side with a comment instructing maintainers to keep them in sync when adding columns
- Behavior-preserving: the "with content" path still refreshes `content_hash` and nulls `summary`; the "no content" path still omits those columns; all positional parameters are unchanged

## Investigation note

The issue title says "structurally identical SET clauses" — they share six fields (`content, tags, importance, updated_at, pattern_confidence, valid_from`) but are **not** identical: the `content != nil` branch additionally sets `content_hash=$5, summary=NULL`. The refactor creates a single source of truth for each query string (as constants), which is the correct fix: a future column addition edits the constants, not inline strings buried inside control flow.

## Test plan

- [x] `go test -race ./internal/db/... ./internal/mcp/...` — both packages GREEN before and after
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./internal/db/...` — 0 issues
- [x] Behavior-preserving: no logic changes, only string literals extracted to constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)