### PR TITLE
fix(security): flag loose ignored env files

### DIFF
--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -21,13 +21,6 @@ set -u
 # Allow override for testing (we never want a guard that fails open by accident)
 GIT="${GIT:-git}"
 
-# ── Collect staged files (added or modified, ignore deletions) ────────────────
-staged_files=$("$GIT" diff --cached --name-only --diff-filter=AM 2>/dev/null || true)
-
-if [ -z "$staged_files" ]; then
-    exit 0
-fi
-
 fail=0
 fail_reason=""
 
@@ -37,21 +30,53 @@ emit_fail() {
 }$1"
 }
 
+is_env_secret_name() {
+    case "$(basename "$1")" in
+        .env.example)
+            return 1
+            ;;
+        .env|.env.local|.env.machine-identity|.env.*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# ── 0. Local ignored env-file mode rules ──────────────────────────────────────
+# Inspect names and modes only. Do not read or print file contents.
+shopt -s nullglob
+for f in .env .env.*; do
+    if ! is_env_secret_name "$f"; then
+        continue
+    fi
+    if ! "$GIT" check-ignore -q -- "$f" 2>/dev/null; then
+        continue
+    fi
+    [ -e "$f" ] || continue
+    mode=$(stat -c '%a' "$f" 2>/dev/null || true)
+    [ -n "$mode" ] || continue
+    last_two="${mode: -2}"
+    group_digit="${last_two:0:1}"
+    world_digit="${last_two:1:1}"
+    if [ "$group_digit" != "0" ] || [ "$world_digit" != "0" ]; then
+        emit_fail "BLOCKED: ignored secret file has group/world permissions: $f mode=$mode (run: chmod 600 '$f')"
+    fi
+done
+shopt -u nullglob
+
+# ── Collect staged files (added or modified, ignore deletions) ────────────────
+staged_files=$("$GIT" diff --cached --name-only --diff-filter=AM 2>/dev/null || true)
+
+if [ -z "$staged_files" ] && [ "$fail" -eq 0 ]; then
+    exit 0
+fi
+
 # ── 1. Filename rules ─────────────────────────────────────────────────────────
 while IFS= read -r f; do
     [ -z "$f" ] && continue
-    base=$(basename "$f")
-    case "$base" in
-        .env.example)
-            ;;  # allowed
-        .env|.env.local|.env.machine-identity)
-            emit_fail "BLOCKED: staged secret file: $f"
-            ;;
-        .env.*)
-            # .env.bak.<ts>, .env.production, .env.<anything> — all blocked
-            emit_fail "BLOCKED: staged secret file: $f"
-            ;;
-    esac
+    if is_env_secret_name "$f"; then
+        emit_fail "BLOCKED: staged secret file: $f"
+    fi
 done <<< "$staged_files"
 
 # ── 2. Content rules — scan staged diff for known secret shapes ───────────────

--- a/scripts/check-secrets.test.sh
+++ b/scripts/check-secrets.test.sh
@@ -119,6 +119,25 @@ out=$(cd "$R" && bash "$GUARD" 2>&1); rc=$?
 assert_exit "unstaged .env in working tree does not block" 0 $rc
 rm -rf "$R"
 
+# ─── Test 10: ignored group-readable .env is blocked without content leak ─────
+R=$(make_repo)
+echo ".env" > "$R/.gitignore"
+git -C "$R" add .gitignore
+git -C "$R" commit -qm "ignore env"
+echo "TOPSECRET_SHOULD_NOT_PRINT=abc123" > "$R/.env"
+chmod 0640 "$R/.env"
+out=$(cd "$R" && bash "$GUARD" 2>&1); rc=$?
+assert_exit "ignored group-readable .env is blocked" 1 $rc
+assert_contains "mode warning names env file" ".env" "$out"
+if echo "$out" | grep -qF "TOPSECRET_SHOULD_NOT_PRINT"; then
+    echo "✗ FAIL: ignored env permission warning leaked file contents"
+    FAIL=$((FAIL+1))
+else
+    echo "✓ PASS: ignored env permission warning does not leak contents"
+    PASS=$((PASS+1))
+fi
+rm -rf "$R"
+
 # ─── Summary ───────────────────────────────────────────────────────────────────
 echo
 echo "─── ${PASS} passed, ${FAIL} failed ───"


### PR DESCRIPTION
## Summary
- add a names-and-modes-only permission check for ignored root .env* files
- fail the secret guard when ignored env secrets are group/world-readable
- add a regression test proving the warning names the file without printing contents
- tightened this checkout's ignored env files to 0600

Fixes #889

## Tests
- bash scripts/check-secrets.test.sh
- bash scripts/check-secrets.sh