### PR TITLE
fix(lme): add temporal recall safety lane

### DIFF
--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -346,6 +346,24 @@ func exitCodeForRunOutcome(attempted, errors int64) int {
 	return 0
 }
 
+type dateRangeRecallFunc func(query string, topK int, since, before *time.Time) ([]string, error)
+
+func recallWithTemporalFallback(query string, topK int, since, before *time.Time, recall dateRangeRecallFunc) ([]string, []string, error) {
+	primary, err := recall(query, topK, since, before)
+	if err != nil {
+		return nil, nil, err
+	}
+	if since == nil && before == nil {
+		return primary, nil, nil
+	}
+	fallback, err := recall(query, topK, nil, nil)
+	if err != nil {
+		log.Printf("WARN temporal fallback recall failed: %v", err)
+		return primary, nil, nil
+	}
+	return longmemeval.UnionMemoryIDs(primary, fallback), fallback, nil
+}
+
 // runWorker processes items from work, writing RunEntry results to out and
 // recording preserved-project names in pl (for S9 end-of-run summary logging).
 func runWorker(cfg *Config, itemMap map[string]longmemeval.Item, work <-chan longmemeval.IngestEntry, out chan<- longmemeval.RunEntry, pl *preservedLog) {
@@ -413,10 +431,13 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// When --disable-query-rewrite is set, use the raw question unchanged.
 	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
 	since, before := temporalRecallWindow(item.Question, item.QuestionType, item.QuestionDate)
-	recall := func(query string, topK int) ([]string, error) {
+	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
+		return mcpClient.RecallWithDateRange(ctx, ingest.Project, query, topK, callSince, callBefore)
+	}
+	recallDefault := func(query string, topK int) ([]string, error) {
 		return mcpClient.RecallWithDateRange(ctx, ingest.Project, query, topK, since, before)
 	}
-	retrievedIDs, err := recall(recallQuery, cfg.RecallTopK)
+	retrievedIDs, temporalFallbackIDs, err := recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)
 	if err != nil {
 		return longmemeval.RunEntry{
 			QuestionID: item.QuestionID,
@@ -424,14 +445,14 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			Error:      fmt.Sprintf("recall: %v", err),
 		}
 	}
-	var secondaryContextIDs []string
+	secondaryContextIDs := temporalFallbackIDs
 
 	// H8 (lme-h8h12h15): exhaustive aggregation recall — run a topK=500 sweep on
 	// the object noun-phrase for count-shaped questions and union with primary.
 	if cfg.ExhaustiveAggregation && longmemeval.IsAggregationQuestion(item.Question) {
 		const aggregationSweepTopK = 500
 		sweepQuery := longmemeval.ExtractAggregationAnchor(item.Question)
-		sweepIDs, sweepErr := recall(sweepQuery, aggregationSweepTopK)
+		sweepIDs, sweepErr := recallDefault(sweepQuery, aggregationSweepTopK)
 		if sweepErr == nil {
 			secondaryContextIDs = append(secondaryContextIDs, sweepIDs...)
 			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, sweepIDs)
@@ -448,7 +469,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			anchorTopK = 1
 		}
 		anchor := longmemeval.PreferenceSubjectAnchorQuery(item.Question)
-		anchorIDs, anchorErr := recall(anchor, anchorTopK)
+		anchorIDs, anchorErr := recallDefault(anchor, anchorTopK)
 		if anchorErr == nil {
 			secondaryContextIDs = append(secondaryContextIDs, anchorIDs...)
 			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, anchorIDs)
