### PR TITLE
fix: harden longmemeval command failures

### DIFF
--- a/cmd/longmemeval/all.go
+++ b/cmd/longmemeval/all.go
@@ -2,20 +2,24 @@ package main
 
 import "log"
 
-func runAll(cfg *Config) {
+func runAll(cfg *Config) int {
 	if cfg.RunID == "" {
 		cfg.RunID = newRunID()
 	}
 	log.Printf("all: run-id=%s data=%s workers=%d", cfg.RunID, cfg.DataFile, cfg.Workers)
 
 	log.Println("--- Stage 1: ingest ---")
-	runIngest(cfg)
+	runIngestFn(cfg)
 
 	log.Println("--- Stage 2: run ---")
-	runRun(cfg)
+	if exit := runRunFn(cfg); exit != 0 {
+		log.Printf("all: run stage failed (run-id=%s exit=%d)", cfg.RunID, exit)
+		return exit
+	}
 
 	log.Println("--- Stage 3: score ---")
-	runScore(cfg)
+	runScoreFn(cfg)
 
 	log.Printf("all: complete (run-id=%s)", cfg.RunID)
+	return 0
 }

--- a/cmd/longmemeval/dispatch_test.go
+++ b/cmd/longmemeval/dispatch_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"io"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -56,6 +58,79 @@ func TestDispatch_UnknownSubcommand(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "unknown subcommand") {
 		t.Errorf("expected 'unknown subcommand' in stderr, got %q", stderr.String())
+	}
+}
+
+func TestHelp_RunSubcommandDoesNotLeakResolvedAPIKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ENGRAM_API_KEY", "engram-secret-for-help-test")
+
+	var stdout, stderr bytes.Buffer
+	exit := dispatch([]string{"longmemeval", "run", "--help"}, &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("dispatch(run --help) exit = %d, want 0", exit)
+	}
+
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, "-api-key") {
+		t.Fatalf("help output missing -api-key flag: %q", combined)
+	}
+	if strings.Contains(combined, "engram-secret-for-help-test") {
+		t.Fatalf("help output leaked resolved API key:\n%s", combined)
+	}
+}
+
+func TestDispatch_SpecialSubcommandsReturnControlledHelpAndParseExitCodes(t *testing.T) {
+	if os.Getenv("LONGMEMEVAL_DISPATCH_HELPER") == "1" {
+		args := strings.Split(os.Getenv("LONGMEMEVAL_DISPATCH_ARGS"), "\n")
+		os.Exit(dispatch(args, os.Stdout, os.Stderr))
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantExit int
+		wantText string
+	}{
+		{name: "score-efficient help", args: []string{"longmemeval", "score-efficient", "--help"}, wantExit: 0, wantText: "Usage of score-efficient:"},
+		{name: "score-batch help", args: []string{"longmemeval", "score-batch", "--help"}, wantExit: 0, wantText: "Usage of score-batch:"},
+		{name: "sample-prepare help", args: []string{"longmemeval", "sample-prepare", "--help"}, wantExit: 0, wantText: "Usage of sample-prepare:"},
+		{name: "sample-analyze help", args: []string{"longmemeval", "sample-analyze", "--help"}, wantExit: 0, wantText: "Usage of sample-analyze:"},
+		{name: "route-discover help", args: []string{"longmemeval", "route-discover", "--help"}, wantExit: 0, wantText: "Usage of route-discover:"},
+		{name: "score-efficient parse error", args: []string{"longmemeval", "score-efficient", "--badflag"}, wantExit: 2, wantText: "flag provided but not defined"},
+		{name: "score-batch parse error", args: []string{"longmemeval", "score-batch", "--badflag"}, wantExit: 2, wantText: "flag provided but not defined"},
+		{name: "sample-prepare parse error", args: []string{"longmemeval", "sample-prepare", "--badflag"}, wantExit: 2, wantText: "flag provided but not defined"},
+		{name: "sample-analyze parse error", args: []string{"longmemeval", "sample-analyze", "--badflag"}, wantExit: 2, wantText: "flag provided but not defined"},
+		{name: "route-discover parse error", args: []string{"longmemeval", "route-discover", "--badflag"}, wantExit: 2, wantText: "flag provided but not defined"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestDispatch_SpecialSubcommandsReturnControlledHelpAndParseExitCodes")
+			cmd.Env = append(os.Environ(),
+				"LONGMEMEVAL_DISPATCH_HELPER=1",
+				"LONGMEMEVAL_DISPATCH_ARGS="+strings.Join(tc.args, "\n"),
+			)
+			out, err := cmd.CombinedOutput()
+
+			if tc.wantExit == 0 {
+				if err != nil {
+					t.Fatalf("subprocess err = %v, output=%s", err, out)
+				}
+			} else {
+				var exitErr *exec.ExitError
+				if !asExitError(err, &exitErr) {
+					t.Fatalf("want exit %d, err=%v, output=%s", tc.wantExit, err, out)
+				}
+				if exitErr.ExitCode() != tc.wantExit {
+					t.Fatalf("exit = %d, want %d, output=%s", exitErr.ExitCode(), tc.wantExit, out)
+				}
+			}
+
+			if !strings.Contains(string(out), tc.wantText) {
+				t.Fatalf("output missing %q:\n%s", tc.wantText, out)
+			}
+		})
 	}
 }
 

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -88,6 +88,12 @@ func main() {
 	os.Exit(dispatch(os.Args, os.Stdout, os.Stderr))
 }
 
