### PR TITLE
fix(lme): fail closed on score checkpoint failures

### DIFF
--- a/cmd/longmemeval/all.go
+++ b/cmd/longmemeval/all.go
@@ -5,7 +5,7 @@ import "log"
 type allStages struct {
 	ingest func(*Config)
 	run    func(*Config) int
-	score  func(*Config)
+	score  func(*Config) int
 }
 
 func runAll(cfg *Config) int {
@@ -32,7 +32,10 @@ func runAllWithStages(cfg *Config, stages allStages) int {
 	}
 
 	log.Println("--- Stage 3: score ---")
-	stages.score(cfg)
+	if exit := stages.score(cfg); exit != 0 {
+		log.Printf("all: score stage failed with exit=%d (run-id=%s)", exit, cfg.RunID)
+		return exit
+	}
 
 	log.Printf("all: complete (run-id=%s)", cfg.RunID)
 	return 0

--- a/cmd/longmemeval/all_test.go
+++ b/cmd/longmemeval/all_test.go
@@ -15,8 +15,9 @@ func TestRunAllWithStagesStopsBeforeScoreWhenRunFails(t *testing.T) {
 			calls = append(calls, "run")
 			return 7
 		},
-		score: func(*Config) {
+		score: func(*Config) int {
 			calls = append(calls, "score")
+			return 0
 		},
 	}
 
@@ -41,8 +42,9 @@ func TestRunAllWithStagesRunsScoreAfterSuccessfulRun(t *testing.T) {
 			calls = append(calls, "run")
 			return 0
 		},
-		score: func(*Config) {
+		score: func(*Config) int {
 			calls = append(calls, "score")
+			return 0
 		},
 	}
 

--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -25,11 +25,12 @@ func runIngest(cfg *Config) {
 	log.Printf("ingest: %d items loaded, %d already done", len(items), len(skip))
 
 	ckptCh := make(chan longmemeval.IngestEntry, cfg.Workers*2)
+	writerErr := make(chan error, 1)
 	var wgWriter sync.WaitGroup
 	wgWriter.Add(1)
 	go func() {
 		defer wgWriter.Done()
-		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+		writerErr <- longmemeval.WriteCheckpoint(ckptPath, ckptCh)
 	}()
 
 	work := make(chan longmemeval.Item, len(items))
@@ -51,6 +52,9 @@ func runIngest(cfg *Config) {
 	wg.Wait()
 	close(ckptCh)
 	wgWriter.Wait()
+	if err := <-writerErr; err != nil {
+		log.Fatalf("write ingest checkpoint: %v", err)
+	}
 
 	log.Printf("ingest: complete")
 }

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -407,7 +407,9 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 			return exit
 		}
 	case "score":
-		runScore(cfg)
+		if exit := runScore(cfg); exit != 0 {
+			return exit
+		}
 	case "all":
 		return runAll(cfg)
 	}

--- a/cmd/longmemeval/orchestration_test.go
+++ b/cmd/longmemeval/orchestration_test.go
@@ -134,6 +134,46 @@ func TestRunScore_SkipsAlreadyDone(t *testing.T) {
 	}
 }
 
