### PR TITLE
fix(lme): make CLI score output and route discovery consistent

### DIFF
--- a/cmd/longmemeval/dispatch_test.go
+++ b/cmd/longmemeval/dispatch_test.go
@@ -220,6 +220,18 @@ func TestApplySharedDefaultsUsesEnvironmentWhenFlagsOmitted(t *testing.T) {
 	}
 }
 
+func TestDispatchRejectsInvalidScoreOutputMode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := dispatch([]string{"longmemeval", "score", "--data", "questions.json", "--score-output", "xml"}, &stdout, &stderr)
+
+	if exit == 0 {
+		t.Fatal("dispatch accepted invalid --score-output")
+	}
+	if !strings.Contains(stderr.String(), "--score-output") {
+		t.Fatalf("stderr = %q, want --score-output validation error", stderr.String())
+	}
+}
+
 func writeClaudeMCPConfig(t *testing.T, home, token string) {
 	t.Helper()
 	dir := filepath.Join(home, ".claude")

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -34,6 +34,8 @@ type Config struct {
 	LLMModel       string // model name for LLMBaseURL endpoint
 	EnableThinking bool   // enable chain-of-thought for models that support it (Qwen3)
 	LLMMaxTokens   int    // output token budget; 0 → default (2048 thinking-off, 8192 thinking-on)
+	ScoreOutput    string // score stdout mode: text, json, or quiet
+	Output         io.Writer
 
 	// score-efficient flags
 	ScorerURL       string // OAI endpoint for score-efficient (env: LME_SCORER_URL)
@@ -174,6 +176,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.LLMModel, "llm-model", envOr("LME_LLM_MODEL", ""), "Model name for --llm-url endpoint")
 	fs.BoolVar(&cfg.EnableThinking, "enable-thinking", false, "Enable chain-of-thought reasoning (Qwen3 and compatible models; do NOT use with Nemotron v3)")
 	fs.IntVar(&cfg.LLMMaxTokens, "max-tokens", 0, "Output token budget for OAI endpoint; 0 = auto (2048 without thinking, 8192 with thinking)")
+	fs.StringVar(&cfg.ScoreOutput, "score-output", envOr("LME_SCORE_OUTPUT", "text"), "score summary stdout mode: text, json, or quiet")
 	fs.StringVar(&cfg.GenerationModel, "generation-model", "sonnet", "Claude model for answer generation: opus, sonnet, or haiku")
 	fs.BoolVar(&cfg.ContextTopKBump, "context-topk-bump", false, "Raise context topK to 15 for all question types")
 	fs.IntVar(&cfg.RecallTopK, "recall-topk", 100, "memories to recall before context trim (1–500)")
@@ -376,6 +379,17 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	if cfg.DataFile == "" {
 		_, _ = fmt.Fprintln(stderr, "--data is required")
+		return 1
+	}
+	cfg.Output = stdout
+
+	switch cfg.ScoreOutput {
+	case "", "text", "json", "quiet":
+		if cfg.ScoreOutput == "" {
+			cfg.ScoreOutput = "text"
+		}
+	default:
+		_, _ = fmt.Fprintf(stderr, "--score-output %q is not allowed; must be one of: text, json, quiet\n", cfg.ScoreOutput)
 		return 1
 	}
 

--- a/cmd/longmemeval/route.go
+++ b/cmd/longmemeval/route.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -35,6 +36,7 @@ type routeDiscoverResult struct {
 	RunFlagHint []string    `json:"run_flag_hint"`
 	ScorerHint  []string    `json:"scorer_flag_hint"`
 	Source      string      `json:"source"`
+	Validated   bool        `json:"validated"`
 }
 
 type fleetHost struct {
@@ -96,6 +98,13 @@ func discoverRoute(cfg routeDiscoverConfig) (routeDiscoverResult, error) {
 		return routeDiscoverResult{}, err
 	}
 	baseURL := strings.TrimRight(cfg.OllaURL, "/") + "/olla/openai/v1"
+	validated := false
+	if requiresChatReadiness(cfg.Purpose) {
+		if err := validateOllaChatRoute(ctx, http.DefaultClient, baseURL, selected); err != nil {
+			return routeDiscoverResult{}, fmt.Errorf("validate Olla chat route for %q: %w", selected, err)
+		}
+		validated = true
+	}
 	return routeDiscoverResult{
 		FleetURL:   cfg.FleetURL,
 		OllaURL:    cfg.OllaURL,
@@ -112,7 +121,8 @@ func discoverRoute(cfg routeDiscoverConfig) (routeDiscoverResult, error) {
 			"--scorer-url", baseURL,
 			"--scorer-model", selected,
 		},
-		Source: "ai-fleet-registry+olla-openai-models",
+		Source:    "ai-fleet-registry+olla-openai-models",
+		Validated: validated,
 	}, nil
 }
 
@@ -220,11 +230,22 @@ func selectRouteModel(requested, purpose string, hosts []fleetHost, ollaModels [
 		if _, ok := fleetModels[requested]; !ok {
 			return "", fmt.Errorf("requested model %q is absent from AI Flight Controller registry", requested)
 		}
+		if purpose == "generation" || purpose == "scoring" {
+			if isEmbeddingRoute(requested, fleetModels[requested].Framework) {
+				return "", fmt.Errorf("requested model %q is embedding-like and not compatible with %s", requested, purpose)
+			}
+		}
+		if !isFleetModelReady(fleetModels[requested]) {
+			return "", fmt.Errorf("requested model %q is not ready in AI Flight Controller registry", requested)
+		}
 		return requested, nil
 	}
 	for _, model := range ollaModels {
 		fm, ok := fleetModels[model]
 		if !ok {
+			continue
+		}
+		if !isFleetModelReady(fm) {
 			continue
 		}
 		if purpose == "generation" || purpose == "scoring" {
@@ -240,4 +261,70 @@ func selectRouteModel(requested, purpose string, hosts []fleetHost, ollaModels [
 func isEmbeddingRoute(name, framework string) bool {
 	lower := strings.ToLower(name + " " + framework)
 	return strings.Contains(lower, "embed") || strings.Contains(lower, "bge") || strings.Contains(lower, "e5")
+}
+
+func isFleetModelReady(model fleetModel) bool {
+	return statusReady(model.Status) && statusReady(model.State)
+}
+
+func statusReady(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "ready", "running", "healthy", "available", "active", "started":
+		return true
+	default:
+		return false
+	}
+}
+
+func requiresChatReadiness(purpose string) bool {
+	switch purpose {
+	case "", "generation", "scoring":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateOllaChatRoute(ctx context.Context, client *http.Client, baseURL, model string) error {
+	body := map[string]any{
+		"model":       model,
+		"messages":    []map[string]string{{"role": "user", "content": "LongMemEval route readiness probe. Reply with READY."}},
+		"max_tokens":  8,
+		"temperature": 0,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+"/chat/completions", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %s", resp.Status)
+	}
+	var payload struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+			Text string `json:"text"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+	if len(payload.Choices) == 0 {
+		return errors.New("readiness probe returned no choices")
+	}
+	if payload.Choices[0].Message.Content == "" && payload.Choices[0].Text == "" {
+		return errors.New("readiness probe returned an empty choice")
+	}
+	return nil
 }

--- a/cmd/longmemeval/route_test.go
+++ b/cmd/longmemeval/route_test.go
@@ -19,17 +19,21 @@ func TestDiscoverRouteSelectsModelPresentInFleetAndOlla(t *testing.T) {
 	}))
 	defer fleet.Close()
 	olla := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/olla/openai/v1/models" {
+		switch r.URL.Path {
+		case "/olla/openai/v1/models":
+			_ = json.NewEncoder(w).Encode(openAIModelsResponse{
+				Object: "list",
+				Data: []openAIModel{
+					{ID: "not-in-fleet"},
+					{ID: "fast-inference"},
+					{ID: "inference"},
+				},
+			})
+		case "/olla/openai/v1/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"choices": []any{map[string]any{"message": map[string]any{"content": "ready"}}}})
+		default:
 			t.Fatalf("olla path = %s, want /olla/openai/v1/models", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(openAIModelsResponse{
-			Object: "list",
-			Data: []openAIModel{
-				{ID: "not-in-fleet"},
-				{ID: "fast-inference"},
-				{ID: "inference"},
-			},
-		})
 	}))
 	defer olla.Close()
 
@@ -49,6 +53,9 @@ func TestDiscoverRouteSelectsModelPresentInFleetAndOlla(t *testing.T) {
 	}
 	if len(result.FleetHosts) != 2 || len(result.OllaModels) != 3 {
 		t.Fatalf("unexpected result shape: %+v", result)
+	}
+	if !result.Validated {
+		t.Fatalf("result.Validated = false, want true")
 	}
 }
 
@@ -89,10 +96,17 @@ func TestDiscoverRouteAvoidsEmbeddingModelsForGeneration(t *testing.T) {
 	}))
 	defer fleet.Close()
 	olla := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(openAIModelsResponse{
-			Object: "list",
-			Data:   []openAIModel{{ID: "BAAI/bge-m3"}, {ID: "inference"}},
-		})
+		switch r.URL.Path {
+		case "/olla/openai/v1/models":
+			_ = json.NewEncoder(w).Encode(openAIModelsResponse{
+				Object: "list",
+				Data:   []openAIModel{{ID: "BAAI/bge-m3"}, {ID: "inference"}},
+			})
+		case "/olla/openai/v1/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"choices": []any{map[string]any{"message": map[string]any{"content": "ready"}}}})
+		default:
+			t.Fatalf("unexpected Olla path %s", r.URL.Path)
+		}
 	}))
 	defer olla.Close()
 
@@ -106,5 +120,67 @@ func TestDiscoverRouteAvoidsEmbeddingModelsForGeneration(t *testing.T) {
 	}
 	if result.LLMModel != "inference" {
 		t.Fatalf("LLMModel = %q, want generation model", result.LLMModel)
+	}
+}
+
+func TestDiscoverRouteRejectsModelThatFailsReadinessProbe(t *testing.T) {
+	fleet := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]fleetHost{
+			{Host: "oblivion", Models: []fleetModel{{Name: "inference", Framework: "vllm", Port: 8000, Status: "running"}}},
+		})
+	}))
+	defer fleet.Close()
+	olla := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/olla/openai/v1/models":
+			_ = json.NewEncoder(w).Encode(openAIModelsResponse{Object: "list", Data: []openAIModel{{ID: "inference"}}})
+		case "/olla/openai/v1/chat/completions":
+			http.Error(w, "model loading", http.StatusServiceUnavailable)
+		default:
+			t.Fatalf("unexpected Olla path %s", r.URL.Path)
+		}
+	}))
+	defer olla.Close()
+
+	_, err := discoverRoute(routeDiscoverConfig{
+		FleetURL: fleet.URL,
+		OllaURL:  olla.URL,
+		Purpose:  "generation",
+	})
+	if err == nil {
+		t.Fatal("discoverRoute returned nil error for a model that failed the readiness probe")
+	}
+}
+
+func TestDiscoverRouteSkipsStoppedFleetModels(t *testing.T) {
+	fleet := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]fleetHost{
+			{Host: "oblivion", Models: []fleetModel{{Name: "stopped", Framework: "vllm", Port: 8000, Status: "stopped"}}},
+			{Host: "precision", Models: []fleetModel{{Name: "ready", Framework: "vllm", Port: 8001, Status: "running"}}},
+		})
+	}))
+	defer fleet.Close()
+	olla := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/olla/openai/v1/models":
+			_ = json.NewEncoder(w).Encode(openAIModelsResponse{Object: "list", Data: []openAIModel{{ID: "stopped"}, {ID: "ready"}}})
+		case "/olla/openai/v1/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"choices": []any{map[string]any{"message": map[string]any{"content": "ready"}}}})
+		default:
+			t.Fatalf("unexpected Olla path %s", r.URL.Path)
+		}
+	}))
+	defer olla.Close()
+
+	result, err := discoverRoute(routeDiscoverConfig{
+		FleetURL: fleet.URL,
+		OllaURL:  olla.URL,
+		Purpose:  "generation",
+	})
+	if err != nil {
+		t.Fatalf("discoverRoute: %v", err)
+	}
+	if result.LLMModel != "ready" {
+		t.Fatalf("LLMModel = %q, want ready", result.LLMModel)
 	}
 }

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -174,6 +175,13 @@ func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap ma
 	writeScoreReport(cfg, scores)
 }
 
+type scoreReportCounts struct {
+	Correct          int `json:"correct"`
+	PartiallyCorrect int `json:"partially_correct"`
+	Incorrect        int `json:"incorrect"`
+	Total            int `json:"total"`
+}
+
 func writeHypotheses(cfg *Config, scores []longmemeval.ScoreEntry) {
 	f, err := createPrivateArtifact(filepath.Join(cfg.OutDir, "hypotheses.jsonl"))
 	if err != nil {
@@ -232,20 +240,14 @@ func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestM
 }
 
 func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
-	type byType struct {
-		Correct          int `json:"correct"`
-		PartiallyCorrect int `json:"partially_correct"`
-		Incorrect        int `json:"incorrect"`
-		Total            int `json:"total"`
-	}
 	// Deduplicate by QuestionID — last-write-wins, matching checkpoint append semantics.
 	deduped := make(map[string]longmemeval.ScoreEntry, len(scores))
 	for _, s := range scores {
 		deduped[s.QuestionID] = s
 	}
 
-	overall := &byType{}
-	byQType := make(map[string]*byType)
+	overall := &scoreReportCounts{}
+	byQType := make(map[string]*scoreReportCounts)
 
 	for _, s := range deduped {
 		if s.Status != "done" {
@@ -253,10 +255,10 @@ func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
 		}
 		qbt := byQType[s.QuestionType]
 		if qbt == nil {
-			qbt = &byType{}
+			qbt = &scoreReportCounts{}
 			byQType[s.QuestionType] = qbt
 		}
-		for _, bt := range []*byType{overall, qbt} {
+		for _, bt := range []*scoreReportCounts{overall, qbt} {
 			bt.Total++
 			switch s.ScoreLabel {
 			case "CORRECT":
@@ -292,15 +294,35 @@ func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
 	}
 	log.Printf("wrote %s", path)
 
-	// Print summary.
-	if overall.Total > 0 {
-		pct := func(n int) float64 { return float64(n) / float64(overall.Total) * 100 }
-		fmt.Printf("\n--- Score Report (run-id: %s) ---\n", cfg.RunID)
-		fmt.Printf("Total scored:       %d\n", overall.Total)
-		fmt.Printf("Correct:            %d (%.1f%%)\n", overall.Correct, pct(overall.Correct))
-		fmt.Printf("Partially correct:  %d (%.1f%%)\n", overall.PartiallyCorrect, pct(overall.PartiallyCorrect))
-		fmt.Printf("Incorrect:          %d (%.1f%%)\n", overall.Incorrect, pct(overall.Incorrect))
+	writeScoreSummary(cfg.Output, cfg.ScoreOutput, report, overall)
+}
+
+func writeScoreSummary(w io.Writer, mode string, report map[string]any, overall *scoreReportCounts) {
+	if w == nil {
+		w = os.Stdout
 	}
+	if mode == "" {
+		mode = "text"
+	}
+	switch mode {
+	case "quiet":
+		return
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return
+	}
+
+	if overall == nil || overall.Total == 0 {
+		return
+	}
+	pct := func(n int) float64 { return float64(n) / float64(overall.Total) * 100 }
+	_, _ = fmt.Fprintf(w, "\n--- Score Report (run-id: %s) ---\n", report["run_id"])
+	_, _ = fmt.Fprintf(w, "Total scored:       %d\n", overall.Total)
+	_, _ = fmt.Fprintf(w, "Correct:            %d (%.1f%%)\n", overall.Correct, pct(overall.Correct))
+	_, _ = fmt.Fprintf(w, "Partially correct:  %d (%.1f%%)\n", overall.PartiallyCorrect, pct(overall.PartiallyCorrect))
+	_, _ = fmt.Fprintf(w, "Incorrect:          %d (%.1f%%)\n", overall.Incorrect, pct(overall.Incorrect))
 }
 
 // normalizeLabel canonicalises a score label: trims surrounding whitespace

--- a/cmd/longmemeval/score_test.go
+++ b/cmd/longmemeval/score_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,6 +10,46 @@ import (
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
+
+func TestWriteScoreReport_QuietSuppressesStdout(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	cfg := &Config{OutDir: dir, RunID: "quiet-test", ScoreOutput: "quiet", Output: &out}
+
+	writeScoreReport(cfg, []longmemeval.ScoreEntry{
+		{QuestionID: "q1", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+	})
+
+	if out.Len() != 0 {
+		t.Fatalf("quiet score output wrote stdout: %q", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "score_report.json")); err != nil {
+		t.Fatalf("score_report.json was not written: %v", err)
+	}
+}
+
+func TestWriteScoreReport_JSONWritesMachineSummaryToConfiguredOutput(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	cfg := &Config{OutDir: dir, RunID: "json-test", ScoreOutput: "json", Output: &out}
+
+	writeScoreReport(cfg, []longmemeval.ScoreEntry{
+		{QuestionID: "q1", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+		{QuestionID: "q2", QuestionType: "single-session-user", ScoreLabel: "INCORRECT", Status: "done"},
+	})
+
+	var report map[string]any
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, out.String())
+	}
+	if report["run_id"] != "json-test" {
+		t.Fatalf("stdout run_id = %v, want json-test", report["run_id"])
+	}
+	overall := report["overall"].(map[string]any)
+	if int(overall["total"].(float64)) != 2 {
+		t.Fatalf("stdout overall.total = %v, want 2", overall["total"])
+	}
+}
 
 // TestWriteScoreReport_ScoreErrorCountsAsIncorrect is the regression guard for
 // issue #793: a ScoreEntry with ScoreLabel="SCORE_ERROR" and Status="done" must


### PR DESCRIPTION
## Summary
- add `--score-output text|json|quiet` and route score summary output through the configured writer
- make `route-discover` filter non-ready fleet models, reject embedding routes for generation/scoring, and validate the Olla chat path before emitting hints
- add httptest coverage for output modes and route-readiness behavior

Fixes #892

## Tests
- `go test ./cmd/longmemeval -run 'TestDispatchRejectsInvalidScoreOutputMode|TestWriteScoreReport_(Quiet|JSON)|TestDiscoverRoute(Selects|RejectsModelThatFailsReadinessProbe|SkipsStoppedFleetModels|AvoidsEmbeddingModels)' -count=1`
- `go test ./cmd/longmemeval ./internal/longmemeval -count=1`
- `golangci-lint run`
- `git diff --check main..HEAD`
