### PR TITLE
feat(lme): project TTL + lme prune (#754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to engram-go are documented here.
 
 ## [Unreleased] — v3.3.0
 
+### LME scratch-project TTL (PR #754)
+
+- **`project_ttl` sidecar table (migration 022):** Stores `created_at` and `expires_at` per project without altering the first-class `memories.project` column. `NULL expires_at` means durable (no expiry).
+- **`--scratch-ttl <duration>` flag (default 168h / 7 days):** Applied to each `lme-*` project at ingest time. Requires `--database-url` to write the `project_ttl` row; failure downgrades to a WARN and leaves the project durable.
+- **`longmemeval prune` subcommand:** Sweeps expired `lme-*` projects via `project_ttl.expires_at < now`, then calls `memory_delete_project` over MCP for each. Supports `--dry-run`, `--limit`, `--prefix`, and `--older-than`. Intended to run as a K8s CronJob (`deploy/lme-prune-cronjob.yaml`).
+- **`Backend` interface:** `SetProjectTTL` and `ListExpiredProjects` added. All test fakes updated.
+- **Operator backfill:** Existing `lme-*` projects with `NULL expires_at` can be stamped via `UPDATE project_ttl SET expires_at = created_at + INTERVAL '7 days' WHERE project LIKE 'lme-%' AND expires_at IS NULL`. See `docs/lme-benchmark-learnings.md §Operator: scratch retention`.
+
+---
+
 ### Reliability (PR #808 — backend-lock hardening)
 
 - **`--exclusive-backend` contention guard (default true):** Prevents two concurrent `lme run` invocations from sharing the same vLLM endpoint and producing contaminated results. A PID-liveness lock file is written to `<lock-dir>/backend-<sha256(url)[:12]>.lock`.

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -9,13 +9,41 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
+
+// ttlStamper writes project_ttl rows during ingest (#754). It is a tiny
+// interface so the ingest worker can be unit-tested with a fake.
+type ttlStamper interface {
+	SetProjectTTL(ctx context.Context, project string, createdAt time.Time, expiresAt *time.Time) error
+}
 
 func runIngest(cfg *Config) {
 	items := loadItems(cfg.DataFile)
 	ckptPath := filepath.Join(cfg.OutDir, "checkpoint-ingest.jsonl")
+
+	// #754: if a scratch TTL is in effect and a DSN is configured, open a
+	// PostgresBackend so each per-question project gets a project_ttl row
+	// stamped at first-store time. Failure to connect downgrades to a WARN
+	// rather than failing ingest — a missing TTL row makes the project durable
+	// (the operator backfill query is documented in the migration header).
+	var stamper ttlStamper
+	if cfg.ScratchTTL > 0 && cfg.DatabaseURL != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		backend, err := db.NewPostgresBackend(ctx, "_lme_ingest", cfg.DatabaseURL)
+		if err != nil {
+			log.Printf("ingest: WARN: cannot open Postgres for TTL stamping (%v); projects will be durable", err)
+		} else {
+			defer backend.Close()
+			stamper = backend
+		}
+	} else if cfg.ScratchTTL > 0 && cfg.DatabaseURL == "" {
+		log.Printf("ingest: WARN: --scratch-ttl set but no --database-url; projects will be durable")
+	}
 
 	skip, err := longmemeval.ReadSkipSet(ckptPath)
 	if err != nil {
@@ -44,7 +72,7 @@ func runIngest(cfg *Config) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ingestWorker(cfg, work, ckptCh)
+			ingestWorker(cfg, stamper, work, ckptCh)
 		}()
 	}
 	wg.Wait()
@@ -54,11 +82,22 @@ func runIngest(cfg *Config) {
 	log.Printf("ingest: complete")
 }
 
