### PR TITLE
fix(lme): add recall repair preset and target-date reranking

### DIFF
--- a/cmd/longmemeval/all_test.go
+++ b/cmd/longmemeval/all_test.go
@@ -60,3 +60,36 @@ func TestRunAllWithStagesRunsScoreAfterSuccessfulRun(t *testing.T) {
 		t.Fatalf("stage calls = %v, want %v", calls, want)
 	}
 }
+
+func TestApplyRepairPresetRecallRepair(t *testing.T) {
+	cfg := &Config{RepairPreset: "recall-repair"}
+	if err := applyRepairPreset(cfg); err != nil {
+		t.Fatalf("applyRepairPreset: %v", err)
+	}
+	if !cfg.DualPreferenceRecall {
+		t.Error("recall-repair preset should enable dual preference recall")
+	}
+	if !cfg.ExhaustiveAggregation {
+		t.Error("recall-repair preset should enable exhaustive aggregation")
+	}
+	if !cfg.EnumerateFirst {
+		t.Error("recall-repair preset should enable enumerate-first")
+	}
+	if !cfg.TemporalPromptAug {
+		t.Error("recall-repair preset should enable temporal prompt augmentation")
+	}
+	if !cfg.ChronoSort {
+		t.Error("recall-repair preset should enable chronological context ordering")
+	}
+}
+
+func TestApplyRepairPresetDefaultBaselineNoop(t *testing.T) {
+	cfg := &Config{}
+	if err := applyRepairPreset(cfg); err != nil {
+		t.Fatalf("applyRepairPreset default: %v", err)
+	}
+	if cfg.DualPreferenceRecall || cfg.ExhaustiveAggregation || cfg.EnumerateFirst ||
+		cfg.TemporalPromptAug || cfg.ChronoSort {
+		t.Fatalf("default config should leave repair switches off: %+v", cfg)
+	}
+}

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -57,6 +57,7 @@ type Config struct {
 	ChronoSort          bool // sort context blocks by Session date ascending before prompt assembly
 	DisableQueryRewrite bool // use raw question as recall query; skip temporal/preference rewriting
 	MaxBlockChars       int  // truncate each context block to this many chars before prompt assembly; 0 = no truncation
+	RepairPreset        string
 
 	// H16: question_date injection
 	InjectQuestionDate bool // prepend "Today's date is: {question_date}" to temporal-reasoning prompts (default off)
@@ -184,6 +185,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.ChronoSort, "chrono-sort", false, "sort context blocks by Session date ascending before prompt assembly")
 	fs.BoolVar(&cfg.DisableQueryRewrite, "disable-query-rewrite", false, "use raw question as recall query; skip temporal/preference rewriting")
 	fs.IntVar(&cfg.MaxBlockChars, "max-block-chars", 0, "truncate each context block to this many chars before prompt assembly; 0 = no limit (use with large --context-topk to stay within vLLM max_model_len)")
+	fs.StringVar(&cfg.RepairPreset, "repair-preset", "", "named LongMemEval repair preset to enable known repair switches: recall-repair")
 	// H16: prepend question_date as first line of temporal-reasoning prompts
 	fs.BoolVar(&cfg.InjectQuestionDate, "inject-question-date", false, "prepend 'Today's date is: {question_date}' as the first line of temporal-reasoning prompts to anchor relative-time references before the model reads memory context (default off)")
 	// Exp-14: H-M5 chrono-sort forcing + H-M1 entity enumeration pass
@@ -351,6 +353,10 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	if noExclusiveBackend {
 		cfg.ExclusiveBackend = false
 	}
+	if err := applyRepairPreset(cfg); err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
+	}
 
 	// B2 (#807): validate --cleanup-policy against the known enum set.
 	// Must fire before any other validation so the error is clearly attributable.
@@ -444,6 +450,22 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func applyRepairPreset(cfg *Config) error {
+	switch strings.TrimSpace(cfg.RepairPreset) {
+	case "":
+		return nil
+	case "recall-repair":
+		cfg.DualPreferenceRecall = true
+		cfg.ExhaustiveAggregation = true
+		cfg.EnumerateFirst = true
+		cfg.TemporalPromptAug = true
+		cfg.ChronoSort = true
+		return nil
+	default:
+		return fmt.Errorf("invalid --repair-preset %q: must be recall-repair", cfg.RepairPreset)
+	}
 }
 
 func defaultAPIKey() string {

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -83,7 +83,54 @@ func buildRecallQuery(question, questionType string, disableRewrite bool) string
 	}
 }
 
