### PR TITLE
fix(mcp): make recall telemetry opt-in

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -169,6 +169,9 @@ memory_recall("authentication JWT", project="my-app", detail="full", limit=10)
 
 # Claude re-ranking after retrieval (requires ENGRAM_CLAUDE_RERANK=true)
 memory_recall("auth", project="my-app", rerank=True)
+
+# Opt in to feedback telemetry when you plan to call memory_feedback
+memory_recall("authentication JWT", project="my-app", record_event=True)
 ```
 
 **detail** controls how much text comes back per result:
@@ -180,6 +183,8 @@ memory_recall("auth", project="my-app", rerank=True)
 | `"full"` | Original content | 200–50,000 chars | Export, debugging, full fidelity |
 
 At scale, summary mode uses roughly 13× less context than full mode. For an agent recalling 10 memories per session, that is the difference between 5% of a context window and 65%.
+
+By default, `memory_recall` is read-only and does not create a retrieval event or increment retrieval counters. Pass `record_event=True` only when you need the returned `event_id` for `memory_feedback`.
 
 You can filter by memory type. This is a hard filter — it excludes everything else regardless of relevance:
 

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -179,6 +179,35 @@ func TestRecall_HandleMode(t *testing.T) {
 	}
 }
 
+func TestRecall_SetsRecordEventFalse(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got, ok := args["record_event"].(bool); !ok || got {
+				t.Errorf("record_event = %#v, want false", args["record_event"])
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{
+					{"id": "h-aaa", "score": 0.8},
+				},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.Recall(ctx, "proj", "query", 5); err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+}
+
 // TestFetchContent_HappyPath verifies content fetching.
 func TestFetchContent_HappyPath(t *testing.T) {
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -262,6 +262,9 @@ func (c *Client) recall(ctx context.Context, project, query string, topK int, si
 		"project": project,
 		"top_k":   topK,
 		"detail":  "summary",
+		// Benchmark retrieval must not mutate retrieval telemetry while
+		// measuring recall quality.
+		"record_event": false,
 		// Handle mode returns lightweight IDs + metadata instead of the
 		// full SearchResult graph. LongMemEval only needs ranked IDs, and
 		// this avoids oversized tool payloads on dense queries.

--- a/internal/mcp/conflicts_test.go
+++ b/internal/mcp/conflicts_test.go
@@ -358,9 +358,9 @@ func TestHandleMemoryRecall_IncludeConflicts_Integration(t *testing.T) {
 }
 
 // TestHandleMemoryRecall_IncludesFeedbackHint verifies that when
-// handleMemoryRecall returns an event_id (single-project, non-rerank path),
-// the response also contains a feedback_hint key so callers know how to
-// submit outcome feedback.
+// handleMemoryRecall is explicitly asked to record a retrieval event, the
+// response also contains a feedback_hint key so callers know how to submit
+// outcome feedback.
 func TestHandleMemoryRecall_IncludesFeedbackHint(t *testing.T) {
 	dsn := testRecallDSN(t)
 	ctx := context.Background()
@@ -380,10 +380,11 @@ func TestHandleMemoryRecall_IncludesFeedbackHint(t *testing.T) {
 	}
 	require.NoError(t, h.Engine.Store(ctx, m))
 
-	out := internalmcp.CallHandleMemoryRecallFull(ctx, t, pool, proj, "feedback hint recall API", nil)
+	out := internalmcp.CallHandleMemoryRecallFull(ctx, t, pool, proj, "feedback hint recall API",
+		map[string]any{"record_event": true})
 
 	eventID, hasEventID := out["event_id"]
-	require.True(t, hasEventID, "recall response must contain event_id on the single-project path")
+	require.True(t, hasEventID, "record_event=true recall response must contain event_id")
 	require.NotEmpty(t, eventID, "event_id must be non-empty")
 
 	hint, hasHint := out["feedback_hint"]

--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -10,9 +10,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +36,46 @@ func (s *recallStubFetcher) GetMemoryByID(_ context.Context, _ string) (*types.M
 
 func (s *recallStubFetcher) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
 	return s.chunks, nil
+}
+
+type recallTrackingBackend struct {
+	noopBackend
+	storedEvents atomic.Int64
+	increments   atomic.Int64
+}
+
+func (b *recallTrackingBackend) FTSSearch(_ context.Context, project, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	return []db.FTSResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   project,
+			Content:   "read-only recall telemetry regression memory",
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+		Score: 1,
+	}}, nil
+}
+
+func (b *recallTrackingBackend) StoreRetrievalEvent(_ context.Context, _ *types.RetrievalEvent) error {
+	b.storedEvents.Add(1)
+	return nil
+}
+
+func (b *recallTrackingBackend) IncrementTimesRetrieved(_ context.Context, _ []string) error {
+	b.increments.Add(1)
+	return nil
+}
+
+func newRecallTrackingPool(t *testing.T, backend *recallTrackingBackend) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, backend, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
 }
 
 // ── execFetch boundary cases not in fetch_exec_test.go ───────────────────────
@@ -171,6 +215,63 @@ func TestHandleMemoryRecall_DefaultMode_ReturnsResultsKey(t *testing.T) {
 
 	_, hasHandles := out["handles"]
 	require.False(t, hasHandles, "default mode must NOT return 'handles' key")
+}
+
+func TestHandleMemoryRecall_DefaultDoesNotRecordRetrievalEvent(t *testing.T) {
+	backend := &recallTrackingBackend{}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "read only recall telemetry",
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(1), out["count"])
+	require.NotContains(t, out, "event_id", "read-only recall must not return a feedback event by default")
+	require.Zero(t, backend.storedEvents.Load(), "read-only recall must not store retrieval events by default")
+	require.Zero(t, backend.increments.Load(), "read-only recall must not increment retrieval counters by default")
+}
+
+func TestHandleMemoryRecall_RecordEventOptInRecordsRetrievalEvent(t *testing.T) {
+	backend := &recallTrackingBackend{}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":      "test",
+		"query":        "record recall telemetry",
+		"record_event": true,
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(1), out["count"])
+	require.NotEmpty(t, out["event_id"], "record_event=true should return a feedback event")
+	require.Equal(t, int64(1), backend.storedEvents.Load())
+	require.Equal(t, int64(1), backend.increments.Load())
+}
+
+func TestHandleMemoryRecall_FederatedDefaultDoesNotRecordRetrievalEvent(t *testing.T) {
+	backend := &recallTrackingBackend{}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"projects": []any{"test-a", "test-b"},
+		"query":    "federated read only recall telemetry",
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(1), out["count"])
+	require.Zero(t, backend.storedEvents.Load(), "federated read-only recall must not store retrieval events by default")
+	require.Zero(t, backend.increments.Load(), "federated read-only recall must not increment retrieval counters by default")
 }
 
 // TestHandleMemoryRecall_EpisodeContextInjected verifies that

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -205,6 +205,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	topK := clampTopK(getInt(args, "top_k", defaultTopK), recallMaxTopK())
 	detail := getString(args, "detail", "summary")
 	includeConflicts := getBool(args, "include_conflicts", false)
+	recordEvent := getBool(args, "record_event", false)
 	mode := getString(args, "mode", cfg.RecallDefaultMode)
 	since, before, err := parseRecallDateBounds(args)
 	if err != nil {
@@ -249,7 +250,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			}
 			engines = append(engines, h.Engine)
 		}
-		results, err := search.RecallAcrossEngines(ctx, engines, query, topK, detail)
+		results, err := search.RecallAcrossEnginesWithEvents(ctx, engines, query, topK, detail, recordEvent)
 		if err != nil {
 			return nil, err
 		}
@@ -304,10 +305,6 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	var embedDegraded bool
 	opts.EmbedDegraded = &embedDegraded
 
-	// Use RecallWithEvent to log the retrieval; on the rerank path we call
-	// RecallWithOpts (which supports a custom Reranker) and then manually
-	// record the retrieval event + warm times_retrieved so the feedback loop
-	// and precision signal work regardless of which path was taken.
 	var results []types.SearchResult
 	var eventID string
 	if opts.Reranker != nil {
@@ -315,66 +312,24 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		if err != nil {
 			return nil, err
 		}
-		// Post-hoc event recording — mirrors RecallWithEvent internals.
-		rerankIDs := make([]string, 0, len(results))
-		for _, r := range results {
-			if r.Memory != nil {
-				rerankIDs = append(rerankIDs, r.Memory.ID)
-			}
-		}
-		if len(rerankIDs) > 0 {
-			event := &types.RetrievalEvent{
-				ID:        types.NewMemoryID(),
-				Project:   project,
-				Query:     query,
-				ResultIDs: rerankIDs,
-				CreatedAt: time.Now().UTC(),
-			}
-			if storeErr := h.Engine.Backend().StoreRetrievalEvent(ctx, event); storeErr != nil {
-				slog.Warn("store retrieval event (rerank path) failed", "project", project, "err", storeErr)
-			} else {
-				eventID = event.ID
-				if incErr := h.Engine.Backend().IncrementTimesRetrieved(ctx, rerankIDs); incErr != nil {
-					slog.Warn("auto-increment times_retrieved (rerank path) failed", "project", project, "err", incErr)
-				}
-			}
+		if recordEvent {
+			eventID = recordRecallEvent(ctx, h, project, query, results, "rerank path")
 		}
 	} else if opts.CurrentEpisodeID != "" || opts.DateSince != nil || opts.DateBefore != nil {
-		// Custom recall options present: use RecallWithOpts so episode boosts
-		// and/or date bounds apply, then record the retrieval event manually
-		// (mirrors RecallWithEvent internals so the feedback loop and precision
-		// signal continue to work on this path).
 		results, err = h.Engine.RecallWithOpts(ctx, query, topK, detail, opts)
 		if err != nil {
 			return nil, err
 		}
-		resultIDs := make([]string, 0, len(results))
-		for _, r := range results {
-			if r.Memory != nil {
-				resultIDs = append(resultIDs, r.Memory.ID)
-			}
-		}
-		if len(resultIDs) > 0 {
-			event := &types.RetrievalEvent{
-				ID:        types.NewMemoryID(),
-				Project:   project,
-				Query:     query,
-				ResultIDs: resultIDs,
-				CreatedAt: time.Now().UTC(),
-			}
-			if storeErr := h.Engine.Backend().StoreRetrievalEvent(ctx, event); storeErr != nil {
-				slog.Warn("store retrieval event (episode path) failed", "project", project, "err", storeErr)
-			} else {
-				eventID = event.ID
-				if incErr := h.Engine.Backend().IncrementTimesRetrieved(ctx, resultIDs); incErr != nil {
-					slog.Warn("auto-increment times_retrieved (episode path) failed", "project", project, "err", incErr)
-				}
-			}
+		if recordEvent {
+			eventID = recordRecallEvent(ctx, h, project, query, results, "option path")
 		}
 	} else {
-		results, eventID, err = h.Engine.RecallWithEvent(ctx, query, topK, detail)
+		results, err = h.Engine.RecallWithOpts(ctx, query, topK, detail, opts)
 		if err != nil {
 			return nil, err
+		}
+		if recordEvent {
+			eventID = recordRecallEvent(ctx, h, project, query, results, "default path")
 		}
 	}
 
@@ -409,6 +364,33 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	ok, reason := cfg.EmbedderHealth.Snapshot(ctx)
 	out["degraded"] = degradedMap(embedDegraded || !ok, reason)
 	return toolResult(out)
+}
+
+func recordRecallEvent(ctx context.Context, h *EngineHandle, project, query string, results []types.SearchResult, path string) string {
+	resultIDs := make([]string, 0, len(results))
+	for _, r := range results {
+		if r.Memory != nil {
+			resultIDs = append(resultIDs, r.Memory.ID)
+		}
+	}
+	if len(resultIDs) == 0 {
+		return ""
+	}
+	event := &types.RetrievalEvent{
+		ID:        types.NewMemoryID(),
+		Project:   project,
+		Query:     query,
+		ResultIDs: resultIDs,
+		CreatedAt: time.Now().UTC(),
+	}
+	if storeErr := h.Engine.Backend().StoreRetrievalEvent(ctx, event); storeErr != nil {
+		slog.Warn("store retrieval event failed", "path", path, "project", project, "err", storeErr)
+		return ""
+	}
+	if incErr := h.Engine.Backend().IncrementTimesRetrieved(ctx, resultIDs); incErr != nil {
+		slog.Warn("auto-increment times_retrieved failed", "path", path, "project", project, "err", incErr)
+	}
+	return event.ID
 }
 
 func parseRecallDateBounds(args map[string]any) (*time.Time, *time.Time, error) {

--- a/internal/search/federation.go
+++ b/internal/search/federation.go
@@ -24,10 +24,20 @@ const maxFederationConcurrency = 4
 // This is the engine-layer primitive for Cross-Project Knowledge Federation (Feature 4).
 // The MCP handler wires project name → engine via EnginePool and calls this function.
 func RecallAcrossEngines(ctx context.Context, engines []*SearchEngine, query string, topK int, detail string) ([]types.SearchResult, error) {
+	return RecallAcrossEnginesWithEvents(ctx, engines, query, topK, detail, true)
+}
+
+// RecallAcrossEnginesWithEvents is RecallAcrossEngines with explicit retrieval
+// telemetry control. When recordEvents is false, federation is a pure read.
+func RecallAcrossEnginesWithEvents(ctx context.Context, engines []*SearchEngine, query string, topK int, detail string, recordEvents bool) ([]types.SearchResult, error) {
 	if len(engines) == 0 {
 		return nil, nil
 	}
 	if len(engines) == 1 {
+		if recordEvents {
+			results, _, err := engines[0].RecallWithEvent(ctx, query, topK, detail)
+			return results, err
+		}
 		return engines[0].Recall(ctx, query, topK, detail)
 	}
 
@@ -48,10 +58,16 @@ func RecallAcrossEngines(ctx context.Context, engines []*SearchEngine, query str
 			defer wg.Done()
 			sem <- struct{}{}        // acquire slot
 			defer func() { <-sem }() // release slot
-			// Use RecallWithEvent so Feature 5 retrieval tracking is emitted
-			// for cross-project queries too (#92). The event IDs are not returned
-			// to the federated caller — they're stored per-project for local feedback.
-			res, _, err := eng.RecallWithEvent(ctx, query, topK, detail)
+			var res []types.SearchResult
+			var err error
+			if recordEvents {
+				// Use RecallWithEvent so Feature 5 retrieval tracking can be emitted
+				// for cross-project queries too (#92). The event IDs are not returned
+				// to the federated caller — they're stored per-project for local feedback.
+				res, _, err = eng.RecallWithEvent(ctx, query, topK, detail)
+			} else {
+				res, err = eng.Recall(ctx, query, topK, detail)
+			}
 			ch <- fanResult{res, err}
 		}()
 	}

--- a/internal/search/federation_test.go
+++ b/internal/search/federation_test.go
@@ -6,6 +6,7 @@ package search_test
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/search"
@@ -74,6 +75,15 @@ func TestFederatedRecall_ResultsAreSortedByScore(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 1; i < len(results); i++ {
+		if math.IsNaN(results[i-1].Score) {
+			assert.True(t, math.IsNaN(results[i].Score),
+				"NaN scores must sort after finite scores; results[%d].Score=%v, results[%d].Score=%v",
+				i-1, results[i-1].Score, i, results[i].Score)
+			continue
+		}
+		if math.IsNaN(results[i].Score) {
+			continue
+		}
 		assert.GreaterOrEqual(t, results[i-1].Score, results[i].Score,
 			"results[%d].Score (%v) must be >= results[%d].Score (%v)", i-1, results[i-1].Score, i, results[i].Score)
 	}


### PR DESCRIPTION
## Summary
- make `memory_recall` read-only by default by adding `record_event=false` semantics
- preserve explicit feedback telemetry with `record_event=true`
- apply the same telemetry control to federated recall
- make LongMemEval send `record_event:false` explicitly
- document the opt-in feedback behavior

Closes #879.

## Verification
- `go test ./internal/mcp ./internal/search ./internal/longmemeval ./cmd/longmemeval -count=1`
- `golangci-lint run`
- `git diff --check`
