### PR TITLE
docs(ops): warn about docker exec -i heredoc footgun; add psql-exec.sh (#646)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -175,6 +175,12 @@ docker exec engram-postgres psql -U engram -d engram -c "SELECT COUNT(*) FROM me
 curl -s http://localhost:8788/sse
 ```
 
+> ⚠️ **Heredoc stdin warning:** `docker exec` without `-i` silently discards
+> stdin — multi-statement heredocs appear to succeed (exit 0) but never run.
+> Use `docker exec -i ...` for inline SQL, or preferably use
+> `scripts/psql-exec.sh <file.sql>` which uses `docker cp` + `psql -f`
+> (unambiguous, no stdin). See issue #646.
+
 If the SSE endpoint returns nothing or hangs, check whether the Go container started correctly (`docker compose ps`) and whether PostgreSQL is accepting connections (`docker compose logs engram-postgres`). Most startup failures are PostgreSQL not finishing its initialization before the Go process tries to connect — restart with `docker compose restart engram-go-app` once PostgreSQL is ready.
 
 ---

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -437,6 +437,12 @@ application-level audit logging of mutations.
 
 For deeper investigation:
 
+> ⚠️ **Heredoc stdin warning:** `docker exec` without `-i` silently discards
+> stdin — multi-statement heredocs appear to succeed (exit 0) but never run.
+> Use `docker exec -i ...` for inline SQL, or preferably use
+> `scripts/psql-exec.sh <file.sql>` which uses `docker cp` + `psql -f`
+> (unambiguous, no stdin). See issue #646.
+
 ```bash
 # Top 10 slowest queries
 docker exec engram-postgres psql -U engram -d engram -c "

--- a/scripts/psql-exec.sh
+++ b/scripts/psql-exec.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# psql-exec.sh — safely run a SQL file against the engram-postgres container.
+#
+# WHY THIS SCRIPT EXISTS:
+# `docker exec ... psql <<'SQL' ... SQL` silently discards stdin without `-i`.
+# Rather than require operators to remember `-i`, this script uses the
+# unambiguous `docker cp` + `psql -f` pattern (issue #646).
+#
+# Usage: ./scripts/psql-exec.sh <path-to-file.sql> [container-name]
+
+set -euo pipefail
+
+SQL_FILE="${1:?Usage: psql-exec.sh <file.sql> [container]}"
+CONTAINER="${2:-engram-postgres}"
+
+if [[ ! -f "$SQL_FILE" ]]; then
+  echo "error: file not found: $SQL_FILE" >&2
+  exit 1
+fi
+
+REMOTE="/tmp/psql-exec-$$.sql"
+docker cp "$SQL_FILE" "$CONTAINER:$REMOTE"
+docker exec "$CONTAINER" psql -U engram -d engram -f "$REMOTE"
+docker exec "$CONTAINER" rm -f "$REMOTE"

--- a/scripts/test-psql-exec.sh
+++ b/scripts/test-psql-exec.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test-psql-exec.sh — TDD tests for psql-exec.sh (issue #646)
+#
+# Tests:
+#   1. psql-exec.sh exists and is executable
+#   2. psql-exec.sh uses the safe `docker cp` + `psql -f` pattern
+#   3. psql-exec.sh does NOT use bare heredoc piping (stdin without -i)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/psql-exec.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# Test 1: script exists and is executable
+if [[ -x "$TARGET" ]]; then
+  pass "psql-exec.sh exists and is executable"
+else
+  fail "psql-exec.sh does not exist or is not executable (expected: $TARGET)"
+fi
+
+# Test 2: uses docker cp (safe pattern)
+if grep -q "docker cp" "$TARGET" 2>/dev/null; then
+  pass "psql-exec.sh contains 'docker cp'"
+else
+  fail "psql-exec.sh is missing 'docker cp'"
+fi
+
+# Test 3: uses psql -f (safe pattern)
+if grep -q "psql -" "$TARGET" 2>/dev/null && grep -q "\-f" "$TARGET" 2>/dev/null; then
+  pass "psql-exec.sh contains 'psql -f' pattern"
+else
+  fail "psql-exec.sh does not use 'psql -f'"
+fi
+
+# Test 4: does NOT pipe stdin without -i (heredoc footgun)
+# A bare `docker exec <container> psql` with a heredoc but no -i is the bad pattern.
+# We check that if the script calls docker exec with psql, it either uses -f or -i.
+if grep -E "docker exec [^|]*psql" "$TARGET" 2>/dev/null | grep -qv "\-f\|\-i"; then
+  fail "psql-exec.sh has a bare 'docker exec ... psql' without -f or -i (heredoc footgun)"
+else
+  pass "psql-exec.sh does not contain bare heredoc-piping pattern"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/psql-exec.sh` — safe wrapper using `docker cp` + `psql -f` to avoid stdin discarding
- Adds heredoc warning callouts to `docs/operations.md` and `docs/runbook.md`
- TDD: `scripts/test-psql-exec.sh` verifies helper exists and uses safe pattern

Closes #646.
🤖 Generated with [Claude Code](https://claude.com/claude-code)