-var relativeAgoRe = regexp.MustCompile(`(?i)\b(\d+)\s+(day|days|week|weeks|month|months|year|years)\s+ago\b`)
+var relativeAgoRe = regexp.MustCompile(`(?i)\b(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(day|days|week|weeks|month|months|year|years)\s+ago\b`)
+
+func parseAgoAmount(raw string) (int, bool) {
+	if n, err := strconv.Atoi(raw); err == nil {
+		return n, n > 0
+	}
+	words := map[string]int{
+		"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+		"seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+	}
+	n := words[strings.ToLower(raw)]
+	return n, n > 0
+}
+
+func targetDateFromQuestion(question, questionType, questionDate string) (time.Time, bool) {
+	if questionType != "temporal-reasoning" {
+		return time.Time{}, false
+	}
+	anchor, ok := parseLongMemEvalQuestionDate(questionDate)
+	if !ok {
+		return time.Time{}, false
+	}
+	lower := strings.ToLower(strings.TrimSpace(question))
+	if strings.Contains(lower, "yesterday") {
+		return dateOnly(anchor).AddDate(0, 0, -1), true
+	}
+	match := relativeAgoRe.FindStringSubmatch(lower)
+	if len(match) != 3 {
+		return time.Time{}, false
+	}
+	n, ok := parseAgoAmount(match[1])
+	if !ok {
+		return time.Time{}, false
+	}
+	target := dateOnly(anchor)
+	switch match[2] {
+	case "day", "days":
+		return target.AddDate(0, 0, -n), true
+	case "week", "weeks":
+		return target.AddDate(0, 0, -7*n), true
+	case "month", "months":
+		return target.AddDate(0, -n, 0), true
+	case "year", "years":
+		return target.AddDate(-n, 0, 0), true
+	default:
+		return time.Time{}, false
+	}
+}
 
 func temporalRecallWindow(question, questionType, questionDate string) (*time.Time, *time.Time) {
 	if questionType != "temporal-reasoning" {
@@ -108,8 +155,8 @@ func temporalRecallWindow(question, questionType, questionDate string) (*time.Ti
 	if len(match) != 3 {
 		return nil, nil
 	}
-	n, err := strconv.Atoi(match[1])
-	if err != nil || n <= 0 {
+	n, ok := parseAgoAmount(match[1])
+	if !ok {
 		return nil, nil
 	}
 	target := dateOnly(anchor)
@@ -470,8 +517,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		}
 	}
 
-	// --chrono-sort: sort blocks by Session date ascending before prompt assembly.
-	if cfg.ChronoSort {
+	// For relative N-ago temporal questions, rank context by proximity to the
+	// requested historical target date. This is more precise than generic
+	// chronological order and prevents nearby sessions from being displaced.
+	if _, ok := targetDateFromQuestion(item.Question, item.QuestionType, item.QuestionDate); ok {
+		contextBlocks = sortBlocksByTargetDate(contextBlocks, item.Question, item.QuestionType, item.QuestionDate)
+	} else if cfg.ChronoSort {
 		contextBlocks = sortBlocksChronologically(contextBlocks)
 	}
 
@@ -616,4 +667,33 @@ func sortBlocksChronologically(blocks []string) []string {
 		return blockDate(out[i]).Before(blockDate(out[j]))
 	})
 	return out
+}
+
+func sortBlocksByTargetDate(blocks []string, question, questionType, questionDate string) []string {
+	target, ok := targetDateFromQuestion(question, questionType, questionDate)
+	if !ok {
+		out := make([]string, len(blocks))
+		copy(out, blocks)
+		return out
+	}
+	out := make([]string, len(blocks))
+	copy(out, blocks)
+	sort.SliceStable(out, func(i, j int) bool {
+		di := blockDistanceToTarget(out[i], target)
+		dj := blockDistanceToTarget(out[j], target)
+		return di < dj
+	})
+	return out
+}
+
+func blockDistanceToTarget(block string, target time.Time) time.Duration {
+	d := blockDate(block)
+	if d.IsZero() {
+		return time.Duration(1<<63 - 1)
+	}
+	delta := dateOnly(d).Sub(dateOnly(target))
+	if delta < 0 {
+		return -delta
+	}
+	return delta
 }

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -531,6 +531,37 @@ func TestTemporalRecallWindow_HowManyAgoDoesNotFilter(t *testing.T) {
 	}
 }
 
+func TestTargetDateFromQuestion_RelativeAgo(t *testing.T) {
+	got, ok := targetDateFromQuestion(
+		"What did I buy 3 weeks ago?",
+		"temporal-reasoning",
+		"2023/05/30 (Tue) 23:50",
+	)
+	if !ok {
+		t.Fatal("targetDateFromQuestion returned ok=false")
+	}
+	want := time.Date(2023, 5, 9, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("targetDateFromQuestion() = %s, want %s", got.Format("2006-01-02"), want.Format("2006-01-02"))
+	}
+}
+
+func TestSortBlocksByTargetDate_ClosestSessionFirst(t *testing.T) {
+	question := "What did I buy 3 weeks ago?"
+	questionDate := "2023/05/30 (Tue) 23:50"
+	farOlder := "Session date: 2023-04-01\nOlder session"
+	closest := "Session date: 2023-05-09\nTarget session"
+	farNewer := "Session date: 2023-05-28\nNewer session"
+
+	got := sortBlocksByTargetDate([]string{farNewer, farOlder, closest}, question, "temporal-reasoning", questionDate)
+	want := []string{closest, farNewer, farOlder}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("position %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestSelectContextIDsReservesSecondarySlots(t *testing.T) {
 	retrieved := []string{"p1", "p2", "p3", "p4", "s1", "s2"}
 	secondary := []string{"s1", "s2"}


### PR DESCRIPTION
## Summary
- add `--repair-preset recall-repair` to turn on the existing recall repair switches as a named benchmark mode
- rank relative temporal questions by proximity to the target historical date before falling back to chronological ordering
- add focused coverage for repair preset defaults and target-date reranking

Fixes #848
Fixes #874

## Notes
- #872 and #873 are already covered by current main behavior and focused tests; they are not claimed by this PR because their implementation predated this commit.

## Tests
- `go test ./cmd/longmemeval -run 'Test(TargetDateFromQuestion|SortBlocksByTargetDate|ApplyRepairPreset|SelectContextIDs|PreferenceSubjectAnchorQuery)' -count=1`
- `go test ./cmd/longmemeval ./internal/longmemeval -count=1`
- `golangci-lint run`
- `git diff --check main..HEAD`
