### PR TITLE
fix(lme): route --scratch-ttl through /quick-store REST body (#837)

### DIFF
--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -11,42 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
-
-// ttlStamper writes project_ttl rows during ingest (#754). It is a tiny
-// interface so the ingest worker can be unit-tested with a fake.
-type ttlStamper interface {
-	SetProjectTTL(ctx context.Context, project string, createdAt time.Time, expiresAt *time.Time) error
-}
 
 func runIngest(cfg *Config) {
 	items := loadItems(cfg.DataFile)
 	ckptPath := filepath.Join(cfg.OutDir, "checkpoint-ingest.jsonl")
-
-	// #754: if a scratch TTL is in effect and a DSN is configured, open a
-	// PostgresBackend so each per-question project gets a project_ttl row
-	// stamped at first-store time. Failure to connect downgrades to a WARN
-	// rather than failing ingest — a missing TTL row makes the project durable
-	// (the operator backfill query is documented in the migration header).
-	var stamper ttlStamper
-	if cfg.ScratchTTL > 0 && cfg.DatabaseURL != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		backend, err := db.NewPostgresBackend(ctx, "_lme_ingest", cfg.DatabaseURL)
-		if err != nil {
-			// Log without the raw DSN/error (which may embed credentials) to
-			// satisfy CodeQL CWE-312. Use redactURL on the URL portion only.
-			log.Printf("ingest: WARN: cannot open Postgres for TTL stamping (dsn=%s); projects will be durable",
-				redactURL(cfg.DatabaseURL))
-		} else {
-			defer backend.Close()
-			stamper = backend
-		}
-	} else if cfg.ScratchTTL > 0 && cfg.DatabaseURL == "" {
-		log.Printf("ingest: WARN: --scratch-ttl set but no --database-url; projects will be durable")
-	}
 
 	skip, err := longmemeval.ReadSkipSet(ckptPath)
 	if err != nil {
@@ -75,7 +45,7 @@ func runIngest(cfg *Config) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ingestWorker(cfg, stamper, work, ckptCh)
+			ingestWorker(cfg, work, ckptCh)
 		}()
 	}
 	wg.Wait()
@@ -85,27 +55,15 @@ func runIngest(cfg *Config) {
 	log.Printf("ingest: complete")
 }
 