@@ -469,7 +490,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			log.Printf("WARN run [%s] paraphrase: %v — falling back to single-pass recall", item.QuestionID, pErr)
 		} else {
 			for _, pq := range paraphrases {
-				pIDs, pErr := recall(pq, cfg.RecallTopK)
+				pIDs, pErr := recallDefault(pq, cfg.RecallTopK)
 				if pErr != nil {
 					log.Printf("WARN run [%s] paraphrase recall (%q): %v", item.QuestionID, pq, pErr)
 					continue

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -562,6 +562,59 @@ func TestSortBlocksByTargetDate_ClosestSessionFirst(t *testing.T) {
 	}
 }
 
+func TestRecallWithTemporalFallbackAddsUnfilteredSafetyLane(t *testing.T) {
+	since := time.Date(2023, 5, 8, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2023, 5, 11, 0, 0, 0, 0, time.UTC)
+	var calls []string
+	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
+		if callSince != nil || callBefore != nil {
+			calls = append(calls, "filtered")
+			return []string{"dated-a", "dated-b"}, nil
+		}
+		calls = append(calls, "unfiltered")
+		return []string{"undated-answer", "dated-a"}, nil
+	}
+
+	retrieved, secondary, err := recallWithTemporalFallback("recent concert", 10, &since, &before, recall)
+	if err != nil {
+		t.Fatalf("recallWithTemporalFallback: %v", err)
+	}
+	if got, want := strings.Join(calls, ","), "filtered,unfiltered"; got != want {
+		t.Fatalf("calls = %s, want %s", got, want)
+	}
+	if got, want := strings.Join(retrieved, ","), "dated-a,dated-b,undated-answer"; got != want {
+		t.Fatalf("retrieved = %s, want %s", got, want)
+	}
+	if got, want := strings.Join(secondary, ","), "undated-answer,dated-a"; got != want {
+		t.Fatalf("secondary = %s, want %s", got, want)
+	}
+}
+
+func TestRecallWithTemporalFallbackSkipsSafetyLaneWithoutDateBounds(t *testing.T) {
+	var calls int
+	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
+		calls++
+		if callSince != nil || callBefore != nil {
+			t.Fatal("non-temporal recall should not pass date bounds")
+		}
+		return []string{"a"}, nil
+	}
+
+	retrieved, secondary, err := recallWithTemporalFallback("plain query", 10, nil, nil, recall)
+	if err != nil {
+		t.Fatalf("recallWithTemporalFallback: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if got := strings.Join(retrieved, ","); got != "a" {
+		t.Fatalf("retrieved = %s, want a", got)
+	}
+	if len(secondary) != 0 {
+		t.Fatalf("secondary = %v, want empty", secondary)
+	}
+}
+
 func TestSelectContextIDsReservesSecondarySlots(t *testing.T) {
 	retrieved := []string{"p1", "p2", "p3", "p4", "s1", "s2"}
 	secondary := []string{"s1", "s2"}

--- a/internal/search/federation.go
+++ b/internal/search/federation.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"log/slog"
+	"math"
 	"sort"
 	"sync"
 
@@ -70,7 +71,7 @@ func RecallAcrossEngines(ctx context.Context, engines []*SearchEngine, query str
 			continue
 		}
 		for _, r := range fan.results {
-			if existing, ok := seen[r.Memory.ID]; !ok || r.Score > existing.Score {
+			if existing, ok := seen[r.Memory.ID]; !ok || federatedScoreGreater(r.Score, existing.Score) {
 				seen[r.Memory.ID] = r
 			}
 		}
@@ -80,10 +81,22 @@ func RecallAcrossEngines(ctx context.Context, engines []*SearchEngine, query str
 	for _, r := range seen {
 		merged = append(merged, r)
 	}
-	sort.Slice(merged, func(i, j int) bool { return merged[i].Score > merged[j].Score })
+	sort.Slice(merged, func(i, j int) bool {
+		return federatedScoreGreater(merged[i].Score, merged[j].Score)
+	})
 
 	if topK > 0 && len(merged) > topK {
 		merged = merged[:topK]
 	}
 	return merged, nil
+}
+
+func federatedScoreGreater(a, b float64) bool {
+	if math.IsNaN(a) {
+		return false
+	}
+	if math.IsNaN(b) {
+		return true
+	}
+	return a > b
 }

--- a/internal/search/federation_internal_test.go
+++ b/internal/search/federation_internal_test.go
@@ -1,0 +1,18 @@
+package search
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFederatedScoreGreaterTreatsNaNAsLowest(t *testing.T) {
+	if federatedScoreGreater(math.NaN(), 0.5) {
+		t.Fatal("NaN score must not outrank a finite score")
+	}
+	if !federatedScoreGreater(0.5, math.NaN()) {
+		t.Fatal("finite score must outrank NaN")
+	}
+	if !federatedScoreGreater(0.8, 0.5) {
+		t.Fatal("higher finite score should outrank lower finite score")
+	}
+}


### PR DESCRIPTION
## Summary
- keep the date-window temporal recall as the primary pass
- add an unfiltered temporal safety lane so memories missing `valid_from` can still be reserved into generation context
- cover both temporal and non-temporal recall behavior with focused tests
- harden federated search ordering so NaN scores cannot outrank finite scores; this fixes the full-repo CI failure surfaced by the first #902 run

Fixes #880

## Tests
- `go test ./cmd/longmemeval -run 'TestRecallWithTemporalFallback|TestSelectContextIDs|TestTargetDateFromQuestion|TestSortBlocksByTargetDate' -count=1`
- `go test ./internal/search -run 'TestFederatedScoreGreaterTreatsNaNAsLowest|TestFederatedRecall_ResultsAreSortedByScore' -count=1`
- `go test ./cmd/longmemeval ./internal/longmemeval ./internal/search -count=1`
- `golangci-lint run`
- `git diff --check`