### PR TITLE
feat(lme): add run completeness analysis

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -104,6 +104,7 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  score-batch     Score all items in one Anthropic Message Batches API call")
 	_, _ = fmt.Fprintln(w, "  sample-prepare  Prepare a no-ingest representative sample output directory")
 	_, _ = fmt.Fprintln(w, "  sample-analyze  Summarize existing sample checkpoints without generation/scoring")
+	_, _ = fmt.Fprintln(w, "  analyze         Summarize result checkpoints and classify score failures")
 	_, _ = fmt.Fprintln(w, "  route-discover  Resolve Olla/OpenAI flags from AI Flight Controller + Olla")
 	_, _ = fmt.Fprintln(w, "  prune           Delete expired lme-* scratch projects (TTL sweep, #754)")
 	_, _ = fmt.Fprintln(w, "  help            Print this usage and exit")
@@ -289,8 +290,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	if subcommand == "sample-analyze" {
-		safs := flag.NewFlagSet("sample-analyze", flag.ContinueOnError)
+	if subcommand == "sample-analyze" || subcommand == "analyze" {
+		safs := flag.NewFlagSet(subcommand, flag.ContinueOnError)
 		safs.SetOutput(stderr)
 		var sa sampleAnalyzeConfig
 		safs.StringVar(&sa.DataFile, "data", "", "path to LongMemEval cohort JSON")
@@ -300,7 +301,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		}
 		summary, err := analyzeSample(sa)
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "sample-analyze: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "%s: %v\n", subcommand, err)
 			return 1
 		}
 		enc := json.NewEncoder(stdout)

