### PR TITLE
fix(lme): write artifacts with private permissions

### DIFF
--- a/cmd/longmemeval/artifacts.go
+++ b/cmd/longmemeval/artifacts.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	privateArtifactFileMode os.FileMode = 0o600
+	privateArtifactDirMode  os.FileMode = 0o700
+)
+
+func createPrivateArtifact(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, privateArtifactFileMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Chmod(privateArtifactFileMode); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return f, nil
+}

--- a/cmd/longmemeval/sample.go
+++ b/cmd/longmemeval/sample.go
@@ -101,8 +101,11 @@ func prepareSample(cfg samplePrepareConfig) (samplePrepareResult, error) {
 		return samplePrepareResult{}, fmt.Errorf("source ingest checkpoint contains %d/%d selected items", len(filteredIngest), len(items))
 	}
 
-	if err := os.MkdirAll(cfg.OutDir, 0o755); err != nil {
+	if err := os.MkdirAll(cfg.OutDir, privateArtifactDirMode); err != nil {
 		return samplePrepareResult{}, fmt.Errorf("create output dir: %w", err)
+	}
+	if err := os.Chmod(cfg.OutDir, privateArtifactDirMode); err != nil {
+		return samplePrepareResult{}, fmt.Errorf("chmod output dir: %w", err)
 	}
 	if err := writeJSON(filepath.Join(cfg.OutDir, "data.json"), items); err != nil {
 		return samplePrepareResult{}, err
@@ -284,7 +287,7 @@ func loadItemsFile(path string) ([]longmemeval.Item, error) {
 }
 
 func writeJSON(path string, v any) error {
-	f, err := os.Create(path)
+	f, err := createPrivateArtifact(path)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", path, err)
 	}
@@ -298,7 +301,7 @@ func writeJSON(path string, v any) error {
 }
 
 func writeJSONL[T any](path string, entries []T) error {
-	f, err := os.Create(path)
+	f, err := createPrivateArtifact(path)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", path, err)
 	}
@@ -321,7 +324,7 @@ func copyFilteredJSONL(src, dst string, idSet map[string]bool) error {
 		return fmt.Errorf("open %s: %w", src, err)
 	}
 	defer func() { _ = in.Close() }()
-	out, err := os.Create(dst)
+	out, err := createPrivateArtifact(dst)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", dst, err)
 	}

--- a/cmd/longmemeval/sample_test.go
+++ b/cmd/longmemeval/sample_test.go
@@ -104,6 +104,7 @@ func TestPrepareSampleAppliesMaxPerType(t *testing.T) {
 }
 
 func TestPrepareSampleCreatesPrivateArtifacts(t *testing.T) {
+	defer withPermissiveUmask(t)()
 	dir := t.TempDir()
 	source := filepath.Join(dir, "source")
 	out := filepath.Join(dir, "out")

--- a/cmd/longmemeval/sample_test.go
+++ b/cmd/longmemeval/sample_test.go
@@ -103,6 +103,46 @@ func TestPrepareSampleAppliesMaxPerType(t *testing.T) {
 	}
 }
 
+func TestPrepareSampleCreatesPrivateArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	out := filepath.Join(dir, "out")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dataPath := filepath.Join(dir, "cohort.json")
+	writeItems(t, dataPath, []longmemeval.Item{
+		{QuestionID: "q1", QuestionType: "temporal-reasoning", Question: "When?", Answer: "A"},
+	})
+	writeCheckpointFile(t, filepath.Join(source, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q1", Project: "lme-old-q1", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(source, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q1", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(source, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q1", Status: "done", ScoreLabel: "CORRECT"},
+	})
+
+	if _, err := prepareSample(samplePrepareConfig{
+		DataFile:  dataPath,
+		Source:    source,
+		OutDir:    out,
+		CopyRun:   true,
+		CopyScore: true,
+	}); err != nil {
+		t.Fatalf("prepareSample: %v", err)
+	}
+
+	assertMode(t, out, 0o700)
+	assertMode(t, filepath.Join(out, "data.json"), 0o600)
+	assertMode(t, filepath.Join(out, "checkpoint-ingest.jsonl"), 0o600)
+	assertMode(t, filepath.Join(out, "checkpoint-run.jsonl"), 0o600)
+	assertMode(t, filepath.Join(out, "checkpoint-score.jsonl"), 0o600)
+	assertMode(t, filepath.Join(out, "sample_manifest.json"), 0o600)
+}
+
 func TestAnalyzeSampleSummarizesScoresAndRetrievalCoverage(t *testing.T) {
 	dir := t.TempDir()
 	dataPath := filepath.Join(dir, "data.json")

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -175,7 +175,7 @@ func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap ma
 }
 
 func writeHypotheses(cfg *Config, scores []longmemeval.ScoreEntry) {
-	f, err := os.Create(filepath.Join(cfg.OutDir, "hypotheses.jsonl"))
+	f, err := createPrivateArtifact(filepath.Join(cfg.OutDir, "hypotheses.jsonl"))
 	if err != nil {
 		log.Printf("WARN write hypotheses.jsonl: %v", err)
 		return
@@ -192,7 +192,7 @@ func writeHypotheses(cfg *Config, scores []longmemeval.ScoreEntry) {
 }
 
 func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, runMap map[string]longmemeval.RunEntry, scores []longmemeval.ScoreEntry) {
-	f, err := os.Create(filepath.Join(cfg.OutDir, "retrieval_log.jsonl"))
+	f, err := createPrivateArtifact(filepath.Join(cfg.OutDir, "retrieval_log.jsonl"))
 	if err != nil {
 		log.Printf("WARN write retrieval_log.jsonl: %v", err)
 		return
@@ -282,8 +282,12 @@ func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
 		return
 	}
 	path := filepath.Join(cfg.OutDir, "score_report.json")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, privateArtifactFileMode); err != nil {
 		log.Printf("WARN write score_report.json: %v", err)
+		return
+	}
+	if err := os.Chmod(path, privateArtifactFileMode); err != nil {
+		log.Printf("WARN chmod score_report.json: %v", err)
 		return
 	}
 	log.Printf("wrote %s", path)

--- a/cmd/longmemeval/score_test.go
+++ b/cmd/longmemeval/score_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
@@ -141,6 +142,7 @@ func TestWriteScoreReport_Basic(t *testing.T) {
 }
 
 func TestWriteOutputArtifactsArePrivate(t *testing.T) {
+	defer withPermissiveUmask(t)()
 	dir := t.TempDir()
 	cfg := &Config{OutDir: dir, RunID: "private-artifacts-test"}
 	scores := []longmemeval.ScoreEntry{
@@ -167,8 +169,12 @@ func TestWriteOutputArtifactsTightenExistingFiles(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &Config{OutDir: dir, RunID: "private-artifacts-test"}
 	for _, name := range []string{"hypotheses.jsonl", "retrieval_log.jsonl", "score_report.json"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("stale"), 0o644); err != nil {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("stale"), 0o600); err != nil {
 			t.Fatalf("seed %s: %v", name, err)
+		}
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatalf("chmod seed %s: %v", name, err)
 		}
 	}
 
@@ -308,6 +314,14 @@ func assertMode(t *testing.T, path string, want os.FileMode) {
 	}
 	if got := info.Mode().Perm(); got != want {
 		t.Fatalf("%s mode = %o, want %o", filepath.Base(path), got, want)
+	}
+}
+
+func withPermissiveUmask(t *testing.T) func() {
+	t.Helper()
+	old := syscall.Umask(0)
+	return func() {
+		syscall.Umask(old)
 	}
 }
 

--- a/cmd/longmemeval/score_test.go
+++ b/cmd/longmemeval/score_test.go
@@ -140,6 +140,45 @@ func TestWriteScoreReport_Basic(t *testing.T) {
 	}
 }
 
+func TestWriteOutputArtifactsArePrivate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{OutDir: dir, RunID: "private-artifacts-test"}
+	scores := []longmemeval.ScoreEntry{
+		{QuestionID: "q1", QuestionType: "single-session-user", Hypothesis: "answer one", ScoreLabel: "CORRECT", Status: "done"},
+	}
+	itemMap := map[string]longmemeval.Item{
+		"q1": {QuestionID: "q1", AnswerSessionIDs: []string{"sid-a"}},
+	}
+	ingestMap := map[string]longmemeval.IngestEntry{
+		"q1": {QuestionID: "q1", MemoryMap: map[string]string{"mem-1": "sid-a"}},
+	}
+	runMap := map[string]longmemeval.RunEntry{
+		"q1": {QuestionID: "q1", RetrievedIDs: []string{"mem-1"}},
+	}
+
+	writeOutputs(cfg, itemMap, ingestMap, runMap, scores)
+
+	assertMode(t, filepath.Join(dir, "hypotheses.jsonl"), 0o600)
+	assertMode(t, filepath.Join(dir, "retrieval_log.jsonl"), 0o600)
+	assertMode(t, filepath.Join(dir, "score_report.json"), 0o600)
+}
+
+func TestWriteOutputArtifactsTightenExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{OutDir: dir, RunID: "private-artifacts-test"}
+	for _, name := range []string{"hypotheses.jsonl", "retrieval_log.jsonl", "score_report.json"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("stale"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	writeOutputs(cfg, nil, nil, nil, nil)
+
+	assertMode(t, filepath.Join(dir, "hypotheses.jsonl"), 0o600)
+	assertMode(t, filepath.Join(dir, "retrieval_log.jsonl"), 0o600)
+	assertMode(t, filepath.Join(dir, "score_report.json"), 0o600)
+}
+
 func TestWriteHypotheses_Basic(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &Config{OutDir: dir}
@@ -258,6 +297,17 @@ func TestNormalizeLabel(t *testing.T) {
 		if got != c.want {
 			t.Errorf("normalizeLabel(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", filepath.Base(path), got, want)
 	}
 }
 

--- a/internal/longmemeval/checkpoint.go
+++ b/internal/longmemeval/checkpoint.go
@@ -12,7 +12,7 @@ import (
 // WriteCheckpoint reads entries from ch and appends each as a JSON line to path.
 // Runs until ch is closed. Designed to run in a dedicated goroutine.
 func WriteCheckpoint[T any](path string, ch <-chan T) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		log.Printf("WARN WriteCheckpoint: open %s: %v — all entries will be lost", path, err)
 		for range ch {
@@ -20,6 +20,9 @@ func WriteCheckpoint[T any](path string, ch <-chan T) error {
 		return err
 	}
 	defer func() { _ = f.Close() }()
+	if err := f.Chmod(0o600); err != nil {
+		log.Printf("WARN WriteCheckpoint: chmod %s: %v", path, err)
+	}
 	enc := json.NewEncoder(f)
 	var encodeErrs int
 	var firstErr error

--- a/internal/longmemeval/checkpoint_test.go
+++ b/internal/longmemeval/checkpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
@@ -19,7 +20,9 @@ func TestCheckpointRoundTrip(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		longmemeval.WriteCheckpoint(path, ch)
+		if err := longmemeval.WriteCheckpoint(path, ch); err != nil {
+			t.Errorf("WriteCheckpoint: %v", err)
+		}
 	}()
 
 	ch <- longmemeval.IngestEntry{QuestionID: "q001", Status: "done", SessionCount: 3}
@@ -40,6 +43,7 @@ func TestCheckpointRoundTrip(t *testing.T) {
 }
 
 func TestWriteCheckpointCreatesPrivateFile(t *testing.T) {
+	defer withPermissiveUmask(t)()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "checkpoint-score.jsonl")
 
@@ -47,7 +51,9 @@ func TestWriteCheckpointCreatesPrivateFile(t *testing.T) {
 	ch <- longmemeval.ScoreEntry{QuestionID: "q001", Status: "done"}
 	close(ch)
 
-	longmemeval.WriteCheckpoint(path, ch)
+	if err := longmemeval.WriteCheckpoint(path, ch); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -61,15 +67,20 @@ func TestWriteCheckpointCreatesPrivateFile(t *testing.T) {
 func TestWriteCheckpointTightensExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "checkpoint-run.jsonl")
-	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
 		t.Fatalf("seed checkpoint: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod seed checkpoint: %v", err)
 	}
 
 	ch := make(chan longmemeval.RunEntry, 1)
 	ch <- longmemeval.RunEntry{QuestionID: "q001", Status: "done"}
 	close(ch)
 
-	longmemeval.WriteCheckpoint(path, ch)
+	if err := longmemeval.WriteCheckpoint(path, ch); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -146,6 +157,14 @@ func TestCheckpointReadersFailClosedOnMalformedJSONL(t *testing.T) {
 				t.Fatal("expected malformed checkpoint line to fail closed")
 			}
 		})
+	}
+}
+
+func withPermissiveUmask(t *testing.T) func() {
+	t.Helper()
+	old := syscall.Umask(0)
+	return func() {
+		syscall.Umask(old)
 	}
 }
 

