### PR TITLE
refactor(llmclient): rename internal/instinctllm to internal/llmclient (#730)

### DIFF
--- a/cmd/audit/judge.go
+++ b/cmd/audit/judge.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // auditPrompt is the production-tuned prompt for pattern quality evaluation.
@@ -44,10 +44,10 @@ REASON: <one sentence>`
 // (prompt construction, line-by-line parsing) lives here.
 //
 // Ported from instinct-python/cmd/audit/main.go:163-219 with these changes:
-//   - client is instinctllm.LLMClient (generic) instead of *ollama.Client (Ollama-specific)
+//   - client is llmclient.LLMClient (generic) instead of *ollama.Client (Ollama-specific)
 //   - model parameter is dropped; model selection is handled by the LLM factory
 //   - timeout is applied via context.WithTimeout wrapping the Complete call
-func Judge(ctx context.Context, client instinctllm.LLMClient, timeout time.Duration, m engramMemory) auditResult {
+func Judge(ctx context.Context, client llmclient.LLMClient, timeout time.Duration, m engramMemory) auditResult {
 	ptype, domain, sig := extractTags(m.Tags)
 	content := m.Content
 	if content == "" {

--- a/cmd/audit/judge_test.go
+++ b/cmd/audit/judge_test.go
@@ -8,12 +8,12 @@ import (
 	"time"
 )
 
-// mockLLMClient is a test spy implementing instinctllm.LLMClient.
+// mockLLMClient is a test spy implementing llmclient.LLMClient.
 // It records calls and returns a fixed response or error.
 type mockLLMClient struct {
-	response    string
-	err         error
-	capturedSys string
+	response     string
+	err          error
+	capturedSys  string
 	capturedUser string
 }
 

--- a/cmd/audit/main.go
+++ b/cmd/audit/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // Version is injected at build time via -ldflags "-X main.Version=<ver>".
@@ -42,7 +42,7 @@ func run() int {
 	// Pass Backend explicitly via Config instead of setting LLM_BACKEND in the
 	// process environment — keeps configuration in the call chain and avoids
 	// race-unsafe global state under parallel tests (Blocker 3).
-	client, err := instinctllm.NewClient(instinctllm.Config{
+	client, err := llmclient.NewClient(llmclient.Config{
 		Backend: *llmBackend,
 		Timeout: *timeout,
 	})
@@ -60,7 +60,7 @@ func run() int {
 
 // runAudit fetches patterns, judges each, and writes the JSON report to out.
 // Extracted from run() so it can be tested without exec.
-func runAudit(base, token string, client instinctllm.LLMClient, timeout time.Duration, out io.Writer) error {
+func runAudit(base, token string, client llmclient.LLMClient, timeout time.Duration, out io.Writer) error {
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}

--- a/cmd/instinct/consolidator/detect.go
+++ b/cmd/instinct/consolidator/detect.go
@@ -1,7 +1,7 @@
 // Package consolidator owns the domain logic for pattern detection: prompt
 // construction, LLM call dispatch, and response parsing/validation.
 //
-// The LLM client (transport layer) is injected via the instinctllm.LLMClient interface
+// The LLM client (transport layer) is injected via the llmclient.LLMClient interface
 // so backends (Anthropic, Olla) can be swapped without touching this package.
 package consolidator
 
@@ -13,7 +13,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // Event is one tool-use record from the PostToolUse hook buffer.
@@ -119,7 +119,7 @@ func stripMarkdownFences(text string) string {
 //     — graceful degradation so the consolidator never crashes on bad LLM output.
 //
 // Zero events short-circuits before calling the LLM.
-func Detect(ctx context.Context, client instinctllm.LLMClient, events []Event) ([]Pattern, error) {
+func Detect(ctx context.Context, client llmclient.LLMClient, events []Event) ([]Pattern, error) {
 	if len(events) == 0 {
 		return nil, nil
 	}
@@ -131,7 +131,7 @@ func Detect(ctx context.Context, client instinctllm.LLMClient, events []Event) (
 		// …) is treated as "skip this batch, don't crash" — the consolidator
 		// runs every N events and should tolerate transient infra failure.
 		// Real parse/protocol errors still propagate.
-		if errors.Is(err, instinctllm.ErrBackendUnavailable) {
+		if errors.Is(err, llmclient.ErrBackendUnavailable) {
 			slog.Info("consolidator: LLM backend unavailable, skipping batch", "err", err)
 			return nil, nil
 		}

--- a/cmd/instinct/consolidator/detect_test.go
+++ b/cmd/instinct/consolidator/detect_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/petersimmons1972/engram/cmd/instinct/consolidator"
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
-// mockLLMClient implements instinctllm.LLMClient for testing.
+// mockLLMClient implements llmclient.LLMClient for testing.
 type mockLLMClient struct {
 	response string
 	err      error
@@ -33,8 +33,8 @@ func (f *failIfCalledClient) Complete(_ context.Context, _, _ string) (string, e
 }
 
 // Compile-time assertion that both mocks satisfy the interface.
-var _ instinctllm.LLMClient = (*mockLLMClient)(nil)
-var _ instinctllm.LLMClient = (*failIfCalledClient)(nil)
+var _ llmclient.LLMClient = (*mockLLMClient)(nil)
+var _ llmclient.LLMClient = (*failIfCalledClient)(nil)
 
 // TestDetectHappyPath: mock returns golden pattern JSON; Detect returns
 // parsed []Pattern.

--- a/cmd/instinct/main.go
+++ b/cmd/instinct/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/petersimmons1972/engram/cmd/instinct/consolidator"
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -278,10 +278,10 @@ type sseEngram struct {
 }
 
 const (
-	mcpConnectTimeout  = 10 * time.Second
-	mcpCallTimeout     = 15 * time.Second
-	mcpRetryWindow     = 30 * time.Second
-	mcpRetryDelayBase  = 200 * time.Millisecond
+	mcpConnectTimeout = 10 * time.Second
+	mcpCallTimeout    = 15 * time.Second
+	mcpRetryWindow    = 30 * time.Second
+	mcpRetryDelayBase = 200 * time.Millisecond
 	// mcpOperationTimeout gives each high-level operation (writeEpisode per-event,
 	// upsertPattern) the full retry window plus a reconnect buffer, ensuring at
 	// least two retry attempts can complete before the outer context expires.
@@ -743,7 +743,7 @@ func run(ctx context.Context, cfg config) error {
 	// here at the binary level and passed explicitly via Config.Backend — the
 	// same pattern cmd/audit uses — so the factory env fallback is dead code
 	// and parallel tests can't race on process environment state.
-	llmClient, err := instinctllm.NewClient(instinctllm.Config{
+	llmClient, err := llmclient.NewClient(llmclient.Config{
 		Backend:  envOr("LLM_BACKEND", "anthropic"),
 		APIKey:   cfg.anthropicKey,
 		Endpoint: cfg.haikuEndpoint,

--- a/cmd/instinct/main_test.go
+++ b/cmd/instinct/main_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/petersimmons1972/engram/cmd/instinct/consolidator"
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 func TestLoadConfig_EnvVars(t *testing.T) {
@@ -374,12 +374,12 @@ func TestEngramClient_Correct(t *testing.T) {
 
 // ── Detect pipeline tests (replaces former callHaiku tests) ──────────────────
 //
-// These are integration tests of the full instinctllm.AnthropicClient → consolidator.Detect
+// These are integration tests of the full llmclient.AnthropicClient → consolidator.Detect
 // path, run from the main package to exercise the wiring.
 
-func newTestAnthropicClient(t *testing.T, endpoint string) instinctllm.LLMClient {
+func newTestAnthropicClient(t *testing.T, endpoint string) llmclient.LLMClient {
 	t.Helper()
-	c, err := instinctllm.NewAnthropicClient(instinctllm.Config{
+	c, err := llmclient.NewAnthropicClient(llmclient.Config{
 		APIKey:   "sk-ant-fake",
 		Endpoint: endpoint,
 		Timeout:  5 * time.Second,

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -2,6 +2,7 @@
 // the summarize and consolidate packages. It targets LiteLLM's
 // /v1/chat/completions endpoint, which is also compatible with direct OpenAI
 // and any other provider LiteLLM proxies.
+// See also: internal/llmclient — the multi-backend (Anthropic + Olla) completion client used by instinct and audit.
 package llm
 
 import (

--- a/internal/llmclient/anthropic.go
+++ b/internal/llmclient/anthropic.go
@@ -1,4 +1,4 @@
-package instinctllm
+package llmclient
 
 import (
 	"bytes"

--- a/internal/llmclient/anthropic_test.go
+++ b/internal/llmclient/anthropic_test.go
@@ -1,4 +1,4 @@
-package instinctllm_test
+package llmclient_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // goldenAnthropicResponse returns a minimal Anthropic Messages API response
@@ -18,14 +18,14 @@ func goldenAnthropicResponse(text string) string {
 	return fmt.Sprintf(`{"content":[{"type":"text","text":%q}],"usage":{"input_tokens":10,"output_tokens":50}}`, text)
 }
 
-func newAnthropicClient(t *testing.T, endpoint string) instinctllm.LLMClient {
+func newAnthropicClient(t *testing.T, endpoint string) llmclient.LLMClient {
 	t.Helper()
-	cfg := instinctllm.Config{
+	cfg := llmclient.Config{
 		APIKey:   "sk-ant-fake",
 		Endpoint: endpoint,
 		Timeout:  5 * time.Second,
 	}
-	c, err := instinctllm.NewAnthropicClient(cfg)
+	c, err := llmclient.NewAnthropicClient(cfg)
 	if err != nil {
 		t.Fatalf("NewAnthropicClient: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestAnthropicEmptyContentNotSentinel(t *testing.T) {
 
 	c := newAnthropicClient(t, srv.URL+"/v1/messages")
 	_, err := c.Complete(context.Background(), "system", "user")
-	if errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("Complete() err = %v, empty content must NOT be ErrBackendUnavailable", err)
 	}
 }
@@ -145,7 +145,7 @@ func TestAnthropicParseFailureIsNotSentinel(t *testing.T) {
 	if err == nil {
 		t.Fatal("Complete() should return error on malformed JSON")
 	}
-	if errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("Complete() err = %v, parse failure must NOT be ErrBackendUnavailable", err)
 	}
 }
@@ -199,7 +199,7 @@ func TestAnthropicTransportError_WrapsBackendUnavailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("Complete() should return error when server is unavailable")
 	}
-	if !errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if !errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("transport error must wrap ErrBackendUnavailable; got: %v", err)
 	}
 }
@@ -217,7 +217,7 @@ func TestAnthropicNon200_WrapsBackendUnavailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("Complete() should return error on 503")
 	}
-	if !errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if !errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("non-200 status must wrap ErrBackendUnavailable; got: %v", err)
 	}
 }
@@ -249,7 +249,7 @@ func TestAnthropicReadBodyError_WrapsBackendUnavailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("Complete() should return error on truncated body")
 	}
-	if !errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if !errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("read-body failure must wrap ErrBackendUnavailable; got: %v", err)
 	}
 }

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -1,8 +1,5 @@
-// Package instinctllm provides a generic LLM completion interface and concrete
-// backends for Anthropic and Olla, used by the instinct consolidator and audit
-// binaries. It is named distinctly from internal/llm (the OpenAI-compatible
-// chat client used by summarize/consolidate) to avoid identifier collision when
-// both packages are imported together.
+// Package llmclient is a generic multi-backend LLM completion client (Anthropic, Olla).
+// Contrast: internal/llm is the single-backend OpenAI-compatible chat client used by summarize/consolidate.
 //
 // # Design rationale
 //
@@ -19,9 +16,9 @@
 //
 // Domain logic (prompt text, JSON parsing, pattern validation) lives in
 // cmd/instinct/consolidator, not here. This package was moved from
-// cmd/instinct/llm to internal/instinctllm to fix a cross-cmd import from
-// cmd/audit.
-package instinctllm
+// cmd/instinct/llm to internal/llmclient to fix a cross-cmd import from
+// cmd/audit (#730).
+package llmclient
 
 import (
 	"context"

--- a/internal/llmclient/factory.go
+++ b/internal/llmclient/factory.go
@@ -1,4 +1,4 @@
-package instinctllm
+package llmclient
 
 import (
 	"fmt"
@@ -28,6 +28,6 @@ func NewClient(cfg Config) (LLMClient, error) {
 	case "olla":
 		return NewOllaClient(cfg)
 	default:
-		return nil, fmt.Errorf("llm: unknown backend %q (valid: anthropic, olla)", backend)
+		return nil, fmt.Errorf("llmclient: unknown backend %q (valid: anthropic, olla)", backend)
 	}
 }

--- a/internal/llmclient/factory_test.go
+++ b/internal/llmclient/factory_test.go
@@ -1,15 +1,15 @@
-package instinctllm_test
+package llmclient_test
 
 import (
 	"testing"
 
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // TestFactoryDefaultsAnthropic: unset LLM_BACKEND → anthropic client.
 func TestFactoryDefaultsAnthropic(t *testing.T) {
 	t.Setenv("LLM_BACKEND", "")
-	c, err := instinctllm.NewClient(instinctllm.Config{APIKey: "sk-fake"})
+	c, err := llmclient.NewClient(llmclient.Config{APIKey: "sk-fake"})
 	if err != nil {
 		t.Fatalf("NewClient() error: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestFactoryDefaultsAnthropic(t *testing.T) {
 // TestFactoryOllaSelected: LLM_BACKEND=olla → olla client.
 func TestFactoryOllaSelected(t *testing.T) {
 	t.Setenv("LLM_BACKEND", "olla")
-	c, err := instinctllm.NewClient(instinctllm.Config{Endpoint: "http://olla.example.invalid"})
+	c, err := llmclient.NewClient(llmclient.Config{Endpoint: "http://olla.example.invalid"})
 	if err != nil {
 		t.Fatalf("NewClient() error: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestFactoryOllaSelected(t *testing.T) {
 // TestFactoryRejectsUnknown: LLM_BACKEND=garbage → error.
 func TestFactoryRejectsUnknown(t *testing.T) {
 	t.Setenv("LLM_BACKEND", "garbage")
-	_, err := instinctllm.NewClient(instinctllm.Config{})
+	_, err := llmclient.NewClient(llmclient.Config{})
 	if err == nil {
 		t.Error("NewClient() should return error for unknown LLM_BACKEND")
 	}
@@ -50,7 +50,7 @@ func TestFactoryRejectsUnknown(t *testing.T) {
 func TestFactoryUsesConfigBackendBeforeEnv(t *testing.T) {
 	// Env says anthropic, config says olla; config must win.
 	t.Setenv("LLM_BACKEND", "anthropic")
-	c, err := instinctllm.NewClient(instinctllm.Config{
+	c, err := llmclient.NewClient(llmclient.Config{
 		Backend:  "olla",
 		Endpoint: "http://olla.example.invalid",
 	})
@@ -65,7 +65,7 @@ func TestFactoryUsesConfigBackendBeforeEnv(t *testing.T) {
 
 	// And the inverse: env=olla, config=anthropic → anthropic must win.
 	t.Setenv("LLM_BACKEND", "olla")
-	c2, err := instinctllm.NewClient(instinctllm.Config{
+	c2, err := llmclient.NewClient(llmclient.Config{
 		Backend: "anthropic",
 		APIKey:  "sk-fake",
 	})
@@ -81,7 +81,7 @@ func TestFactoryUsesConfigBackendBeforeEnv(t *testing.T) {
 // Preserves backward compatibility with the consolidator's env-only setup.
 func TestFactoryFallsBackToEnvWhenConfigEmpty(t *testing.T) {
 	t.Setenv("LLM_BACKEND", "olla")
-	c, err := instinctllm.NewClient(instinctllm.Config{
+	c, err := llmclient.NewClient(llmclient.Config{
 		// Backend deliberately empty.
 		Endpoint: "http://olla.example.invalid",
 	})
@@ -97,7 +97,7 @@ func TestFactoryFallsBackToEnvWhenConfigEmpty(t *testing.T) {
 // same as env-set garbage.
 func TestFactoryConfigBackendRejectsUnknown(t *testing.T) {
 	t.Setenv("LLM_BACKEND", "anthropic") // valid env; should not save us
-	_, err := instinctllm.NewClient(instinctllm.Config{Backend: "garbage"})
+	_, err := llmclient.NewClient(llmclient.Config{Backend: "garbage"})
 	if err == nil {
 		t.Error("NewClient() should reject garbage Config.Backend even with valid env")
 	}

--- a/internal/llmclient/olla.go
+++ b/internal/llmclient/olla.go
@@ -1,4 +1,4 @@
-package instinctllm
+package llmclient
 
 import (
 	"bytes"

--- a/internal/llmclient/olla_test.go
+++ b/internal/llmclient/olla_test.go
@@ -1,4 +1,4 @@
-package instinctllm_test
+package llmclient_test
 
 import (
 	"context"
@@ -11,15 +11,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petersimmons1972/engram/internal/instinctllm"
+	"github.com/petersimmons1972/engram/internal/llmclient"
 )
 
 // ollaModelList builds a minimal Olla /olla/models response.
 type ollaModelEntry struct {
-	id       string
-	family   string
-	caps     []string
-	states   []string // availability states
+	id     string
+	family string
+	caps   []string
+	states []string // availability states
 }
 
 func buildOllaModelsResponse(models []ollaModelEntry) string {
@@ -93,13 +93,13 @@ func newOllaTestServer(
 	}))
 }
 
-func newOllaClient(t *testing.T, endpoint string) instinctllm.LLMClient {
+func newOllaClient(t *testing.T, endpoint string) llmclient.LLMClient {
 	t.Helper()
-	cfg := instinctllm.Config{
+	cfg := llmclient.Config{
 		Endpoint: endpoint,
 		Timeout:  5 * time.Second,
 	}
-	c, err := instinctllm.NewOllaClient(cfg)
+	c, err := llmclient.NewOllaClient(cfg)
 	if err != nil {
 		t.Fatalf("NewOllaClient: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestOllaNoModelAvailable(t *testing.T) {
 
 	c := newOllaClient(t, srv.URL)
 	got, err := c.Complete(context.Background(), "sys", "user")
-	if !errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if !errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("Complete() err = %v, want ErrBackendUnavailable", err)
 	}
 	if got != "" {
@@ -249,7 +249,7 @@ func TestOllaModelDiscoveryFailure(t *testing.T) {
 
 	c := newOllaClient(t, srv.URL)
 	got, err := c.Complete(context.Background(), "sys", "user")
-	if !errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if !errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("Complete() err = %v, want ErrBackendUnavailable", err)
 	}
 	if got != "" {
@@ -262,7 +262,7 @@ func TestOllaModelDiscoveryFailure(t *testing.T) {
 // write backend-agnostic logic via errors.Is.
 func TestOllaUnavailableIsSentinel(t *testing.T) {
 	// Point at a bogus host so the discovery request fails at the transport layer.
-	c, err := instinctllm.NewOllaClient(instinctllm.Config{
+	c, err := llmclient.NewOllaClient(llmclient.Config{
 		Endpoint: "http://127.0.0.1:1", // reserved discard port; refuses connections
 		Timeout:  500 * time.Millisecond,
 	})
@@ -270,7 +270,7 @@ func TestOllaUnavailableIsSentinel(t *testing.T) {
 		t.Fatalf("NewOllaClient(): %v", err)
 	}
 	got, err := c.Complete(context.Background(), "sys", "user")
-	if !errors.Is(err, instinctllm.ErrBackendUnavailable) {
+	if !errors.Is(err, llmclient.ErrBackendUnavailable) {
 		t.Errorf("Complete() err = %v, want errors.Is(..., ErrBackendUnavailable) = true", err)
 	}
 	if got != "" {


### PR DESCRIPTION
Closes #730. Atomic rename per opus-advisor RECOMMENDATION (Wave 4E).

## Files moved (git mv, history preserved)

- `internal/instinctllm/client.go` → `internal/llmclient/client.go`
- `internal/instinctllm/factory.go` → `internal/llmclient/factory.go`
- `internal/instinctllm/anthropic.go` → `internal/llmclient/anthropic.go`
- `internal/instinctllm/olla.go` → `internal/llmclient/olla.go`
- `internal/instinctllm/anthropic_test.go` → `internal/llmclient/anthropic_test.go`
- `internal/instinctllm/factory_test.go` → `internal/llmclient/factory_test.go`
- `internal/instinctllm/olla_test.go` → `internal/llmclient/olla_test.go`

## Import sweep (7 consumer files)

- `cmd/audit/judge.go`, `judge_test.go`, `main.go`
- `cmd/instinct/consolidator/detect.go`, `detect_test.go`
- `cmd/instinct/main.go`, `main_test.go`
- `internal/llmclient/*_test.go` (self-imports updated)

Call-site qualifier: `instinctllm.` → `llmclient.` across all consumers.

## Additional changes

- **Error string**: `factory.go` `"llm: unknown backend %q"` → `"llmclient: unknown backend %q"`
- **Doc comment** (`internal/llmclient/client.go`): Rewrote package header. Removed "named distinctly from internal/llm to avoid identifier collision" wording. Now reads: *"Package llmclient is a generic multi-backend LLM completion client (Anthropic, Olla). Contrast: internal/llm is the single-backend OpenAI-compatible chat client used by summarize/consolidate."*
- **Reciprocal note** (`internal/llm/client.go`): Added one-line pointer to llmclient.

## Verification

- `grep -rn 'instinctllm' --include='*.go' .` → **zero matches**
- `go build ./...` → clean
- `go test -race ./...` → all green
- `go vet ./...` → clean
- `golangci-lint run ./...` → 0 issues

> Labeled `ai-generated` per CLAUDE.md policy. Requires three-round adversarial review before merge.

Labels: ai-generated