--- a/cmd/longmemeval/manifest.go
+++ b/cmd/longmemeval/manifest.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+type scoreCompleteness struct {
+	ExpectedTotal       int
+	IngestDoneTotal     int
+	CompletedRunTotal   int
+	CompletedScoreTotal int
+	RunErrorTotal       int
+	ScoreErrorTotal     int
+	Complete            bool
+}
+
+func scoreCompletenessFromScores(scores []longmemeval.ScoreEntry) scoreCompleteness {
+	scoreDone, scoreErrors := scoreOutcomeCounts(scores)
+	total := scoreDone + scoreErrors
+	return scoreCompleteness{
+		ExpectedTotal:       total,
+		CompletedScoreTotal: scoreDone,
+		ScoreErrorTotal:     scoreErrors,
+		Complete:            total > 0 && scoreDone == total,
+	}
+}
+
+func scoreCompletenessFromMaps(
+	itemMap map[string]longmemeval.Item,
+	ingestMap map[string]longmemeval.IngestEntry,
+	runMap map[string]longmemeval.RunEntry,
+	scores []longmemeval.ScoreEntry,
+) scoreCompleteness {
+	runDone, runErrors := runOutcomeCounts(runMap)
+	scoreDone, scoreErrors := scoreOutcomeCounts(scores)
+	expected := len(itemMap)
+	return scoreCompleteness{
+		ExpectedTotal:       expected,
+		IngestDoneTotal:     len(ingestMap),
+		CompletedRunTotal:   runDone,
+		CompletedScoreTotal: scoreDone,
+		RunErrorTotal:       runErrors,
+		ScoreErrorTotal:     scoreErrors,
+		Complete:            expected > 0 && runDone == expected && scoreDone == expected && runErrors == 0 && scoreErrors == 0,
+	}
+}
+
+func runOutcomeCounts(runMap map[string]longmemeval.RunEntry) (done, errors int) {
+	for _, entry := range runMap {
+		switch entry.Status {
+		case "done":
+			done++
+		case "error":
+			errors++
+		}
+	}
+	return done, errors
+}
+
+func scoreOutcomeCounts(scores []longmemeval.ScoreEntry) (done, errors int) {
+	deduped := make(map[string]longmemeval.ScoreEntry, len(scores))
+	for _, entry := range scores {
+		deduped[entry.QuestionID] = entry
+	}
+	for _, entry := range deduped {
+		switch entry.Status {
+		case "done":
+			done++
+		case "error":
+			errors++
+		}
+	}
+	return done, errors
+}
+
+func writeRunManifest(
+	cfg *Config,
+	stage string,
+	itemMap map[string]longmemeval.Item,
+	ingestMap map[string]longmemeval.IngestEntry,
+	runMap map[string]longmemeval.RunEntry,
+	scores []longmemeval.ScoreEntry,
+) {
+	completeness := scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scores)
+	exe, _ := os.Executable()
+	manifest := map[string]any{
+		"run_id":                cfg.RunID,
+		"stage":                 stage,
+		"generated_at":          time.Now().UTC().Format(time.RFC3339),
+		"expected_total":        completeness.ExpectedTotal,
+		"ingest_done_total":     completeness.IngestDoneTotal,
+		"completed_run_total":   completeness.CompletedRunTotal,
+		"completed_score_total": completeness.CompletedScoreTotal,
+		"run_error_total":       completeness.RunErrorTotal,
+		"score_error_total":     completeness.ScoreErrorTotal,
+		"complete":              completeness.Complete,
+		"binary_path":           exe,
+		"command_line":          os.Args,
+		"git_sha":               bestEffortGit("rev-parse", "HEAD"),
+		"git_dirty":             bestEffortGitDirty(),
+		"llm_url":               redactURL(cfg.LLMBaseURL),
+		"llm_model":             cfg.LLMModel,
+		"scorer_url":            redactURL(cfg.ScorerURL),
+		"scorer_model":          cfg.ScorerModel,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		log.Printf("WARN marshal run_manifest.json: %v", err)
+		return
+	}
+	path := filepath.Join(cfg.OutDir, "run_manifest.json")
+	if err := os.WriteFile(path, data, privateArtifactFileMode); err != nil {
+		log.Printf("WARN write run_manifest.json: %v", err)
+		return
+	}
+	if err := os.Chmod(path, privateArtifactFileMode); err != nil {
+		log.Printf("WARN chmod run_manifest.json: %v", err)
+		return
+	}
+	log.Printf("wrote %s", path)
+}
+
+func bestEffortGit(args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func bestEffortGitDirty() bool {
+	out := bestEffortGit("status", "--porcelain")
+	return out != ""
+}

--- a/cmd/longmemeval/orchestration_test.go
+++ b/cmd/longmemeval/orchestration_test.go
@@ -134,6 +134,114 @@ func TestRunScore_SkipsAlreadyDone(t *testing.T) {
 	}
 }
 
