### PR TITLE
fix(ops): harden Kubernetes status truth

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,17 +164,25 @@ The SHA-256 hash in `memories` is a content integrity check. `memory_verify` com
 
 ## Logs and Diagnostics
 
+For the live Engram deployment in this environment, Kubernetes is the operational source of truth. Start with the read-only namespace status command:
+
 ```bash
-# Check container state
+make status-k8s
+```
+
+It summarizes deployment readiness, image identity, pod restarts, previous container termination reasons, recent warning events, `/health`, `/ready`, and authenticated metrics when `ENGRAM_API_KEY` is available. Use the Docker commands below only for a confirmed local Docker/Compose stack.
+
+```bash
+# Local Docker only: check container state
 docker compose ps
 
-# Application logs — last 50 lines
+# Local Docker only: application logs - last 50 lines
 docker compose logs engram-go-app --tail=50
 
-# PostgreSQL logs
+# Local Docker only: PostgreSQL logs
 docker compose logs engram-postgres --tail=20
 
-# Memory count — quick health check
+# Local Docker only: memory count - quick health check
 docker exec engram-postgres psql -U engram -d engram -c "SELECT COUNT(*) FROM memories;"
 
 # Confirm the SSE endpoint is responding
@@ -187,7 +195,7 @@ curl -s http://localhost:8788/sse
 > `scripts/psql-exec.sh <file.sql>` which uses `docker cp` + `psql -f`
 > (unambiguous, no stdin). See issue #646.
 
-If the SSE endpoint returns nothing or hangs, check whether the Go container started correctly (`docker compose ps`) and whether PostgreSQL is accepting connections (`docker compose logs engram-postgres`). Most startup failures are PostgreSQL not finishing its initialization before the Go process tries to connect — restart with `docker compose restart engram-go-app` once PostgreSQL is ready.
+If the SSE endpoint returns nothing or hangs in live Kubernetes, run `make status-k8s` first and inspect the restart/crash/event rows before restarting anything. If the affected runtime is local Docker, check whether the Go container started correctly (`docker compose ps`) and whether PostgreSQL is accepting connections (`docker compose logs engram-postgres`). Most local startup failures are PostgreSQL not finishing its initialization before the Go process tries to connect - restart with `docker compose restart engram-go-app` once PostgreSQL is ready.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -4,6 +4,24 @@ This page documents Engram's observable metrics and how to interpret them. Each 
 
 ---
 
+## Runtime Source of Truth
+
+The live Engram service for this environment runs in Kubernetes namespace `engram`. Start live incidents with:
+
+```bash
+make status-k8s
+```
+
+That command is read-only. It reports deployment readiness, pod restart counts, previous container termination reasons, recent warning events, `/health`, `/ready`, and authenticated `/metrics` summaries when `ENGRAM_API_KEY` is set.
+
+Use Docker commands in this runbook only for local Docker/Compose development or when you have confirmed the affected runtime is a local Compose stack. The local Docker status command is:
+
+```bash
+make status NO_REMOTE=1
+```
+
+---
+
 ## Metrics Overview
 
 Engram exports Prometheus metrics on port 8788 at `/metrics`. The endpoint requires `Authorization: Bearer $ENGRAM_API_KEY`. The canonical set appears below. All metrics are prefixed `engram_`.
@@ -32,15 +50,18 @@ curl -H "Authorization: Bearer $ENGRAM_API_KEY" http://localhost:8788/metrics
 **Diagnostic commands:**
 
 ```bash
-# Check the re-embedder container health
+# Live Kubernetes: deployment, restart, crash, event, and metrics summary
+make status-k8s
+
+# Local Docker only: check the re-embedder container health
 docker ps | grep engram-reembed
 docker logs engram-reembed | tail -50
 
-# Check if the embedding service is responding
+# Local Docker only: check if the embedding service is responding
 curl -s http://localhost:11434/api/tags  # (Ollama local profile)
 curl -s http://your-litellm:4000/v1/models  # (LiteLLM hybrid profile)
 
-# Check database schema version
+# Local Docker only: check database schema version
 docker exec engram-postgres psql -U engram -d engram -c "SELECT version FROM schema_versions ORDER BY applied_at DESC LIMIT 1;"
 ```
 
@@ -68,13 +89,13 @@ docker exec engram-postgres psql -U engram -d engram -c "SELECT version FROM sch
 
 ```bash
 # Get the current metric value