+func TestRunScore_AllAttemptedRowsFailReturnsNonZero(t *testing.T) {
+	dir := t.TempDir()
+
+	items := []longmemeval.Item{
+		{QuestionID: "q001", QuestionType: "single-session-user", Question: "?", Answer: "A"},
+		{QuestionID: "q002", QuestionType: "single-session-user", Question: "?", Answer: "B"},
+	}
+	data, _ := json.Marshal(items)
+	dataPath := filepath.Join(dir, "data.json")
+	if err := os.WriteFile(dataPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q001", Status: "done"},
+		longmemeval.IngestEntry{QuestionID: "q002", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q001", Hypothesis: "wrong", Status: "done"},
+		longmemeval.RunEntry{QuestionID: "q002", Hypothesis: "wrong", Status: "done"},
+	})
+
+	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "judge unavailable", http.StatusInternalServerError)
+	}))
+	defer llmSrv.Close()
+
+	cfg := &Config{
+		DataFile:   dataPath,
+		OutDir:     dir,
+		Workers:    1,
+		Retries:    0,
+		RunID:      "testrun",
+		LLMBaseURL: llmSrv.URL,
+		LLMModel:   "test-model",
+	}
+	if exit := runScore(cfg); exit == 0 {
+		t.Fatal("runScore returned 0 after every attempted score row failed")
+	}
+}
+
 // writeCheckpointFile writes a JSONL checkpoint file from a slice of values.
 func writeCheckpointFile(t *testing.T, path string, items []any) {
 	t.Helper()

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -218,10 +218,11 @@ func runRun(cfg *Config) int {
 	}()
 
 	var wgWriter sync.WaitGroup
+	writerErr := make(chan error, 1)
 	wgWriter.Add(1)
 	go func() {
 		defer wgWriter.Done()
-		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+		writerErr <- longmemeval.WriteCheckpoint(ckptPath, ckptCh)
 	}()
 
 	work := make(chan longmemeval.IngestEntry, len(ingestEntries))
@@ -250,6 +251,10 @@ func runRun(cfg *Config) int {
 	wg.Wait()
 	close(innerCh)
 	wgWriter.Wait()
+	if err := <-writerErr; err != nil {
+		log.Printf("ERROR run checkpoint write failed: %v", err)
+		return 1
+	}
 
 	// S9 (#807): emit one end-of-run summary line (token: cleanup-summary).
 	preserved := pl.names()

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -13,7 +13,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
 
-func runScore(cfg *Config) {
+func runScore(cfg *Config) int {
 	items := loadItems(cfg.DataFile)
 	itemMap := make(map[string]longmemeval.Item, len(items))
 	for _, item := range items {
@@ -42,11 +42,13 @@ func runScore(cfg *Config) {
 	log.Printf("score: %d run entries loaded, %d already done", len(runEntries), len(skip))
 
 	ckptCh := make(chan longmemeval.ScoreEntry, cfg.Workers*2)
+	scoreStats := make(chan longmemeval.ScoreEntry, len(runEntries))
+	writerErr := make(chan error, 1)
 	var wgWriter sync.WaitGroup
 	wgWriter.Add(1)
 	go func() {
 		defer wgWriter.Done()
-		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+		writerErr <- longmemeval.WriteCheckpoint(ckptPath, ckptCh)
 	}()
 
 	// Buffer sized to full input so pre-load before workers start cannot block.
@@ -63,12 +65,22 @@ func runScore(cfg *Config) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			scoreWorker(cfg, itemMap, work, ckptCh)
+			scoreWorker(cfg, itemMap, work, ckptCh, scoreStats)
 		}()
 	}
 	wg.Wait()
+	close(scoreStats)
 	close(ckptCh)
 	wgWriter.Wait()
+	checkpointErr := <-writerErr
+
+	var attempted, failed int
+	for entry := range scoreStats {
+		attempted++
+		if entry.Status != "done" {
+			failed++
+		}
+	}
 
 	// Load all score entries and write output files.
 	allScores, err := longmemeval.ReadAllScore(ckptPath)
@@ -76,7 +88,16 @@ func runScore(cfg *Config) {
 		log.Fatalf("read final scores: %v", err)
 	}
 	writeOutputs(cfg, itemMap, ingestMap, runMap, allScores)
+	if checkpointErr != nil {
+		log.Printf("ERROR score checkpoint write failed: %v", checkpointErr)
+		return 1
+	}
+	if attempted > 0 && failed == attempted {
+		log.Printf("ERROR score: all attempted rows failed (attempted=%d failed=%d)", attempted, failed)
+		return 1
+	}
 	log.Printf("score: complete")
+	return 0
 }
 
 func loadIngestMap(outDir string) (map[string]longmemeval.IngestEntry, error) {
@@ -93,16 +114,19 @@ func loadIngestMap(outDir string) (map[string]longmemeval.IngestEntry, error) {
 	return ingestMap, nil
 }
 
-func scoreWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.RunEntry, out chan<- longmemeval.ScoreEntry) {
+func scoreWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.RunEntry, out chan<- longmemeval.ScoreEntry, stats chan<- longmemeval.ScoreEntry) {
 	ctx := context.Background()
 	for runEntry := range work {
 		item, ok := itemMap[runEntry.QuestionID]
 		if !ok {
-			out <- longmemeval.ScoreEntry{QuestionID: runEntry.QuestionID, Status: "error", Error: "item not in data file"}
+			entry := longmemeval.ScoreEntry{QuestionID: runEntry.QuestionID, Status: "error", Error: "item not in data file"}
+			out <- entry
+			stats <- entry
 			continue
 		}
 		entry := scoreOne(ctx, cfg, item, runEntry)
 		out <- entry
+		stats <- entry
 		log.Printf("score [%s] label=%s", runEntry.QuestionID, entry.ScoreLabel)
 	}
 }

--- a/cmd/longmemeval/score_batch.go
+++ b/cmd/longmemeval/score_batch.go
@@ -113,7 +113,10 @@ func runScoreBatch(cfg *Config) int {
 		close(ckptCh)
 		// WriteCheckpoint is designed for goroutine use but works synchronously
 		// when the channel is already closed.
-		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+		if err := longmemeval.WriteCheckpoint(ckptPath, ckptCh); err != nil {
+			log.Printf("ERROR score-batch checkpoint write failed: %v", err)
+			return 1
+		}
 	}
 
 	// Load all scores and write output files.

--- a/cmd/longmemeval/score_efficient.go
+++ b/cmd/longmemeval/score_efficient.go
@@ -105,11 +105,12 @@ func runScoreEfficient(cfg *Config) int {
 	log.Printf("score-efficient: skipped=%d(CORRECT) queued=%d", skipped, queued)
 
 	ckptCh := make(chan longmemeval.ScoreEntry, cfg.Workers*2)
+	writerErr := make(chan error, 1)
 	var wgWriter sync.WaitGroup
 	wgWriter.Add(1)
 	go func() {
 		defer wgWriter.Done()
-		longmemeval.WriteCheckpoint(ckptPath, ckptCh)
+		writerErr <- longmemeval.WriteCheckpoint(ckptPath, ckptCh)
 	}()
 
 	var wg sync.WaitGroup
@@ -123,6 +124,10 @@ func runScoreEfficient(cfg *Config) int {
 	wg.Wait()
 	close(ckptCh)
 	wgWriter.Wait()
+	if err := <-writerErr; err != nil {
+		log.Printf("ERROR score-efficient checkpoint write failed: %v", err)
+		return 1
+	}
 
 	allScores, err := longmemeval.ReadAllScore(ckptPath)
 	if err != nil {

--- a/internal/longmemeval/checkpoint.go
+++ b/internal/longmemeval/checkpoint.go
@@ -4,26 +4,31 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 )
 
 // WriteCheckpoint reads entries from ch and appends each as a JSON line to path.
 // Runs until ch is closed. Designed to run in a dedicated goroutine.
-func WriteCheckpoint[T any](path string, ch <-chan T) {
+func WriteCheckpoint[T any](path string, ch <-chan T) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		log.Printf("WARN WriteCheckpoint: open %s: %v — all entries will be lost", path, err)
 		for range ch {
 		}
-		return
+		return err
 	}
 	defer func() { _ = f.Close() }()
 	enc := json.NewEncoder(f)
 	var encodeErrs int
+	var firstErr error
 	for entry := range ch {
 		if err := enc.Encode(entry); err != nil {
 			encodeErrs++
+			if firstErr == nil {
+				firstErr = err
+			}
 			// Log every individual failure so on-call can identify which entry
 			// was lost. #670: previously discarded silently — silent loss of
 			// expensive LLM-call results is unacceptable.
@@ -33,6 +38,10 @@ func WriteCheckpoint[T any](path string, ch <-chan T) {
 	if encodeErrs > 0 {
 		log.Printf("WARN WriteCheckpoint: %d entries failed to encode in %s — results may be incomplete (#670)", encodeErrs, path)
 	}
+	if firstErr != nil {
+		return fmt.Errorf("write checkpoint %s: %d encode failures: %w", path, encodeErrs, firstErr)
+	}
+	return nil
 }
 
 // ReadSkipSet reads a checkpoint file and returns a set of question IDs with
@@ -50,13 +59,15 @@ func ReadSkipSet(path string) (map[string]bool, error) {
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	line := 0
 	for scanner.Scan() {
+		line++
 		var entry struct {
 			QuestionID string `json:"question_id"`
 			Status     string `json:"status"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
+			return nil, fmt.Errorf("read checkpoint %s line %d: %w", path, line, err)
 		}
 		if entry.Status == "done" {
 			skip[entry.QuestionID] = true
@@ -81,14 +92,16 @@ func ReadScoredLabels(path string) (map[string]string, error) {
 	defer func() { _ = f.Close() }()
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	line := 0
 	for scanner.Scan() {
+		line++
 		var entry struct {
 			QuestionID string `json:"question_id"`
 			Status     string `json:"status"`
 			ScoreLabel string `json:"score_label"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
+			return nil, fmt.Errorf("read checkpoint %s line %d: %w", path, line, err)
 		}
 		if entry.QuestionID == "" {
 			continue
@@ -130,10 +143,12 @@ func readAll[T any](path string) ([]T, error) {
 	var out []T
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	line := 0
 	for scanner.Scan() {
+		line++
 		var entry T
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
+			return nil, fmt.Errorf("read checkpoint %s line %d: %w", path, line, err)
 		}
 		out = append(out, entry)
 	}

--- a/internal/longmemeval/checkpoint_test.go
+++ b/internal/longmemeval/checkpoint_test.go
@@ -1,9 +1,11 @@
 package longmemeval_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
@@ -44,6 +46,65 @@ func TestReadSkipSet_Missing(t *testing.T) {
 	}
 	if len(skip) != 0 {
 		t.Errorf("expected empty skip set, got %d entries", len(skip))
+	}
+}
+
+func TestCheckpointReadersFailClosedOnMalformedJSONL(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name string
+		read func(string) error
+	}{
+		{
+			name: "skip set",
+			read: func(path string) error {
+				_, err := longmemeval.ReadSkipSet(path)
+				return err
+			},
+		},
+		{
+			name: "scored labels",
+			read: func(path string) error {
+				_, err := longmemeval.ReadScoredLabels(path)
+				return err
+			},
+		},
+		{
+			name: "all ingest",
+			read: func(path string) error {
+				_, err := longmemeval.ReadAllIngest(path)
+				return err
+			},
+		},
+		{
+			name: "all run",
+			read: func(path string) error {
+				_, err := longmemeval.ReadAllRun(path)
+				return err
+			},
+		},
+		{
+			name: "all score",
+			read: func(path string) error {
+				_, err := longmemeval.ReadAllScore(path)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "-")+".jsonl")
+			data := []byte("{\"question_id\":\"q001\",\"status\":\"done\"}\n{bad-json\n")
+			if err := os.WriteFile(path, data, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := tt.read(path); err == nil {
+				t.Fatal("expected malformed checkpoint line to fail closed")
+			}
+		})
 	}
 }
 
@@ -117,4 +178,18 @@ func TestReadAllIngest(t *testing.T) {
 	if len(entries) != 1 || entries[0].Project != "lme-x-q001" {
 		t.Errorf("unexpected entries: %+v", entries)
 	}
+}
+
+func TestWriteCheckpointReturnsOpenError(t *testing.T) {
+	ch := make(chan longmemeval.IngestEntry)
+	close(ch)
+
+	err := longmemeval.WriteCheckpoint(filepath.Join(t.TempDir(), "missing", "ckpt.jsonl"), ch)
+	if err == nil {
+		t.Fatal("expected open failure to be returned")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	t.Fatalf("expected not-exist error, got %v", err)
 }


### PR DESCRIPTION
## Summary
- make LongMemEval checkpoint readers fail closed on malformed JSONL instead of silently skipping corrupt rows
- make checkpoint writer errors observable to score orchestration
- make `score` and `all` return non-zero when every attempted score row fails

Fixes #881
Fixes #882

## Tests
- `go test ./cmd/longmemeval ./internal/longmemeval -count=1`
- `git diff --check main..HEAD`