+func TestRunScore_ReportIncludesExpectedDenominatorForPartialRun(t *testing.T) {
+	dir := t.TempDir()
+
+	items := []longmemeval.Item{
+		{QuestionID: "q001", QuestionType: "single-session-user", Question: "?", Answer: "A"},
+		{QuestionID: "q002", QuestionType: "single-session-user", Question: "?", Answer: "B"},
+	}
+	data, _ := json.Marshal(items)
+	dataPath := filepath.Join(dir, "data.json")
+	if err := os.WriteFile(dataPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q001", Status: "done"},
+		longmemeval.IngestEntry{QuestionID: "q002", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q001", Hypothesis: "A", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q001", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+	})
+
+	cfg := &Config{
+		DataFile: dataPath,
+		OutDir:   dir,
+		Workers:  1,
+		RunID:    "partial-run",
+	}
+	if exit := runScore(cfg); exit != 0 {
+		t.Fatalf("runScore exit = %d, want 0 for resume-only partial report", exit)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "score_report.json"))
+	if err != nil {
+		t.Fatalf("read score_report.json: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse score_report.json: %v", err)
+	}
+	if got := int(report["expected_total"].(float64)); got != 2 {
+		t.Fatalf("expected_total = %d, want 2", got)
+	}
+	if got := int(report["completed_run_total"].(float64)); got != 1 {
+		t.Fatalf("completed_run_total = %d, want 1", got)
+	}
+	if got := int(report["completed_score_total"].(float64)); got != 1 {
+		t.Fatalf("completed_score_total = %d, want 1", got)
+	}
+	if complete, ok := report["complete"].(bool); !ok || complete {
+		t.Fatalf("complete = %v (%T), want false", report["complete"], report["complete"])
+	}
+}
+
+func TestRunScore_WritesRunManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	items := []longmemeval.Item{
+		{QuestionID: "q001", QuestionType: "single-session-user", Question: "?", Answer: "A"},
+	}
+	data, _ := json.Marshal(items)
+	dataPath := filepath.Join(dir, "data.json")
+	if err := os.WriteFile(dataPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q001", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q001", Hypothesis: "A", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q001", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+	})
+
+	cfg := &Config{
+		DataFile: dataPath,
+		OutDir:   dir,
+		Workers:  1,
+		RunID:    "manifest-run",
+	}
+	if exit := runScore(cfg); exit != 0 {
+		t.Fatalf("runScore exit = %d, want 0", exit)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "run_manifest.json"))
+	if err != nil {
+		t.Fatalf("read run_manifest.json: %v", err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse run_manifest.json: %v", err)
+	}
+	if manifest["run_id"] != "manifest-run" {
+		t.Fatalf("run_id = %v, want manifest-run", manifest["run_id"])
+	}
+	if manifest["stage"] != "score" {
+		t.Fatalf("stage = %v, want score", manifest["stage"])
+	}
+	if got := int(manifest["expected_total"].(float64)); got != 1 {
+		t.Fatalf("expected_total = %d, want 1", got)
+	}
+	if complete, ok := manifest["complete"].(bool); !ok || !complete {
+		t.Fatalf("complete = %v (%T), want true", manifest["complete"], manifest["complete"])
+	}
+}
+
 func TestRunScore_AllAttemptedRowsFailReturnsNonZero(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/longmemeval/sample.go
+++ b/cmd/longmemeval/sample.go
@@ -38,26 +38,30 @@ type sampleAnalyzeConfig struct {
 }
 
 type sampleAnalyzeSummary struct {
-	Items                int                      `json:"items"`
-	RunDone              int                      `json:"run_done"`
-	RunErrors            int                      `json:"run_errors"`
-	Scored               int                      `json:"scored"`
-	Correct              int                      `json:"correct"`
-	PartiallyCorrect     int                      `json:"partially_correct"`
-	Incorrect            int                      `json:"incorrect"`
-	ScoreErrors          int                      `json:"score_errors"`
-	RetrievedGoldSession int                      `json:"retrieved_gold_session"`
-	ByType               map[string]sampleTypeRow `json:"by_type"`
+	Items                        int                      `json:"items"`
+	RunDone                      int                      `json:"run_done"`
+	RunErrors                    int                      `json:"run_errors"`
+	Scored                       int                      `json:"scored"`
+	Correct                      int                      `json:"correct"`
+	PartiallyCorrect             int                      `json:"partially_correct"`
+	Incorrect                    int                      `json:"incorrect"`
+	ScoreErrors                  int                      `json:"score_errors"`
+	RetrievedGoldSession         int                      `json:"retrieved_gold_session"`
+	RetrievalMiss                int                      `json:"retrieval_miss"`
+	ContextPresentGenerationMiss int                      `json:"context_present_generation_miss"`
+	ByType                       map[string]sampleTypeRow `json:"by_type"`
 }
 
 type sampleTypeRow struct {
-	Items                int `json:"items"`
-	RunDone              int `json:"run_done"`
-	Scored               int `json:"scored"`
-	Correct              int `json:"correct"`
-	PartiallyCorrect     int `json:"partially_correct"`
-	Incorrect            int `json:"incorrect"`
-	RetrievedGoldSession int `json:"retrieved_gold_session"`
+	Items                        int `json:"items"`
+	RunDone                      int `json:"run_done"`
+	Scored                       int `json:"scored"`
+	Correct                      int `json:"correct"`
+	PartiallyCorrect             int `json:"partially_correct"`
+	Incorrect                    int `json:"incorrect"`
+	RetrievedGoldSession         int `json:"retrieved_gold_session"`
+	RetrievalMiss                int `json:"retrieval_miss"`
+	ContextPresentGenerationMiss int `json:"context_present_generation_miss"`
 }
 
 func prepareSample(cfg samplePrepareConfig) (samplePrepareResult, error) {
@@ -151,19 +155,8 @@ func prepareSample(cfg samplePrepareConfig) (samplePrepareResult, error) {
 }
 
 func analyzeSample(cfg sampleAnalyzeConfig) (sampleAnalyzeSummary, error) {
-	if cfg.DataFile == "" {
-		return sampleAnalyzeSummary{}, errors.New("--data is required")
-	}
 	if cfg.ResultsDir == "" {
 		return sampleAnalyzeSummary{}, errors.New("--results is required")
-	}
-	items, err := loadItemsFile(cfg.DataFile)
-	if err != nil {
-		return sampleAnalyzeSummary{}, err
-	}
-	itemMap := make(map[string]longmemeval.Item, len(items))
-	for _, item := range items {
-		itemMap[item.QuestionID] = item
 	}
 	ingestEntries, err := longmemeval.ReadAllIngest(filepath.Join(cfg.ResultsDir, "checkpoint-ingest.jsonl"))
 	if err != nil {
@@ -190,6 +183,10 @@ func analyzeSample(cfg sampleAnalyzeConfig) (sampleAnalyzeSummary, error) {
 		scoreMap[entry.QuestionID] = entry
 	}
 
+	items, err := analyzeItems(cfg.DataFile, runMap, scoreMap)
+	if err != nil {
+		return sampleAnalyzeSummary{}, err
+	}
 	summary := sampleAnalyzeSummary{
 		Items:  len(items),
 		ByType: make(map[string]sampleTypeRow),
@@ -227,6 +224,17 @@ func analyzeSample(cfg sampleAnalyzeConfig) (sampleAnalyzeSummary, error) {
 					summary.Incorrect++
 					row.Incorrect++
 				}
+				if score.ScoreLabel != "CORRECT" && len(item.AnswerSessionIDs) > 0 {
+					run, runOK := runMap[item.QuestionID]
+					retrievedGold := runOK && run.Status == "done" && hasGoldSession(run.RetrievedIDs, ingestMap[item.QuestionID].MemoryMap, item.AnswerSessionIDs)
+					if retrievedGold {
+						summary.ContextPresentGenerationMiss++
+						row.ContextPresentGenerationMiss++
+					} else {
+						summary.RetrievalMiss++
+						row.RetrievalMiss++
+					}
+				}
 			case "error":
 				summary.ScoreErrors++
 			}
@@ -234,6 +242,31 @@ func analyzeSample(cfg sampleAnalyzeConfig) (sampleAnalyzeSummary, error) {
 		summary.ByType[item.QuestionType] = row
 	}
 	return summary, nil
+}
+
+func analyzeItems(dataFile string, runMap map[string]longmemeval.RunEntry, scoreMap map[string]longmemeval.ScoreEntry) ([]longmemeval.Item, error) {
+	if dataFile != "" {
+		return loadItemsFile(dataFile)
+	}
+	ids := make(map[string]longmemeval.Item, len(runMap)+len(scoreMap))
+	for id := range runMap {
+		ids[id] = longmemeval.Item{QuestionID: id, QuestionType: "unknown"}
+	}
+	for id, score := range scoreMap {
+		item := ids[id]
+		item.QuestionID = id
+		if score.QuestionType != "" {
+			item.QuestionType = score.QuestionType
+		} else if item.QuestionType == "" {
+			item.QuestionType = "unknown"
+		}
+		ids[id] = item
+	}
+	items := make([]longmemeval.Item, 0, len(ids))
+	for _, item := range ids {
+		items = append(items, item)
+	}
+	return items, nil
 }
 
 func selectSampleItems(items []longmemeval.Item, limit, maxPerType int) []longmemeval.Item {

--- a/cmd/longmemeval/sample_test.go
+++ b/cmd/longmemeval/sample_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -174,6 +175,104 @@ func TestAnalyzeSampleSummarizesScoresAndRetrievalCoverage(t *testing.T) {
 	}
 	if summary.RetrievedGoldSession != 1 || summary.RunDone != 2 {
 		t.Fatalf("retrieval counts = %+v, want one gold-covered run out of two", summary)
+	}
+}
+
+func TestAnalyzeSampleClassifiesIncorrectFailureClusters(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "data.json")
+	writeItems(t, dataPath, []longmemeval.Item{
+		{QuestionID: "q1", QuestionType: "temporal-reasoning", AnswerSessionIDs: []string{"sid-a"}},
+		{QuestionID: "q2", QuestionType: "multi-session", AnswerSessionIDs: []string{"sid-b"}},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q1", Status: "done", MemoryMap: map[string]string{"m1": "sid-a"}},
+		longmemeval.IngestEntry{QuestionID: "q2", Status: "done", MemoryMap: map[string]string{"m2": "sid-x"}},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q1", Status: "done", RetrievedIDs: []string{"m1"}},
+		longmemeval.RunEntry{QuestionID: "q2", Status: "done", RetrievedIDs: []string{"m2"}},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q1", QuestionType: "temporal-reasoning", ScoreLabel: "INCORRECT", Status: "done"},
+		longmemeval.ScoreEntry{QuestionID: "q2", QuestionType: "multi-session", ScoreLabel: "INCORRECT", Status: "done"},
+	})
+
+	summary, err := analyzeSample(sampleAnalyzeConfig{DataFile: dataPath, ResultsDir: dir})
+	if err != nil {
+		t.Fatalf("analyzeSample: %v", err)
+	}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	if int(got["context_present_generation_miss"].(float64)) != 1 {
+		t.Fatalf("context_present_generation_miss = %v, want 1", got["context_present_generation_miss"])
+	}
+	if int(got["retrieval_miss"].(float64)) != 1 {
+		t.Fatalf("retrieval_miss = %v, want 1", got["retrieval_miss"])
+	}
+}
+
+func TestDispatchAnalyzeAliasWritesSummaryJSON(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "data.json")
+	writeItems(t, dataPath, []longmemeval.Item{
+		{QuestionID: "q1", QuestionType: "single-session-user", AnswerSessionIDs: []string{"sid-a"}},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q1", Status: "done", MemoryMap: map[string]string{"m1": "sid-a"}},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q1", Status: "done", RetrievedIDs: []string{"m1"}},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q1", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	exit := dispatch([]string{"longmemeval", "analyze", "--data", dataPath, "--results", dir}, &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("dispatch analyze exit = %d, stderr=%q", exit, stderr.String())
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if int(summary["items"].(float64)) != 1 {
+		t.Fatalf("items = %v, want 1", summary["items"])
+	}
+}
+
+func TestAnalyzeSampleWithoutDataSummarizesScoreCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q1", Status: "done"},
+		longmemeval.RunEntry{QuestionID: "q2", Status: "error"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q1", QuestionType: "temporal-reasoning", ScoreLabel: "CORRECT", Status: "done"},
+		longmemeval.ScoreEntry{QuestionID: "q2", QuestionType: "multi-session", ScoreLabel: "INCORRECT", Status: "done"},
+	})
+
+	summary, err := analyzeSample(sampleAnalyzeConfig{ResultsDir: dir})
+	if err != nil {
+		t.Fatalf("analyzeSample without data: %v", err)
+	}
+	if summary.Items != 2 || summary.Scored != 2 || summary.Correct != 1 || summary.Incorrect != 1 {
+		t.Fatalf("summary = %+v, want checkpoint-derived counts", summary)
+	}
+	if summary.ByType["temporal-reasoning"].Correct != 1 {
+		t.Fatalf("temporal row = %+v, want one correct", summary.ByType["temporal-reasoning"])
+	}
+	if summary.RetrievalMiss != 0 || summary.ContextPresentGenerationMiss != 0 {
+		t.Fatalf("gold-session failure clusters = retrieval_miss=%d generation_miss=%d, want zero without data",
+			summary.RetrievalMiss, summary.ContextPresentGenerationMiss)
 	}
 }
 

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -89,6 +89,7 @@ func runScore(cfg *Config) int {
 		log.Fatalf("read final scores: %v", err)
 	}
 	writeOutputs(cfg, itemMap, ingestMap, runMap, allScores)