-curl -s http://localhost:8788/metrics | grep engram_episodes_ended_by_reaper_total
+curl -s -H "Authorization: Bearer $ENGRAM_API_KEY" http://localhost:8788/metrics | grep engram_episodes_ended_by_reaper_total
 
-# Check SSE connection logs
+# Local Docker only: check SSE connection logs
 docker logs engram-go-app | grep "episode" | tail -20
 
 # Monitor in real-time
-watch -n 1 'curl -s http://localhost:8788/metrics | grep engram_episodes'
+watch -n 1 'curl -s -H "Authorization: Bearer $ENGRAM_API_KEY" http://localhost:8788/metrics | grep engram_episodes'
 ```
 
 **Typical fixes:**
@@ -98,9 +119,9 @@ watch -n 1 'curl -s http://localhost:8788/metrics | grep engram_episodes'
 
 ```bash
 # Get the current metric value
-curl -s http://localhost:8788/metrics | grep engram_worker_panics_total
+curl -s -H "Authorization: Bearer $ENGRAM_API_KEY" http://localhost:8788/metrics | grep engram_worker_panics_total
 
-# Get detailed panic logs
+# Local Docker only: get detailed panic logs
 docker logs engram-go-app 2>&1 | grep -i panic
 ```
 
@@ -133,10 +154,13 @@ curl http://localhost:8788/ready
 The server is starting up, migrations are running, or a component failed to initialize. In Kubernetes, start with `make status-k8s`; for local Docker, use `make status`. If it persists:
 
 ```bash
-# Check startup logs
+# Live Kubernetes: inspect the deployment and recent warnings
+make status-k8s
+
+# Local Docker only: check startup logs
 docker logs engram-go-app | tail -50
 
