### PR TITLE
chore: rename LITELLM_URL → ENGRAM_ROUTER_URL; keep deprecated fallback — closes #636

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -84,11 +84,11 @@ func run() error {
 
 	versionFlag := fs.Bool("version", false, "print version and exit")
 	databaseURL := fs.String("database-url", envOr("DATABASE_URL", ""), "PostgreSQL DSN (required)")
-	litellmURL := fs.String("litellm-url", envOr("LITELLM_URL", "http://litellm:4000"), "LiteLLM base URL (generation)")
+	routerURL := fs.String("litellm-url", routerURLFromEnv("http://litellm:4000", slog.Default()), "Router base URL (generation); env: ENGRAM_ROUTER_URL (LITELLM_URL accepted as deprecated fallback)")
 	litellmAPIKey := envOr("LITELLM_API_KEY", "")
-	// ENGRAM_EMBED_URL overrides LITELLM_URL for embeddings only — use when the
+	// ENGRAM_EMBED_URL overrides ENGRAM_ROUTER_URL for embeddings only — use when the
 	// embed backend is different from the generation backend (e.g. direct llama.cpp).
-	embedURL := envOr("ENGRAM_EMBED_URL", envOr("LITELLM_URL", "http://litellm:4000"))
+	embedURL := envOr("ENGRAM_EMBED_URL", routerURLFromEnv("http://litellm:4000", slog.Default()))
 	embedModel := fs.String("model", envOr("ENGRAM_EMBED_MODEL", envOr("ENGRAM_OLLAMA_MODEL", "")), "Embedding model (required; set ENGRAM_EMBED_MODEL or --model)")
 	embedDims := fs.Int("embed-dims", envInt("ENGRAM_EMBED_DIMENSIONS", 0), "MRL truncation target for embedding model (0 = native output)")
 	summarizeModel := fs.String("summarize-model", envOr("ENGRAM_SUMMARIZE_MODEL", "llama3.2"), "Summarization model")
@@ -231,7 +231,7 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	// LITELLM_URL and ENGRAM_EMBED_URL come from operator config (env vars at process start),
+	// ENGRAM_ROUTER_URL and ENGRAM_EMBED_URL come from operator config (env vars at process start),
 	// not from user input. Operators self-host on private networks by design — Docker bridges,
 	// LAN DNS, RFC1918 — so blocking private IPs at startup is a category error: it asserts a
 	// SaaS threat model on a homelab deployment.
@@ -241,16 +241,16 @@ func run() error {
 	//
 	// We still parse + reject the URL if it isn't a valid http(s) URL — that's not SSRF, that's
 	// basic config sanity.
-	parsedLiteLLMURL, err := url.ParseRequestURI(*litellmURL)
-	if err != nil || (parsedLiteLLMURL.Scheme != "http" && parsedLiteLLMURL.Scheme != "https") {
-		return fmt.Errorf("invalid --litellm-url %q: must be an http:// or https:// URL", *litellmURL)
+	parsedRouterURL, err := url.ParseRequestURI(*routerURL)
+	if err != nil || (parsedRouterURL.Scheme != "http" && parsedRouterURL.Scheme != "https") {
+		return fmt.Errorf("invalid --litellm-url %q: must be an http:// or https:// URL", *routerURL)
 	}
 	if parsedEmbedURL, err := url.ParseRequestURI(embedURL); err != nil || (parsedEmbedURL.Scheme != "http" && parsedEmbedURL.Scheme != "https") {
 		return fmt.Errorf("invalid ENGRAM_EMBED_URL %q: must be an http:// or https:// URL", embedURL)
 	}
-	safeLiteLLMURL := *parsedLiteLLMURL
-	safeLiteLLMURL.User = nil
-	slog.Info("connecting to LiteLLM", "url", safeLiteLLMURL.String(), "model", *embedModel)
+	safeRouterURL := *parsedRouterURL
+	safeRouterURL.User = nil
+	slog.Info("connecting to router", "url", safeRouterURL.String(), "model", *embedModel)
 
 	// E6: startup probe is non-fatal. Server starts in degraded mode when
 	// LiteLLM is unavailable; /health reports embed:degraded with HTTP 200.
@@ -281,7 +281,7 @@ func run() error {
 	}
 
 	dsn := *databaseURL
-	litellmURLVal := *litellmURL
+	routerURLVal := *routerURL
 	sumModel := *summarizeModel
 	sumEnabled := *summarizeEnabled
 
@@ -349,7 +349,7 @@ func run() error {
 		if err != nil {
 			return nil, fmt.Errorf("postgres backend for project %q: %w", project, err)
 		}
-		engine := search.New(serverCtx, backend, embedClient, project, litellmURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval, *embedDims)
+		engine := search.New(serverCtx, backend, embedClient, project, routerURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval, *embedDims)
 		engine.SetGlobalReembedder(globalReembedder)
 		return &internalmcp.EngineHandle{Engine: engine}, nil
 	}
@@ -378,7 +378,7 @@ func run() error {
 	sessionRehydrateWindow := envDuration("ENGRAM_SESSION_REHYDRATE_WINDOW", 0)
 
 	cfg := internalmcp.Config{
-		LiteLLMURL:               *litellmURL,
+		RouterURL:                *routerURL,
 		EmbedModel:               *embedModel,
 		SummarizeModel:           *summarizeModel,
 		SummarizeEnabled:         *summarizeEnabled,
@@ -599,6 +599,20 @@ func checkBindInterlock(host string, rateLimitDisable bool) error {
 		return nil
 	}
 	return fmt.Errorf("refusing to start: ENGRAM_RATE_LIMIT_DISABLE=true is forbidden when bound to non-loopback host %q (#666). Set ENGRAM_HOST=127.0.0.1 or unset ENGRAM_RATE_LIMIT_DISABLE", host)
+}
+
+// routerURLFromEnv resolves the router URL from environment variables.
+// Priority: ENGRAM_ROUTER_URL > LITELLM_URL (deprecated) > def.
+// When LITELLM_URL is used as a fallback, a deprecation warning is logged.
+func routerURLFromEnv(def string, logger *slog.Logger) string {
+	if v := os.Getenv("ENGRAM_ROUTER_URL"); v != "" {
+		return v
+	}
+	if legacy := os.Getenv("LITELLM_URL"); legacy != "" {
+		logger.Warn("LITELLM_URL is deprecated; set ENGRAM_ROUTER_URL instead")
+		return legacy
+	}
+	return def
 }
 
 func envOr(key, def string) string {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"fmt"
 	"net/http"
@@ -10,6 +12,51 @@ import (
 
 	"github.com/petersimmons1972/engram/internal/netutil"
 )
+
+// TestRouterURLFallback verifies the deprecation fallback:
+// - ENGRAM_ROUTER_URL takes priority when set.
+// - When only LITELLM_URL is set, its value is used and a deprecation warning is emitted.
+// - When neither is set, the default is returned.
+func TestRouterURLFallback(t *testing.T) {
+	t.Run("ENGRAM_ROUTER_URL wins when both set", func(t *testing.T) {
+		t.Setenv("ENGRAM_ROUTER_URL", "http://router:4000")
+		t.Setenv("LITELLM_URL", "http://legacy:4000")
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		got := routerURLFromEnv("http://litellm:4000", logger)
+		if got != "http://router:4000" {
+			t.Errorf("routerURLFromEnv = %q, want %q", got, "http://router:4000")
+		}
+		if strings.Contains(buf.String(), "deprecated") {
+			t.Error("unexpected deprecation warning when ENGRAM_ROUTER_URL is set")
+		}
+	})
+
+	t.Run("LITELLM_URL fallback with deprecation warning", func(t *testing.T) {
+		t.Setenv("ENGRAM_ROUTER_URL", "")
+		t.Setenv("LITELLM_URL", "http://legacy:4000")
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		got := routerURLFromEnv("http://litellm:4000", logger)
+		if got != "http://legacy:4000" {
+			t.Errorf("routerURLFromEnv = %q, want %q", got, "http://legacy:4000")
+		}
+		if !strings.Contains(buf.String(), "deprecated") {
+			t.Error("expected deprecation warning when only LITELLM_URL is set, got none")
+		}
+	})
+
+	t.Run("default returned when neither set", func(t *testing.T) {
+		t.Setenv("ENGRAM_ROUTER_URL", "")
+		t.Setenv("LITELLM_URL", "")
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		got := routerURLFromEnv("http://litellm:4000", logger)
+		if got != "http://litellm:4000" {
+			t.Errorf("routerURLFromEnv = %q, want %q", got, "http://litellm:4000")
+		}
+	})
+}
 
 func TestRecallDefaultModeDefault(t *testing.T) {
 	const key = "ENGRAM_RECALL_DEFAULT_MODE"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -91,7 +91,8 @@ services:
         required: true
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
-      - LITELLM_URL=http://ollama:11434/v1
+      - ENGRAM_ROUTER_URL=http://ollama:11434/v1
+      # LITELLM_URL is accepted as a deprecated fallback
       - LITELLM_API_KEY=
       - ENGRAM_EMBED_URL=http://ollama:11434/v1
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
@@ -133,7 +134,8 @@ services:
         required: false
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/engram?sslmode=disable
-      - LITELLM_URL=${LITELLM_URL:-http://ollama:11434/v1}
+      - ENGRAM_ROUTER_URL=${ENGRAM_ROUTER_URL:-${LITELLM_URL:-http://ollama:11434/v1}}
+      # LITELLM_URL is accepted as a deprecated fallback
       - LITELLM_API_KEY=
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,8 @@ services:
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@trunas.petersimmons.com:5434/engram?sslmode=disable
       # OpenAI-compatible upstream (olla load balancer; LiteLLM container retired 2026-05-05)
-      - LITELLM_URL=${LITELLM_URL:-http://olla:40114/olla/openai}
+      # LITELLM_URL is accepted as a deprecated fallback
+      - ENGRAM_ROUTER_URL=${ENGRAM_ROUTER_URL:-${LITELLM_URL:-http://olla:40114/olla/openai}}
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       # Embedding service — Infinity/bge-m3 on oblivion (2026-05-08: switched from vLLM/jina-v5, 14x throughput)
       # #668: default placeholder — set ENGRAM_EMBED_URL in .env to your real embed endpoint
@@ -185,7 +186,8 @@ services:
     # so W6800 wins the FOR UPDATE SKIP LOCKED race on new work. Override via .env.
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@trunas.petersimmons.com:5434/engram?sslmode=disable
-      - LITELLM_URL=${REEMBED_7900XT_URL:-http://172.23.0.1:8004}
+      - ENGRAM_ROUTER_URL=${REEMBED_7900XT_URL:-http://172.23.0.1:8004}
+      # LITELLM_URL is accepted as a deprecated fallback
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-1024}
@@ -210,7 +212,8 @@ services:
     environment:
       - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@trunas.petersimmons.com:5434/engram?sslmode=disable
       # #668: default placeholder — set REEMBED_W6800_URL in .env to your real W6800 host
-      - LITELLM_URL=${REEMBED_W6800_URL:-http://example.invalid:8005}
+      - ENGRAM_ROUTER_URL=${REEMBED_W6800_URL:-http://example.invalid:8005}
+      # LITELLM_URL is accepted as a deprecated fallback
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
       - ENGRAM_EMBED_MODEL=${ENGRAM_EMBED_MODEL:-BAAI/bge-m3}
       - ENGRAM_EMBED_DIMENSIONS=${ENGRAM_EMBED_DIMENSIONS:-1024}

--- a/internal/consolidate/consolidate.go
+++ b/internal/consolidate/consolidate.go
@@ -191,13 +191,13 @@ type RunOptions struct {
 	ContradictionDetectionLimit int
 
 	// LLM contradiction detection (opt-in).
-	// When LLMContradictionDetection is true and LiteLLMURL is non-empty,
+	// When LLMContradictionDetection is true and RouterURL is non-empty,
 	// DetectContradictions runs a second pass using the local Ollama model to
 	// classify high-similarity pairs that the heuristic missed. This catches
 	// competing affirmative claims ("model is X" vs "model is Y") that carry no
 	// negation, version, or temporal markers.
 	LLMContradictionDetection bool
-	LiteLLMURL                 string
+	RouterURL                 string
 	OllamaModel               string
 	// LLMMaxCalls caps how many Ollama calls are made per DetectContradictions
 	// cycle to bound latency. Zero or negative means use the default (10).
@@ -434,7 +434,7 @@ func (r *Runner) detectContradictions(ctx context.Context, minSimilarity float64
 			// Heuristic pass — pattern-based, no LLM.
 			if !isContradiction(chunk.ChunkText, hit.ChunkText) {
 				// Queue for LLM second pass if enabled.
-				if opts.LLMContradictionDetection && opts.LiteLLMURL != "" {
+				if opts.LLMContradictionDetection && opts.RouterURL != "" {
 					uncaught = append(uncaught, uncaughtPair{
 						sourceID: memID,
 						targetID: hit.MemoryID,
@@ -466,7 +466,7 @@ func (r *Runner) detectContradictions(ctx context.Context, minSimilarity float64
 	// LLM second pass — classify pairs that the heuristic missed.
 	// Best-effort: errors from individual LLM calls are logged and skipped so
 	// a transient Ollama failure does not abort the entire consolidation run.
-	if opts.LLMContradictionDetection && opts.LiteLLMURL != "" && len(uncaught) > 0 {
+	if opts.LLMContradictionDetection && opts.RouterURL != "" && len(uncaught) > 0 {
 		maxCalls := opts.LLMMaxCalls
 		if maxCalls <= 0 {
 			maxCalls = 10
@@ -476,7 +476,7 @@ func (r *Runner) detectContradictions(ctx context.Context, minSimilarity float64
 			if llmCalls >= maxCalls {
 				break
 			}
-			isContra, err := ClassifyContradictionLLM(ctx, pair.textA, pair.textB, opts.LiteLLMURL, opts.OllamaModel)
+			isContra, err := ClassifyContradictionLLM(ctx, pair.textA, pair.textB, opts.RouterURL, opts.OllamaModel)
 			llmCalls++ // count every attempt — erroring calls still consume latency budget
 			if err != nil {
 				// Best-effort: skip this pair, keep going.

--- a/internal/consolidate/llm_contradiction_test.go
+++ b/internal/consolidate/llm_contradiction_test.go
@@ -224,7 +224,7 @@ func TestDetectContradictions_LLMPassCatchesAffirmative(t *testing.T) {
 		InferRelationshipsMinSimilarity: 0.5,
 		InferRelationshipsLimit:         100,
 		LLMContradictionDetection:       true,
-		LiteLLMURL:                      srv.URL,
+		RouterURL:                      srv.URL,
 		OllamaModel:                     "llama3.2:3b",
 		LLMMaxCalls:                     10,
 	})
@@ -304,7 +304,7 @@ func TestDetectContradictions_LLMPassDisabled(t *testing.T) {
 		InferRelationshipsMinSimilarity: 0.5,
 		InferRelationshipsLimit:         100,
 		LLMContradictionDetection:       false, // disabled
-		LiteLLMURL:                      srv.URL,
+		RouterURL:                      srv.URL,
 		OllamaModel:                     "llama3.2:3b",
 	})
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestDetectContradictions_LLMMaxCalls(t *testing.T) {
 		InferRelationshipsMinSimilarity: 0.5,
 		InferRelationshipsLimit:         100,
 		LLMContradictionDetection:       true,
-		LiteLLMURL:                      srv.URL,
+		RouterURL:                      srv.URL,
 		OllamaModel:                     "llama3.2:3b",
 		LLMMaxCalls:                     2, // cap at 2 regardless of pairs available
 	})

--- a/internal/mcp/health_test.go
+++ b/internal/mcp/health_test.go
@@ -29,7 +29,7 @@ type healthResponse struct {
 func newHealthServer(ollamaURL string) *Server {
 	return &Server{
 		cfg: Config{
-			LiteLLMURL: ollamaURL,
+			RouterURL: ollamaURL,
 		},
 		embedDegraded: &atomic.Bool{},
 	}

--- a/internal/mcp/migrate_embedder_test.go
+++ b/internal/mcp/migrate_embedder_test.go
@@ -84,7 +84,7 @@ func makeMigrateRequest(project, newModel string) mcpgo.CallToolRequest {
 func TestHandleMemoryMigrateEmbedder_NoDimsStored(t *testing.T) {
 	pool := newDimPool(t, "", 384)
 	req := makeMigrateRequest("proj", "new-model")
-	cfg := Config{LiteLLMURL: "http://ollama-test:11434"}
+	cfg := Config{RouterURL: "http://ollama-test:11434"}
 
 	// The noop backend's Begin() returns nil; MigrateEmbedder will panic.
 	// We use a deferred recover to catch it and assert the panic is NOT from
@@ -110,7 +110,7 @@ func TestHandleMemoryMigrateEmbedder_EmptyNewModel(t *testing.T) {
 	pool := newDimPool(t, "384", 384)
 
 	req := makeMigrateRequest("proj", "")
-	cfg := Config{LiteLLMURL: "http://ollama-test:11434"}
+	cfg := Config{RouterURL: "http://ollama-test:11434"}
 
 	result, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestHandleMemoryMigrateEmbedder_ProbeError(t *testing.T) {
 	pool := newDimPool(t, "384", 384)
 	req := makeMigrateRequest("proj", "unreachable-model")
 	cfg := Config{
-		LiteLLMURL: "http://ollama-test:11434",
+		RouterURL: "http://ollama-test:11434",
 		testHooks: &testHooks{
 			embedProbe: func(_ context.Context, _, _ string) (embed.Client, error) {
 				return nil, fmt.Errorf("dial tcp: connect: connection refused")
@@ -149,7 +149,7 @@ func TestHandleMemoryMigrateEmbedder_DimensionMismatch(t *testing.T) {
 	pool := newDimPool(t, "384", 384) // stored: 384-dim
 	req := makeMigrateRequest("proj", "wide-model")
 	cfg := Config{
-		LiteLLMURL: "http://ollama-test:11434",
+		RouterURL: "http://ollama-test:11434",
 		testHooks: &testHooks{
 			embedProbe: func(_ context.Context, _, _ string) (embed.Client, error) {
 				return dimEmbedder{dims: 1024}, nil // new model: 1024-dim — mismatch
@@ -182,7 +182,7 @@ func TestHandleMemoryMigrateEmbedder_MigrateError(t *testing.T) {
 
 	var postMigrateFired bool
 	cfg := Config{
-		LiteLLMURL: "http://ollama-test:11434",
+		RouterURL: "http://ollama-test:11434",
 		testHooks: &testHooks{
 			migrateFunc: func(_ context.Context, _ string) (map[string]any, error) {
 				return nil, fmt.Errorf("db unavailable")
@@ -209,7 +209,7 @@ func TestHandleMemoryMigrateEmbedder_HappyPath(t *testing.T) {
 
 	var postMigrateFired bool
 	cfg := Config{
-		LiteLLMURL: "http://ollama-test:11434",
+		RouterURL: "http://ollama-test:11434",
 		testHooks: &testHooks{
 			embedProbe: func(_ context.Context, _, _ string) (embed.Client, error) {
 				return dimEmbedder{dims: 384}, nil // pre-flight passes
@@ -246,7 +246,7 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_PrivateIPBlocked(t *testing.T) {
 		"new_model":  "some-model",
 		"ollama_url": "http://192.168.1.100:11434",
 	}
-	cfg := Config{LiteLLMURL: "http://safe-ollama:11434"}
+	cfg := Config{RouterURL: "http://safe-ollama:11434"}
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.Error(t, err)
@@ -264,7 +264,7 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_LoopbackBlocked(t *testing.T) {
 		"new_model":  "some-model",
 		"ollama_url": "http://127.0.0.1:11434",
 	}
-	cfg := Config{LiteLLMURL: "http://safe-ollama:11434"}
+	cfg := Config{RouterURL: "http://safe-ollama:11434"}
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.Error(t, err)
@@ -282,7 +282,7 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_InvalidURLBlocked(t *testing.T) {
 		"new_model":  "some-model",
 		"ollama_url": "not-a-url",
 	}
-	cfg := Config{LiteLLMURL: "http://safe-ollama:11434"}
+	cfg := Config{RouterURL: "http://safe-ollama:11434"}
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.Error(t, err)
@@ -301,7 +301,7 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_HostnameResolvingPrivateBlocked(t
 		"new_model":  "some-model",
 		"ollama_url": "http://localhost:11434",
 	}
-	cfg := Config{LiteLLMURL: "http://safe-ollama:11434"}
+	cfg := Config{RouterURL: "http://safe-ollama:11434"}
 
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.Error(t, err)
@@ -316,7 +316,7 @@ func TestHandleMemoryMigrateEmbedder_DimsMatch_ProceedToMigrate(t *testing.T) {
 	pool := newDimPool(t, "384", 384) // stored: 384-dim
 	req := makeMigrateRequest("proj", "same-dim-model")
 	cfg := Config{
-		LiteLLMURL: "http://ollama-test:11434",
+		RouterURL: "http://ollama-test:11434",
 		testHooks: &testHooks{
 			embedProbe: func(_ context.Context, _, _ string) (embed.Client, error) {
 				return dimEmbedder{dims: 384}, nil // same dim: pre-flight passes

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -369,9 +369,9 @@ func NewServer(pool *EnginePool, cfg Config) *Server {
 		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
-		// Construct a minimal LiteLLMClient for the probe.
+		// Construct a minimal LiteLLMClient for the probe (uses RouterURL).
 		// We only use it once per TTL interval.
-		client := embed.NewLiteLLMClientNoProbe(cfg.LiteLLMURL, cfg.EmbedModel, "", cfg.EmbedDimensions)
+		client := embed.NewLiteLLMClientNoProbe(cfg.RouterURL, cfg.EmbedModel, "", cfg.EmbedDimensions)
 		ok, reason := client.Probe(probeCtx)
 		return ok, reason
 	}, 5*time.Second)
@@ -1452,14 +1452,14 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		pgStatus = "ok"
 	}
 
-	// Probe LiteLLM via InfinityQueueCheck: GETs /v1/models and parses Infinity
+	// Probe router via InfinityQueueCheck: GETs /v1/models and parses Infinity
 	// queue stats to detect GPU thread deadlock (queue_fraction > 1.0,
 	// results_pending == 0). Subsumes the former status-code-only check (#649).
 	embedLiveOK := false
-	if s.cfg.LiteLLMURL != "" {
+	if s.cfg.RouterURL != "" {
 		embedCtx, embedCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer embedCancel()
-		probeOK, probeReason := embed.InfinityQueueCheck(embedCtx, http.DefaultClient, s.cfg.LiteLLMURL)
+		probeOK, probeReason := embed.InfinityQueueCheck(embedCtx, http.DefaultClient, s.cfg.RouterURL)
 		if !probeOK {
 			ollamaStatus = "error" //nolint:ineffassign // overwritten if EmbedDegraded
 			slog.Warn("health: litellm probe failed", "reason", probeReason)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -391,7 +391,7 @@ func TestHealthProbe_OllamaDegraded_Returns200WithDegradedField(t *testing.T) {
 	b.Store(true)
 	s := &Server{
 		cfg: Config{
-			LiteLLMURL:      unreachableOllama,
+			RouterURL:      unreachableOllama,
 			EmbedDegraded: true, // set as if startup probe failed
 		},
 		embedDegraded: b,
@@ -428,7 +428,7 @@ func TestHealthProbe_OllamaDegraded_RecoveredOllamaReportsOK(t *testing.T) {
 	b.Store(true)
 	s := &Server{
 		cfg: Config{
-			LiteLLMURL:      fakeOllama.URL,
+			RouterURL:      fakeOllama.URL,
 			EmbedDegraded: true, // startup probe failed, but Ollama recovered
 		},
 		embedDegraded: b,
@@ -517,7 +517,7 @@ func TestHealthProbe_IgnoresExpiredRequestContext(t *testing.T) {
 	// Build a minimal Server pointing at the fake Ollama. No PgPool, so the
 	// Postgres probe is skipped and only the Ollama probe exercises the context.
 	s := &Server{
-		cfg:           Config{LiteLLMURL: fakeOllama.URL},
+		cfg:           Config{RouterURL: fakeOllama.URL},
 		embedDegraded: &atomic.Bool{},
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -21,7 +21,7 @@ import (
 
 // Config holds server-wide configuration passed to tool handlers.
 type Config struct {
-	LiteLLMURL               string
+	RouterURL                string
 	EmbedModel               string
 	SummarizeModel           string
 	SummarizeEnabled         bool

--- a/internal/mcp/tools_consolidate.go
+++ b/internal/mcp/tools_consolidate.go
@@ -26,7 +26,7 @@ func handleMemorySummarize(ctx context.Context, pool *EnginePool, req mcpgo.Call
 	if errResult != nil {
 		return errResult, nil
 	}
-	if err := summarize.SummarizeOne(ctx, h.Engine.Backend(), id, cfg.LiteLLMURL, cfg.SummarizeModel); err != nil {
+	if err := summarize.SummarizeOne(ctx, h.Engine.Backend(), id, cfg.RouterURL, cfg.SummarizeModel); err != nil {
 		return nil, fmt.Errorf("%w (project=%q — did you mean a different project?)", err, project)
 	}
 	return toolResult(map[string]any{"status": "summarized", "memory_id": id})
@@ -87,7 +87,7 @@ func handleMemoryConsolidate(ctx context.Context, pool *EnginePool, req mcpgo.Ca
 }
 
 // handleMemorySleep runs the full sleep-consolidation cycle (Feature 3).
-// cfg is passed so the handler can read LiteLLMURL for the LLM second pass.
+// cfg is passed so the handler can read RouterURL for the LLM second pass.
 func handleMemorySleep(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	// Cap wall-clock time so the handler cannot run past the HTTP server's ReadTimeout.
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
@@ -108,7 +108,7 @@ func handleMemorySleep(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		return nil, err
 	}
 	// Optional LLM contradiction detection params (opt-in, default off).
-	// LiteLLMURL comes from server config; model and call cap are per-request.
+	// RouterURL comes from server config; model and call cap are per-request.
 	llmDetect := getBool(args, "llm_contradiction_detection", false)
 	llmModel := getString(args, "llm_model", "llama3.2:3b")
 	llmMaxCalls := getInt(args, "llm_max_calls", 10)
@@ -122,7 +122,7 @@ func handleMemorySleep(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		InferRelationshipsLimit:         limit,
 		ContradictionDetectionLimit:     contradictionLimit,
 		LLMContradictionDetection:       llmDetect,
-		LiteLLMURL:                       cfg.LiteLLMURL,
+		RouterURL:                        cfg.RouterURL,
 		OllamaModel:                     llmModel,
 		LLMMaxCalls:                     llmMaxCalls,
 		AutoSupersede:                   autoSupersede,

--- a/internal/mcp/tools_embedder.go
+++ b/internal/mcp/tools_embedder.go
@@ -36,7 +36,7 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 	// override the server default; if present, apply the same SSRF guard used at
 	// startup (#291). Only literal private IPs are blocked — hostnames are allowed
 	// because they resolve to container IPs by design and are not attacker-controlled.
-	ollamaURL := cfg.LiteLLMURL
+	ollamaURL := cfg.RouterURL
 	if raw := getString(args, "ollama_url", ""); raw != "" {
 		if err := netutil.ValidateUpstreamURL(raw); err != nil {
 			return nil, fmt.Errorf("invalid ollama_url %q: %w", raw, err)
@@ -114,7 +114,7 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 // handleMemoryExportAll exports all memories to markdown files in output_path.
 
 func handleMemoryModels(ctx context.Context, _ *EnginePool, _ mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
-	installed, err := fetchLiteLLMModels(ctx, cfg.LiteLLMURL)
+	installed, err := fetchLiteLLMModels(ctx, cfg.RouterURL)
 	if err != nil {
 		// Non-fatal: return registry with installed=false for all entries.
 		installed = map[string]bool{}
@@ -233,8 +233,8 @@ func handleMemoryEmbeddingEval(ctx context.Context, _ *EnginePool, req mcpgo.Cal
 		return nil, fmt.Errorf("memory_embedding_eval: model_a and model_b must differ")
 	}
 
-	clientA := embed.NewLiteLLMClientNoProbe(cfg.LiteLLMURL, modelA, "", cfg.EmbedDimensions)
-	clientB := embed.NewLiteLLMClientNoProbe(cfg.LiteLLMURL, modelB, "", cfg.EmbedDimensions)
+	clientA := embed.NewLiteLLMClientNoProbe(cfg.RouterURL, modelA, "", cfg.EmbedDimensions)
+	clientB := embed.NewLiteLLMClientNoProbe(cfg.RouterURL, modelB, "", cfg.EmbedDimensions)
 
 	type embedResult struct {
 		sentence string

--- a/internal/mcp/tools_models_test.go
+++ b/internal/mcp/tools_models_test.go
@@ -150,7 +150,7 @@ func TestHandleMemoryModels_HappyPath(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := Config{LiteLLMURL: srv.URL, EmbedModel: "nomic-embed-text"}
+	cfg := Config{RouterURL: srv.URL, EmbedModel: "nomic-embed-text"}
 	result, err := handleMemoryModels(context.Background(), nil, mcpgo.CallToolRequest{}, cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -184,7 +184,7 @@ func TestHandleMemoryModels_OllamaUnreachable_GracefulDegradation(t *testing.T) 
 	url := srv.URL
 	srv.Close()
 
-	cfg := Config{LiteLLMURL: url, EmbedModel: "nomic-embed-text"}
+	cfg := Config{RouterURL: url, EmbedModel: "nomic-embed-text"}
 	result, err := handleMemoryModels(context.Background(), nil, mcpgo.CallToolRequest{}, cfg)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
@@ -224,7 +224,7 @@ func TestHandleMemoryEmbeddingEval_SameModelsRejected(t *testing.T) {
 		"model_a": "nomic-embed-text",
 		"model_b": "nomic-embed-text",
 	}
-	cfg := Config{LiteLLMURL: "http://127.0.0.1:0", EmbedModel: "nomic-embed-text"}
+	cfg := Config{RouterURL: "http://127.0.0.1:0", EmbedModel: "nomic-embed-text"}
 	_, err := handleMemoryEmbeddingEval(context.Background(), nil, req, cfg)
 	if err == nil {
 		t.Fatal("expected error when model_a == model_b")
@@ -242,7 +242,7 @@ func TestHandleMemoryEmbeddingEval_ModelADefaultsFromConfig(t *testing.T) {
 	req.Params.Arguments = map[string]any{
 		"model_b": "mxbai-embed-large",
 	}
-	cfg := Config{LiteLLMURL: "http://127.0.0.1:0", EmbedModel: "mxbai-embed-large"}
+	cfg := Config{RouterURL: "http://127.0.0.1:0", EmbedModel: "mxbai-embed-large"}
 	_, err := handleMemoryEmbeddingEval(context.Background(), nil, req, cfg)
 	if err == nil {
 		t.Fatal("expected must-differ error: model_a defaulted to cfg.EmbedModel should equal explicit model_b")
@@ -261,7 +261,7 @@ func TestHandleMemoryEmbeddingEval_HappyPath(t *testing.T) {
 		"model_a": "nomic-embed-text",
 		"model_b": "mxbai-embed-large",
 	}
-	cfg := Config{LiteLLMURL: srv.URL, EmbedModel: "nomic-embed-text"}
+	cfg := Config{RouterURL: srv.URL, EmbedModel: "nomic-embed-text"}
 	result, err := handleMemoryEmbeddingEval(context.Background(), nil, req, cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -295,7 +295,7 @@ func TestHandleMemoryEmbeddingEval_OllamaUnreachable(t *testing.T) {
 		"model_a": "nomic-embed-text",
 		"model_b": "mxbai-embed-large",
 	}
-	cfg := Config{LiteLLMURL: url, EmbedModel: "nomic-embed-text"}
+	cfg := Config{RouterURL: url, EmbedModel: "nomic-embed-text"}
 	_, err := handleMemoryEmbeddingEval(context.Background(), nil, req, cfg)
 	if err == nil {
 		t.Error("expected error when Ollama is unreachable")


### PR DESCRIPTION
## Summary
- `ENGRAM_ROUTER_URL` is now the primary env var; `Config.LiteLLMURL` → `Config.RouterURL`
- `LITELLM_URL` still accepted as a deprecated fallback with `slog.Warn` deprecation log
- 14 files updated: cmd/engram, internal/mcp, internal/consolidate, docker-compose files
- New `TestRouterURLFallback` covers primary, legacy fallback, and unset cases

Closes #636.
🤖 Generated with [Claude Code](https://claude.com/claude-code)