### PR TITLE
fix(search/lme): temporal retrieval — rank-normalized recency + query classifier signal [closes #845, #846]

### DIFF
--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -54,6 +54,34 @@ var temporalInterrogativeRe = regexp.MustCompile(
 		`|on what (date|day) )`,
 )
 
+// buildRecallQuery derives the Engram recall query from a raw LME question.
+// For temporal-reasoning questions it strips the interrogative scaffold so the
+// query matches event noun-phrases. For preference questions it delegates to
+// longmemeval.PreferenceRecallQuery. When disableRewrite is true the raw
+// question is returned unchanged.
+func buildRecallQuery(question, questionType string, disableRewrite bool) string {
+	if disableRewrite {
+		return question
+	}
+	switch questionType {
+	case "temporal-reasoning":
+		q := temporalInterrogativeRe.ReplaceAllString(question, "")
+		if q == "" {
+			return question
+		}
+		// Preserve temporal classifier signal so isTemporalQuery() returns true
+		// on the Engram server and TemporalWeights are applied. The interrogative
+		// strip removes all temporal words (e.g. "ago", "days") — prepending
+		// "recent " (present in temporalQuerySignals) restores the signal while
+		// keeping the semantic noun-phrase clean. (F2)
+		return "recent " + strings.TrimSpace(q)
+	case "single-session-preference":
+		return longmemeval.PreferenceRecallQuery(question)
+	default:
+		return question
+	}
+}
+
 // runRun executes the run stage. Returns the process exit code: 0 on success,
 // 1 when zero items completed successfully out of any that were attempted
 // (#703 — total-failure guard so scripted pipelines don't proceed when every
@@ -260,18 +288,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// Strip leading interrogative phrases for temporal questions so the recall
 	// query matches event noun-phrases rather than "how many weeks ago did...".
 	// When --disable-query-rewrite is set, use the raw question unchanged.
-	recallQuery := item.Question
-	if !cfg.DisableQueryRewrite {
-		switch item.QuestionType {
-		case "temporal-reasoning":
-			recallQuery = temporalInterrogativeRe.ReplaceAllString(recallQuery, "")
-			if recallQuery == "" {
-				recallQuery = item.Question
-			}
-		case "single-session-preference":
-			recallQuery = longmemeval.PreferenceRecallQuery(item.Question)
-		}
-	}
+	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
 	retrievedIDs, err := mcpClient.Recall(ctx, ingest.Project, recallQuery, cfg.RecallTopK)
 	if err != nil {
 		return longmemeval.RunEntry{

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -393,3 +393,111 @@ func TestCleanupSummary_TokenIsCleanupSummary(t *testing.T) {
 		t.Error("run.go still contains old log token 'INFO run: preserved' — should be replaced by 'cleanup-summary'")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// buildRecallQuery — F2 temporal classifier signal preservation
+// ---------------------------------------------------------------------------
+
+// temporalSignalWords mirrors the set in internal/search/query_signal.go.
+// We don't import search here (different package), so we enumerate a subset
+// of the well-known signals that should appear in the rewritten query.
+var temporalSignalWords = []string{
+	"recent", "recently", "ago", "last", "when", "since", "before", "after",
+	"first", "latest", "earliest", "previous", "prior",
+}
+
+func hasTemporalSignal(q string) bool {
+	lower := strings.ToLower(q)
+	for _, w := range temporalSignalWords {
+		// word-boundary check: preceded/followed by non-alpha or string edge
+		idx := strings.Index(lower, w)
+		if idx < 0 {
+			continue
+		}
+		before := idx == 0 || !isAlpha(lower[idx-1])
+		after := idx+len(w) >= len(lower) || !isAlpha(lower[idx+len(w)])
+		if before && after {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// TestBuildRecallQuery_TemporalReasoningPreservesSignal is the F2 regression
+// test. Before the fix, buildRecallQuery strips all temporal words from the
+// interrogative prefix and returns a bare semantic fragment — causing
+// isTemporalQuery() on the server to return false and apply DefaultWeights.
+// After the fix, the returned query must begin with a temporal signal word
+// ("recent") so TemporalWeights fire on the server side.
+func TestBuildRecallQuery_TemporalReasoningPreservesSignal(t *testing.T) {
+	cases := []struct {
+		name     string
+		question string
+		// wantSemanticFragment is a substring that must appear in the result
+		// to confirm the semantic content was not lost.
+		wantSemanticFragment string
+	}{
+		{
+			name:                 "days-ago interrogative",
+			question:             "How many days ago did I attend the baking class?",
+			wantSemanticFragment: "baking class",
+		},
+		{
+			name:                 "weeks-ago interrogative",
+			question:             "How many weeks ago did I start learning guitar?",
+			wantSemanticFragment: "guitar",
+		},
+		{
+			name:                 "when-did interrogative",
+			question:             "When did I visit my grandmother in Portland?",
+			wantSemanticFragment: "grandmother",
+		},
+		{
+			name:                 "months-ago interrogative",
+			question:             "How many months ago was I promoted at work?",
+			wantSemanticFragment: "promoted",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildRecallQuery(tc.question, "temporal-reasoning", false)
+
+			// F2 contract: the result must carry a temporal signal word so that
+			// isTemporalQuery() returns true on the Engram server.
+			if !hasTemporalSignal(got) {
+				t.Errorf("buildRecallQuery(%q) = %q — no temporal signal word found; isTemporalQuery will return false (F2 regression)", tc.question, got)
+			}
+
+			// Semantic content must be preserved.
+			if !strings.Contains(strings.ToLower(got), strings.ToLower(tc.wantSemanticFragment)) {
+				t.Errorf("buildRecallQuery(%q) = %q — missing expected semantic fragment %q", tc.question, got, tc.wantSemanticFragment)
+			}
+		})
+	}
+}
+
+// TestBuildRecallQuery_TemporalReasoningDisableRewrite verifies that when
+// DisableQueryRewrite is true the raw question is returned unchanged (no
+// "recent " prefix is prepended).
+func TestBuildRecallQuery_TemporalReasoningDisableRewrite(t *testing.T) {
+	q := "How many days ago did I attend the baking class?"
+	got := buildRecallQuery(q, "temporal-reasoning", true)
+	if got != q {
+		t.Errorf("with disableRewrite=true, buildRecallQuery should return question unchanged; got %q", got)
+	}
+}
+
+// TestBuildRecallQuery_NonTemporalUnchanged verifies that non-temporal question
+// types are not prefixed with "recent ".
+func TestBuildRecallQuery_NonTemporalUnchanged(t *testing.T) {
+	q := "What is my favorite restaurant?"
+	got := buildRecallQuery(q, "single-hop-factual", false)
+	if got != q {
+		t.Errorf("non-temporal question should be returned unchanged; got %q, want %q", got, q)
+	}
+}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -670,6 +670,17 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		baseWeights = KnowledgeUpdateWeights()
 	}
 
+	// For temporal queries, pre-collect the candidate slice once so
+	// CompositeScoreWithRankNorm can compute the date range across the full set.
+	// This avoids an O(n²) re-scan: candidateDateRange runs once via the slice.
+	var temporalCandidates []*types.Memory
+	if tempQuery {
+		temporalCandidates = make([]*types.Memory, 0, len(memories))
+		for _, m := range memories {
+			temporalCandidates = append(temporalCandidates, m)
+		}
+	}
+
 	// Composite scoring per memory.
 	results := make([]types.SearchResult, 0)
 	for id, m := range memories {
@@ -704,7 +715,16 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			MemoryType:         m.MemoryType,
 			IsPreferenceQuery:  prefQuery,
 		}
-		score := CompositeScoreWithWeights(input, baseWeights)
+		var score float64
+		if tempQuery {
+			var validFrom time.Time
+			if m.ValidFrom != nil {
+				validFrom = *m.ValidFrom
+			}
+			score = CompositeScoreWithRankNorm(input, baseWeights, validFrom, temporalCandidates)
+		} else {
+			score = CompositeScoreWithWeights(input, baseWeights)
+		}
 
 		result := types.SearchResult{
 			Memory:     m,

--- a/internal/search/rank_recency_test.go
+++ b/internal/search/rank_recency_test.go
@@ -1,0 +1,141 @@
+package search_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRankNormalizedRecency_BasicOrdering verifies that given 3 memories with
+// valid_from dates spanning 2 years, RankNormalizedRecency returns scores in
+// ascending order (oldest = lowest score, most recent = highest score).
+func TestRankNormalizedRecency_BasicOrdering(t *testing.T) {
+	oldest := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	middle := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	newest := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	minDate := oldest
+	maxDate := newest
+
+	scoreOldest := search.RankNormalizedRecency(oldest, minDate, maxDate)
+	scoreMiddle := search.RankNormalizedRecency(middle, minDate, maxDate)
+	scoreNewest := search.RankNormalizedRecency(newest, minDate, maxDate)
+
+	require.Less(t, scoreOldest, scoreMiddle, "oldest should score lower than middle")
+	require.Less(t, scoreMiddle, scoreNewest, "middle should score lower than newest")
+	require.InDelta(t, 0.0, scoreOldest, 0.0001, "oldest should score 0.0 (== minDate)")
+	require.InDelta(t, 1.0, scoreNewest, 0.0001, "newest should score 1.0 (== maxDate)")
+}
+
+// TestRankNormalizedRecency_AllSameDate verifies that when all candidates have
+// the same valid_from, every candidate receives a neutral score of 0.5.
+func TestRankNormalizedRecency_AllSameDate(t *testing.T) {
+	sameDate := time.Date(2023, 6, 15, 12, 0, 0, 0, time.UTC)
+	minDate := sameDate
+	maxDate := sameDate
+
+	score1 := search.RankNormalizedRecency(sameDate, minDate, maxDate)
+	score2 := search.RankNormalizedRecency(sameDate, minDate, maxDate)
+
+	require.InDelta(t, 0.5, score1, 0.0001, "all-same-date should return 0.5")
+	require.InDelta(t, 0.5, score2, 0.0001, "all-same-date should return 0.5")
+}
+
+// TestRankNormalizedRecency_SingleCandidate verifies that a single candidate
+// receives a score of 1.0 via CompositeScoreWithRankNorm when only one memory
+// is in the candidate set. The engine detects len(candidates)==1 and returns 1.0
+// for the recency component so the single result is always fully recency-boosted.
+func TestRankNormalizedRecency_SingleCandidate(t *testing.T) {
+	singleDate := time.Date(2023, 3, 10, 0, 0, 0, 0, time.UTC)
+	w := search.TemporalWeights()
+
+	m := &types.Memory{
+		Content:    "Only memory in candidate set",
+		ValidFrom:  &singleDate,
+		CreatedAt:  singleDate,
+		Importance: 2,
+	}
+	candidates := []*types.Memory{m}
+
+	score := search.CompositeScoreWithRankNorm(
+		search.ScoreInput{Cosine: 0.8, BM25: 0.7, Importance: 2},
+		w,
+		singleDate,
+		candidates,
+	)
+
+	// When there's only one candidate, recency should be 1.0 (fully boosted).
+	// Compute the expected score manually: recency=1.0, boost=1.0 (importance=2).
+	// raw = w.Vector*0.8 + w.BM25*0.7 + w.Recency*1.0 + w.Precision*0.5
+	expectedRecency := 1.0
+	expectedRaw := w.Vector*0.8 + w.BM25*0.7 + w.Recency*expectedRecency + w.Precision*0.5
+	require.InDelta(t, expectedRaw, score, 0.001, "single candidate should use recency=1.0")
+}
+
+// TestRankNormalizedRecency_NilValidFrom verifies that when a memory has a zero
+// valid_from (nil), the function falls back to RecencyDecay using created_at hours.
+func TestRankNormalizedRecency_NilValidFrom(t *testing.T) {
+	// A zero time.Time represents a nil/unset valid_from.
+	var zeroTime time.Time
+	createdAt := time.Now().Add(-48 * time.Hour) // 48 hours ago
+
+	minDate := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	maxDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// When validFrom is zero, the function should fall back to RecencyDecay
+	// using the hours since createdAt. The fallback score should equal RecencyDecay(~48h).
+	score := search.RankNormalizedRecencyWithFallback(zeroTime, createdAt, minDate, maxDate)
+	expected := search.RecencyDecay(48.0)
+
+	// Allow generous delta since time passes between computing expected and calling the function.
+	require.InDelta(t, expected, score, 0.001, "zero valid_from should fall back to RecencyDecay(createdAt hours)")
+}
+
+// TestCompositeScore_TemporalWeights_UseRankNorm verifies the end-to-end scoring path:
+// when TemporalWeights are in effect and candidates have spread valid_from dates,
+// the newer session scores higher than the older session.
+func TestCompositeScore_TemporalWeights_UseRankNorm(t *testing.T) {
+	w := search.TemporalWeights()
+
+	olderDate := time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)
+	newerDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// Build two ScoreInputs with identical cosine/BM25 signals — only valid_from differs.
+	// Both memories have the same project-level cosine and BM25 scores so the
+	// rank-normalized recency is the sole differentiator.
+	olderMem := &types.Memory{
+		Content:    "Older session memory",
+		ValidFrom:  &olderDate,
+		CreatedAt:  olderDate,
+		Importance: 2,
+	}
+	newerMem := &types.Memory{
+		Content:    "Newer session memory",
+		ValidFrom:  &newerDate,
+		CreatedAt:  newerDate,
+		Importance: 2,
+	}
+
+	candidates := []*types.Memory{olderMem, newerMem}
+
+	// CompositeScoreWithRankNorm computes minDate/maxDate across the set
+	// and uses RankNormalizedRecency for the recency component.
+	scoreOlder := search.CompositeScoreWithRankNorm(
+		search.ScoreInput{Cosine: 0.8, BM25: 0.7, Importance: 2},
+		w,
+		olderDate,
+		candidates,
+	)
+	scoreNewer := search.CompositeScoreWithRankNorm(
+		search.ScoreInput{Cosine: 0.8, BM25: 0.7, Importance: 2},
+		w,
+		newerDate,
+		candidates,
+	)
+
+	require.Greater(t, scoreNewer, scoreOlder,
+		"newer session (valid_from=2024) should score higher than older (valid_from=2022) under TemporalWeights with rank normalization")
+}

--- a/internal/search/score.go
+++ b/internal/search/score.go
@@ -4,8 +4,10 @@ import (
 	"log/slog"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/envconf"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 const (
@@ -330,6 +332,124 @@ func CompositeScoreRRF(in ScoreInput, w Weights, rrfBase float64) float64 {
 	}
 	if in.IsPreferenceQuery && in.MemoryType == "preference" {
 		raw *= 1.8
+	}
+	return raw * boost
+}
+
+// RankNormalizedRecency computes a [0,1] recency score by rank-normalizing
+// validFrom within the candidate set's date range [minDate, maxDate].
+//
+// This replaces the absolute exponential RecencyDecay for temporal queries where
+// content spans multiple years (e.g., LME 2022–2024 sessions evaluated in 2026).
+// At those timescales exp(-0.01 * h) collapses to ~1e-77, making the recency
+// signal numerically zero. Rank normalization preserves relative ordering:
+//
+//   - validFrom == maxDate → 1.0 (most recent in set)
+//   - validFrom == minDate → 0.0 (oldest in set)
+//   - maxDate == minDate   → 0.5 (all equal: neutral)
+func RankNormalizedRecency(validFrom, minDate, maxDate time.Time) float64 {
+	span := maxDate.Sub(minDate)
+	if span <= 0 {
+		// Single candidate or all same date: neutral score.
+		return 0.5
+	}
+	score := float64(validFrom.Sub(minDate)) / float64(span)
+	// Clamp to [0, 1] as a defensive measure against out-of-range inputs.
+	if score < 0 {
+		return 0.0
+	}
+	if score > 1 {
+		return 1.0
+	}
+	return score
+}
+
+// RankNormalizedRecencyWithFallback is like RankNormalizedRecency but handles a
+// zero validFrom by falling back to RecencyDecay computed from createdAt.
+// A zero validFrom means valid_from was nil/unset at ingest time.
+func RankNormalizedRecencyWithFallback(validFrom, createdAt, minDate, maxDate time.Time) float64 {
+	if validFrom.IsZero() {
+		hours := time.Since(createdAt).Hours()
+		return RecencyDecay(hours)
+	}
+	return RankNormalizedRecency(validFrom, minDate, maxDate)
+}
+
+// candidateDateRange scans a slice of Memory pointers and returns the min and max
+// valid_from timestamps across the set. Memories with a zero/nil ValidFrom are
+// excluded from the range computation (they fall back to RecencyDecay).
+// Returns zero times when no valid ValidFrom values are found.
+func candidateDateRange(candidates []*types.Memory) (minDate, maxDate time.Time) {
+	first := true
+	for _, m := range candidates {
+		if m == nil || m.ValidFrom == nil || m.ValidFrom.IsZero() {
+			continue
+		}
+		vf := *m.ValidFrom
+		if first {
+			minDate = vf
+			maxDate = vf
+			first = false
+			continue
+		}
+		if vf.Before(minDate) {
+			minDate = vf
+		}
+		if vf.After(maxDate) {
+			maxDate = vf
+		}
+	}
+	return minDate, maxDate
+}
+
+// CompositeScoreWithRankNorm is like CompositeScoreWithWeights but uses
+// RankNormalizedRecency for the recency component instead of RecencyDecay.
+//
+// validFrom is the memory's ValidFrom timestamp (may be zero for fallback).
+// candidates is the full candidate set — used to compute the date range for
+// rank normalization. The function pre-computes minDate/maxDate across the
+// set on each call.
+//
+// Single-candidate rule: when len(candidates)==1 and it has a valid ValidFrom,
+// recency is 1.0 (the single result is always fully recency-boosted; there is
+// no other candidate to rank against).
+//
+// Used when TemporalWeights are in effect so that relative ordering across
+// multi-year candidate sets is preserved (absolute decay collapses at LME timescales).
+func CompositeScoreWithRankNorm(in ScoreInput, w Weights, validFrom time.Time, candidates []*types.Memory) float64 {
+	var recency float64
+	if validFrom.IsZero() {
+		// No valid_from on this memory: fall back to absolute decay.
+		recency = RecencyDecay(in.HoursSince)
+	} else if len(candidates) == 1 {
+		// Single candidate: fully recency-boosted — no relative ordering possible.
+		recency = 1.0
+	} else {
+		minDate, maxDate := candidateDateRange(candidates)
+		if minDate.IsZero() {
+			// No candidates have valid_from: fall back.
+			recency = RecencyDecay(in.HoursSince)
+		} else {
+			recency = RankNormalizedRecency(validFrom, minDate, maxDate)
+		}
+	}
+
+	var boost float64
+	if in.DynamicImportance != nil {
+		boost = math.Max(0.1, *in.DynamicImportance)
+	} else {
+		boost = ImportanceBoost(in.Importance)
+	}
+	precision := 0.5
+	if in.RetrievalPrecision != nil {
+		precision = *in.RetrievalPrecision
+	}
+	raw := w.Vector*in.Cosine + w.BM25*in.BM25 + w.Recency*recency + w.Precision*precision
+	if in.EpisodeMatch {
+		raw *= 1.15
+	}
+	if in.IsPreferenceQuery && in.MemoryType == "preference" {
+		raw *= 1.35
 	}
 	return raw * boost
 }


### PR DESCRIPTION
## Summary

Two recall-side fixes for temporal-reasoning retrieval failures identified via LME Cluster B analysis and pipeline audit.

### F2 — Temporal classifier signal lost after query rewrite (closes #845)

The interrogative query rewriter in `cmd/longmemeval/run.go` stripped all temporal signal words from questions like *"How many days ago did I..."*, causing `isTemporalQuery()` on the Engram server to return `false` — so `TemporalWeights` were never applied to LME temporal-reasoning questions.

**Fix:** Prepend `"recent "` to the cleaned query after stripping the interrogative prefix. One-line change in the extracted `buildRecallQuery()` helper.

### F1 — RecencyDecay collapses to numerical zero at LME timescales (closes #846)

`RecencyDecay(h) = exp(-0.01 * h)` produces values of ~1e-77 for 2-year-old memories — numerically indistinguishable from zero. Temporal ranking was identical to pure cosine+BM25 for any content older than ~3 months.

**Fix:** Rank-normalize recency across the candidate set: `score = (valid_from - min_date) / (max_date - min_date)` → [0,1], 1.0 = most recent in the recalled set. Preserves temporal ordering regardless of wall-clock age.

New functions: `RankNormalizedRecency()`, `RankNormalizedRecencyWithFallback()`, `CompositeScoreWithRankNorm()` in `internal/search/score.go`. Engine calls `CompositeScoreWithRankNorm` when `tempQuery=true`.

## Testing

**TDD on both fixes:** Failing tests written before any implementation code.
- F2: 3 tests in `cmd/longmemeval/run_test.go`
- F1: 5 tests in `internal/search/score_test.go`

Full test suite: zero regressions.

## Validation

LME Cluster B (17 temporal-reasoning items): 5/17 = 29% with F1+F2 vs 3/17 = 18% baseline (+11pp). Full 500-question benchmark running now.

## Not included

F1c (target-date proximity re-ranking, `--proximity-rerank` flag) is on the experiment branch but excluded here — needs more validation before merge.