### PR TITLE
fix(embedder): canonicalize model names to allow GGUF/HF aliases [closes #855]

### DIFF
--- a/internal/instinctllm/olla.go
+++ b/internal/instinctllm/olla.go
@@ -21,7 +21,7 @@ const (
 
 // skipFamilies lists Olla model families whose thinking-mode token leakage
 // breaks structured JSON output (benchmark 2026-04-24).
-// See: ~/projects/instinct/consolidator/instinct/haiku_client.py:30
+// See: ~/projects/instinct/consolidator/instinct/haiku_client.py:30.
 var skipFamilies = map[string]struct{}{
 	"qwen3":    {},
 	"qwen3moe": {},

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1003,6 +1003,30 @@ func (e *SearchEngine) RecallWithinMemory(ctx context.Context, query string, mem
 	return out, nil
 }
 
+// embedderAliases maps known alternative name strings for the same underlying
+// model to a single canonical form. This allows GGUF filenames (as reported by
+// llama.cpp / olla) and HuggingFace IDs (as reported by Infinity / LiteLLM) to
+// be treated as compatible without triggering a false embedder_mismatch error.
+//
+// Rules: every alias for a model family must map to the same canonical string.
+// When adding a new quant variant, add it here — do not add fuzzy matching.
+var embedderAliases = map[string]string{
+	// BAAI/bge-m3 — official embedding model (2026-05-08+)
+	"bge-m3-Q8_0.gguf":   "BAAI/bge-m3",
+	"bge-m3-Q4_K_M.gguf": "BAAI/bge-m3",
+	"bge-m3":             "BAAI/bge-m3",
+	"BAAI/bge-m3":        "BAAI/bge-m3",
+}
+
+// canonicalEmbedderName returns the canonical model identifier for s.
+// If s has no alias entry, it is returned unchanged.
+func canonicalEmbedderName(s string) string {
+	if c, ok := embedderAliases[s]; ok {
+		return c
+	}
+	return s
+}
+
 // checkEmbedderMeta ensures the stored embedder name matches the current client,
 // or registers it if this is the first store for the project.
 func (e *SearchEngine) checkEmbedderMeta(ctx context.Context) error {
@@ -1018,7 +1042,7 @@ func (e *SearchEngine) checkEmbedderMeta(ctx context.Context) error {
 		return e.backend.SetMeta(ctx, e.project, "embedder_dimensions",
 			fmt.Sprintf("%d", emb.Dimensions()))
 	}
-	if storedName != emb.Name() {
+	if canonicalEmbedderName(storedName) != canonicalEmbedderName(emb.Name()) {
 		return &embed.PermanentError{
 			Code:        "embedder_mismatch",
 			Stored:      storedName,

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -477,3 +477,102 @@ func TestSearchEngine_EmbedderDimensionsMismatchReturnsPermanentError(t *testing
 	require.Contains(t, pe.Remediation, "memory_migrate_embedder",
 		"Remediation should mention memory_migrate_embedder")
 }
+
+// TestSearchEngine_EmbedderNameAliasesAreCompatible verifies that known aliases
+// of the same underlying model (e.g. GGUF filename vs HuggingFace ID) are treated
+// as compatible rather than triggering an embedder_mismatch error (#855).
+func TestSearchEngine_EmbedderNameAliasesAreCompatible(t *testing.T) {
+	ctx := context.Background()
+
+	// Subtest 1: bge-m3-Q8_0.gguf (stored by llama.cpp) vs BAAI/bge-m3 (incoming
+	// from Infinity/LiteLLM) — same model, different name conventions.
+	t.Run("gguf_filename_and_hf_id_are_compatible", func(t *testing.T) {
+		project := uniqueProject("test-embedder-alias-gguf-hf")
+
+		backend1, err := db.NewPostgresBackend(ctx, project, testDSN(t))
+		require.NoError(t, err)
+		t.Cleanup(func() { backend1.Close() })
+
+		// First engine uses the GGUF filename (as llama.cpp reports it).
+		engine1 := search.New(ctx, backend1, &fakeClientWithName{name: "bge-m3-Q8_0.gguf", dims: 1024}, project,
+			"http://ollama:11434", "llama3.2", false, nil, 0)
+		t.Cleanup(func() { engine1.Close() })
+
+		m := &types.Memory{
+			ID:          types.NewMemoryID(),
+			Content:     "stored with gguf filename embedder",
+			MemoryType:  types.MemoryTypePattern,
+			Importance:  1,
+			StorageMode: "focused",
+		}
+		err = engine1.Store(ctx, m)
+		require.NoError(t, err, "initial store with gguf filename should succeed")
+
+		backend2, err := db.NewPostgresBackend(ctx, project, testDSN(t))
+		require.NoError(t, err)
+		t.Cleanup(func() { backend2.Close() })
+
+		// Second engine uses the HuggingFace ID (as Infinity/LiteLLM reports it).
+		engine2 := search.New(ctx, backend2, &fakeClientWithName{name: "BAAI/bge-m3", dims: 1024}, project,
+			"http://ollama:11434", "llama3.2", false, nil, 0)
+		t.Cleanup(func() { engine2.Close() })
+
+		m2 := &types.Memory{
+			ID:          types.NewMemoryID(),
+			Content:     "stored with hf id embedder",
+			MemoryType:  types.MemoryTypePattern,
+			Importance:  1,
+			StorageMode: "focused",
+		}
+		// This MUST succeed — both names refer to the same BAAI/bge-m3 model.
+		err = engine2.Store(ctx, m2)
+		require.NoError(t, err, "store with HuggingFace ID should succeed when GGUF filename is stored (same model)")
+	})
+
+	// Subtest 2: genuinely different models must still be rejected.
+	t.Run("different_models_are_still_rejected", func(t *testing.T) {
+		project := uniqueProject("test-embedder-alias-different")
+
+		backend1, err := db.NewPostgresBackend(ctx, project, testDSN(t))
+		require.NoError(t, err)
+		t.Cleanup(func() { backend1.Close() })
+
+		engine1 := search.New(ctx, backend1, &fakeClientWithName{name: "BAAI/bge-m3", dims: 1024}, project,
+			"http://ollama:11434", "llama3.2", false, nil, 0)
+		t.Cleanup(func() { engine1.Close() })
+
+		m := &types.Memory{
+			ID:          types.NewMemoryID(),
+			Content:     "stored with bge-m3",
+			MemoryType:  types.MemoryTypePattern,
+			Importance:  1,
+			StorageMode: "focused",
+		}
+		err = engine1.Store(ctx, m)
+		require.NoError(t, err, "initial store should succeed")
+
+		backend2, err := db.NewPostgresBackend(ctx, project, testDSN(t))
+		require.NoError(t, err)
+		t.Cleanup(func() { backend2.Close() })
+
+		// Different model entirely — must still be rejected.
+		engine2 := search.New(ctx, backend2, &fakeClientWithName{name: "text-embedding-3-small", dims: 1536}, project,
+			"http://ollama:11434", "llama3.2", false, nil, 0)
+		t.Cleanup(func() { engine2.Close() })
+
+		m2 := &types.Memory{
+			ID:          types.NewMemoryID(),
+			Content:     "stored with text-embedding-3-small",
+			MemoryType:  types.MemoryTypePattern,
+			Importance:  1,
+			StorageMode: "focused",
+		}
+		err = engine2.Store(ctx, m2)
+		require.Error(t, err, "store with a genuinely different model should be rejected")
+		require.True(t, errors.Is(err, embed.ErrPermanent),
+			"error should wrap embed.ErrPermanent, got %v", err)
+		var pe *embed.PermanentError
+		require.True(t, errors.As(err, &pe))
+		require.Equal(t, "embedder_mismatch", pe.Code)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `embedderAliases` map and `canonicalEmbedderName()` to `internal/search/engine.go`
- Both sides of the name comparison in `checkEmbedderMeta` are now canonicalized before equality check
- `bge-m3-Q8_0.gguf` (llama.cpp / olla) and `BAAI/bge-m3` (Infinity / LiteLLM) resolve to the same canonical name and are accepted as compatible writes
- Genuinely different models (e.g. `text-embedding-3-small`) still produce `embedder_mismatch` as before

## Alias entries added

| Raw name | Canonical |
|---|---|
| `bge-m3-Q8_0.gguf` | `BAAI/bge-m3` |
| `bge-m3-Q4_K_M.gguf` | `BAAI/bge-m3` |
| `bge-m3` | `BAAI/bge-m3` |
| `BAAI/bge-m3` | `BAAI/bge-m3` |

## Implementation note

Small explicit alias map chosen over fuzzy matching — founder decision 2026-05-24. New quant variants require an explicit entry here; this is intentional to keep the match surface auditable.

## Test plan

- [x] `TestSearchEngine_EmbedderNameAliasesAreCompatible/gguf_filename_and_hf_id_are_compatible` — written as failing first (commit fc204f5), passes after fix (commit d52c972)
- [x] `TestSearchEngine_EmbedderNameAliasesAreCompatible/different_models_are_still_rejected` — different models still rejected
- [x] Full `go test -race ./...` green
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/search/...` — 0 issues