### PR TITLE
fix(lme): make prune execution explicit

### DIFF
--- a/cmd/longmemeval/docs_test.go
+++ b/cmd/longmemeval/docs_test.go
@@ -26,6 +26,34 @@ func TestLMEBenchmarkLearningsScratchTTLIngestExampleUsesCurrentFlags(t *testing
 	}
 }
 
+func TestLMEBenchmarkLearningsPruneExampleUsesSafeExecuteFlags(t *testing.T) {
+	data, err := os.ReadFile("../../docs/lme-benchmark-learnings.md")
+	if err != nil {
+		t.Fatalf("read docs/lme-benchmark-learnings.md: %v", err)
+	}
+	doc := string(data)
+	section := between(t, doc, "### Running the prune sweep", "### Backfilling existing runs")
+
+	for _, current := range []string{"--execute", "--confirm-prefix lme-", "--limit 50"} {
+		if !strings.Contains(section, current) {
+			t.Fatalf("prune example missing safe execute flag text %q:\n%s", current, section)
+		}
+	}
+}
+
+func TestLMEPruneCronJobUsesSafeExecuteFlags(t *testing.T) {
+	data, err := os.ReadFile("../../deploy/lme-prune-cronjob.yaml")
+	if err != nil {
+		t.Fatalf("read deploy/lme-prune-cronjob.yaml: %v", err)
+	}
+	manifest := string(data)
+	for _, current := range []string{"--execute", "--confirm-prefix=lme-", "--limit=200", "--use-default-token"} {
+		if !strings.Contains(manifest, current) {
+			t.Fatalf("prune CronJob missing safe execute flag text %q:\n%s", current, manifest)
+		}
+	}
+}
+
 func between(t *testing.T, s, start, end string) string {
 	t.Helper()
 	startIdx := strings.Index(s, start)

--- a/cmd/longmemeval/prune.go
+++ b/cmd/longmemeval/prune.go
@@ -50,9 +50,19 @@ type PruneConfig struct {
 	// mutations.
 	DryRun bool
 
+	// Execute is the explicit opt-in that allows deletion. Without it, prune
+	// always plans only, even when DryRun is false.
+	Execute bool
+
+	// ConfirmPrefix must match Prefix when Execute is true.
+	ConfirmPrefix string
+
 	// Limit caps the number of projects considered for deletion in a single
-	// invocation. Zero means no cap. Used to bound blast radius on first runs.
+	// invocation. In execute mode this must be positive unless Unlimited is set.
 	Limit int
+
+	// Unlimited permits execute mode without a positive Limit.
+	Unlimited bool
 
 	// DatabaseURL is the PostgreSQL DSN; falls back to env DATABASE_URL.
 	DatabaseURL string
@@ -62,6 +72,13 @@ type PruneConfig struct {
 
 	// APIKey is the engram bearer token.
 	APIKey string
+
+	// ExplicitAPIKey tracks whether credentials were supplied by a CLI flag
+	// rather than automatic discovery.
+	ExplicitAPIKey bool
+
+	// UseDefaultToken permits automatic token discovery for execute mode.
+	UseDefaultToken bool
 }
 
 // projectTTLEntry is the in-memory shape used by selectExpiredProjects. It
@@ -144,7 +161,7 @@ func runPruneWithEntries(cfg *PruneConfig, entries []projectTTLEntry, deleteFn f
 		return 0
 	}
 
-	if cfg.DryRun {
+	if effectiveDryRun(cfg) {
 		_, _ = fmt.Fprintf(out, "prune: DRY RUN — would delete %d project(s):\n", len(victims))
 		for _, name := range victims {
 			_, _ = fmt.Fprintf(out, "  %s\n", name)
@@ -172,11 +189,50 @@ func runPruneWithEntries(cfg *PruneConfig, entries []projectTTLEntry, deleteFn f
 	return 0
 }
 
+func effectiveDryRun(cfg *PruneConfig) bool {
+	return cfg.DryRun || !cfg.Execute
+}
+
+func validatePruneConfig(cfg *PruneConfig) error {
+	if cfg.Prefix == "" {
+		return errors.New("prune: --prefix is required")
+	}
+	if cfg.Limit < 0 {
+		return errors.New("prune: --limit must be >= 0")
+	}
+	if cfg.Execute && cfg.DryRun {
+		return errors.New("prune: --execute and --dry-run cannot be combined")
+	}
+	if !cfg.Execute {
+		return nil
+	}
+	if cfg.ConfirmPrefix != cfg.Prefix {
+		return fmt.Errorf("prune: --confirm-prefix must exactly match --prefix (%q)", cfg.Prefix)
+	}
+	if cfg.Unlimited && cfg.Limit > 0 {
+		return errors.New("prune: use either --limit N or --unlimited, not both")
+	}
+	if !cfg.Unlimited && cfg.Limit <= 0 {
+		return errors.New("prune: --execute requires --limit N > 0 or --unlimited")
+	}
+	if !cfg.ExplicitAPIKey && !cfg.UseDefaultToken {
+		return errors.New("prune: --execute requires --api-key, or --use-default-token to allow discovered credentials")
+	}
+	if cfg.APIKey == "" {
+		return errors.New("prune: --execute requires a non-empty API key")
+	}
+	return nil
+}
+
 // runPrune is the wired-up entrypoint that connects to Postgres, lists
 // expired projects from project_ttl, and calls memory_delete_project over MCP
 // for each. Errors during list/connect return non-zero exit; per-delete errors
 // are aggregated by runPruneWithEntries.
 func runPrune(cfg *PruneConfig, stdout, stderr io.Writer) int {
+	if err := validatePruneConfig(cfg); err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 2
+	}
 	if cfg.DatabaseURL == "" {
 		_, _ = fmt.Fprintln(stderr, "prune: DATABASE_URL or --database-url is required")
 		return 1
@@ -215,7 +271,7 @@ func runPrune(cfg *PruneConfig, stdout, stderr io.Writer) int {
 	deleteFn := func(name string) error {
 		return errors.New("prune: delete client not initialised — use --dry-run")
 	}
-	if !cfg.DryRun {
+	if !effectiveDryRun(cfg) {
 		client, err := longmemeval.Connect(ctx, cfg.ServerURL, cfg.APIKey)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "prune: MCP connect: %v\n", err)
@@ -240,11 +296,15 @@ func dispatchPrune(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.Prefix, "prefix", "lme-", "delete only projects whose names start with this prefix")
 	fs.DurationVar(&cfg.OlderThan, "older-than", 0, "additional cushion past expires_at before pruning (e.g. 24h); 0 means use expires_at as-is")
 	fs.DurationVar(&cfg.OlderThan, "scratch-ttl", 0, "alias for --older-than; documents intent for lme scratch retention windows")
-	fs.BoolVar(&cfg.DryRun, "dry-run", false, "print projects that would be deleted but make no changes")
-	fs.IntVar(&cfg.Limit, "limit", 0, "cap deletions to this many projects per invocation; 0 = no cap")
+	fs.BoolVar(&cfg.DryRun, "dry-run", false, "print projects that would be deleted but make no changes (default behavior)")
+	fs.BoolVar(&cfg.Execute, "execute", false, "delete matching projects; requires --confirm-prefix and --limit N or --unlimited")
+	fs.StringVar(&cfg.ConfirmPrefix, "confirm-prefix", "", "required with --execute; must exactly match --prefix")
+	fs.IntVar(&cfg.Limit, "limit", 0, "cap deletions to this many projects per invocation; required with --execute unless --unlimited")
+	fs.BoolVar(&cfg.Unlimited, "unlimited", false, "allow --execute without a deletion limit")
 	fs.StringVar(&cfg.DatabaseURL, "database-url", envOr("DATABASE_URL", ""), "PostgreSQL DSN (env: DATABASE_URL)")
 	fs.StringVar(&cfg.ServerURL, "url", "", "Engram server URL")
 	fs.StringVar(&cfg.APIKey, "api-key", "", "Engram API key")
+	fs.BoolVar(&cfg.UseDefaultToken, "use-default-token", false, "allow --execute to use ENGRAM_API_KEY or Claude MCP config token")
 
 	fs.Usage = func() {
 		_, _ = fmt.Fprintln(stderr, "Usage: longmemeval prune [flags]")
@@ -261,7 +321,8 @@ func dispatchPrune(args []string, stdout, stderr io.Writer) int {
 		}
 		return 2
 	}
-	if !flagWasProvided(fs, "api-key") {
+	cfg.ExplicitAPIKey = flagWasProvided(fs, "api-key")
+	if !cfg.ExplicitAPIKey && cfg.UseDefaultToken {
 		cfg.APIKey = defaultAPIKey()
 	}
 	if !flagWasProvided(fs, "url") {

--- a/cmd/longmemeval/prune_test.go
+++ b/cmd/longmemeval/prune_test.go
@@ -74,6 +74,86 @@ func TestPrune_DryRunNoMutation(t *testing.T) {
 	}
 }
 
+func TestPrune_DefaultNoMutation(t *testing.T) {
+	now := time.Now()
+	entries := []projectTTLEntry{
+		{Name: "lme-run1-q001", ExpiresAt: ptr(now.Add(-time.Hour))},
+	}
+
+	var deleted []string
+	deleteFn := func(name string) error {
+		deleted = append(deleted, name)
+		return nil
+	}
+
+	cfg := &PruneConfig{
+		Prefix: "lme-",
+	}
+
+	var out strings.Builder
+	code := runPruneWithEntries(cfg, entries, deleteFn, now, &out)
+	if code != 0 {
+		t.Errorf("default prune plan must exit 0, got %d", code)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("default prune must not call delete; got deletions: %v", deleted)
+	}
+	if !strings.Contains(out.String(), "DRY RUN") {
+		t.Fatalf("default prune output must identify dry-run mode, got: %q", out.String())
+	}
+}
+
+func TestPrune_ExecuteRequiresConfirmPrefix(t *testing.T) {
+	cfg := &PruneConfig{
+		Prefix:         "lme-",
+		Execute:        true,
+		Limit:          1,
+		APIKey:         "x",
+		ExplicitAPIKey: true,
+	}
+
+	err := validatePruneConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "--confirm-prefix") {
+		t.Fatalf("validatePruneConfig() error = %v, want --confirm-prefix error", err)
+	}
+}
+
+func TestPrune_ExecuteRequiresLimitOrUnlimited(t *testing.T) {
+	cfg := &PruneConfig{
+		Prefix:         "lme-",
+		Execute:        true,
+		ConfirmPrefix:  "lme-",
+		APIKey:         "x",
+		ExplicitAPIKey: true,
+	}
+
+	err := validatePruneConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "--limit") {
+		t.Fatalf("validatePruneConfig() error = %v, want --limit error", err)
+	}
+}
+
+func TestPrune_ExecuteRejectsImplicitDefaultToken(t *testing.T) {
+	const implicitValue = "placeholder-no-leak-value"
+	t.Setenv("ENGRAM_API_KEY", implicitValue)
+	t.Setenv("DATABASE_URL", "postgres://unused")
+	var stdout, stderr strings.Builder
+
+	exit := dispatch([]string{
+		"longmemeval", "prune",
+		"--execute",
+		"--confirm-prefix", "lme-",
+		"--limit", "1",
+	}, &stdout, &stderr)
+
+	if exit == 0 {
+		t.Fatalf("execute without explicit token opt-in must fail")
+	}
+	if !strings.Contains(stderr.String(), "--api-key") || strings.Contains(stderr.String(), implicitValue) {
+		t.Fatalf("stderr should require explicit token without leaking it, got: %q", stderr.String())
+	}
+}
+
 // TestPrune_NullExpiresAtPreserved verifies that projects with NULL expires_at
 // are never selected for deletion (durable semantics).
 func TestPrune_NullExpiresAtPreserved(t *testing.T) {

--- a/deploy/lme-prune-cronjob.yaml
+++ b/deploy/lme-prune-cronjob.yaml
@@ -7,6 +7,8 @@
 #   - Image: ghcr.io/petersimmons1972/engram-go/longmemeval:latest (or pin to a SHA)
 #
 # Tune --limit on first run to verify blast radius before allowing unlimited.
+# Deletion is explicit: --execute, --confirm-prefix, and --use-default-token are
+# all required because prune defaults to plan-only mode.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -42,7 +44,10 @@ spec:
               args:
                 - prune
                 - --prefix=lme-
+                - --execute
+                - --confirm-prefix=lme-
                 - --limit=200       # cap per-run; remove once first run is verified
+                - --use-default-token
               env:
                 - name: DATABASE_URL
                   valueFrom:

--- a/docs/lme-benchmark-learnings.md
+++ b/docs/lme-benchmark-learnings.md
@@ -416,7 +416,19 @@ longmemeval prune \
   --api-key "${ENGRAM_API_KEY}"
 ```
 
-Add `--dry-run` to preview. Add `--limit 50` to cap blast radius on first run.
+By default this is a plan-only dry run. To delete, opt in explicitly:
+
+```
+longmemeval prune \
+  --database-url "${DATABASE_URL}" \
+  --url "${ENGRAM_URL}" \
+  --use-default-token \
+  --execute \
+  --confirm-prefix lme- \
+  --limit 50
+```
+
+Use `--unlimited` only for a deliberately unbounded sweep. If you want prune to discover `ENGRAM_API_KEY` or a Claude MCP token in execute mode, pass `--use-default-token`; otherwise deletion requires `--api-key`.
 
 The sweep is deployed as a weekly K8s CronJob at `deploy/lme-prune-cronjob.yaml`.
 


### PR DESCRIPTION
## Summary
- make `longmemeval prune` plan-only by default
- require `--execute`, matching `--confirm-prefix`, and `--limit N` or `--unlimited` before deletion
- reject implicit token discovery in execute mode unless `--use-default-token` is supplied
- update prune docs and the CronJob manifest for the explicit-delete contract

Closes #886.

## Verification
- `go test ./cmd/longmemeval -run 'TestPrune|TestScratchTTL|TestLMEBenchmarkLearnings|TestLMEPruneCronJob' -count=1`
- `go test ./cmd/longmemeval ./internal/longmemeval -count=1`
- `golangci-lint run`
- `git diff --check`
