### PR TITLE
feat(instinct): #396 Phase 1 measurement instrumentation

### DIFF
--- a/cmd/instinct/main.go
+++ b/cmd/instinct/main.go
@@ -694,13 +694,25 @@ func main() {
 
 // run is the top-level pipeline: load buffer → group by session → write
 // episodes to Engram → detect patterns via Haiku → upsert patterns.
+//
+// Phase 1 timing (#396): stageTimes is populated at each major checkpoint and
+// flushed to hook-timings-v2.tsv on exit (always, including error paths).
 func run(ctx context.Context, cfg config) error {
+	st := newStageTimes()
+	exitCode := 0
+	defer func() {
+		st.exitTime = time.Now()
+		appendTimingRow(st.toTSVRow("instinct", exitCode))
+	}()
+
 	events, processedPath, outcome, err := loadAndRotate(cfg.bufferPath, cfg.minEvents)
 	if err != nil {
+		exitCode = 1
 		return err
 	}
 	if len(events) == 0 {
 		if outcome == bufferLoadRejected {
+			exitCode = 1
 			return fmt.Errorf("instinct: malformed buffer rejected: %s", processedPath)
 		}
 		slog.Info("instinct: noop", "reason", "buffer below min events or missing")
@@ -709,21 +721,33 @@ func run(ctx context.Context, cfg config) error {
 
 	slog.Info("instinct: processing", "events", len(events))
 
+	// Phase 1 timing: auth is resolved once loadConfig succeeds; mark it here
+	// (config is already loaded; this is the point we first use the token).
+	st.authResolved = time.Now()
+
 	if cfg.engramURL == "" {
 		requeue(cfg.bufferPath, processedPath)
+		exitCode = 1
 		return fmt.Errorf("ENGRAM_BASE_URL not set")
 	}
 
 	e, err := newHybridEngram(cfg.engramURL, cfg.engramToken, cfg.engramRESTURL)
 	if err != nil {
 		requeue(cfg.bufferPath, processedPath)
+		exitCode = 1
 		return fmt.Errorf("newHybridEngram: %w", err)
 	}
 	if err := e.connect(ctx); err != nil {
 		requeue(cfg.bufferPath, processedPath)
+		exitCode = 1
 		return fmt.Errorf("connect: %w", err)
 	}
+	// Phase 1 timing: MCP connection established.
+	st.mcpConnected = time.Now()
 	defer func() { _ = e.close() }()
+
+	// Phase 1 timing: first payload is sent when the first writeEpisode begins.
+	st.requestSent = time.Now()
 
 	groups := groupBySession(events)
 	for key, group := range groups {
@@ -770,6 +794,9 @@ func run(ctx context.Context, cfg config) error {
 		upsertPattern(opCtx, e, p, events)
 		cancel()
 	}
+
+	// Phase 1 timing: all Engram writes complete; final response received.
+	st.responseReceived = time.Now()
 
 	slog.Info("instinct: done", "events", len(events), "patterns", len(patterns))
 	return nil

--- a/cmd/instinct/timing.go
+++ b/cmd/instinct/timing.go
@@ -1,0 +1,121 @@
+// Package main — per-stage wall-clock instrumentation for Phase 1 of #396.
+//
+// Phase 1 is measurement-only: always-on, zero-overhead-on-happy-path,
+// appends a single TSV row to ~/.claude/hook-timings-v2.tsv when the binary
+// exits. No daemon, no session cache, no new flags.
+//
+// TSV schema (tab-separated, header row on first line):
+//
+//	iso_ts          hook_name            exec_start_ms auth_resolved_ms
+//	mcp_connected_ms request_sent_ms response_received_ms exit_ms
+//	exit_code pid
+//
+// All *_ms fields are millisecond offsets from exec_start_ms (== 0 for that
+// column). exec_start_ms is the absolute epoch-ms of program start, so rows
+// from different sources (bash hooks + this binary) can be joined on that.
+//
+// See docs/design/396-phase1-measurement.md for the full schema spec.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HookTimingV2File is the path to the per-stage timing log.
+// Exported so tests can override via the HOOK_TIMING_V2_LOG env variable.
+const HookTimingV2File = ".claude/hook-timings-v2.tsv"
+
+// HookTimingV2Header is the TSV header line written once when the file is created.
+const HookTimingV2Header = "iso_ts\thook_name\texec_start_ms\tauth_resolved_ms\tmcp_connected_ms\trequest_sent_ms\tresponse_received_ms\texit_ms\texit_code\tpid"
+
+// stageTimes captures the absolute time.Time for each instrumentation point.
+// Zero value means "not reached yet" — emitted as empty string in the TSV row.
+type stageTimes struct {
+	execStart        time.Time
+	authResolved     time.Time
+	mcpConnected     time.Time
+	requestSent      time.Time
+	responseReceived time.Time
+	exitTime         time.Time
+}
+
+// newStageTimes initialises a stageTimes with execStart set to now.
+func newStageTimes() *stageTimes {
+	return &stageTimes{execStart: time.Now()}
+}
+
+// msOffset returns the millisecond delta from s.execStart to t,
+// or an empty string if t is the zero value (stage not reached).
+func (s *stageTimes) msOffset(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return strconv.FormatInt(t.Sub(s.execStart).Milliseconds(), 10)
+}
+
+// toTSVRow formats one row in the hook-timings-v2.tsv schema.
+// hookName is "instinct" (the binary name); exitCode is the process exit code.
+func (s *stageTimes) toTSVRow(hookName string, exitCode int) string {
+	isoTs := s.execStart.UTC().Format(time.RFC3339)
+	execStartMs := strconv.FormatInt(s.execStart.UnixMilli(), 10)
+	pid := strconv.Itoa(os.Getpid())
+
+	fields := []string{
+		isoTs,
+		hookName,
+		execStartMs,
+		s.msOffset(s.authResolved),
+		s.msOffset(s.mcpConnected),
+		s.msOffset(s.requestSent),
+		s.msOffset(s.responseReceived),
+		s.msOffset(s.exitTime),
+		strconv.Itoa(exitCode),
+		pid,
+	}
+	return strings.Join(fields, "\t")
+}
+
+// timingLogPath returns the path for the per-stage TSV log.
+// Override via HOOK_TIMING_V2_LOG env variable (for tests).
+func timingLogPath() string {
+	if v := os.Getenv("HOOK_TIMING_V2_LOG"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, HookTimingV2File)
+}
+
+// appendTimingRow appends one TSV row to the per-stage timing log.
+// Creates the file with header if it does not exist. Failures are silently
+// swallowed — timing instrumentation must never affect hook exit codes.
+func appendTimingRow(row string) {
+	path := timingLogPath()
+	if path == "" {
+		return
+	}
+
+	// Check whether file exists and needs a header.
+	needsHeader := false
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		needsHeader = true
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	if needsHeader {
+		_, _ = fmt.Fprintln(f, HookTimingV2Header)
+	}
+	_, _ = fmt.Fprintln(f, row)
+}

--- a/cmd/instinct/timing_test.go
+++ b/cmd/instinct/timing_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStageTimes_ToTSVRow verifies that toTSVRow emits the correct column
+// count, correct hook name, and correct millisecond offsets from execStart.
+func TestStageTimes_ToTSVRow(t *testing.T) {
+	base := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	s := &stageTimes{
+		execStart:        base,
+		authResolved:     base.Add(50 * time.Millisecond),
+		mcpConnected:     base.Add(120 * time.Millisecond),
+		requestSent:      base.Add(130 * time.Millisecond),
+		responseReceived: base.Add(310 * time.Millisecond),
+		exitTime:         base.Add(315 * time.Millisecond),
+	}
+
+	row := s.toTSVRow("instinct", 0)
+	fields := strings.Split(row, "\t")
+
+	// Schema: iso_ts hook_name exec_start_ms auth_resolved_ms mcp_connected_ms
+	//         request_sent_ms response_received_ms exit_ms exit_code pid
+	const wantColumns = 10
+	if len(fields) != wantColumns {
+		t.Fatalf("toTSVRow: got %d columns, want %d\nrow: %q", len(fields), wantColumns, row)
+	}
+
+	t.Run("hook_name", func(t *testing.T) {
+		if fields[1] != "instinct" {
+			t.Errorf("hook_name = %q, want %q", fields[1], "instinct")
+		}
+	})
+
+	t.Run("auth_resolved_ms", func(t *testing.T) {
+		if fields[3] != "50" {
+			t.Errorf("auth_resolved_ms = %q, want \"50\"", fields[3])
+		}
+	})
+
+	t.Run("mcp_connected_ms", func(t *testing.T) {
+		if fields[4] != "120" {
+			t.Errorf("mcp_connected_ms = %q, want \"120\"", fields[4])
+		}
+	})
+
+	t.Run("request_sent_ms", func(t *testing.T) {
+		if fields[5] != "130" {
+			t.Errorf("request_sent_ms = %q, want \"130\"", fields[5])
+		}
+	})
+
+	t.Run("response_received_ms", func(t *testing.T) {
+		if fields[6] != "310" {
+			t.Errorf("response_received_ms = %q, want \"310\"", fields[6])
+		}
+	})
+
+	t.Run("exit_ms", func(t *testing.T) {
+		if fields[7] != "315" {
+			t.Errorf("exit_ms = %q, want \"315\"", fields[7])
+		}
+	})
+
+	t.Run("exit_code", func(t *testing.T) {
+		if fields[8] != "0" {
+			t.Errorf("exit_code = %q, want \"0\"", fields[8])
+		}
+	})
+}
+
+// TestStageTimes_ToTSVRow_PartialStages verifies that unreached stages
+// (zero time.Time) emit empty strings rather than garbage offsets.
+func TestStageTimes_ToTSVRow_PartialStages(t *testing.T) {
+	base := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	s := &stageTimes{
+		execStart:    base,
+		authResolved: base.Add(40 * time.Millisecond),
+		// mcpConnected, requestSent, responseReceived, exitTime all zero
+	}
+
+	row := s.toTSVRow("instinct", 1)
+	fields := strings.Split(row, "\t")
+
+	if len(fields) != 10 {
+		t.Fatalf("partial row: got %d columns, want 10\nrow: %q", len(fields), row)
+	}
+
+	// auth_resolved should be present
+	if fields[3] != "40" {
+		t.Errorf("auth_resolved_ms = %q, want \"40\"", fields[3])
+	}
+
+	// mcp_connected through exit should be empty
+	for i, col := range []int{4, 5, 6, 7} {
+		if fields[col] != "" {
+			t.Errorf("unreached stage col[%d] = %q, want empty (stage index %d)", col, fields[col], i)
+		}
+	}
+
+	// exit_code should be 1
+	if fields[8] != "1" {
+		t.Errorf("exit_code = %q, want \"1\"", fields[8])
+	}
+}
+
+// TestAppendTimingRow_CreatesFileWithHeader verifies that appendTimingRow
+// creates the file with the correct header on first write, then appends
+// subsequent rows without re-writing the header.
+func TestAppendTimingRow_CreatesFileWithHeader(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "hook-timings-v2.tsv")
+	t.Setenv("HOOK_TIMING_V2_LOG", logPath)
+
+	base := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	s := &stageTimes{
+		execStart: base,
+		exitTime:  base.Add(200 * time.Millisecond),
+	}
+
+	// First write — file must not exist yet.
+	appendTimingRow(s.toTSVRow("instinct", 0))
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile after first write: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("after first write: got %d lines, want 2 (header + row)\ncontent: %q", len(lines), string(data))
+	}
+	if lines[0] != HookTimingV2Header {
+		t.Errorf("line[0] = %q, want header %q", lines[0], HookTimingV2Header)
+	}
+
+	// Second write — no additional header.
+	s2 := &stageTimes{
+		execStart: base.Add(time.Minute),
+		exitTime:  base.Add(time.Minute + 100*time.Millisecond),
+	}
+	appendTimingRow(s2.toTSVRow("instinct", 0))
+
+	data2, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile after second write: %v", err)
+	}
+	lines2 := strings.Split(strings.TrimRight(string(data2), "\n"), "\n")
+	if len(lines2) != 3 {
+		t.Fatalf("after second write: got %d lines, want 3 (header + 2 rows)\ncontent: %q", len(lines2), string(data2))
+	}
+	// Confirm header still appears exactly once.
+	headerCount := 0
+	for _, l := range lines2 {
+		if l == HookTimingV2Header {
+			headerCount++
+		}
+	}
+	if headerCount != 1 {
+		t.Errorf("header appeared %d times, want exactly 1", headerCount)
+	}
+}
+
+// TestTimingLogPath_EnvOverride verifies that HOOK_TIMING_V2_LOG overrides
+// the default path, enabling test isolation.
+func TestTimingLogPath_EnvOverride(t *testing.T) {
+	want := "/tmp/test-hook-timings.tsv"
+	t.Setenv("HOOK_TIMING_V2_LOG", want)
+	got := timingLogPath()
+	if got != want {
+		t.Errorf("timingLogPath() = %q, want %q", got, want)
+	}
+}

--- a/docs/design/396-phase1-measurement.md
+++ b/docs/design/396-phase1-measurement.md
@@ -1,0 +1,178 @@
+# Issue #396 — Phase 1: Hook Timing Measurement
+
+Status: in progress (`fix/wave4-hook-timing-phase1`)
+Phase: 1 of 3 — **measurement only**
+Author: Wave 4 hook-timing campaign
+
+## Question this phase answers
+
+> Where, exactly, does each Engram-aware hook spend its wall-clock time?
+
+Specifically:
+
+1. Which stage dominates total hook latency — token resolution, MCP connect,
+   request send, or response wait?
+2. Does the dominant stage differ across the five hooks (`engram-precheck`,
+   `engram-auth-check`, `engram-token-refresh`, `engram-session-recall`,
+   `engram-session-end`) and the Go `instinct` binary?
+3. Is per-stage variance high enough to justify Phase 2 (session reuse, auth
+   cache), or is the median already inside the budget?
+
+Phase 1 is strictly **measurement**. No daemon. No session-reuse code. No new
+auth-token cache file. No systemd unit. No Prometheus exporter. Those belong
+in Phase 2 and Phase 3 and are explicitly out of scope here.
+
+## What changes in this PR
+
+| Path | Purpose |
+|------|---------|
+| `cmd/instinct/timing.go` | `stageTimes` struct, `newStageTimes`, `toTSVRow`, `appendTimingRow`, file/header bootstrap |
+| `cmd/instinct/timing_test.go` | Unit tests for offset math, header bootstrap, append semantics, empty-stage rendering |
+| `cmd/instinct/main.go` | Four stage marks inside `run()`: `authResolved`, `mcpConnected`, `requestSent`, `responseReceived`; exit time + TSV append in `defer` |
+| `hooks/lib/timing-v2.sh` | Bash counterpart — same schema, same file, `EXIT` trap emits one row |
+| `hooks/engram/engram-precheck.sh` | Marks `request_sent` before `/health`, `response_received` after |
+| `hooks/engram/engram-auth-check.sh` | Marks `auth_resolved` after token load, `request_sent`/`response_received` around `/quick-recall` probe |
+| `hooks/engram/engram-token-refresh.sh` | Marks `auth_resolved` after token resolution (cached or freshly fetched), `request_sent`/`response_received` around `_test_auth` |
+| `hooks/engram/engram-session-recall.sh` | Marks `auth_resolved` after token load, `request_sent` before recall, `response_received` after last response |
+| `hooks/engram/engram-session-end.sh` | Marks `auth_resolved` after token load, `request_sent`/`response_received` around `/quick-store` |
+| `hooks/install.sh` | Installs `timing-v2.sh` to `~/.claude/hooks/lib/` and the engram hooks to `~/.claude/hooks/` |
+
+## TSV schema
+
+All rows — from the Go binary and from bash hooks — append to a single file:
+
+    $HOME/.claude/hook-timings-v2.tsv
+
+(Override via the `HOOK_TIMING_V2_LOG` environment variable.)
+
+The file is created on first write with a single header line.
+
+Schema (tab-separated, ten columns):
+
+| # | Column                  | Type     | Meaning |
+|---|-------------------------|----------|---------|
+| 1 | `iso_ts`                | string   | UTC RFC3339 timestamp of process start |
+| 2 | `hook_name`             | string   | `instinct` for the Go binary; bash hooks emit the script's `basename` |
+| 3 | `exec_start_ms`         | int64    | Epoch milliseconds at process start (absolute clock) |
+| 4 | `auth_resolved_ms`      | int (ms) | Offset from `exec_start` to "token usable" — **empty if not reached** |
+| 5 | `mcp_connected_ms`      | int (ms) | Offset to MCP connection established (Go binary only) — empty if not reached |
+| 6 | `request_sent_ms`       | int (ms) | Offset to first byte of request sent |
+| 7 | `response_received_ms`  | int (ms) | Offset to final response fully received |
+| 8 | `exit_ms`               | int (ms) | Offset to process exit |
+| 9 | `exit_code`             | int      | Process exit code |
+| 10| `pid`                   | int      | Process PID |
+
+Design notes on the schema:
+
+- **Offsets from `exec_start`, not absolute times** — three reasons: smaller
+  numbers in the log, immune to clock skew between rows, and trivially
+  comparable across hooks.
+- **Empty field, not zero, for unreached stages** — a bash hook that exits
+  early because no token was found should distinguish "auth resolved at t=0"
+  (impossible) from "auth never resolved" (the real case). Zero is a valid
+  offset value; emptiness is the right "missing" signal.
+- **`mcp_connected` is Go-only** — bash hooks talk to Engram via REST, not
+  MCP/SSE. They leave that column empty by construction.
+
+## Stage definitions (which checkpoint maps to which transition)
+
+| Stage             | Defined as (Go)                              | Defined as (bash hook) |
+|-------------------|----------------------------------------------|------------------------|
+| `exec_start`      | `newStageTimes()` returns, top of `run()`    | `_tv2_t0_ns` set at top of `timing-v2.sh` |
+| `auth_resolved`   | `loadConfig` succeeded and we hold a token   | Token successfully read from `mcp_servers.json` or `/setup-token` |
+| `mcp_connected`   | `e.connect(ctx)` returned without error      | n/a — bash hooks are REST-only |
+| `request_sent`    | About to call first `writeEpisode`           | About to call the first `curl` that contacts Engram |
+| `response_received` | Last write/recall completed                | After the final `curl` returns |
+| `exit`            | `defer` runs at the bottom of `run()`        | `trap _tv2_on_exit EXIT` fires |
+
+## Why bash + Go share one file
+
+Phase 2 will compare:
+
+- Bash hook auth probe (cold curl) vs Go binary auth probe (`hybridEngram.connect`)
+- Bash recall (one POST) vs Go recall (MCP/SSE)
+- Same hook re-invoked back-to-back (cache hit vs cache miss)
+
+Joining the two TSV streams requires no schema translation: `exec_start_ms` is
+an absolute clock and the hook_name disambiguates the source.
+
+## Analysis snippet (Phase 1 reads, no writes)
+
+Run this against `~/.claude/hook-timings-v2.tsv` after a normal day of Claude
+Code use. It prints a per-hook stage breakdown (median, p90):
+
+```bash
+# Median + p90 per stage per hook
+mlr --tsv stats1 \
+  -a p50,p90,count \
+  -f auth_resolved_ms,mcp_connected_ms,request_sent_ms,response_received_ms,exit_ms \
+  -g hook_name \
+  ~/.claude/hook-timings-v2.tsv
+```
+
+Equivalent using `awk` (when `mlr` is not available):
+
+```bash
+awk -F'\t' 'NR>1 && $4!="" { sum[$2"_auth"]+=$4; n[$2"_auth"]++ }
+            NR>1 && $7!="" { sum[$2"_resp"]+=$7; n[$2"_resp"]++ }
+            END { for (k in sum) printf "%-50s %.1f ms (n=%d)\n", k, sum[k]/n[k], n[k] }' \
+  ~/.claude/hook-timings-v2.tsv | sort
+```
+
+To find the dominant stage per row (which checkpoint took longest):
+
+```bash
+mlr --tsv put '
+  $delta_auth   = $auth_resolved_ms      != "" ? $auth_resolved_ms                                            : 0;
+  $delta_mcp    = $mcp_connected_ms      != "" ? $mcp_connected_ms      - ($auth_resolved_ms       != "" ? $auth_resolved_ms      : 0) : 0;
+  $delta_req    = $request_sent_ms       != "" ? $request_sent_ms       - ($mcp_connected_ms       != "" ? $mcp_connected_ms      : ($auth_resolved_ms != "" ? $auth_resolved_ms : 0)) : 0;
+  $delta_resp   = $response_received_ms  != "" ? $response_received_ms  - ($request_sent_ms        != "" ? $request_sent_ms       : 0) : 0;
+  $delta_exit   = $exit_ms               != "" ? $exit_ms               - ($response_received_ms   != "" ? $response_received_ms : 0) : 0;
+' then cut -f hook_name,delta_auth,delta_mcp,delta_req,delta_resp,delta_exit \
+  ~/.claude/hook-timings-v2.tsv
+```
+
+## Decision gate: when do we move to Phase 2?
+
+The promotion criterion is **evidence-driven**, not time-driven. We move to
+Phase 2 (session reuse / auth cache) only when **both** are true:
+
+1. **Sample size**: at least **500 rows** from real Claude Code sessions,
+   across at least **5 distinct calendar days**, with at least **20 rows per
+   instrumented hook**. This bounds the influence of one-off cold-start
+   outliers.
+2. **Effect size**: a single stage's p50 contribution is **≥ 100 ms** AND
+   that stage represents **≥ 40%** of total wall-clock time for its hook.
+
+Conversely, we **do not** ship Phase 2 when:
+
+- The dominant stage is `auth_resolved` at < 50 ms p50 (already cheap).
+- The dominant stage is `response_received_ms − request_sent_ms` (that's
+  server-side latency, not hook overhead — Phase 2 cannot help).
+- Total p50 exec time per hook is < 200 ms across the board (no perceivable
+  user impact).
+
+The Phase 1 deliverable is therefore a **decision document**, not a fix. It
+either justifies Phase 2 with numbers or closes the wave with "no action."
+
+## Safety / risk notes
+
+- Every timing call is wrapped (`2>/dev/null || true` in bash;
+  `appendTimingRow` swallows errors in Go). A buggy `date`, a read-only home
+  directory, or a missing file will not change a hook's exit code.
+- `appendTimingRow` uses `O_APPEND` — concurrent invocations write whole
+  lines atomically up to `PIPE_BUF` (4 KB on Linux). Our rows are < 200 B.
+- File is created mode 0600. No secrets are logged; only offsets and the hook
+  name.
+- Disk cost: ~150 bytes per invocation. At 200 hook invocations per active
+  day, the log grows ~30 KB/day. Rotation can wait until Phase 2.
+
+## Out of scope (explicitly)
+
+- Persistent daemon to keep MCP session warm — Phase 2.
+- Auth token cache file (separate from `mcp_servers.json`) — Phase 2.
+- Systemd unit, Prometheus exporter, Grafana dashboard — Phase 3.
+- Any change to MCP wire protocol, server endpoints, or `engram-go` binaries
+  beyond `cmd/instinct/`.
+- Sampling, log rotation, structured JSON output — not justified until we see
+  the data volume.

--- a/hooks/engram/engram-auth-check.sh
+++ b/hooks/engram/engram-auth-check.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+. ~/.claude/hooks/lib/timing.sh 2>/dev/null || true
+. ~/.claude/hooks/lib/timing-v2.sh 2>/dev/null || true
+# UserPromptSubmit hook: fast per-message Engram auth check.
+# If auth is broken: auto-runs engram-setup to refresh the token,
+# then outputs a systemMessage telling Claude to surface the /mcp step.
+# If auth is healthy: silent, exits 0 in under 200ms.
+# Never blocks the session — auth check has a hard 3s timeout. (#376)
+
+set -euo pipefail
+
+PORT="${ENGRAM_TEST_PORT:-8788}"
+ENGRAM_DIR="$HOME/projects/engram-go"
+MCP_CONFIG="$HOME/.claude/mcp_servers.json"
+
+# shellcheck source=lib/engram-state.sh
+source "$HOME/.claude/hooks/lib/engram-state.sh" 2>/dev/null || true
+
+# Skip if engram-go project not installed
+[[ -d "$ENGRAM_DIR" ]] || exit 0
+[[ -f "$MCP_CONFIG" ]] || exit 0
+
+# Read token from config (#395)
+TOKEN=$(python3 -c "
+import json, os, sys
+try:
+    with open(os.path.expanduser('~/.claude/mcp_servers.json')) as f:
+        d = json.load(f)
+    tok = d.get('mcpServers',{}).get('engram',{}).get('headers',{}).get('Authorization','')
+    print(tok.removeprefix('Bearer ').strip())
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+[[ -z "$TOKEN" ]] && exit 0
+
+# Phase 1 timing (#396): token loaded, auth can proceed.
+timing_mark_auth_resolved 2>/dev/null || true
+
+# File-based auth cache — 120s TTL to avoid per-message latency (#400)
+CACHE="$HOME/.claude/.engram-auth-ok"
+CACHE_TTL=120
+
+if [[ -f "$CACHE" ]]; then
+  age=$(( $(date +%s) - $(date -r "$CACHE" +%s 2>/dev/null || echo 0) ))
+  [[ "$age" -lt "$CACHE_TTL" ]] && exit 0
+fi
+
+# Phase 1 timing (#396): about to send auth probe to Engram.
+timing_mark_request_sent 2>/dev/null || true
+
+# Fast auth probe — 3s hard limit
+# 200 or 500 = auth OK (500 = recall backend error, but token was accepted)
+# 401 or 000 = auth broken
+HTTP_STATUS=$(curl -so /dev/null -w "%{http_code}" --max-time 3 \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+  -d '{"query":"auth-check","project":"global","limit":1}' 2>/dev/null || echo "000")
+
+# Phase 1 timing (#396): response received from auth probe.
+timing_mark_response_received 2>/dev/null || true
+
+if [[ "$HTTP_STATUS" == "401" || "$HTTP_STATUS" == "000" ]]; then
+  # Invalidate stale cache on auth failure; track in state (#404)
+  rm -f "$CACHE"
+  increment_state "consecutive_auth_failures" 2>/dev/null || true
+
+  # Recovery path 1: engram-setup (works when /setup-token doesn't require auth).
+  # Since #540 /setup-token requires Bearer auth, this will fail if we have no
+  # valid token — but try it first in case it's been fixed or the server is older.
+  REFRESHED=false
+  if [[ -d "$ENGRAM_DIR" ]]; then
+    if command -v engram-setup &>/dev/null; then
+      engram-setup >/dev/null 2>&1 && REFRESHED=true || true
+    elif [[ -x "$ENGRAM_DIR/engram-setup" ]]; then
+      "$ENGRAM_DIR/engram-setup" >/dev/null 2>&1 && REFRESHED=true || true
+    else
+      (cd "$ENGRAM_DIR" && timeout 30 go run ./cmd/engram-setup >/dev/null 2>&1) && REFRESHED=true || true
+    fi
+  fi
+
+  # Recovery path 2 (#614, #616): probe fallback key sources in priority order:
+  #   1. ~/.config/engram/api_key  — backup of the Infisical key (most reliable)
+  #   2. ENGRAM_API_KEY in .env    — docker-level default (may diverge from Infisical)
+  # /starter injects the real key from Infisical at runtime; .env is NOT authoritative.
+  if [[ "$REFRESHED" == "false" ]]; then
+    FALLBACK_KEY=""
+    # Try Infisical backup first
+    if [[ -f "$HOME/.config/engram/api_key" ]]; then
+      FALLBACK_KEY=$(cat "$HOME/.config/engram/api_key" | tr -d '[:space:]')
+    fi
+    # Fall back to .env if config backup didn't work or is absent
+    if [[ -z "$FALLBACK_KEY" && -f "$ENGRAM_DIR/.env" ]]; then
+      FALLBACK_KEY=$(grep '^ENGRAM_API_KEY=' "$ENGRAM_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '[:space:]')
+    fi
+    ENV_KEY="$FALLBACK_KEY"
+    if [[ -n "$ENV_KEY" ]]; then
+      ENV_STATUS=$(curl -so /dev/null -w "%{http_code}" --max-time 3 \
+        -H "Authorization: Bearer ${ENV_KEY}" \
+        -H "Content-Type: application/json" \
+        -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+        -d '{"query":"auth-check","project":"global","limit":1}' 2>/dev/null || echo "000")
+      if [[ "$ENV_STATUS" != "401" && "$ENV_STATUS" != "000" ]]; then
+        # Fallback key is valid — write it atomically to mcp_servers.json (#614)
+        python3 - "$MCP_CONFIG" "$ENV_KEY" <<'PYEOF' 2>/dev/null && REFRESHED=true || true
+import json, os, sys, tempfile
+path, key = sys.argv[1], sys.argv[2]
+if not os.path.exists(path):
+    sys.exit(1)
+with open(path) as f:
+    cfg = json.load(f)
+cfg.setdefault("mcpServers", {}).setdefault("engram", {})["headers"] = {"Authorization": "Bearer " + key}
+dir_ = os.path.dirname(path) or "."
+fd, tmp = tempfile.mkstemp(dir=dir_, prefix=".engram_token_tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+except Exception:
+    os.unlink(tmp)
+    raise
+PYEOF
+      fi
+    fi
+  fi
+
+  if [[ "$REFRESHED" == "true" ]]; then
+    printf '{"systemMessage":"⚠️  Engram auth token was stale — recovered from .env.\\nRun /mcp in Claude Code to reconnect memory."}'
+  else
+    printf '{"systemMessage":"❌ Engram auth failed and auto-recovery failed.\\nRun: cd ~/projects/engram-go && make restart && make setup\\nThen run /mcp in Claude Code."}'
+  fi
+  exit 0  # must exit here — fall-through would overwrite failure state updates
+fi
+
+# Auth OK: update cache, reset failure counter, silent exit (#404)
+touch "$CACHE"
+update_state "consecutive_auth_failures" "0" 2>/dev/null || true
+update_state "last_auth_ok_at" "\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" 2>/dev/null || true
+exit 0

--- a/hooks/engram/engram-precheck.sh
+++ b/hooks/engram/engram-precheck.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+. ~/.claude/hooks/lib/timing.sh 2>/dev/null || true
+. ~/.claude/hooks/lib/timing-v2.sh 2>/dev/null || true
+# PreToolUse hook: fast connectivity check before any mcp__engram__* call.
+# If Engram responds healthy → silent exit 0 (<100ms).
+# If Engram is down → kick off a background restart, emit a systemMessage,
+#   exit 0 immediately. Never polls. Never blocks.
+#
+# engram-go#408: polling loop removed — polling held the PreToolUse hook for
+# up to 20s, making Claude appear hung and prompting accidental user interrupts.
+
+set -euo pipefail
+
+PORT="${ENGRAM_TEST_PORT:-8788}"
+ENGRAM_DIR="${ENGRAM_TEST_DIR:-$HOME/projects/engram-go}"
+HEALTH_URL="http://localhost:${PORT}/health"
+
+# Phase 1 timing (#396): about to send health probe to Engram.
+timing_mark_request_sent 2>/dev/null || true
+
+# Fast path: healthy → done in <100ms
+if curl -sf --max-time 1 "$HEALTH_URL" >/dev/null 2>&1; then
+    timing_mark_response_received 2>/dev/null || true
+    exit 0
+fi
+
+# Health check failed — still mark response received before background restart.
+timing_mark_response_received 2>/dev/null || true
+
+# Engram not responding. Kick off a background restart and return immediately.
+# Never poll here — polling blocks the MCP call and makes Claude appear hung.
+if [[ -d "$ENGRAM_DIR" ]]; then
+    (cd "$ENGRAM_DIR" && docker compose up -d engram-go >/dev/null 2>&1) &
+    disown $! 2>/dev/null || true
+fi
+
+printf '{"systemMessage":"⚠️  Engram health check failed — background restart initiated. This MCP call may fail; if so, the result will be captured to fallback.md. Check: docker logs engram-go-app"}'
+exit 0

--- a/hooks/engram/engram-session-end.sh
+++ b/hooks/engram/engram-session-end.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+. ~/.claude/hooks/lib/timing.sh 2>/dev/null || true
+. ~/.claude/hooks/lib/timing-v2.sh 2>/dev/null || true
+# Stop hook: record a session-end marker in Engram via /quick-store.
+# Keeps engram_episodes_ended_clean_total accurate vs reaper count.
+set -euo pipefail
+
+PORT="${ENGRAM_TEST_PORT:-8788}"
+BASE="http://127.0.0.1:${PORT}"
+
+# shellcheck source=lib/engram-state.sh
+source "$HOME/.claude/hooks/lib/engram-state.sh" 2>/dev/null || true
+
+# Never block session end
+if ! curl -sf --max-time 2 "${BASE}/health" > /dev/null 2>&1; then
+    exit 0
+fi
+
+TOKEN=$(python3 -c "
+import json, os
+try:
+    with open(os.path.expanduser('~/.claude/mcp_servers.json')) as f:
+        d = json.load(f)
+    tok = d.get('mcpServers',{}).get('engram',{}).get('headers',{}).get('Authorization','')
+    print(tok.removeprefix('Bearer ').strip())
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+[[ -z "$TOKEN" ]] && exit 0
+
+# Phase 1 timing (#396): token loaded, auth can proceed.
+timing_mark_auth_resolved 2>/dev/null || true
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+PAYLOAD=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'content': f'[session-end] Claude Code session ended cleanly at {sys.argv[1]}',
+    'project': 'global',
+    'tags': ['session-end', 'lifecycle'],
+    'importance': 1,
+}))" "$TIMESTAMP")
+
+# Phase 1 timing (#396): about to send session-end marker to Engram.
+timing_mark_request_sent 2>/dev/null || true
+
+curl -sf --max-time 5 \
+    -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    "${BASE}/quick-store" > /dev/null 2>&1 || true
+
+# Phase 1 timing (#396): session-end marker stored (or attempt finished).
+timing_mark_response_received 2>/dev/null || true
+
+# Emit session summary from state (#404)
+_recall=$(read_state "last_recall_results" 2>/dev/null || echo "0")
+_fallback=$(read_state "fallback_entry_count" 2>/dev/null || echo "0")
+_auth_failures=$(read_state "consecutive_auth_failures" 2>/dev/null || echo "0")
+_auth_status="ok"
+[[ "${_auth_failures:-0}" -gt 0 ]] && _auth_status="${_auth_failures} failure(s)"
+echo "[engram] session closed — recall: ${_recall:-0} results | fallback: ${_fallback:-0} queued | auth: ${_auth_status}"
+
+exit 0

--- a/hooks/engram/engram-session-recall.sh
+++ b/hooks/engram/engram-session-recall.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+. ~/.claude/hooks/lib/timing.sh 2>/dev/null || true
+. ~/.claude/hooks/lib/timing-v2.sh 2>/dev/null || true
+# SessionStart hook: inject recent Engram memories into MEMORY.md so Claude
+# starts every session with relevant context already loaded. (#378)
+#
+# Uses POST /quick-recall (REST, no SSE handshake required) to keep this fast.
+# Appends results under "## Engram Session Recall" in MEMORY.md — that section
+# is already included in Claude's context at session start.
+#
+# Fails silently if Engram is unreachable — never blocks the session.
+
+set -euo pipefail
+
+PORT=8788
+MEMORY_FILE="$HOME/.claude/projects/-home-psimmons/memory/MEMORY.md"
+MAX_RESULTS=5
+
+# Read token from mcp_servers.json
+TOKEN=$(python3 -c "
+import json, os
+try:
+    with open(os.path.expanduser('~/.claude/mcp_servers.json')) as f:
+        d = json.load(f)
+    tok = d.get('mcpServers',{}).get('engram',{}).get('headers',{}).get('Authorization','')
+    print(tok.removeprefix('Bearer ').strip())
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+[[ -z "$TOKEN" ]] && exit 0
+
+# Phase 1 timing (#396): token loaded, auth can proceed.
+timing_mark_auth_resolved 2>/dev/null || true
+
+# Infer engram project from git repo name (#402)
+INFERRED_PROJECT=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo '')" 2>/dev/null || echo "")
+case "$INFERRED_PROJECT" in
+  clearwatch*) ENGRAM_PROJECT="clearwatch" ;;
+  engram*)     ENGRAM_PROJECT="engram" ;;
+  homelab*)    ENGRAM_PROJECT="homelab" ;;
+  instinct*)   ENGRAM_PROJECT="instinct" ;;
+  *)           ENGRAM_PROJECT="" ;;
+esac
+
+# Quick auth smoke-test — same endpoint used by all other hooks (#393)
+HTTP_STATUS=$(curl -so /dev/null -w "%{http_code}" --max-time 3 \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+  -d '{"query":"auth-check","project":"global","limit":1}' 2>/dev/null || echo "000")
+[[ "$HTTP_STATUS" == "401" || "$HTTP_STATUS" == "000" ]] && exit 0
+
+# Phase 1 timing (#396): about to send recall request to Engram.
+timing_mark_request_sent 2>/dev/null || true
+
+# Call /quick-recall for global project context
+RECALL_JSON=$(curl -sf --max-time 8 \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+  -d "{\"query\":\"current project status recent work decisions\",\"project\":\"global\",\"limit\":3}" \
+  2>/dev/null || true)
+
+# Second recall for inferred project, merged with global results (#402)
+if [[ -n "$ENGRAM_PROJECT" && "$ENGRAM_PROJECT" != "global" ]]; then
+  PROJECT_RECALL=$(curl -sf --max-time 8 \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+    -d "{\"query\":\"current project status recent work decisions\",\"project\":\"${ENGRAM_PROJECT}\",\"limit\":3}" \
+    2>/dev/null || true)
+  # Merge: combine both JSON result arrays, deduplicate by id, sort by score, cap at MAX_RESULTS
+  if [[ -n "$PROJECT_RECALL" && -n "$RECALL_JSON" ]]; then
+    RECALL_JSON=$(python3 -c "
+import json, sys
+a = json.loads(sys.argv[1]).get('results', [])
+b = json.loads(sys.argv[2]).get('results', [])
+seen = set()
+merged = []
+for r in a + b:
+    rid = r.get('id', '') or r.get('summary', '')[:40]
+    if rid not in seen:
+        seen.add(rid)
+        merged.append(r)
+merged.sort(key=lambda r: r.get('score', 0), reverse=True)
+print(json.dumps({'results': merged[:5]}))
+" "$RECALL_JSON" "$PROJECT_RECALL" 2>/dev/null || echo "$RECALL_JSON")
+  elif [[ -n "$PROJECT_RECALL" ]]; then
+    RECALL_JSON="$PROJECT_RECALL"
+  fi
+fi
+
+[[ -z "$RECALL_JSON" ]] && exit 0
+
+# Phase 1 timing (#396): all recall responses received from Engram.
+timing_mark_response_received 2>/dev/null || true
+
+# Write RECALL_JSON to a temp file to avoid shell injection into Python (#393)
+_recall_tmp=$(mktemp)
+printf '%s' "$RECALL_JSON" > "$_recall_tmp"
+RECALL_SECTION=$(python3 - "$_recall_tmp" <<'PYEOF'
+import json, sys
+
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    results = data.get('results', [])
+except Exception:
+    sys.exit(0)
+
+if not results:
+    sys.exit(0)
+
+lines = ["", "## Engram Session Recall", ""]
+for i, r in enumerate(results, 1):
+    summary = r.get('summary') or r.get('content', '')[:120]
+    tags = ', '.join(r.get('tags', [])[:4])
+    score = r.get('score', 0)
+    lines.append(f"**{i}.** {summary}")
+    if tags:
+        lines.append(f"   *tags: {tags} | score: {score:.2f}*")
+    lines.append("")
+
+print('\n'.join(lines))
+PYEOF
+)
+rm -f "$_recall_tmp"
+
+[[ -z "$RECALL_SECTION" ]] && exit 0
+
+# Strip any previous recall section and append fresh one
+if [[ -f "$MEMORY_FILE" ]]; then
+  MEMORY_LOCK="${MEMORY_FILE}.lock"
+  python3 - "$MEMORY_FILE" "$MEMORY_LOCK" "$RECALL_SECTION" <<'PYEOF'
+import sys, os, tempfile, fcntl
+
+path = sys.argv[1]
+lock_path = sys.argv[2]
+new_section = sys.argv[3]
+
+with open(lock_path, "w") as lf:
+    fcntl.flock(lf, fcntl.LOCK_EX)
+    try:
+        with open(path) as f:
+            content = f.read()
+    except FileNotFoundError:
+        content = ""
+
+    # Remove previous recall section if present
+    if "## Engram Session Recall" in content:
+        content = content[:content.index("## Engram Session Recall")].rstrip()
+
+    content = content.rstrip() + "\n" + new_section + "\n"
+
+    # Atomic write — never leaves MEMORY.md truncated on interrupt (#393)
+    dir_ = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=dir_, prefix=".memory_recall_tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        os.unlink(tmp)
+        raise
+
+    print("✅ Engram: session recall injected into MEMORY.md")
+PYEOF
+else
+  echo "⚠️  Engram session recall: MEMORY.md not found at ${MEMORY_FILE}"
+fi

--- a/hooks/engram/engram-token-refresh.sh
+++ b/hooks/engram/engram-token-refresh.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+. ~/.claude/hooks/lib/timing.sh 2>/dev/null || true
+. ~/.claude/hooks/lib/timing-v2.sh 2>/dev/null || true
+# SessionStart hook: ensure Engram is running and MCP token is current.
+# Self-heals: starts Engram if down, syncs token, never just warns and gives up.
+# Uses atomic writes (write-then-rename) so Claude Code never reads a partial file.
+
+set -euo pipefail
+
+ENGRAM_DIR="$HOME/projects/engram-go"
+PORT="${ENGRAM_TEST_PORT:-8788}"
+
+[[ -d "$ENGRAM_DIR" ]] || exit 0
+
+# shellcheck source=lib/engram-state.sh
+source "$HOME/.claude/hooks/lib/engram-state.sh" 2>/dev/null || true
+
+# ── 1. Ensure server is up ───────────────────────────────────────────────────
+if ! curl -sf --max-time 2 "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+  echo "⚠️  Engram: server not responding — starting it now..."
+  (cd "$ENGRAM_DIR" && timeout 30 make up) 2>&1 | sed 's/^/   /'
+
+  # Wait up to 15s for it to become healthy
+  for i in $(seq 1 15); do
+    sleep 1
+    if curl -sf --max-time 1 "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+      echo "✅ Engram: started (took ${i}s)"
+      break
+    fi
+    if [[ "$i" == "15" ]]; then
+      echo "❌ Engram: failed to start after 15s — memory recall disabled this session"
+      echo "   Debug: cd ~/projects/engram-go && make logs"
+      exit 0
+    fi
+  done
+fi
+
+# ── 2. Read existing token from config (avoid /setup-token rate limit) ───────
+# /setup-token is rate-limited to 3 calls per 5 minutes. Read the cached token
+# from mcp_servers.json first; only call /setup-token if the cached token fails
+# auth or is missing. (#375, #376)
+EXISTING_TOKEN=$(python3 -c "
+import json, os
+try:
+    with open(os.path.expanduser('~/.claude/mcp_servers.json')) as f:
+        d = json.load(f)
+    tok = d.get('mcpServers',{}).get('engram',{}).get('headers',{}).get('Authorization','')
+    print(tok.removeprefix('Bearer ').strip())
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+_fetch_setup_token() {
+  local json
+  json=$(curl -sf --max-time 5 "http://127.0.0.1:${PORT}/setup-token" 2>/dev/null || true)
+  if [[ -z "$json" ]]; then
+    sleep 3
+    json=$(curl -sf --max-time 5 "http://127.0.0.1:${PORT}/setup-token" 2>/dev/null || true)
+  fi
+  echo "$json"
+}
+
+TOKEN=""
+ENDPOINT="http://127.0.0.1:${PORT}/sse"
+
+if [[ -n "$EXISTING_TOKEN" ]]; then
+  TOKEN="$EXISTING_TOKEN"
+  # Phase 1 timing (#396): token resolved from cached MCP config.
+  timing_mark_auth_resolved 2>/dev/null || true
+fi
+
+# If no cached token, fetch from server
+if [[ -z "$TOKEN" ]]; then
+  TOKEN_JSON=$(_fetch_setup_token)
+  if [[ -z "$TOKEN_JSON" ]]; then
+    echo "❌ Engram: /setup-token unreachable — memory recall disabled this session"
+    exit 0
+  fi
+  TOKEN=$(echo "$TOKEN_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || true)
+  ENDPOINT=$(echo "$TOKEN_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('endpoint',''))" 2>/dev/null || true)
+  if [[ -z "$TOKEN" ]]; then
+    echo "❌ Engram: /setup-token returned malformed response"
+    exit 0
+  fi
+  # Phase 1 timing (#396): token freshly fetched from /setup-token.
+  timing_mark_auth_resolved 2>/dev/null || true
+fi
+
+# ── 3. Write token to both MCP config files (atomic) ────────────────────────
+_write_token() {
+  python3 - "$1" <<PYEOF
+import json, os, sys, tempfile
+from urllib.parse import urlparse, urlencode, parse_qs, urlunparse
+
+def merge_url(existing: str, new: str) -> str:
+    ep = urlparse(existing)
+    np = urlparse(new)
+    merged = {**parse_qs(ep.query, keep_blank_values=True),
+              **parse_qs(np.query, keep_blank_values=True)}
+    q = urlencode({k: v[0] for k, v in merged.items()})
+    return urlunparse((np.scheme, np.netloc, np.path, '', q, ''))
+
+path = sys.argv[1]
+if not os.path.exists(path):
+    sys.exit(0)
+
+with open(path) as f:
+    cfg = json.load(f)
+
+# For .claude.json: only update if engram key already present (#395)
+is_claude_json = "mcpServers" in cfg
+servers = cfg.setdefault("mcpServers", {})
+
+if os.path.basename(path) == ".claude.json" and "engram" not in servers:
+    sys.exit(0)
+
+existing_url = servers.get("engram", {}).get("url", "$ENDPOINT")
+servers["engram"] = {
+    "type": "sse",
+    "url": merge_url(existing_url, "$ENDPOINT"),
+    "headers": {"Authorization": "Bearer $TOKEN"}
+}
+
+dir_ = os.path.dirname(path) or "."
+fd, tmp = tempfile.mkstemp(dir=dir_, prefix=".engram_token_tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+except Exception:
+    os.unlink(tmp)
+    raise
+PYEOF
+}
+
+_write_token "$HOME/.claude/mcp_servers.json"
+_write_token "$HOME/.claude.json"
+
+# ── 4. Validate auth — /health is not enough, /quick-recall requires Bearer ──
+# Tests the actual authenticated REST endpoint rather than the SSE/MCP protocol.
+# Uses /quick-recall because it's a simple POST that requires Bearer auth and
+# doesn't require an SSE handshake. Returns 401 on bad token, 200 on good.
+# (#375)
+_test_auth() {
+  local tok="$1"
+  local http_status
+  http_status=$(curl -so /dev/null -w "%{http_code}" --max-time 5 \
+    -H "Authorization: Bearer ${tok}" \
+    -H "Content-Type: application/json" \
+    -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+    -d '{"query":"auth-check","project":"global","limit":1}' 2>/dev/null || echo "000")
+  # 401 = bad token; 000 = unreachable; anything else = auth OK (500 = recall
+  # failed internally, but token was accepted)
+  [[ "$http_status" != "401" && "$http_status" != "000" ]]
+}
+
+# Phase 1 timing (#396): about to send auth probe to Engram.
+timing_mark_request_sent 2>/dev/null || true
+if _test_auth "$TOKEN"; then
+  # Phase 1 timing (#396): auth probe completed successfully.
+  timing_mark_response_received 2>/dev/null || true
+  # ── 5. Detect container restart since last token write ───────────────────────
+  # If the container restarted after the last time mcp_servers.json was written,
+  # the Claude Code MCP connection is using a token from before the restart.
+  # The token itself is stable (same ENGRAM_API_KEY), but the SSE session was
+  # dropped. Prompt the user to run /mcp to reconnect. (#376)
+  CONTAINER_STARTED=$(docker inspect --format '{{.State.StartedAt}}' engram-go-app 2>/dev/null || true)
+  CONFIG_MTIME=$(python3 -c "import os; print(os.path.getmtime(os.path.expanduser('~/.claude/mcp_servers.json')))" 2>/dev/null || true)
+
+  if [[ -n "$CONTAINER_STARTED" && -n "$CONFIG_MTIME" ]]; then
+    CONTAINER_TS=$(python3 -c "
+from datetime import datetime, timezone
+import sys
+try:
+    s = '${CONTAINER_STARTED}'.replace('Z','+00:00')
+    print(datetime.fromisoformat(s).timestamp())
+except Exception:
+    print(0)
+" 2>/dev/null || echo "0")
+
+    NEEDS_MCP=$(python3 -c "print('yes' if ${CONTAINER_TS} > ${CONFIG_MTIME} else 'no')" 2>/dev/null || echo "no")
+    if [[ "$NEEDS_MCP" == "yes" ]]; then
+      # Container restarted since last config write — SSE session is stale.
+      # Output systemMessage so Claude surfaces the /mcp step immediately.
+      printf '{"systemMessage":"⚠️  Engram container restarted since last session.\\nRun /mcp in Claude Code to reconnect memory — this is the only step needed."}'
+      exit 0
+    fi
+  fi
+
+  # Record session start and check for degraded state (#404)
+  _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  update_state "last_session_start" "\"${_now}\"" 2>/dev/null || true
+  increment_state "sessions_since_last_flush" 2>/dev/null || true
+
+  # Emit degraded-state systemMessage if thresholds exceeded
+  _degraded=$(python3 - "$STATE_FILE" 2>/dev/null <<'PYEOF'
+import json, sys
+try:
+    s = json.load(open(sys.argv[1]))
+    msgs = []
+    fc = int(s.get("fallback_entry_count") or 0)
+    sf = int(s.get("sessions_since_last_flush") or 0)
+    af = int(s.get("consecutive_auth_failures") or 0)
+    if fc > 10:
+        msgs.append(f"{fc} entries queued in fallback.md")
+    if sf > 2:
+        msgs.append(f"no successful flush in {sf} sessions")
+    if af > 0:
+        msgs.append(f"{af} consecutive auth failure(s)")
+    if msgs:
+        detail = " | ".join(msgs)
+        print(f'{{"systemMessage":"⚠️  Engram memory is degraded: {detail}.\\nRun: engram-flush --force  or restart Engram to recover."}}')
+except Exception:
+    pass
+PYEOF
+  )
+  if [[ -n "$_degraded" ]]; then
+    printf '%s' "$_degraded"
+  else
+    echo "✅ Engram: MCP authenticated and ready"
+  fi
+else
+  # Phase 1 timing (#396): auth probe completed (failure path).
+  timing_mark_response_received 2>/dev/null || true
+  # Recovery path (#615, #616): cached token failed — try fallback key sources.
+  # Priority: ~/.config/engram/api_key (Infisical backup) > .env (docker default).
+  # /starter injects the real key from Infisical at runtime; .env may diverge.
+  ENV_KEY=""
+  if [[ -f "$HOME/.config/engram/api_key" ]]; then
+    ENV_KEY=$(cat "$HOME/.config/engram/api_key" | tr -d '[:space:]')
+  fi
+  if [[ -z "$ENV_KEY" ]]; then
+    ENV_KEY=$(grep '^ENGRAM_API_KEY=' "$ENGRAM_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '[:space:]')
+  fi
+  ENV_RECOVERED=false
+  if [[ -n "$ENV_KEY" ]]; then
+    ENV_STATUS=$(curl -so /dev/null -w "%{http_code}" --max-time 5 \
+      -H "Authorization: Bearer ${ENV_KEY}" \
+      -H "Content-Type: application/json" \
+      -X POST "http://127.0.0.1:${PORT}/quick-recall" \
+      -d '{"query":"auth-check","project":"global","limit":1}' 2>/dev/null || echo "000")
+    if [[ "$ENV_STATUS" != "401" && "$ENV_STATUS" != "000" ]]; then
+      TOKEN="$ENV_KEY"
+      _write_token "$HOME/.claude/mcp_servers.json"
+      _write_token "$HOME/.claude.json"
+      ENV_RECOVERED=true
+    fi
+  fi
+
+  if [[ "$ENV_RECOVERED" == "true" ]]; then
+    echo "✅ Engram: recovered from .env key — token updated in MCP config"
+    update_state "last_session_start" "\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" 2>/dev/null || true
+    update_state "consecutive_auth_failures" "0" 2>/dev/null || true
+  else
+    echo "❌ Engram: MCP auth failed — token written but Claude Code MCP connection is stale"
+    echo ""
+    echo "   To reconnect, run these two steps:"
+    echo "   1.  cd ~/projects/engram-go && make restart && make setup"
+    echo "   2.  Type /mcp in Claude Code to reconnect"
+    echo ""
+    echo "   Memory recall is DISABLED this session until reconnected."
+    # Exit 0 — don't block the session, but make the error impossible to miss
+  fi
+fi

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -46,11 +46,28 @@ fi
 echo "Installing instinct hooks..."
 
 # 1. Copy hook scripts
-mkdir -p "$HOOKS_DEST"
+mkdir -p "$HOOKS_DEST" "$HOOKS_DEST/lib"
 cp "$HOOKS_SRC/pre-tool-use.sh"  "$HOOKS_DEST/instinct-pre-tool-use.sh"
 cp "$HOOKS_SRC/post-tool-use.sh" "$HOOKS_DEST/instinct-post-tool-use.sh"
 chmod +x "$HOOKS_DEST/instinct-pre-tool-use.sh" "$HOOKS_DEST/instinct-post-tool-use.sh"
 echo "  Copied hooks to $HOOKS_DEST"
+
+# 1b. Install Phase 1 timing-v2 library (#396) and instrumented engram hooks.
+# These are measurement-only; they source timing-v2.sh and emit one TSV row per
+# invocation to ~/.claude/hook-timings-v2.tsv. Safe no-op if Engram is absent.
+if [ -f "$HOOKS_SRC/lib/timing-v2.sh" ]; then
+    cp "$HOOKS_SRC/lib/timing-v2.sh" "$HOOKS_DEST/lib/timing-v2.sh"
+    echo "  Installed timing-v2.sh (Phase 1 measurement, #396)"
+fi
+if [ -d "$HOOKS_SRC/engram" ]; then
+    for f in "$HOOKS_SRC/engram"/*.sh; do
+        [ -f "$f" ] || continue
+        base=$(basename "$f")
+        cp "$f" "$HOOKS_DEST/$base"
+        chmod +x "$HOOKS_DEST/$base"
+    done
+    echo "  Installed engram hooks with timing-v2 instrumentation"
+fi
 
 # 2. Patch settings.json (idempotent via Python)
 python3 - <<PYEOF

--- a/hooks/lib/timing-v2.sh
+++ b/hooks/lib/timing-v2.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# timing-v2.sh — per-stage hook timing library for engram hooks (Phase 1, #396).
+#
+# Source this file at the TOP of any engram hook script:
+#   . "$HOME/.claude/hooks/lib/timing-v2.sh" 2>/dev/null || true
+#
+# Then call these functions at each major checkpoint:
+#   timing_mark_auth_resolved
+#   timing_mark_mcp_connected
+#   timing_mark_request_sent
+#   timing_mark_response_received
+#
+# On EXIT the hook emits one TSV row to HOOK_TIMING_V2_LOG
+# (default: ~/.claude/hook-timings-v2.tsv).
+#
+# TSV schema (tab-separated, matches Go timing.go):
+#   iso_ts  hook_name  exec_start_ms  auth_resolved_ms  mcp_connected_ms
+#   request_sent_ms  response_received_ms  exit_ms  exit_code  pid
+#
+# All *_ms fields are millisecond offsets from exec_start_ms (== 0 for that
+# column). exec_start_ms is the absolute epoch-ms of process start.
+# Unreached stages emit an empty field, not zero, so consumers can
+# distinguish "not reached" from "reached at time 0".
+#
+# Safe: all code is wrapped in { } 2>/dev/null so a buggy bash version or
+# missing `date` never propagates an error into the sourcing hook.
+#
+# Reference: docs/design/396-phase1-measurement.md
+
+{
+  # nanosecond-precision monotonic start time
+  _tv2_t0_ns=$(date +%s%N 2>/dev/null) || _tv2_t0_ns=
+  _tv2_t0_ms=$(( ${_tv2_t0_ns:-0} / 1000000 ))
+
+  _tv2_hook=$(basename "${BASH_SOURCE[1]:-${BASH_SOURCE[0]:-$0}}" 2>/dev/null) || _tv2_hook=unknown
+  _tv2_log="${HOOK_TIMING_V2_LOG:-$HOME/.claude/hook-timings-v2.tsv}"
+
+  # Stage timestamps (ns); empty = not reached
+  _tv2_auth_ns=
+  _tv2_mcp_ns=
+  _tv2_req_ns=
+  _tv2_resp_ns=
+} 2>/dev/null
+
+# ── Stage mark helpers ─────────────────────────────────────────────────────────
+
+timing_mark_auth_resolved()     { _tv2_auth_ns=$(date +%s%N 2>/dev/null) || true; }
+timing_mark_mcp_connected()     { _tv2_mcp_ns=$(date +%s%N 2>/dev/null)  || true; }
+timing_mark_request_sent()      { _tv2_req_ns=$(date +%s%N 2>/dev/null)   || true; }
+timing_mark_response_received() { _tv2_resp_ns=$(date +%s%N 2>/dev/null)  || true; }
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+# _tv2_ms_offset <ns_var_value>
+# Prints the millisecond offset from _tv2_t0_ns, or empty if arg is blank.
+_tv2_ms_offset() {
+  local ns="$1"
+  if [[ -z "$ns" || -z "$_tv2_t0_ns" ]]; then
+    printf ''
+    return
+  fi
+  printf '%s' "$(( (ns - _tv2_t0_ns) / 1000000 ))"
+}
+
+# _tv2_write_header <path>
+# Writes the TSV header to <path>. Called only when the file does not yet exist.
+_tv2_write_header() {
+  printf '%s\n' \
+    "iso_ts	hook_name	exec_start_ms	auth_resolved_ms	mcp_connected_ms	request_sent_ms	response_received_ms	exit_ms	exit_code	pid" \
+    >> "$1" 2>/dev/null || true
+}
+
+# ── EXIT trap ─────────────────────────────────────────────────────────────────
+
+_tv2_on_exit() {
+  local _exit_code=$?
+  {
+    local _t_exit_ns
+    _t_exit_ns=$(date +%s%N 2>/dev/null) || _t_exit_ns=
+
+    local _iso_ts
+    _iso_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || _iso_ts=unknown
+
+    local _auth_ms _mcp_ms _req_ms _resp_ms _exit_ms
+    _auth_ms=$(_tv2_ms_offset "${_tv2_auth_ns:-}")
+    _mcp_ms=$(_tv2_ms_offset "${_tv2_mcp_ns:-}")
+    _req_ms=$(_tv2_ms_offset "${_tv2_req_ns:-}")
+    _resp_ms=$(_tv2_ms_offset "${_tv2_resp_ns:-}")
+    _exit_ms=$(_tv2_ms_offset "${_t_exit_ns:-}")
+
+    # Create file + header if needed
+    if [[ ! -f "$_tv2_log" ]]; then
+      _tv2_write_header "$_tv2_log"
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$_iso_ts" \
+      "$_tv2_hook" \
+      "${_tv2_t0_ms:-}" \
+      "$_auth_ms" \
+      "$_mcp_ms" \
+      "$_req_ms" \
+      "$_resp_ms" \
+      "$_exit_ms" \
+      "$_exit_code" \
+      "$$" \
+      >> "$_tv2_log" 2>/dev/null || true
+  } 2>/dev/null
+  return "$_exit_code"
+}
+
+trap _tv2_on_exit EXIT 2>/dev/null || true


### PR DESCRIPTION
## Summary

Per opus-advisor (Wave 4F). Phase 1 measurement only.

- `cmd/instinct/timing.go`: `StageTimes` struct captures timestamps at each major pipeline checkpoint; `appendTimingRow()` writes to `hook-timings-v2.tsv` on exit (always, including error paths). Zero runtime overhead on warm runs.
- `cmd/instinct/main.go`: timing wired into `run()`; `exitCode` propagated through all early-return paths; defer flushes TSV row.
- `hooks/engram/`: 5 hook scripts (auth-check, precheck, session-end, session-recall, token-refresh)
- `hooks/lib/timing-v2.sh`: shared timing helper for shell-side hooks
- `hooks/install.sh`: updated to install new scripts
- `docs/design/396-phase1-measurement.md`: design doc covering Phase 1 scope, TSV schema, and Phase 2/3 decision criteria

**Scope boundary:** NO daemon, NO session reuse, NO Prometheus. Those are Phase 2/3, contingent on 1 week of telemetry from this instrumentation per the design doc.

## Test plan

- [x] `go build ./cmd/instinct/...` — clean
- [x] `go test -race ./cmd/instinct/...` — all green
- [x] `go vet ./cmd/instinct/...` — clean
- [x] `golangci-lint run ./cmd/instinct/...` — 0 issues
- [ ] Deploy hook update (`hooks/install.sh`) and verify `hook-timings-v2.tsv` is written after an instinct run
- [ ] Confirm `exitCode=0` on success and `exitCode=1` on load error in the TSV row

🤖 Generated with [Claude Code](https://claude.com/claude-code)