+var (
+	runIngestFn = runIngest
+	runRunFn    = runRun
+	runScoreFn  = runScore
+)
+
 // printUsage writes the top-level usage banner.
 func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Usage: longmemeval <subcommand> [flags]")
@@ -129,6 +135,16 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  Exit 75 (EX_TEMPFAIL): backend lock held by another lme run — wait and retry")
 }
 
+func parseFlagSet(fs *flag.FlagSet, args []string) int {
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	return -1
+}
+
 // dispatch parses args and runs the requested subcommand. Returns the process
 // exit code. Extracted from main() so it is testable without spawning a
 // subprocess. Writers are injected so tests can capture output.
@@ -153,7 +169,9 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.RunID, "run-id", "", "Run ID (hex); auto-generated if empty")
 	defaultURL, defaultKey := mcpDefaults()
 	fs.StringVar(&cfg.ServerURL, "url", envOr("ENGRAM_URL", defaultURL), "Engram server URL")
-	fs.StringVar(&cfg.APIKey, "api-key", envOr("ENGRAM_API_KEY", defaultKey), "Engram API key")
+	resolvedAPIKey := envOr("ENGRAM_API_KEY", defaultKey)
+	var apiKeyOverride string
+	fs.StringVar(&apiKeyOverride, "api-key", "", "Engram API key")
 	// #751: cleanup-policy enum replaces the old boolean --no-cleanup flag.
 	// v0.x: cleanup is now scoped to ephemeral projects only. Pass --cleanup-policy=always to restore prior unconditional deletion.
 	fs.StringVar((*string)(&cfg.CleanupPolicy), "cleanup-policy", string(CleanupPolicyAuto), "Project cleanup after run stage: auto (default, delete only projects created by this run), always (unconditional), never (preserve all)")