-func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
+func ingestWorker(cfg *Config, stamper ttlStamper, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
 	ctx := context.Background()
 	restClient := longmemeval.NewRestClient(cfg.ServerURL, cfg.APIKey)
 	for item := range work {
 		entry := ingestOne(ctx, cfg, restClient, item)
+		// #754: stamp TTL once per successful project so the prune sweep can
+		// reclaim it later. Best-effort: stamping failure is logged but does
+		// not flip ingest status — the memories landed, only the metadata is
+		// missing, and an operator backfill exists.
+		if entry.Status == "done" && stamper != nil && cfg.ScratchTTL > 0 {
+			now := time.Now().UTC()
+			exp := now.Add(cfg.ScratchTTL)
+			if err := stamper.SetProjectTTL(ctx, entry.Project, now, &exp); err != nil {
+				log.Printf("ingest [%s] WARN: set TTL: %v", item.QuestionID, err)
+			}
+		}
 		out <- entry
 		log.Printf("ingest [%s] project=%s sessions=%d status=%s error=%q", item.QuestionID, entry.Project, entry.SessionCount, entry.Status, entry.Error)
 	}

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -36,7 +36,10 @@ func runIngest(cfg *Config) {
 		defer cancel()
 		backend, err := db.NewPostgresBackend(ctx, "_lme_ingest", cfg.DatabaseURL)
 		if err != nil {
-			log.Printf("ingest: WARN: cannot open Postgres for TTL stamping (%v); projects will be durable", err)
+			// Log without the raw DSN/error (which may embed credentials) to
+			// satisfy CodeQL CWE-312. Use redactURL on the URL portion only.
+			log.Printf("ingest: WARN: cannot open Postgres for TTL stamping (dsn=%s); projects will be durable",
+				redactURL(cfg.DatabaseURL))
 		} else {
 			defer backend.Close()
 			stamper = backend

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
@@ -65,6 +66,15 @@ type Config struct {
 	// #749: contention guard
 	ExclusiveBackend bool   // guard the vLLM endpoint with a PID-liveness lockfile (default true)
 	BackendLockDir   string // override lock file directory (default: $XDG_RUNTIME_DIR/lme or /tmp/lme)
+
+	// #754: scratch TTL. Applied at ingest time to project_ttl.expires_at so
+	// the `prune` subcommand can sweep expired lme-* projects later. Zero
+	// means "use the package default (168h / 7 days)".
+	ScratchTTL time.Duration
+
+	// DatabaseURL is consulted by ingest to write project_ttl rows. Falls back
+	// to env DATABASE_URL.
+	DatabaseURL string
 }
 
 func main() {
@@ -82,6 +92,7 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  all             Run ingest → run → score in one invocation")
 	_, _ = fmt.Fprintln(w, "  score-efficient Score with olla OAI backend; preserves CORRECT items by default")
 	_, _ = fmt.Fprintln(w, "  score-batch     Score all items in one Anthropic Message Batches API call")
+	_, _ = fmt.Fprintln(w, "  prune           Delete expired lme-* scratch projects (TTL sweep, #754)")
 	_, _ = fmt.Fprintln(w, "  help            Print this usage and exit")
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "Common flags (see <subcommand> --help for the full set):")
@@ -161,6 +172,16 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	cfg.ExclusiveBackend = true // default on
 	fs.BoolVar(&noExclusiveBackend, "no-exclusive-backend", false, "disable the backend lock; use when you accept result contamination from parallel runs")
 	fs.StringVar(&cfg.BackendLockDir, "backend-lock-dir", "", "override lock file directory (default: $XDG_RUNTIME_DIR/lme or /tmp/lme)")
+	// #754: TTL stamped on per-question scratch projects at ingest time. The
+	// prune subcommand sweeps anything older than this.
+	fs.DurationVar(&cfg.ScratchTTL, "scratch-ttl", defaultScratchTTL(), "TTL applied to ephemeral lme-* projects at ingest time (e.g. 168h = 7 days); 0 = durable, no expiry")
+	fs.StringVar(&cfg.DatabaseURL, "database-url", envOr("DATABASE_URL", ""), "PostgreSQL DSN; required when --scratch-ttl > 0 so ingest can write project_ttl rows")
+
+	// prune has its own flag set and early return — it does not share the
+	// ingest/run/score data-file workflow. See cmd/longmemeval/prune.go (#754).
+	if subcommand == "prune" {
+		return dispatchPrune(args[2:], stdout, stderr)
+	}
 
 	// score-efficient has its own flag set and early return.
 	if subcommand == "score-efficient" {
@@ -208,6 +229,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	switch subcommand {
 	case "ingest", "run", "score", "all":
 		// known subcommand — fall through to flag parsing
+	case "prune":
+		// handled above; dispatch never reaches here for prune
 	default:
 		_, _ = fmt.Fprintf(stderr, "unknown subcommand %q\n", subcommand)
 		printUsage(stderr)

--- a/cmd/longmemeval/prune.go
+++ b/cmd/longmemeval/prune.go
@@ -1,0 +1,267 @@
+package main
+
+// prune deletes LongMemEval scratch projects whose project_ttl.expires_at has
+// elapsed. Intended to run as a periodic CronJob (deploy/lme-prune-cronjob.yaml)
+// or ad-hoc from an operator shell.
+//
+// Schema deviation note (#754): projects are not a first-class table in
+// engram-go — they are DISTINCT values of memories.project. TTL metadata is
+// stored in the sidecar table project_ttl (migration 022). This CLI reads that
+// sidecar table directly via PostgresBackend, then calls memory_delete_project
+// over MCP for each expired entry so server-side invariants (cache
+// invalidation, audit log) fire normally.
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+// DefaultScratchTTL is the default TTL applied to ephemeral lme-* projects at
+// ingest time when no explicit --scratch-ttl is given. 7 days balances the
+// cost of re-ingesting a haystack (~hours) against indefinite scratch
+// accumulation that risks index bloat and accidental re-use.
+const DefaultScratchTTL = 168 * time.Hour
+
+// defaultScratchTTL returns the package-level default. Wrapped in a function
+// so tests can pin the constant without referencing the literal.
+func defaultScratchTTL() time.Duration {
+	return DefaultScratchTTL
+}
+
+// PruneConfig holds the flags accepted by `longmemeval prune`.
+type PruneConfig struct {
+	// Prefix restricts deletion to projects whose names LIKE prefix+'%'. The
+	// default "lme-" matches the ingest-stage naming convention.
+	Prefix string
+
+	// OlderThan shifts the effective cutoff to (now - OlderThan). A zero
+	// duration means "use expires_at as-is" (anything strictly before now).
+	OlderThan time.Duration
+
+	// DryRun prints the projects that would be deleted but performs no
+	// mutations.
+	DryRun bool
+
+	// Limit caps the number of projects considered for deletion in a single
+	// invocation. Zero means no cap. Used to bound blast radius on first runs.
+	Limit int
+
+	// DatabaseURL is the PostgreSQL DSN; falls back to env DATABASE_URL.
+	DatabaseURL string
+
+	// ServerURL is the engram MCP endpoint used to call memory_delete_project.
+	ServerURL string
+
+	// APIKey is the engram bearer token.
+	APIKey string
+}
+
+// projectTTLEntry is the in-memory shape used by selectExpiredProjects. It
+// mirrors the project_ttl table columns relevant to prune selection.
+type projectTTLEntry struct {
+	Name      string
+	ExpiresAt *time.Time // nil = durable, never selected
+}
+
+// selectOption is a variadic option for selectExpiredProjects. It exists so
+// that the older-than cutoff shift can stay an optional concern without
+// bloating the function signature.
+type selectOption func(*selectOptions)
+
+// selectOptions is the resolved option struct consumed inside
+// selectExpiredProjects.
+type selectOptions struct {
+	olderThan time.Duration
+}
+
+// withOlderThan overrides the effective cutoff to (now - d). A zero or
+// negative duration is a no-op; callers should omit the option in that case.
+func withOlderThan(d time.Duration) selectOption {
+	return func(o *selectOptions) { o.olderThan = d }
+}
+
+// selectExpiredProjects filters entries down to those that are (a) prefixed
+// with prefix, (b) have non-nil ExpiresAt, and (c) have ExpiresAt at or
+// before the effective cutoff (now, or now-olderThan when withOlderThan is
+// passed).
+//
+// When limit > 0, at most limit names are returned. The slice is in input
+// order; callers that need a deterministic order should sort entries first.
+func selectExpiredProjects(entries []projectTTLEntry, prefix string, limit int, now time.Time, opts ...selectOption) []string {
+	var so selectOptions
+	for _, opt := range opts {
+		opt(&so)
+	}
+	cutoff := now
+	if so.olderThan > 0 {
+		cutoff = now.Add(-so.olderThan)
+	}
+
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.ExpiresAt == nil {
+			continue // durable — never prune
+		}
+		if !strings.HasPrefix(e.Name, prefix) {
+			continue
+		}
+		// Tests assert that exact-boundary (expires_at == cutoff) is included;
+		// use !After rather than Before so cutoff itself is treated as expired.
+		if e.ExpiresAt.After(cutoff) {
+			continue
+		}
+		out = append(out, e.Name)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+// runPruneWithEntries is the pure, side-effect-isolated core of the prune
+// command. It receives the candidate entries, a delete function, and an output
+// writer. Returns the process exit code.
+//
+// Returning 0 on an empty result set is intentional: the CronJob path runs on
+// an interval and should not page when there is nothing to do.
+func runPruneWithEntries(cfg *PruneConfig, entries []projectTTLEntry, deleteFn func(string) error, now time.Time, out io.Writer) int {
+	var opts []selectOption
+	if cfg.OlderThan > 0 {
+		opts = append(opts, withOlderThan(cfg.OlderThan))
+	}
+	victims := selectExpiredProjects(entries, cfg.Prefix, cfg.Limit, now, opts...)
+
+	if len(victims) == 0 {
+		_, _ = fmt.Fprintln(out, "prune: no expired projects matching prefix")
+		return 0
+	}
+
+	if cfg.DryRun {
+		_, _ = fmt.Fprintf(out, "prune: DRY RUN — would delete %d project(s):\n", len(victims))
+		for _, name := range victims {
+			_, _ = fmt.Fprintf(out, "  %s\n", name)
+		}
+		return 0
+	}
+
+	var firstErr error
+	deleted := 0
+	for _, name := range victims {
+		if err := deleteFn(name); err != nil {
+			_, _ = fmt.Fprintf(out, "prune: delete %q failed: %v\n", name, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		deleted++
+		_, _ = fmt.Fprintf(out, "prune: deleted %s\n", name)
+	}
+	_, _ = fmt.Fprintf(out, "prune: %d of %d project(s) deleted\n", deleted, len(victims))
+	if firstErr != nil {
+		return 1
+	}
+	return 0
+}
+
+// runPrune is the wired-up entrypoint that connects to Postgres, lists
+// expired projects from project_ttl, and calls memory_delete_project over MCP
+// for each. Errors during list/connect return non-zero exit; per-delete errors
+// are aggregated by runPruneWithEntries.
+func runPrune(cfg *PruneConfig, stdout, stderr io.Writer) int {
+	if cfg.DatabaseURL == "" {
+		_, _ = fmt.Fprintln(stderr, "prune: DATABASE_URL or --database-url is required")
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	backend, err := db.NewPostgresBackend(ctx, "_prune", cfg.DatabaseURL)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "prune: connect: %v\n", err)
+		return 1
+	}
+	defer backend.Close()
+
+	now := time.Now()
+	cutoff := now
+	if cfg.OlderThan > 0 {
+		cutoff = now.Add(-cfg.OlderThan)
+	}
+	names, err := backend.ListExpiredProjects(ctx, cfg.Prefix, cutoff, cfg.Limit)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "prune: list expired: %v\n", err)
+		return 1
+	}
+
+	// ListExpiredProjects already filters by expires_at < cutoff and prefix.
+	// Synthesise a past-expires marker so the in-memory selectExpiredProjects
+	// re-filter is a no-op (defence in depth against SQL drift).
+	pastMarker := now.Add(-time.Second)
+	entries := make([]projectTTLEntry, 0, len(names))
+	for _, n := range names {
+		entries = append(entries, projectTTLEntry{Name: n, ExpiresAt: &pastMarker})
+	}
+
+	deleteFn := func(name string) error {
+		return errors.New("prune: delete client not initialised — use --dry-run")
+	}
+	if !cfg.DryRun {
+		client, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "prune: MCP connect: %v\n", err)
+			return 1
+		}
+		defer func() { _ = client.Close() }()
+		deleteFn = func(name string) error {
+			return client.DeleteProject(ctx, name)
+		}
+	}
+
+	return runPruneWithEntries(cfg, entries, deleteFn, now, stdout)
+}
+
+// dispatchPrune handles the `prune` subcommand: parses flags and invokes
+// runPrune. Returns the process exit code.
+func dispatchPrune(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("prune", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	cfg := &PruneConfig{}
+	fs.StringVar(&cfg.Prefix, "prefix", "lme-", "delete only projects whose names start with this prefix")
+	fs.DurationVar(&cfg.OlderThan, "older-than", 0, "additional cushion past expires_at before pruning (e.g. 24h); 0 means use expires_at as-is")
+	fs.DurationVar(&cfg.OlderThan, "scratch-ttl", 0, "alias for --older-than; documents intent for lme scratch retention windows")
+	fs.BoolVar(&cfg.DryRun, "dry-run", false, "print projects that would be deleted but make no changes")
+	fs.IntVar(&cfg.Limit, "limit", 0, "cap deletions to this many projects per invocation; 0 = no cap")
+	fs.StringVar(&cfg.DatabaseURL, "database-url", envOr("DATABASE_URL", ""), "PostgreSQL DSN (env: DATABASE_URL)")
+	defaultURL, defaultKey := mcpDefaults()
+	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", defaultURL), "Engram server URL")
+	fs.StringVar(&cfg.APIKey, "api-key", envOr("ENGRAM_API_KEY", defaultKey), "Engram API key")
+
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "Usage: longmemeval prune [flags]")
+		_, _ = fmt.Fprintln(stderr)
+		_, _ = fmt.Fprintln(stderr, "Delete LongMemEval scratch projects whose project_ttl.expires_at has elapsed.")
+		_, _ = fmt.Fprintln(stderr)
+		_, _ = fmt.Fprintln(stderr, "Flags:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+
+	return runPrune(cfg, stdout, stderr)
+}

--- a/cmd/longmemeval/prune_test.go
+++ b/cmd/longmemeval/prune_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests for prune logic — #754
+// ---------------------------------------------------------------------------
+
+// TestPrune_SelectsOnlyExpiredPrefixed verifies that selectExpiredProjects
+// returns only entries that are both (a) prefixed with the target prefix and
+// (b) have expires_at strictly before now.
+func TestPrune_SelectsOnlyExpiredPrefixed(t *testing.T) {
+	now := time.Now()
+
+	entries := []projectTTLEntry{
+		{Name: "lme-abc-q001", ExpiresAt: ptr(now.Add(-time.Hour))},   // expired, prefixed ✓
+		{Name: "lme-abc-q002", ExpiresAt: ptr(now.Add(time.Hour))},    // not expired
+		{Name: "other-project", ExpiresAt: ptr(now.Add(-time.Hour))},  // expired, wrong prefix
+		{Name: "lme-abc-q003", ExpiresAt: nil},                        // NULL expires_at = durable
+		{Name: "lme-abc-q004", ExpiresAt: ptr(now.Add(-2 * time.Hour))}, // expired, prefixed ✓
+	}
+
+	got := selectExpiredProjects(entries, "lme-", 0, now)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 expired+prefixed projects, got %d: %v", len(got), got)
+	}
+	want := map[string]bool{"lme-abc-q001": true, "lme-abc-q004": true}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("unexpected project in result: %q", name)
+		}
+	}
+}
+
+// TestPrune_DryRunNoMutation verifies that runPrune with --dry-run writes
+// intended deletions to output but does not call the delete function.
+func TestPrune_DryRunNoMutation(t *testing.T) {
+	now := time.Now()
+	entries := []projectTTLEntry{
+		{Name: "lme-run1-q001", ExpiresAt: ptr(now.Add(-time.Hour))},
+		{Name: "lme-run1-q002", ExpiresAt: ptr(now.Add(-2 * time.Hour))},
+	}
+
+	var deleted []string
+	deleteFn := func(name string) error {
+		deleted = append(deleted, name)
+		return nil
+	}
+
+	cfg := &PruneConfig{
+		Prefix:    "lme-",
+		OlderThan: 0,
+		DryRun:    true,
+		Limit:     0,
+	}
+
+	var out strings.Builder
+	code := runPruneWithEntries(cfg, entries, deleteFn, now, &out)
+	if code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+	if len(deleted) != 0 {
+		t.Errorf("dry-run must not call delete; got deletions: %v", deleted)
+	}
+	// Output should mention the would-be deletions
+	outStr := out.String()
+	if !strings.Contains(outStr, "lme-run1-q001") {
+		t.Errorf("dry-run output should mention lme-run1-q001; got: %q", outStr)
+	}
+}
+
+// TestPrune_NullExpiresAtPreserved verifies that projects with NULL expires_at
+// are never selected for deletion (durable semantics).
+func TestPrune_NullExpiresAtPreserved(t *testing.T) {
+	now := time.Now()
+	entries := []projectTTLEntry{
+		{Name: "lme-abc-q001", ExpiresAt: nil},                         // durable
+		{Name: "lme-abc-q002", ExpiresAt: nil},                         // durable
+		{Name: "lme-abc-q003", ExpiresAt: ptr(now.Add(-time.Hour))},    // expired
+	}
+
+	got := selectExpiredProjects(entries, "lme-", 0, now)
+
+	for _, name := range got {
+		if name == "lme-abc-q001" || name == "lme-abc-q002" {
+			t.Errorf("durable project %q (NULL expires_at) must not be selected for pruning", name)
+		}
+	}
+	if len(got) != 1 || got[0] != "lme-abc-q003" {
+		t.Errorf("expected only lme-abc-q003, got %v", got)
+	}
+}
+
+// TestPrune_EmptyResultZeroExit verifies that when no expired+prefixed projects
+// exist, runPruneWithEntries exits 0 (not an error condition).
+func TestPrune_EmptyResultZeroExit(t *testing.T) {
+	now := time.Now()
+	entries := []projectTTLEntry{
+		{Name: "lme-abc-q001", ExpiresAt: ptr(now.Add(time.Hour))}, // not expired
+	}
+
+	var deleted []string
+	deleteFn := func(name string) error {
+		deleted = append(deleted, name)
+		return nil
+	}
+
+	cfg := &PruneConfig{
+		Prefix:    "lme-",
+		OlderThan: 0,
+		DryRun:    false,
+		Limit:     0,
+	}
+
+	var out strings.Builder
+	code := runPruneWithEntries(cfg, entries, deleteFn, now, &out)
+	if code != 0 {
+		t.Errorf("empty result set must exit 0, got %d; output: %q", code, out.String())
+	}
+	if len(deleted) != 0 {
+		t.Errorf("no deletions expected; got: %v", deleted)
+	}
+}
+
+// TestPrune_BoundaryAtExpiry verifies that a project whose expires_at equals
+// exactly now (or is in the past by any amount) is included.
+// expires_at < now → expired; expires_at == now → boundary case, included.
+func TestPrune_BoundaryAtExpiry(t *testing.T) {
+	now := time.Now()
+
+	entries := []projectTTLEntry{
+		// Exactly at expiry boundary: now - 1ns (1 nanosecond past)
+		{Name: "lme-abc-boundary", ExpiresAt: ptr(now.Add(-1))},
+		// 1ns in the future: not yet expired
+		{Name: "lme-abc-future", ExpiresAt: ptr(now.Add(1))},
+	}
+
+	got := selectExpiredProjects(entries, "lme-", 0, now)
+
+	found := false
+	for _, name := range got {
+		if name == "lme-abc-boundary" {
+			found = true
+		}
+		if name == "lme-abc-future" {
+			t.Errorf("project expiring in the future must not be pruned")
+		}
+	}
+	if !found {
+		t.Errorf("project at exact expiry boundary must be included in prune set")
+	}
+}
+
+// TestPrune_LimitCapsResults verifies that when --limit N is set, at most N
+// projects are returned for deletion.
+func TestPrune_LimitCapsResults(t *testing.T) {
+	now := time.Now()
+	entries := []projectTTLEntry{
+		{Name: "lme-abc-q001", ExpiresAt: ptr(now.Add(-time.Hour))},
+		{Name: "lme-abc-q002", ExpiresAt: ptr(now.Add(-2 * time.Hour))},
+		{Name: "lme-abc-q003", ExpiresAt: ptr(now.Add(-3 * time.Hour))},
+	}
+
+	got := selectExpiredProjects(entries, "lme-", 2, now)
+	if len(got) > 2 {
+		t.Errorf("limit=2 must cap results at 2, got %d", len(got))
+	}
+}
+
+// TestPrune_OlderThanShiftsWindow verifies that --older-than shifts the
+// effective cutoff so that only projects expired longer than the duration ago
+// are selected.
+func TestPrune_OlderThanShiftsWindow(t *testing.T) {
+	now := time.Now()
+
+	// Project expired 30 minutes ago — within 1h older-than window, so NOT selected
+	recent := ptr(now.Add(-30 * time.Minute))
+	// Project expired 2 hours ago — outside 1h older-than window, selected
+	old := ptr(now.Add(-2 * time.Hour))
+
+	entries := []projectTTLEntry{
+		{Name: "lme-abc-recent", ExpiresAt: recent},
+		{Name: "lme-abc-old", ExpiresAt: old},
+	}
+
+	// With olderThan=1h, effective cutoff = now - 1h
+	// Only lme-abc-old (expired 2h ago, before cutoff) should be selected.
+	got := selectExpiredProjects(entries, "lme-", 0, now, withOlderThan(time.Hour))
+
+	for _, name := range got {
+		if name == "lme-abc-recent" {
+			t.Errorf("project expired 30m ago must not be selected with older-than=1h")
+		}
+	}
+	found := false
+	for _, name := range got {
+		if name == "lme-abc-old" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("project expired 2h ago must be selected with older-than=1h")
+	}
+}
+
+// TestPrune_ScratchTTLFlagRegistered verifies the --scratch-ttl flag is wired
+// into the dispatch function (structural test on main.go / prune.go).
+func TestPrune_ScratchTTLFlagRegistered(t *testing.T) {
+	var stdout, stderr strings.Builder
+	// "prune --help" should mention scratch-ttl somewhere in usage
+	args := []string{"longmemeval", "prune", "--help"}
+	dispatch(args, &stdout, &stderr)
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, "scratch-ttl") && !strings.Contains(combined, "older-than") {
+		t.Errorf("prune subcommand help must mention TTL-related flags; got: %q", combined)
+	}
+}
+
+// TestScratchTTL_DefaultIs168h verifies that Config.ScratchTTL defaults to
+// 168h (7 days).
+func TestScratchTTL_DefaultIs168h(t *testing.T) {
+	const want = 168 * time.Hour
+	cfg := defaultScratchTTL()
+	if cfg != want {
+		t.Errorf("defaultScratchTTL() = %v, want %v", cfg, want)
+	}
+}
+
+// ptr is a helper to convert a time.Time into a *time.Time.
+func ptr(t time.Time) *time.Time {
+	return &t
+}