-func ingestWorker(cfg *Config, stamper ttlStamper, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
+func ingestWorker(cfg *Config, work <-chan longmemeval.Item, out chan<- longmemeval.IngestEntry) {
 	ctx := context.Background()
 	restClient := longmemeval.NewRestClient(cfg.ServerURL, cfg.APIKey)
 	for item := range work {
 		entry := ingestOne(ctx, cfg, restClient, item)
-		// #754: stamp TTL once per successful project so the prune sweep can
-		// reclaim it later. Best-effort: stamping failure is logged but does
-		// not flip ingest status — the memories landed, only the metadata is
-		// missing, and an operator backfill exists.
-		if entry.Status == "done" && stamper != nil && cfg.ScratchTTL > 0 {
-			now := time.Now().UTC()
-			exp := now.Add(cfg.ScratchTTL)
-			if err := stamper.SetProjectTTL(ctx, entry.Project, now, &exp); err != nil {
-				log.Printf("ingest [%s] WARN: set TTL: %v", item.QuestionID, err)
-			}
-		}
 		out <- entry
 		log.Printf("ingest [%s] project=%s sessions=%d status=%s error=%q", item.QuestionID, entry.Project, entry.SessionCount, entry.Status, entry.Error)
 	}
 }
-
 
 func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestClient, item longmemeval.Item) (entry longmemeval.IngestEntry) {
 	defer func() {
@@ -119,6 +77,14 @@ func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestCli
 	}()
 
 	project := projectName(cfg.RunID, item.QuestionID)
+
+	// #837: compute expiresAt once per question. Passed to every QuickStore call;
+	// SetProjectTTL is idempotent (ON CONFLICT DO UPDATE) so repeated upserts are safe.
+	var expiresAt *time.Time
+	if cfg.ScratchTTL > 0 {
+		t := time.Now().UTC().Add(cfg.ScratchTTL)
+		expiresAt = &t
+	}
 
 	// Collect non-empty sessions with their IDs.
 	type sessionEntry struct {
@@ -149,7 +115,7 @@ func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestCli
 
 	memoryMap := make(map[string]string, len(sessions))
 	for i, s := range sessions {
-		id, err := restClient.QuickStore(ctx, project, s.item.Content, s.item.Tags, nil)
+		id, err := restClient.QuickStore(ctx, project, s.item.Content, s.item.Tags, expiresAt)
 		if err != nil {
 			return longmemeval.IngestEntry{
 				QuestionID: item.QuestionID,

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -149,7 +149,7 @@ func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestCli
 
 	memoryMap := make(map[string]string, len(sessions))
 	for i, s := range sessions {
-		id, err := restClient.QuickStore(ctx, project, s.item.Content, s.item.Tags)
+		id, err := restClient.QuickStore(ctx, project, s.item.Content, s.item.Tags, nil)
 		if err != nil {
 			return longmemeval.IngestEntry{
 				QuestionID: item.QuestionID,

--- a/cmd/longmemeval/ingest_test.go
+++ b/cmd/longmemeval/ingest_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
@@ -115,5 +116,78 @@ func TestIngestOne_EmptySessionsSkipped(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("expected 1 REST call for 1 non-empty session, got %d", calls)
+	}
+}
+
+// TestIngestOne_ScratchTTL_PassesExpiresAt verifies that when ScratchTTL > 0,
+// ingestOne passes a non-nil expires_at in the QuickStore request body.
+func TestIngestOne_ScratchTTL_PassesExpiresAt(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "m-ttl"})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL, "")
+	cfg := &Config{RunID: "run-ttl", Workers: 1, ScratchTTL: 168 * time.Hour}
+	item := longmemeval.Item{
+		QuestionID:         "q-ttl",
+		HaystackSessionIDs: []string{"sid-1"},
+		HaystackSessions: [][]longmemeval.Turn{
+			{{Role: "user", Content: "session content"}},
+		},
+	}
+
+	before := time.Now().UTC()
+	entry := ingestOne(t.Context(), cfg, rc, item)
+	after := time.Now().UTC()
+
+	if entry.Status != "done" {
+		t.Fatalf("expected done, got %s: %s", entry.Status, entry.Error)
+	}
+
+	raw, ok := gotBody["expires_at"]
+	if !ok {
+		t.Fatal("expires_at missing from QuickStore request body")
+	}
+	parsed, err := time.Parse(time.RFC3339, raw.(string))
+	if err != nil {
+		t.Fatalf("expires_at is not RFC3339: %v", err)
+	}
+	// expires_at is serialized as RFC3339 (second precision), so truncate to seconds for comparison.
+	expectedMin := before.Add(168 * time.Hour).Truncate(time.Second)
+	expectedMax := after.Add(168 * time.Hour).Add(time.Second) // +1s to account for truncation
+	if parsed.Before(expectedMin) || parsed.After(expectedMax) {
+		t.Errorf("expires_at %v outside expected range [%v, %v]", parsed, expectedMin, expectedMax)
+	}
+}
+
+// TestIngestOne_NoScratchTTL_OmitsExpiresAt verifies that when ScratchTTL == 0,
+// expires_at is absent from the QuickStore request body.
+func TestIngestOne_NoScratchTTL_OmitsExpiresAt(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "m-durable"})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL, "")
+	cfg := &Config{RunID: "run-durable", Workers: 1, ScratchTTL: 0}
+	item := longmemeval.Item{
+		QuestionID:         "q-durable",
+		HaystackSessionIDs: []string{"sid-1"},
+		HaystackSessions: [][]longmemeval.Turn{
+			{{Role: "user", Content: "durable content"}},
+		},
+	}
+
+	entry := ingestOne(t.Context(), cfg, rc, item)
+	if entry.Status != "done" {
+		t.Fatalf("expected done, got %s: %s", entry.Status, entry.Error)
+	}
+	if _, ok := gotBody["expires_at"]; ok {
+		t.Error("expires_at must be absent from QuickStore body when ScratchTTL is 0")
 	}
 }

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -67,14 +67,11 @@ type Config struct {
 	ExclusiveBackend bool   // guard the vLLM endpoint with a PID-liveness lockfile (default true)
 	BackendLockDir   string // override lock file directory (default: $XDG_RUNTIME_DIR/lme or /tmp/lme)
 
-	// #754: scratch TTL. Applied at ingest time to project_ttl.expires_at so
-	// the `prune` subcommand can sweep expired lme-* projects later. Zero
-	// means "use the package default (168h / 7 days)".
+	// #754/#837: scratch TTL. Applied at ingest time via the /quick-store
+	// expires_at field so the `prune` subcommand can sweep expired lme-*
+	// projects later. Zero means durable (no expiry).
 	ScratchTTL time.Duration
 
-	// DatabaseURL is consulted by ingest to write project_ttl rows. Falls back
-	// to env DATABASE_URL.
-	DatabaseURL string
 }
 
 func main() {
@@ -175,7 +172,6 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	// #754: TTL stamped on per-question scratch projects at ingest time. The
 	// prune subcommand sweeps anything older than this.
 	fs.DurationVar(&cfg.ScratchTTL, "scratch-ttl", defaultScratchTTL(), "TTL applied to ephemeral lme-* projects at ingest time (e.g. 168h = 7 days); 0 = durable, no expiry")
-	fs.StringVar(&cfg.DatabaseURL, "database-url", envOr("DATABASE_URL", ""), "PostgreSQL DSN; required when --scratch-ttl > 0 so ingest can write project_ttl rows")
 
 	// prune has its own flag set and early return — it does not share the
 	// ingest/run/score data-file workflow. See cmd/longmemeval/prune.go (#754).

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -370,18 +370,20 @@ func NewRestClient(baseURL, token string) *RestClient {
 }
 
 // QuickStore stores a single memory via POST /quick-store and returns its ID.
-// Retries once on 5xx (server-side pool init can transiently time out when
-// many projects are created concurrently; a brief pause and retry succeeds
-// because the pool entry is warm on the second attempt).
-func (r *RestClient) QuickStore(ctx context.Context, project, content string, tags []string) (string, error) {
+// When expiresAt is non-nil, the server stamps project_ttl so the project can
+// be swept later by lme prune. Retries on 429 and 5xx with exponential backoff.
+func (r *RestClient) QuickStore(ctx context.Context, project, content string, tags []string, expiresAt *time.Time) (string, error) {
 	body := map[string]any{
 		"content": content,
 		"project": project,
 		"tags":    tags,
 	}
+	if expiresAt != nil {
+		body["expires_at"] = expiresAt.UTC().Format(time.RFC3339)
+	}
 	data, err := json.Marshal(body)
 	if err != nil {
-		return "", fmt.Errorf("marshal QuickStore body: %w", err) // #710
+		return "", fmt.Errorf("marshal QuickStore body: %w", err)
 	}
 
 	var lastErr error

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -55,7 +55,7 @@ func TestRestClient_QuickStore_HappyPath(t *testing.T) {
 
 	rc := longmemeval.NewRestClient(srv.URL, "")
 	ctx := context.Background()
-	id, err := rc.QuickStore(ctx, "proj-1", "content here", []string{"tag1"})
+	id, err := rc.QuickStore(ctx, "proj-1", "content here", []string{"tag1"}, nil)
 	if err != nil {
 		t.Fatalf("QuickStore: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestRestClient_QuickStore_RateLimitRetry(t *testing.T) {
 	// Use a short-timeout context so we don't wait real exponential backoff.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	id, err := rc.QuickStore(ctx, "proj-x", "hello", nil)
+	id, err := rc.QuickStore(ctx, "proj-x", "hello", nil, nil)
 	if err != nil {
 		t.Fatalf("QuickStore after retry: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestRestClient_QuickStore_ServerError(t *testing.T) {
 	rc := longmemeval.NewRestClient(srv.URL, "")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	id, err := rc.QuickStore(ctx, "p", "c", nil)
+	id, err := rc.QuickStore(ctx, "p", "c", nil, nil)
 	if err != nil {
 		t.Fatalf("QuickStore after 500+retry: %v", err)
 	}
@@ -138,6 +138,71 @@ func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 	}
 	if len(ids) != 2 || ids[0] != "id-1" {
 		t.Errorf("ids = %v, want [id-1, id-2]", ids)
+	}
+}
+
+// TestRestClient_QuickStore_ExpiresAt_Set verifies that a non-nil expiresAt is
+// serialized as "expires_at" (RFC3339) in the POST body.
+func TestRestClient_QuickStore_ExpiresAt_Set(t *testing.T) {
+	future := time.Now().UTC().Add(72 * time.Hour)
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "mem-ttl"})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL, "")
+	id, err := rc.QuickStore(context.Background(), "proj-ttl", "content", nil, &future)
+	if err != nil {
+		t.Fatalf("QuickStore: %v", err)
+	}
+	if id != "mem-ttl" {
+		t.Errorf("id = %q, want mem-ttl", id)
+	}
+	raw, ok := gotBody["expires_at"]
+	if !ok {
+		t.Fatal("expires_at field missing from request body")
+	}
+	parsed, err := time.Parse(time.RFC3339, raw.(string))
+	if err != nil {
+		t.Fatalf("expires_at is not RFC3339: %v", err)
+	}
+	delta := parsed.Sub(future)
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > 2*time.Second {
+		t.Errorf("expires_at delta = %v, want < 2s", delta)
+	}
+}
+
+// TestRestClient_QuickStore_ExpiresAt_Nil verifies that a nil expiresAt does NOT
+// include an "expires_at" key in the POST body (not null — fully absent).
+func TestRestClient_QuickStore_ExpiresAt_Nil(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "mem-no-ttl"})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL, "")
+	id, err := rc.QuickStore(context.Background(), "proj-no-ttl", "content", nil, nil)
+	if err != nil {
+		t.Fatalf("QuickStore: %v", err)
+	}
+	if id != "mem-no-ttl" {
+		t.Errorf("id = %q, want mem-no-ttl", id)
+	}
+	if _, ok := gotBody["expires_at"]; ok {
+		t.Error("expires_at must be absent from request body when expiresAt is nil")
 	}
 }
 

--- a/internal/mcp/quick_store_handler_test.go
+++ b/internal/mcp/quick_store_handler_test.go
@@ -8,10 +8,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/search"
@@ -250,4 +253,154 @@ func TestQuickStoreHandler_InvalidProjectName(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, w.Code)
 		})
 	}