@@ -202,7 +220,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	// score-efficient has its own flag set and early return.
 	if subcommand == "score-efficient" {
-		sefs := flag.NewFlagSet("score-efficient", flag.ExitOnError)
+		sefs := flag.NewFlagSet("score-efficient", flag.ContinueOnError)
+		sefs.SetOutput(stderr)
 		sefs.StringVar(&cfg.DataFile, "data", "", "path to longmemeval JSON (required)")
 		sefs.IntVar(&cfg.Workers, "workers", 4, "parallel workers")
 		sefs.StringVar(&cfg.OutDir, "out", ".", "output directory")
@@ -212,7 +231,9 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		sefs.IntVar(&cfg.ScorerMaxTokens, "scorer-max-tokens", longmemeval.DefaultScorerMaxTokens, "max_tokens for scoring requests (default 2048)")
 		sefs.BoolVar(&cfg.PreserveCorrect, "preserve-correct", true, "skip items already scored CORRECT")
 		sefs.BoolVar(&cfg.ForceRescore, "force-rescore", false, "ignore checkpoint, re-score everything")
-		_ = sefs.Parse(args[2:])
+		if exit := parseFlagSet(sefs, args[2:]); exit >= 0 {
+			return exit
+		}
 		if cfg.DataFile == "" {
 			_, _ = fmt.Fprintln(stderr, "--data is required")
 			return 1
@@ -225,14 +246,17 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	// score-batch has its own flag set and early return.
 	if subcommand == "score-batch" {
-		sbfs := flag.NewFlagSet("score-batch", flag.ExitOnError)
+		sbfs := flag.NewFlagSet("score-batch", flag.ContinueOnError)
+		sbfs.SetOutput(stderr)
 		sbfs.StringVar(&cfg.DataFile, "data", "", "path to longmemeval JSON (required)")
 		sbfs.StringVar(&cfg.OutDir, "out", ".", "output directory")
 		sbfs.StringVar(&cfg.ScorerModel, "scorer-model", "claude-haiku-4-5", "Anthropic model ID for batch scoring")
 		sbfs.BoolVar(&cfg.PreserveCorrect, "preserve-correct", true, "skip items already scored CORRECT")
 		sbfs.BoolVar(&cfg.ForceRescore, "force-rescore", false, "ignore checkpoint, re-score everything")
 		sbfs.StringVar(&cfg.ScorerBatchAPIKey, "api-key-anthropic", envOr("ANTHROPIC_API_KEY", ""), "Anthropic API key (env: ANTHROPIC_API_KEY)")
-		_ = sbfs.Parse(args[2:])
+		if exit := parseFlagSet(sbfs, args[2:]); exit >= 0 {
+			return exit
+		}
 		if cfg.DataFile == "" {
 			_, _ = fmt.Fprintln(stderr, "--data is required")
 			return 1
@@ -244,7 +268,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if subcommand == "sample-prepare" {
-		spfs := flag.NewFlagSet("sample-prepare", flag.ExitOnError)
+		spfs := flag.NewFlagSet("sample-prepare", flag.ContinueOnError)
+		spfs.SetOutput(stderr)
 		var sp samplePrepareConfig
 		spfs.StringVar(&sp.DataFile, "data", "", "path to LongMemEval cohort JSON")
 		spfs.StringVar(&sp.Source, "source", "", "source results directory containing checkpoint-ingest.jsonl")
@@ -254,7 +279,9 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		spfs.BoolVar(&sp.CopyRun, "copy-run", false, "copy matching checkpoint-run.jsonl rows from source")
 		spfs.BoolVar(&sp.CopyScore, "copy-score", false, "copy matching checkpoint-score.jsonl rows from source")
 		spfs.StringVar(&sp.Description, "description", "", "description recorded in sample_manifest.json")
-		_ = spfs.Parse(args[2:])
+		if exit := parseFlagSet(spfs, args[2:]); exit >= 0 {
+			return exit
+		}
 		result, err := prepareSample(sp)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "sample-prepare: %v\n", err)
@@ -267,11 +294,14 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if subcommand == "sample-analyze" {
-		safs := flag.NewFlagSet("sample-analyze", flag.ExitOnError)
+		safs := flag.NewFlagSet("sample-analyze", flag.ContinueOnError)
+		safs.SetOutput(stderr)
 		var sa sampleAnalyzeConfig
 		safs.StringVar(&sa.DataFile, "data", "", "path to LongMemEval cohort JSON")
 		safs.StringVar(&sa.ResultsDir, "results", "", "results directory containing checkpoints")
-		_ = safs.Parse(args[2:])
+		if exit := parseFlagSet(safs, args[2:]); exit >= 0 {
+			return exit
+		}
 		summary, err := analyzeSample(sa)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "sample-analyze: %v\n", err)
@@ -284,7 +314,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if subcommand == "route-discover" {
-		rdfs := flag.NewFlagSet("route-discover", flag.ExitOnError)
+		rdfs := flag.NewFlagSet("route-discover", flag.ContinueOnError)
+		rdfs.SetOutput(stderr)
 		var rd routeDiscoverConfig
 		rdfs.StringVar(&rd.FleetURL, "fleet-url", envOr("LME_FLEET_URL", "https://ai-fleet.petersimmons.com"), "AI Flight Controller base URL")
 		rdfs.StringVar(&rd.OllaURL, "olla-url", envOr("LME_OLLA_URL", "https://olla.petersimmons.com"), "Olla base URL")
@@ -294,7 +325,9 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		rdfs.StringVar(&rd.FleetKey, "fleet-key", envOr("LME_FLEET_KEY", ""), "AI Flight Controller mTLS client key")
 		rdfs.StringVar(&rd.FleetCA, "fleet-ca", envOr("LME_FLEET_CA", ""), "AI Flight Controller CA certificate")
 		rdfs.DurationVar(&rd.RequestLimit, "timeout", 10*time.Second, "request timeout for discovery calls")
-		_ = rdfs.Parse(args[2:])
+		if exit := parseFlagSet(rdfs, args[2:]); exit >= 0 {
+			return exit
+		}
 		result, err := discoverRoute(rd)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "route-discover: %v\n", err)
@@ -317,8 +350,13 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	if err := fs.Parse(args[2:]); err != nil {
-		return 2
+	if exit := parseFlagSet(fs, args[2:]); exit >= 0 {
+		return exit
+	}
+	if apiKeyOverride != "" {
+		cfg.APIKey = apiKeyOverride
+	} else {
+		cfg.APIKey = resolvedAPIKey
 	}
 	if noExclusiveBackend {
 		cfg.ExclusiveBackend = false
@@ -375,16 +413,16 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	switch subcommand {
 	case "ingest":
-		runIngest(cfg)
+		runIngestFn(cfg)
 	case "run":
 		// #703: surface non-zero exit when runRun reports any errors.
-		if exit := runRun(cfg); exit != 0 {
+		if exit := runRunFn(cfg); exit != 0 {
 			return exit
 		}
 	case "score":
-		runScore(cfg)
+		runScoreFn(cfg)
 	case "all":
-		runAll(cfg)
+		return runAll(cfg)
 	}
 	return 0
 }

--- a/cmd/longmemeval/orchestration_test.go
+++ b/cmd/longmemeval/orchestration_test.go
@@ -7,10 +7,42 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
+
+func TestRunAll_StopsWhenRunFails(t *testing.T) {
+	oldRunIngest := runIngestFn
+	oldRunRun := runRunFn
+	oldRunScore := runScoreFn
+	defer func() {
+		runIngestFn = oldRunIngest
+		runRunFn = oldRunRun
+		runScoreFn = oldRunScore
+	}()
+
+	var stages []string
+	runIngestFn = func(cfg *Config) {
+		stages = append(stages, "ingest")
+	}
+	runRunFn = func(cfg *Config) int {
+		stages = append(stages, "run")
+		return 23
+	}
+	runScoreFn = func(cfg *Config) {
+		stages = append(stages, "score")
+	}
+
+	exit := runAll(&Config{DataFile: "testdata.json", Workers: 1})
+	if exit != 23 {
+		t.Fatalf("runAll exit = %d, want 23", exit)
+	}
+	if got := strings.Join(stages, ","); got != "ingest,run" {
+		t.Fatalf("stages = %q, want ingest,run", got)
+	}
+}
 
 // TestRunScore_EndToEnd exercises the full runScore pipeline with stub data.
 // This test verifies that the orchestration code reads checkpoints, dispatches

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -22,10 +22,9 @@ import (
 var ErrDisallowedModel = errors.New("disallowed model")
 
 // debugOAIRequests gates verbose request/response logging for OAI calls.
-// Set LME_DEBUG_REQUESTS=1 to enable. Logs request body size and full response
-// body on non-200, so 400 errors include the vLLM error detail.
+// Set LME_DEBUG_REQUESTS=1 to enable. Logs endpoint/status and body sizes only;
+// response text is redacted because benchmark prompts can contain private memory.
 var debugOAIRequests = os.Getenv("LME_DEBUG_REQUESTS") == "1"
-
 
 // claudePrintTimeout is the hard cap for one claude --print call.
 
@@ -239,7 +238,7 @@ func callOAI(ctx context.Context, prompt, baseURL, model string, opts OAIOptions
 		if debugOAIRequests {
 			body, _ := io.ReadAll(resp.Body)
 			log.Printf("DEBUG callOAI: status=%d request_body_bytes=%d response_body=%s",
-				resp.StatusCode, len(reqBody), strings.TrimSpace(string(body)))
+				resp.StatusCode, len(reqBody), sanitizeOAIDebugBody(body))
 		}
 		return "", fmt.Errorf("OAI request: status %d", resp.StatusCode)
 	}
@@ -277,6 +276,10 @@ func callOAI(ctx context.Context, prompt, baseURL, model string, opts OAIOptions
 		content = strings.TrimSpace(content[idx+len("</think>"):])
 	}
 	return content, nil
+}
+
+func sanitizeOAIDebugBody(body []byte) string {
+	return fmt.Sprintf("[redacted bytes=%d]", len(bytes.TrimSpace(body)))
 }
 
 // DefaultScorerMaxTokens is the default max_tokens for OAI scoring requests.
@@ -367,7 +370,9 @@ func callOAIScoring(ctx context.Context, question, referenceAnswer, hypothesis, 
 	}
 	var oaiResp struct {
 		Choices []struct {
-			Message struct{ Content string `json:"content"` } `json:"message"`
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
 		} `json:"choices"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&oaiResp); err != nil {
@@ -393,7 +398,6 @@ func ScoreOAI(ctx context.Context, question, referenceAnswer, hypothesis, baseUR
 	label, explanation := ParseScoreLabel(out)
 	return ScoreResult{Label: label, Explanation: explanation}, nil
 }
-
 
 // GenerationPromptForType builds a generation prompt tailored to the question type.
 // For single-session-preference questions the model is instructed to describe the
@@ -607,7 +611,6 @@ func ParseScoreLabel(raw string) (label, explanation string) {
 	// Pass 3: no label found — explicit error, not a silent PARTIALLY_CORRECT.
 	return "SCORE_ERROR", strings.TrimSpace(raw)
 }
-
 
 // oaiMessage is one entry in an OpenAI-compatible chat completion request.
 type oaiMessage struct {

--- a/internal/longmemeval/claude_internal_test.go
+++ b/internal/longmemeval/claude_internal_test.go
@@ -1,0 +1,27 @@
+package longmemeval
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeOAIDebugBodyRedactsSensitiveContent(t *testing.T) {
+	body := []byte(`{"error":"bad request","prompt":"private memory context","api_key":"sk-test-secret","messages":[{"content":"user profile details"}]}`)
+
+	got := sanitizeOAIDebugBody(body)
+
+	for _, sensitive := range []string{
+		"private memory context",
+		"sk-test-secret",
+		"user profile details",
+		`"prompt"`,
+		`"messages"`,
+	} {
+		if strings.Contains(got, sensitive) {
+			t.Fatalf("sanitized debug body leaked %q in %q", sensitive, got)
+		}
+	}
+	if !strings.Contains(got, "bytes=") {
+		t.Fatalf("sanitized debug body should retain safe size metadata, got %q", got)
+	}
+}

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"strings"
 	"sync/atomic"
@@ -392,11 +393,11 @@ func TestGenerationPrompt_DefaultType_UsesGenericPrompt(t *testing.T) {
 	}
 }
 
-// TestGenerate_RequiresClaude is skipped in short mode.
+// TestGenerate_RequiresClaude is an opt-in integration test.
 func TestGenerate_RequiresClaude(t *testing.T) {
-	// #678: the claude binary is an undocumented prerequisite for this test.
-	// In CI it is not in PATH; skip rather than fail. Locally (with claude
-	// installed) the test still exercises the real code path.
+	if os.Getenv("LME_CLAUDE_INTEGRATION") != "1" {
+		t.Skip("set LME_CLAUDE_INTEGRATION=1 to run real claude --print integration test (#891)")
+	}
 	if _, err := exec.LookPath("claude"); err != nil {
 		t.Skip("claude binary not in PATH — skipping (#678)")
 	}
@@ -646,4 +647,3 @@ func TestGenerationPromptForTypeEnumerate_IgnoresEnumerateFirstForNonAggregation
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary
- stop `longmemeval all` after a failed run stage instead of scoring stale/incomplete output
- prevent longmemeval help from showing resolved Engram API key defaults
- convert special subcommands from `flag.ExitOnError` to controlled dispatch return codes
- redact OAI non-200 debug response bodies and gate real Claude CLI integration tests behind `LME_CLAUDE_INTEGRATION=1`

Fixes #876
Fixes #877
Fixes #887
Fixes #891
Partially addresses #892

## Tests
- `go test ./cmd/longmemeval -run 'TestDispatch|TestRunAll|TestHelp|TestParse' -count=1 -v`\n- `go test ./internal/longmemeval -run 'TestGenerate_RequiresClaude|TestSanitizeOAIDebugBodyRedactsSensitiveContent' -count=1 -v`\n- `go test ./cmd/longmemeval -count=1`\n- `go test ./cmd/longmemeval ./internal/longmemeval -run 'TestDispatch|TestRunAll|TestHelp|TestParse|TestGenerate_RequiresClaude|TestSanitizeOAIDebugBodyRedactsSensitiveContent' -count=1`