--- a/deploy/lme-prune-cronjob.yaml
+++ b/deploy/lme-prune-cronjob.yaml
@@ -1,0 +1,74 @@
+# lme-prune-cronjob.yaml — weekly sweep of expired lme-* scratch projects (#754)
+#
+# Runs `longmemeval prune` every Sunday at 02:00 UTC.
+# Requires:
+#   - Secret "engram-lme" with keys: database-url, engram-url, engram-api-key
+#   - RBAC: no cluster permissions needed (contacts Postgres + Engram HTTP only)
+#   - Image: ghcr.io/petersimmons1972/engram-go/longmemeval:latest (or pin to a SHA)
+#
+# Tune --limit on first run to verify blast radius before allowing unlimited.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: lme-prune
+  namespace: engram
+  labels:
+    app.kubernetes.io/name: lme-prune
+    app.kubernetes.io/component: maintenance
+    app.kubernetes.io/part-of: engram
+spec:
+  schedule: "0 2 * * 0"  # Every Sunday at 02:00 UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600  # 10 minutes max; prune is not long-running
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: lme-prune
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            fsGroup: 65532
+          containers:
+            - name: lme-prune
+              image: ghcr.io/petersimmons1972/engram-go/longmemeval:latest
+              imagePullPolicy: IfNotPresent
+              args:
+                - prune
+                - --prefix=lme-
+                - --limit=200       # cap per-run; remove once first run is verified
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: engram-lme
+                      key: database-url
+                - name: ENGRAM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: engram-lme
+                      key: engram-url
+                - name: ENGRAM_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: engram-lme
+                      key: engram-api-key
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "500m"
+                  memory: "256Mi"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL

--- a/docs/lme-benchmark-learnings.md
+++ b/docs/lme-benchmark-learnings.md
@@ -390,6 +390,60 @@ SessionLimit: 470          // Typical LME dataset size
 
 ---
 
+## Operator: Scratch Retention (TTL, #754)
+
+LME benchmark runs create ephemeral `lme-<run-id>` projects. Without cleanup these accumulate indefinitely, inflating index size and risking accidental re-use of stale haystacks.
+
+### Stamping TTL at ingest time
+
+Pass `--scratch-ttl <duration>` and `--database-url <dsn>` to `longmemeval ingest`:
+
+```
+longmemeval ingest \
+  --data-file questions.json \
+  --out-dir /tmp/lme-run-001 \
+  --scratch-ttl 168h \
+  --database-url "${DATABASE_URL}"
+```
+
+The default TTL is **168 h (7 days)** — long enough to re-run scoring without re-ingesting; short enough to prevent unbounded growth.
+
+### Running the prune sweep
+
+```
+longmemeval prune \
+  --database-url "${DATABASE_URL}" \
+  --url "${ENGRAM_URL}" \
+  --api-key "${ENGRAM_API_KEY}"
+```
+
+Add `--dry-run` to preview. Add `--limit 50` to cap blast radius on first run.
+
+The sweep is deployed as a weekly K8s CronJob at `deploy/lme-prune-cronjob.yaml`.
+
+### Backfilling existing runs
+
+Existing `lme-*` projects (created before migration 022) have `NULL expires_at`. To opt them into the sweep:
+
+```sql
+UPDATE project_ttl
+   SET expires_at = created_at + INTERVAL '7 days'
+ WHERE project LIKE 'lme-%'
+   AND expires_at IS NULL;
+```
+
+Projects without a `project_ttl` row at all can be enrolled with:
+
+```sql
+INSERT INTO project_ttl (project, created_at, expires_at)
+SELECT DISTINCT project, NOW() - INTERVAL '1 day', NOW() + INTERVAL '7 days'
+  FROM memories
+ WHERE project LIKE 'lme-%'
+ON CONFLICT (project) DO NOTHING;
+```
+
+---
+
 ## References
 
 - **vLLM Repository**: https://github.com/vllm-project/vllm (GH#39103 — Nemotron v3 reasoning parser)

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -219,6 +219,16 @@ type Backend interface {
 	// and metadata for a project. Irreversible. Used for eval isolation project cleanup.
 	DeleteProject(ctx context.Context, project string) error
 
+	// ── Project TTL (#754) ──────────────────────────────────────────────────
+
+	// SetProjectTTL upserts the created_at and expires_at for a project into
+	// project_ttl. Pass nil expiresAt for a durable (non-expiring) project.
+	SetProjectTTL(ctx context.Context, project string, createdAt time.Time, expiresAt *time.Time) error
+	// ListExpiredProjects returns names of projects whose expires_at is non-NULL
+	// and before cutoff, optionally filtered to names with the given prefix and
+	// capped to limit rows (0 = unlimited).
+	ListExpiredProjects(ctx context.Context, prefix string, cutoff time.Time, limit int) ([]string, error)
+
 	// ── Full-text search ────────────────────────────────────────────────────
 
 	// FTSSearch runs a PostgreSQL plainto_tsquery search. Returns (memory, score) pairs.

--- a/internal/db/migrations/022_project_ttl.sql
+++ b/internal/db/migrations/022_project_ttl.sql
@@ -1,0 +1,37 @@
+-- Migration 022: project TTL metadata (created_at, expires_at) — #754
+--
+-- Projects are not a first-class table in engram-go; they are derived from
+-- DISTINCT values of memories.project. TTL metadata is therefore stored in
+-- project_meta (the existing per-project key/value store) rather than via a
+-- new projects table.
+--
+-- This migration adds a dedicated table for project-level TTL so we can:
+--   1. Index expires_at for efficient range queries without a full table scan
+--      of project_meta.
+--   2. Store created_at alongside expires_at in a single, typed row.
+--
+-- NULL expires_at means "durable" (no expiry). Non-NULL means ephemeral.
+-- lme-* projects are stamped at creation time by the ingest stage.
+--
+-- This table is additive — no existing data is affected.
+-- Down-migration: DROP TABLE IF EXISTS project_ttl;
+
+CREATE TABLE IF NOT EXISTS project_ttl (
+    project    TEXT        PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_ttl_expires_at
+    ON project_ttl(expires_at)
+    WHERE expires_at IS NOT NULL;
+
+-- Existing lme-* projects (if any) get NULL expires_at on INSERT conflict —
+-- they are treated as durable until an operator runs the optional backfill:
+--
+--   UPDATE project_ttl
+--      SET expires_at = created_at + INTERVAL '7 days'
+--    WHERE project LIKE 'lme-%' AND expires_at IS NULL;
+--
+-- See docs/lme-benchmark-learnings.md §Operator: scratch retention for the
+-- full backfill procedure.

--- a/internal/db/postgres_project_ttl.go
+++ b/internal/db/postgres_project_ttl.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// SetProjectTTL upserts (project, created_at, expires_at) into project_ttl.
+// A nil expiresAt means the project is durable (no expiry).
+// Uses ON CONFLICT DO UPDATE so repeated calls are idempotent.
+func (b *PostgresBackend) SetProjectTTL(ctx context.Context, project string, createdAt time.Time, expiresAt *time.Time) error {
+	var pgExpires pgtype.Timestamptz
+	if expiresAt != nil {
+		pgExpires = pgtype.Timestamptz{Time: expiresAt.UTC(), Valid: true}
+	} else {
+		pgExpires = pgtype.Timestamptz{Valid: false}
+	}
+	_, err := b.pool.Exec(ctx, `
+		INSERT INTO project_ttl (project, created_at, expires_at)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (project) DO UPDATE
+		  SET created_at = EXCLUDED.created_at,
+		      expires_at = EXCLUDED.expires_at
+	`, project, createdAt.UTC(), pgExpires)
+	return err
+}
+
+// ListExpiredProjects queries project_ttl for rows whose expires_at is
+// non-NULL and strictly before cutoff, filtered to names LIKE prefix+'%'.
+// When limit > 0, at most limit rows are returned.
+func (b *PostgresBackend) ListExpiredProjects(ctx context.Context, prefix string, cutoff time.Time, limit int) ([]string, error) {
+	pattern := escapeLike(prefix) + "%"
+
+	var (
+		query string
+		args  []any
+	)
+	if limit > 0 {
+		query = `
+			SELECT project FROM project_ttl
+			WHERE expires_at IS NOT NULL
+			  AND expires_at < $1
+			  AND project LIKE $2
+			ORDER BY expires_at
+			LIMIT $3`
+		args = []any{cutoff.UTC(), pattern, limit}
+	} else {
+		query = `
+			SELECT project FROM project_ttl
+			WHERE expires_at IS NOT NULL
+			  AND expires_at < $1
+			  AND project LIKE $2
+			ORDER BY expires_at`
+		args = []any{cutoff.UTC(), pattern}
+	}
+
+	rows, err := b.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var projects []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, rows.Err()
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -150,6 +150,12 @@ func (noopBackend) PruneColdDocuments(_ context.Context, _ string, _ float64, _ 
 	return 0, nil
 }
 func (noopBackend) DeleteProject(_ context.Context, _ string) error { return nil }
+func (noopBackend) SetProjectTTL(_ context.Context, _ string, _ time.Time, _ *time.Time) error {
+	return nil
+}
+func (noopBackend) ListExpiredProjects(_ context.Context, _ string, _ time.Time, _ int) ([]string, error) {
+	return nil, nil
+}
 func (noopBackend) FTSSearch(_ context.Context, _, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
 	return nil, nil
 }

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -260,7 +260,13 @@ func (noopBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db
 }
 func (noopBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error { return nil }
 func (noopBackend) DeleteProject(_ context.Context, _ string) error                  { return nil }
-func (noopBackend) EnqueueChunkLeases(_ context.Context, _ []string) error              { return nil }
+func (noopBackend) SetProjectTTL(_ context.Context, _ string, _ time.Time, _ *time.Time) error {
+	return nil
+}
+func (noopBackend) ListExpiredProjects(_ context.Context, _ string, _ time.Time, _ int) ([]string, error) {
+	return nil, nil
+}
+func (noopBackend) EnqueueChunkLeases(_ context.Context, _ []string) error { return nil }
 
 // concurrentEmbedder records the peak number of Embed calls in-flight simultaneously.
 // Each call increments active, records the peak, then waits on the ready channel

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -411,6 +411,12 @@ func (s *stubBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([
 }
 func (s *stubBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error { return nil }
 func (s *stubBackend) DeleteProject(_ context.Context, _ string) error                  { return nil }
+func (s *stubBackend) SetProjectTTL(_ context.Context, _ string, _ time.Time, _ *time.Time) error {
+	return nil
+}
+func (s *stubBackend) ListExpiredProjects(_ context.Context, _ string, _ time.Time, _ int) ([]string, error) {
+	return nil, nil
+}
 
 // compile-time check: stubBackend must satisfy db.Backend.
 var _ db.Backend = (*stubBackend)(nil)


### PR DESCRIPTION
## Summary

Closes #754. Per opus-advisor Path A (Wave 4D).

- **Migration 022** (`project_ttl`): additive sidecar table storing `created_at` / `expires_at` per project. No existing data affected. `NULL expires_at` = durable.
- **`Backend` interface extended**: `SetProjectTTL` + `ListExpiredProjects`. All test fakes updated.
- **`longmemeval ingest`**: `--scratch-ttl <duration>` (default 168h) stamps each `lme-*` project in `project_ttl` at ingest time. Requires `--database-url`; failure downgrades to WARN (project becomes durable, not a fatal error).
- **`longmemeval prune`**: new subcommand lists `project_ttl` rows with elapsed `expires_at` and calls `memory_delete_project` over MCP for each. Supports `--dry-run`, `--limit`, `--prefix`, `--older-than`.
- **K8s CronJob** (`deploy/lme-prune-cronjob.yaml`): weekly sweep on Sunday 02:00 UTC, namespace `engram`, Chainguard-compatible security context.
- **Docs**: operator scratch-retention runbook added to `docs/lme-benchmark-learnings.md`.

**Schema note:** projects are `DISTINCT` values of `memories.project` (not a first-class table). This PR adds a sidecar `project_ttl` table rather than altering a hypothetical `projects` table — consistent with the existing architecture.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./...` — all green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Deploy migration 022 to staging, verify `project_ttl` table created
- [ ] Run `longmemeval ingest --scratch-ttl 1h` + wait + `longmemeval prune --dry-run`, confirm project appears in output
- [ ] Run `longmemeval prune` (without dry-run), confirm project deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)