+}
+
+// ttlCaptureBackend embeds storeBackend and records SetProjectTTL calls.
+type ttlCaptureBackend struct {
+	storeBackend
+	mu              sync.Mutex
+	capturedProject string
+	capturedExpires *time.Time
+	returnErr       error
+}
+
+var _ db.Backend = (*ttlCaptureBackend)(nil)
+
+func (b *ttlCaptureBackend) SetProjectTTL(_ context.Context, project string, _ time.Time, expiresAt *time.Time) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.capturedProject = project
+	if expiresAt != nil {
+		t := *expiresAt
+		b.capturedExpires = &t
+	}
+	return b.returnErr
+}
+
+// newQuickStoreServerWithBackend builds a *Server that uses the given backend,
+// letting tests observe SetProjectTTL calls.
+func newQuickStoreServerWithBackend(t *testing.T, backend db.Backend) *Server {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, backend, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	pool := NewEnginePool(factory)
+	cfg := testConfig()
+	return &Server{pool: pool, cfg: cfg, embedderHealth: cfg.EmbedderHealth}
+}
+
+// TestQuickStoreHandler_ExpiresAt_FutureTimestamp verifies that a POST with a
+// future expires_at stores the memory and calls SetProjectTTL with the given time.
+func TestQuickStoreHandler_ExpiresAt_FutureTimestamp(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	future := time.Now().UTC().Add(48 * time.Hour)
+	body, _ := json.Marshal(map[string]any{
+		"content":    "lme session content",
+		"project":    "lme-run1-q001",
+		"tags":       []string{"lme"},
+		"expires_at": future.Format(time.RFC3339),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, true, resp["ok"])
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, "lme-run1-q001", backend.capturedProject, "SetProjectTTL should be called with the correct project")
+	require.NotNil(t, backend.capturedExpires, "SetProjectTTL should receive a non-nil expiresAt")
+	delta := backend.capturedExpires.Sub(future)
+	if delta < 0 {
+		delta = -delta
+	}
+	require.Less(t, delta, 2*time.Second, "captured expiresAt should be within 2s of the requested value")
+}
+
+// TestQuickStoreHandler_ExpiresAt_PastTimestamp verifies that a past expires_at
+// is rejected with 400 before the store is written.
+func TestQuickStoreHandler_ExpiresAt_PastTimestamp(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	body, _ := json.Marshal(map[string]any{
+		"content":    "lme session content",
+		"project":    "lme-run1-q001",
+		"expires_at": past.Format(time.RFC3339),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called when expires_at is in the past")
+}
+
+// TestQuickStoreHandler_ExpiresAt_Absent verifies that omitting expires_at stores
+// the memory successfully without calling SetProjectTTL.
+func TestQuickStoreHandler_ExpiresAt_Absent(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	body, _ := json.Marshal(map[string]any{
+		"content": "ordinary memory",
+		"project": "global",
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called when expires_at is absent")
+}
+
+// TestQuickStoreHandler_ExpiresAt_TTLError verifies that a SetProjectTTL error
+// does not fail the store — the response is still 200 (best-effort semantics).
+func TestQuickStoreHandler_ExpiresAt_TTLError(t *testing.T) {
+	backend := &ttlCaptureBackend{returnErr: errors.New("simulated TTL write failure")}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	future := time.Now().UTC().Add(24 * time.Hour)
+	body, _ := json.Marshal(map[string]any{
+		"content":    "lme session content",
+		"project":    "lme-run1-q002",
+		"expires_at": future.Format(time.RFC3339),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	// Store must succeed even when TTL stamping fails.
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, true, resp["ok"])
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, "lme-run1-q002", backend.capturedProject, "SetProjectTTL must be called even when it returns an error")
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1558,10 +1558,11 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Content    string   `json:"content"`
-		Project    string   `json:"project"`
-		Tags       []string `json:"tags"`
-		Importance int      `json:"importance"`
+		Content    string     `json:"content"`
+		Project    string     `json:"project"`
+		Tags       []string   `json:"tags"`
+		Importance int        `json:"importance"`
+		ExpiresAt  *time.Time `json:"expires_at"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body")
@@ -1579,6 +1580,10 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := validateQuickStoreInput(body.Content, project, body.Tags, body.Importance); err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if body.ExpiresAt != nil && !body.ExpiresAt.After(time.Now()) {
+		writeJSONError(w, http.StatusBadRequest, "expires_at must be a future timestamp")
 		return
 	}
 
@@ -1628,6 +1633,16 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": id})
+
+	// #837: if expires_at was provided, stamp project_ttl via the engine pool.
+	// Best-effort: failure is logged but does not affect the store response.
+	if body.ExpiresAt != nil {
+		if h, poolErr := s.pool.Get(r.Context(), project); poolErr != nil {
+			slog.Warn("quick-store: pool.Get failed for SetProjectTTL", "project", project, "err", poolErr)
+		} else if ttlErr := h.Engine.Backend().SetProjectTTL(r.Context(), project, time.Now().UTC(), body.ExpiresAt); ttlErr != nil {
+			slog.Warn("quick-store: SetProjectTTL failed", "project", project, "err", ttlErr)
+		}
+	}
 }
 
 // handleQuickRecall is a sessionless REST endpoint that recalls memories by


### PR DESCRIPTION
## Summary

- Extends `POST /quick-store` body to accept optional `expires_at` (RFC3339)
- Server calls `SetProjectTTL` after a successful store when `expires_at` is present; failure is WARN-logged, not propagated
- `RestClient.QuickStore` gains `expiresAt *time.Time` final parameter; nil omits the field from the body
- `ingestOne` computes `now + ScratchTTL` and passes it to every `QuickStore` call when `ScratchTTL > 0`
- Removes `ttlStamper` interface, direct `db.NewPostgresBackend` block, `DatabaseURL` field, and `--database-url` flag entirely

Closes #837.

## Test plan

- `TestQuickStoreHandler_ExpiresAt_*` (4 tests) — server-side TTL stamping, past-timestamp rejection, absent field, error tolerance
- `TestRestClient_QuickStore_ExpiresAt_*` (2 tests) — body serialization with and without `expiresAt`
- `TestIngestOne_ScratchTTL_*` (2 tests) — `expires_at` present when TTL > 0, absent when TTL == 0
- Full suite `go test ./... -race` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)