--- a/internal/longmemeval/checkpoint_test.go
+++ b/internal/longmemeval/checkpoint_test.go
@@ -39,6 +39,47 @@ func TestCheckpointRoundTrip(t *testing.T) {
 	}
 }
 
+func TestWriteCheckpointCreatesPrivateFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint-score.jsonl")
+
+	ch := make(chan longmemeval.ScoreEntry, 1)
+	ch <- longmemeval.ScoreEntry{QuestionID: "q001", Status: "done"}
+	close(ch)
+
+	longmemeval.WriteCheckpoint(path, ch)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat checkpoint: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("checkpoint mode = %o, want 600", got)
+	}
+}
+
+func TestWriteCheckpointTightensExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint-run.jsonl")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatalf("seed checkpoint: %v", err)
+	}
+
+	ch := make(chan longmemeval.RunEntry, 1)
+	ch <- longmemeval.RunEntry{QuestionID: "q001", Status: "done"}
+	close(ch)
+
+	longmemeval.WriteCheckpoint(path, ch)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat checkpoint: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("checkpoint mode = %o, want 600", got)
+	}
+}
+
 func TestReadSkipSet_Missing(t *testing.T) {
 	skip, err := longmemeval.ReadSkipSet("/tmp/nonexistent-ckpt-xyz.jsonl")
 	if err != nil {


### PR DESCRIPTION
## Summary
- write LongMemEval checkpoint and result artifacts with private file permissions by default
- create sample output directories privately
- add deterministic permission tests for checkpoints, hypotheses, retrieval logs, score reports, and sample outputs

Fixes #888

## Existing related issue
- #866 is already fixed on current main: score-efficient and score-batch both load ingest checkpoints before `writeOutputs`, and `TestRunScoreEfficient_WritesRetrievalLogFromIngestCheckpoint` verifies retrieval-log regeneration.

## Tests
- `golangci-lint run`
- `go test -count=1 ./internal/longmemeval ./cmd/longmemeval`
- `git diff --check main..HEAD`