-# Check database connectivity
+# Local Docker only: check database connectivity
 docker exec engram-postgres pg_isready -U engram
 ```
 

--- a/infra/status-k8s.sh
+++ b/infra/status-k8s.sh
@@ -30,30 +30,38 @@ require_kubectl() {
 
 probe_deploy() {
   local name="$1"
-  local ready available desired
+  local ready available desired images detail
   ready=$(kubectl -n "$NAMESPACE" get deploy "$name" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)
   available=$(kubectl -n "$NAMESPACE" get deploy "$name" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)
   desired=$(kubectl -n "$NAMESPACE" get deploy "$name" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+  images=$(kubectl -n "$NAMESPACE" get deploy "$name" -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{" "}{end}' 2>/dev/null || true)
   ready="${ready:-0}"
   available="${available:-0}"
   desired="${desired:-0}"
+  images="${images:-unknown}"
+  detail="ready=${ready}/${desired}, available=${available}/${desired}, image=${images% }"
   if [ "$ready" = "$desired" ] && [ "$available" = "$desired" ] && [ "$desired" != "0" ]; then
-    print_row "$name" "OK" "ready=${ready}/${desired}, available=${available}/${desired}"
+    print_row "$name" "OK" "$detail"
   else
-    print_row "$name" "WARN" "ready=${ready}/${desired}, available=${available}/${desired}"
+    print_row "$name" "WARN" "$detail"
   fi
 }
 
 probe_pod_restarts() {
   local selector="$1"
   local label="$2"
-  local rows
-  rows=$(kubectl -n "$NAMESPACE" get pods -l "$selector" -o jsonpath='{range .items[*]}{.metadata.name}{" restarts="}{range .status.containerStatuses[*]}{.restartCount}{" "}{end}{"age="}{.metadata.creationTimestamp}{"\n"}{end}' 2>/dev/null || true)
+  local rows status
+  rows=$(kubectl -n "$NAMESPACE" get pods -l "$selector" -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{range .status.containerStatuses[*]}{.name}{":"}{.restartCount}{":prev="}{.lastState.terminated.reason}{":exit="}{.lastState.terminated.exitCode}{" "}{end}{"\n"}{end}' 2>/dev/null || true)
   if [ -z "$rows" ]; then
     print_row "$label pods" "WARN" "no pods found for selector ${selector}"
     return
   fi
-  print_row "$label pods" "INFO" "$rows"
+  status="OK"
+  if echo "$rows" | grep -Eq ':[1-9][0-9]*:prev='; then
+    status="WARN"
+  fi
+  rows=$(echo "$rows" | sed -e 's/prev=:exit=/prev=none:exit=none/g' -e 's/:exit= /:exit=none /g')
+  print_row "$label pods" "$status" "$rows"
 }
 
 probe_local_http() {
@@ -79,6 +87,50 @@ probe_recent_warnings() {
   fi
 }
 
+probe_metrics() {
+  local body code pending acquired max status detail ratio
+  if [ -z "${ENGRAM_API_KEY:-}" ]; then
+    print_row "metrics auth" "WARN" "skipped; set ENGRAM_API_KEY to probe authenticated /metrics"
+    return
+  fi
+
+  body=$(mktemp)
+  code=$(curl -sS --max-time "$PROBE_TIMEOUT" -o "$body" -w "%{http_code}" \
+    -H "Authorization: Bearer ${ENGRAM_API_KEY}" \
+    "http://127.0.0.1:${LOCAL_PORT}/metrics" 2>/dev/null || echo "000")
+  if [ "$code" != "200" ]; then
+    print_row "metrics auth" "WARN" "HTTP ${code}; verify ENGRAM_API_KEY and any active port-forward"
+    rm -f "$body"
+    return
+  fi
+
+  pending=$(awk '$1 == "engram_chunks_pending_reembed" {print $2; found=1; exit} END {if (!found) print "missing"}' "$body")
+  status="OK"
+  detail="pending=${pending}"
+  if [ "$pending" = "missing" ]; then
+    status="WARN"
+  elif [ "$pending" -gt 0 ] 2>/dev/null; then
+    status="WARN"
+  fi
+  print_row "metrics backlog" "$status" "$detail"
+
+  acquired=$(awk '$1 == "engram_db_pool_acquired_conns" {print $2; found=1; exit} END {if (!found) print "missing"}' "$body")
+  max=$(awk '$1 == "engram_db_pool_max_conns" {print $2; found=1; exit} END {if (!found) print "missing"}' "$body")
+  status="OK"
+  detail="acquired=${acquired}, max=${max}"
+  if [ "$acquired" = "missing" ] || [ "$max" = "missing" ] || [ "$max" = "0" ]; then
+    status="WARN"
+  else
+    ratio=$(awk -v acquired="$acquired" -v max="$max" 'BEGIN { if (max > 0) printf "%.2f", acquired / max; else print "nan" }')
+    detail="${detail}, saturation=${ratio}"
+    if awk -v ratio="$ratio" 'BEGIN { exit !(ratio >= 0.80) }'; then
+      status="WARN"
+    fi
+  fi
+  print_row "metrics db pool" "$status" "$detail"
+  rm -f "$body"
+}
+
 require_kubectl
 print_header
 print_row "context" "INFO" "$(kubectl config current-context 2>/dev/null || echo unknown)"
@@ -88,6 +140,7 @@ probe_pod_restarts "app=engram-go" "engram-go"
 probe_pod_restarts "app=engram-reembed" "engram-reembed"
 probe_local_http "/health"
 probe_local_http "/ready"
+probe_metrics
 probe_recent_warnings
 echo ""
 echo "Metrics require Bearer auth: curl -H \"Authorization: Bearer \$ENGRAM_API_KEY\" http://127.0.0.1:${LOCAL_PORT}/metrics"

--- a/scripts/status-k8s.test.sh
+++ b/scripts/status-k8s.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Test suite for infra/status-k8s.sh
+# Usage: bash scripts/status-k8s.test.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STATUS="${REPO_ROOT}/infra/status-k8s.sh"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" -eq "$actual" ]; then
+        echo "PASS: $desc (exit=$actual)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc (expected exit=$expected, got=$actual)"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "PASS: $desc"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc (missing '$needle')"
+        echo "$haystack"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+make_fake_tools() {
+    local d="$1"
+    mkdir -p "$d/bin"
+    cat > "$d/bin/kubectl" <<'FAKE_KUBECTL'
+#!/usr/bin/env bash
+args="$*"
+
+if [ "$args" = "config current-context" ]; then
+    echo "kind-engram"
+    exit 0
+fi
+
+if [[ "$args" == *"get deploy engram-go"* && "$args" == *".status.readyReplicas"* ]]; then echo 1; exit 0; fi
+if [[ "$args" == *"get deploy engram-go"* && "$args" == *".status.availableReplicas"* ]]; then echo 1; exit 0; fi
+if [[ "$args" == *"get deploy engram-go"* && "$args" == *".spec.replicas"* ]]; then echo 1; exit 0; fi
+if [[ "$args" == *"get deploy engram-go"* && "$args" == *".spec.template.spec.containers"* ]]; then echo "engram-go=engram-go:sha-a1"; exit 0; fi
+
+if [[ "$args" == *"get deploy engram-reembed"* && "$args" == *".status.readyReplicas"* ]]; then echo 1; exit 0; fi
+if [[ "$args" == *"get deploy engram-reembed"* && "$args" == *".status.availableReplicas"* ]]; then echo 1; exit 0; fi
+if [[ "$args" == *"get deploy engram-reembed"* && "$args" == *".spec.replicas"* ]]; then echo 1; exit 0; fi
+if [[ "$args" == *"get deploy engram-reembed"* && "$args" == *".spec.template.spec.containers"* ]]; then echo "reembed=engram-reembed:sha-b2"; exit 0; fi
+
+if [[ "$args" == *"get pods -l app=engram-go"* ]]; then
+    echo "engram-go-abc|engram-go:0:prev=none:exit=none"
+    exit 0
+fi
+if [[ "$args" == *"get pods -l app=engram-reembed"* ]]; then
+    echo "engram-reembed-def|reembed:12:prev=Error:exit=1"
+    exit 0
+fi
+
+if [[ "$args" == *"get events"* ]]; then
+    echo "LAST SEEN   TYPE      REASON    OBJECT                  MESSAGE"
+    echo "2m          Warning   BackOff   pod/engram-reembed-def   Back-off restarting failed container"
+    exit 0
+fi
+
+exit 0
+FAKE_KUBECTL
+    chmod +x "$d/bin/kubectl"
+
+    cat > "$d/bin/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+out=""
+write_code=false
+url=""
+auth=false
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) shift; out="$1" ;;
+        -w) write_code=true; shift ;;
+        -H) shift; [[ "$1" == Authorization:* ]] && auth=true ;;
+        http://*) url="$1" ;;
+    esac
+    shift || true
+done
+
+if [[ "$url" == */health ]]; then
+    echo "ok" > "$out"
+    $write_code && printf "200"
+    exit 0
+fi
+if [[ "$url" == */ready ]]; then
+    echo "ready" > "$out"
+    $write_code && printf "200"
+    exit 0
+fi
+if [[ "$url" == */metrics ]]; then
+    if ! $auth; then
+        echo "missing auth" > "$out"
+        $write_code && printf "401"
+        exit 0
+    fi
+    cat > "$out" <<'METRICS'
+engram_chunks_pending_reembed 42
+engram_db_pool_acquired_conns 3
+engram_db_pool_max_conns 10
+METRICS
+    $write_code && printf "200"
+    exit 0
+fi
+
+$write_code && printf "000"
+exit 0
+FAKE_CURL
+    chmod +x "$d/bin/curl"
+}
+
+TMPDIR=$(mktemp -d)
+make_fake_tools "$TMPDIR"
+
+out=$(PATH="$TMPDIR/bin:$PATH" ENGRAM_API_KEY=test-token bash "$STATUS" 2>&1)
+rc=$?
+assert_exit "status-k8s exits cleanly with fake Kubernetes and metrics" 0 "$rc"
+assert_contains "deployment image identity is shown" "image=engram-go=engram-go:sha-a1" "$out"
+assert_contains "reembed restart count warns" "engram-reembed pods           WARN" "$out"
+assert_contains "previous crash reason is included" "prev=Error" "$out"
+assert_contains "recent warning events are surfaced" "Back-off restarting failed container" "$out"
+assert_contains "pending reembed backlog is parsed from metrics" "metrics backlog               WARN" "$out"
+assert_contains "DB pool usage is parsed from metrics" "metrics db pool               OK" "$out"
+
+out=$(PATH="$TMPDIR/bin:$PATH" ENGRAM_API_KEY='' bash "$STATUS" 2>&1)
+rc=$?
+assert_exit "status-k8s exits cleanly without metrics token" 0 "$rc"
+assert_contains "missing metrics token is explicit" "metrics auth                  WARN" "$out"
+
+rm -rf "$TMPDIR"
+
+echo
+echo "--- ${PASS} passed, ${FAIL} failed ---"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- make `status-k8s` surface image identity, pod restarts, previous crash state, recent warning events, health, ready, and authenticated metrics summaries
- clarify live Kubernetes versus local Docker diagnostics in operations docs/runbook
- add a shell test suite for status-k8s behavior

Fixes #867
Fixes #885

## Tests
- `bash scripts/status-k8s.test.sh`
- `bash -n infra/status-k8s.sh scripts/status-k8s.test.sh`
- `shellcheck infra/status-k8s.sh scripts/status-k8s.test.sh`
- `git diff --check main..HEAD`