+	writeRunManifest(cfg, "score", itemMap, ingestMap, runMap, allScores)
 	if checkpointErr != nil {
 		log.Printf("ERROR score checkpoint write failed: %v", checkpointErr)
 		return 1
@@ -172,7 +173,7 @@ func scoreOne(ctx context.Context, cfg *Config, item longmemeval.Item, run longm
 func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap map[string]longmemeval.IngestEntry, runMap map[string]longmemeval.RunEntry, scores []longmemeval.ScoreEntry) {
 	writeHypotheses(cfg, scores)
 	writeRetrievalLog(cfg, itemMap, ingestMap, runMap, scores)
-	writeScoreReport(cfg, scores)
+	writeScoreReportWithCompleteness(cfg, scores, scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scores))
 }
 
 type scoreReportCounts struct {
@@ -240,6 +241,10 @@ func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestM
 }
 
 func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
+	writeScoreReportWithCompleteness(cfg, scores, scoreCompletenessFromScores(scores))
+}
+
+func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEntry, completeness scoreCompleteness) {
 	// Deduplicate by QuestionID — last-write-wins, matching checkpoint append semantics.
 	deduped := make(map[string]longmemeval.ScoreEntry, len(scores))
 	for _, s := range scores {
@@ -272,10 +277,17 @@ func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
 	}
 
 	report := map[string]any{
-		"overall":      overall,
-		"by_type":      byQType,
-		"run_id":       cfg.RunID,
-		"total_scored": len(deduped),
+		"overall":               overall,
+		"by_type":               byQType,
+		"run_id":                cfg.RunID,
+		"total_scored":          len(deduped),
+		"expected_total":        completeness.ExpectedTotal,
+		"ingest_done_total":     completeness.IngestDoneTotal,
+		"completed_run_total":   completeness.CompletedRunTotal,
+		"completed_score_total": completeness.CompletedScoreTotal,
+		"run_error_total":       completeness.RunErrorTotal,
+		"score_error_total":     completeness.ScoreErrorTotal,
+		"complete":              completeness.Complete,
 	}
 
 	data, err := json.MarshalIndent(report, "", "  ")


### PR DESCRIPTION
## Summary
- add completeness fields to `score_report.json` so partial runs expose expected/run/score denominators
- write `run_manifest.json` for the score stage with command, git, model/route, and completeness metadata
- add `longmemeval analyze` as a general checkpoint analyzer, including optional gold-data failure clustering

Part of #884 and #883.

## Tests
- `go test ./cmd/longmemeval ./internal/longmemeval -count=1`
- `golangci-lint run`
- `git diff --check`
- `go run ./cmd/longmemeval analyze --results results/lme-camp-22-f1f2-full500`
- `go run ./cmd/longmemeval analyze --data results/lme-quick-stratified-live-20260526/data.json --results results/lme-quick-stratified-live-20260526`
