### PR TITLE
fix(mcp): expose memory_migrate_embedder

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ After `make setup`:
 /mcp
 ```
 
-All <!-- count:visible-default -->17<!-- /count --> visible tools (+ <!-- count:hidden -->29<!-- /count --> hidden maintenance tools, callable via `tools/call`) activate immediately. Four optional AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) activate when `ANTHROPIC_API_KEY` is set in `.env`. `memory_diagnose` is a built-in hidden tool, not AI-gated.
+All <!-- count:visible-default -->18<!-- /count --> visible tools (+ <!-- count:hidden -->28<!-- /count --> hidden maintenance tools, callable via `tools/call`) activate immediately. Four optional AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) activate when `ANTHROPIC_API_KEY` is set in `.env`. `memory_diagnose` is a built-in hidden tool, not AI-gated.
 
 ### Important: RFC1918 and `/setup-token`
 
@@ -156,7 +156,7 @@ For a narrower allowlist, copy the `permissions.allow` snippet logged by engram 
 
 <p align="center"><img src="docs/architecture.svg" alt="Engram Architecture" width="900"></p>
 
-Your AI client speaks MCP over SSE. Engram registers <!-- count:total-callable-default -->46<!-- /count --> tools by default (<!-- count:visible-default -->17<!-- /count --> visible in `tools/list` + <!-- count:hidden -->29<!-- /count --> hidden but callable via `tools/call`), all running entirely locally. Four AI-enhanced tools (<!-- count:ai-enhanced -->4<!-- /count -->) activate when `ANTHROPIC_API_KEY` is set, bringing the total to <!-- count:total-callable-with-ai -->50<!-- /count -->. PostgreSQL with pgvector stores everything. Ollama (local) runs the embeddings.
+Your AI client speaks MCP over SSE. Engram registers <!-- count:total-callable-default -->46<!-- /count --> tools by default (<!-- count:visible-default -->18<!-- /count --> visible in `tools/list` + <!-- count:hidden -->28<!-- /count --> hidden but callable via `tools/call`), all running entirely locally. Four AI-enhanced tools (<!-- count:ai-enhanced -->4<!-- /count -->) activate when `ANTHROPIC_API_KEY` is set, bringing the total to <!-- count:total-callable-with-ai -->50<!-- /count -->. PostgreSQL with pgvector stores everything. Ollama (local) runs the embeddings.
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -12,7 +12,7 @@ Three calls answer that — one to recall recent context, one targeted at the wo
 
 ## MCP Tool Profiles
 
-By default, engram exposes <!-- count:visible-default -->17<!-- /count --> tools in its `tools/list` MCP surface. An additional <!-- count:hidden -->29<!-- /count --> maintenance and operational tools are registered but hidden from `tools/list` — they do not appear in AI client context but remain callable via `POST /mcp tools/call`. When `ANTHROPIC_API_KEY` is set, <!-- count:ai-enhanced -->4<!-- /count --> AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) are also registered, bringing the visible total to <!-- count:visible-with-ai -->21<!-- /count -->.
+By default, engram exposes <!-- count:visible-default -->18<!-- /count --> tools in its `tools/list` MCP surface. An additional <!-- count:hidden -->28<!-- /count --> maintenance and operational tools are registered but hidden from `tools/list` — they do not appear in AI client context but remain callable via `POST /mcp tools/call`. When `ANTHROPIC_API_KEY` is set, <!-- count:ai-enhanced -->4<!-- /count --> AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) are also registered, bringing the visible total to <!-- count:visible-with-ai -->22<!-- /count -->.
 
 The three canonical numbers used throughout this doc:
 
@@ -766,4 +766,4 @@ Returns the relevant spans + a Claude-synthesised answer.
 
 ---
 
-*Canonical surface: <!-- count:unconditional -->46<!-- /count --> tools registered unconditionally (<!-- count:visible-default -->17<!-- /count --> visible in `tools/list`, <!-- count:hidden -->29<!-- /count --> hidden but callable via `tools/call`), + <!-- count:ai-enhanced -->4<!-- /count --> AI-enhanced tools when `ANTHROPIC_API_KEY` is set (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`). `memory_diagnose` is unconditional + hidden, not AI-gated.*
+*Canonical surface: <!-- count:unconditional -->46<!-- /count --> tools registered unconditionally (<!-- count:visible-default -->18<!-- /count --> visible in `tools/list`, <!-- count:hidden -->28<!-- /count --> hidden but callable via `tools/call`), + <!-- count:ai-enhanced -->4<!-- /count --> AI-enhanced tools when `ANTHROPIC_API_KEY` is set (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`). `memory_diagnose` is unconditional + hidden, not AI-gated.*

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -297,7 +297,6 @@ func hiddenToolNames() map[string]bool {
 		"memory_audit_compare":           true,
 		"memory_weight_history":          true,
 		// Embedder management
-		"memory_migrate_embedder":        true,
 		"memory_embedding_eval":          true,
 		"memory_models":                  true,
 		// Consolidation & maintenance


### PR DESCRIPTION
## Summary
- expose `memory_migrate_embedder` in the default MCP `tools/list` surface
- keep the tool registered as a normal mutating tool, not read-only
- update tool count markers after moving it from hidden to visible

## Verification
```bash
go test ./internal/mcp -run 'TestHiddenToolsAbsentFromList|TestReadOnlyHiddenOverlapIsStable|TestToolCountsMatchDocs|TestHandleMemoryMigrateEmbedder'
```

Result: `ok github.com/petersimmons1972/engram/internal/mcp 0.016s`

Closes petersimmons1972/aifleet#240
