### PR TITLE
docs(lme): refresh command catalog and routing guide

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,6 +1,6 @@
 # Command-Line Tools
 
-Engram ships six binaries. This page documents what each does, who typically runs it, and when.
+Engram ships seven binaries. This page documents what each does, who typically runs it, and when.
 
 ---
 
@@ -195,6 +195,44 @@ go run ./cmd/benchmark/main.go \
 
 ---
 
+## longmemeval
+
+**Location:** `cmd/longmemeval`
+
+**Who runs it:** Developers and benchmark operators evaluating Engram against LongMemEval.
+
+**Purpose:** Run the LongMemEval pipeline against a live Engram server: ingest per-question haystacks, recall context, generate answers, score against gold answers, analyze failures, discover Olla routes, and prune expired scratch projects.
+
+**Usage:**
+
+```bash
+go run ./cmd/longmemeval help
+go run ./cmd/longmemeval ingest --data questions.json --out results/lme-run --cleanup-policy=never
+go run ./cmd/longmemeval run --data questions.json --out results/lme-run --recall-topk 100 --context-topk 8
+go run ./cmd/longmemeval score-efficient --data questions.json --out results/lme-run
+go run ./cmd/longmemeval analyze --results results/lme-run
+```
+
+**Current subcommands:**
+
+- `ingest` — load the dataset into per-question Engram projects.
+- `run` — recall context and generate hypotheses.
+- `score` — score hypotheses against gold answers.
+- `all` — run ingest, run, and score in one invocation.
+- `score-efficient` — score with an Olla/OpenAI-compatible backend while preserving already-correct rows by default.
+- `score-batch` — score via Anthropic Message Batches.
+- `sample-prepare` — create a representative no-ingest sample output directory.
+- `sample-analyze` / `analyze` — summarize result checkpoints and classify score failures.
+- `route-discover` — resolve Olla/OpenAI flags from AI Flight Controller and Olla.
+- `prune` — plan or explicitly execute expired `lme-*` scratch project cleanup.
+
+**When to run:**
+- Before and after retrieval, prompt, routing, or scoring changes that may affect LongMemEval.
+- For score-only reuse of existing checkpoints after scorer changes.
+- To produce failure-analysis artifacts before deciding the next benchmark optimization.
+
+---
+
 ## Summary Table
 
 | Binary | Purpose | Who Runs It | Frequency |
@@ -205,6 +243,7 @@ go run ./cmd/benchmark/main.go \
 | `engram-eval` | Evaluate retrieval quality | Developer, CI | Before/after model changes, CI gate |
 | `instinct` | Extract and store tool-use patterns | Claude Code hook or developer | After coding sessions, optional |
 | `benchmark` | Synthetic embedding throughput test | Performance engineer, CI | Model evaluation, infra tuning |
+| `longmemeval` | LongMemEval benchmark pipeline | Developer, benchmark operator | LME runs and score-only analysis |
 
 ---
 
@@ -221,6 +260,7 @@ This produces:
 - `./engram-setup` — Setup tool
 - `./engram-eval` — Eval harness
 - `./instinct-benchmark` — Benchmark binary (note: different name from `cmd/benchmark`)
+- `./longmemeval` — LongMemEval benchmark CLI
 
 Docker images are built with `make build` and `make build-postgres`.
 

--- a/cmd/longmemeval/docs_test.go
+++ b/cmd/longmemeval/docs_test.go
@@ -54,6 +54,72 @@ func TestLMEPruneCronJobUsesSafeExecuteFlags(t *testing.T) {
 	}
 }
 
+func TestCommandCatalogDocumentsLongMemEval(t *testing.T) {
+	data, err := os.ReadFile("../../cmd/README.md")
+	if err != nil {
+		t.Fatalf("read cmd/README.md: %v", err)
+	}
+	doc := string(data)
+	for _, current := range []string{"## longmemeval", "score-efficient", "route-discover", "prune", "`longmemeval`"} {
+		if !strings.Contains(doc, current) {
+			t.Fatalf("command catalog missing %q", current)
+		}
+	}
+	if strings.Contains(doc, "Engram ships six binaries") {
+		t.Fatalf("command catalog still says Engram ships six binaries")
+	}
+}
+
+func TestLMEBenchmarkLearningsQuickStartUsesCurrentFlags(t *testing.T) {
+	data, err := os.ReadFile("../../docs/lme-benchmark-learnings.md")
+	if err != nil {
+		t.Fatalf("read docs/lme-benchmark-learnings.md: %v", err)
+	}
+	doc := string(data)
+	section := between(t, doc, "## Quick Start for Future Benchmark Runs", "### Docker Compose Configuration")
+
+	for _, stale := range []string{"--no-cleanup", "compile-time constants"} {
+		if strings.Contains(section, stale) {
+			t.Fatalf("quick start contains stale text %q:\n%s", stale, section)
+		}
+	}
+	for _, current := range []string{"--cleanup-policy=never", "--recall-topk", "--context-topk", "score-efficient", "route-discover"} {
+		if !strings.Contains(section, current) {
+			t.Fatalf("quick start missing current text %q:\n%s", current, section)
+		}
+	}
+}
+
+func TestRunbookW6800CanaryHasConcreteOllaChecks(t *testing.T) {
+	data, err := os.ReadFile("../../docs/runbook.md")
+	if err != nil {
+		t.Fatalf("read docs/runbook.md: %v", err)
+	}
+	doc := string(data)
+	section := between(t, doc, "## W6800 Canary", "## Common Issues")
+
+	for _, current := range []string{"/v1/models", "/v1/chat/completions", "llama3.1:8b", "BAAI/bge-m3"} {
+		if !strings.Contains(section, current) {
+			t.Fatalf("W6800 canary section missing concrete check text %q:\n%s", current, section)
+		}
+	}
+}
+
+func TestDeploymentNotesW6800CanaryHasConcreteOllaChecks(t *testing.T) {
+	data, err := os.ReadFile("../../docs/deployment-notes.md")
+	if err != nil {
+		t.Fatalf("read docs/deployment-notes.md: %v", err)
+	}
+	doc := string(data)
+	section := between(t, doc, "## W6800 Canary Rollout", "Current verified split:")
+
+	for _, current := range []string{"/v1/models", "/v1/chat/completions", "route-discover", "llama3.1:8b", "BAAI/bge-m3"} {
+		if !strings.Contains(section, current) {
+			t.Fatalf("deployment W6800 section missing concrete check text %q:\n%s", current, section)
+		}
+	}
+}
+
 func between(t *testing.T, s, start, end string) string {
 	t.Helper()
 	startIdx := strings.Index(s, start)

--- a/docs/deployment-notes.md
+++ b/docs/deployment-notes.md
@@ -62,6 +62,24 @@ Recommended rollout:
 3. Expand to a small general traffic share only after the canary behaves cleanly.
 4. Keep the current backend and the 7900XT path available as fallback targets.
 
+Concrete checks before sending benchmark traffic:
+
+```bash
+export OLLA_URL="${OLLA_URL:-https://olla.petersimmons.com}"
+
+curl -fsS "${OLLA_URL}/v1/models" \
+  | jq -r '.data[].id' \
+  | grep -E '^(BAAI/bge-m3|llama3.1:8b)$'
+
+curl -fsS "${OLLA_URL}/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"llama3.1:8b","messages":[{"role":"user","content":"Reply with W6800 canary ok."}],"max_tokens":16,"temperature":0}' \
+  | jq -r '.choices[0].message.content'
+
+go run ./cmd/longmemeval route-discover --purpose generation \
+  | jq '{llm_url, llm_model, olla_models}'
+```
+
 Current verified split:
 
 - `BAAI/bge-m3` is pinned on the embedding backend.

--- a/docs/lme-benchmark-learnings.md
+++ b/docs/lme-benchmark-learnings.md
@@ -273,35 +273,46 @@ Use these exact settings to replicate the working configuration:
 ### Benchmark Launch Command
 
 ```bash
+# Resolve the generation endpoint/model from AI Flight Controller + Olla.
+./longmemeval route-discover --purpose generation > /tmp/lme-route.json
+export LME_LLM_URL="$(jq -r .llm_url /tmp/lme-route.json)"
+export LME_LLM_MODEL="$(jq -r .llm_model /tmp/lme-route.json)"
+
 # Stage 1: ingest the dataset into Engram (per-question isolation projects).
 ./longmemeval ingest \
   --data ~/path/to/longmemeval_m_cleaned.json \
   --url http://localhost:8788 \
   --workers 32 \
   --out ~/benchmarks/lme-m \
-  --no-cleanup
+  --cleanup-policy=never \
+  --scratch-ttl 168h
 
 # Stage 2: recall + generate hypotheses per question.
 ./longmemeval run \
   --data ~/path/to/longmemeval_m_cleaned.json \
   --url http://localhost:8788 \
-  --llm-url http://oblivion:8000/v1 \
-  --llm-model nemotron-3-nano-omni \
+  --llm-url "${LME_LLM_URL}" \
+  --llm-model "${LME_LLM_MODEL}" \
   --workers 32 \
-  --out ~/benchmarks/lme-m
+  --out ~/benchmarks/lme-m \
+  --recall-topk 100 \
+  --context-topk 8
 
-# Stage 3: score hypotheses against gold answers.
-./longmemeval score \
+# Stage 3: score hypotheses against gold answers using score-only reuse.
+./longmemeval score-efficient \
   --data ~/path/to/longmemeval_m_cleaned.json \
-  --llm-url http://oblivion:8000/v1 \
-  --llm-model nemotron-3-nano-omni \
+  --scorer-url "${LME_SCORER_URL:-${LME_LLM_URL}}" \
+  --scorer-model "${LME_SCORER_MODEL:-${LME_LLM_MODEL}}" \
   --workers 16 \
   --out ~/benchmarks/lme-m
+
+# Stage 4: summarize completeness and failure classes.
+./longmemeval analyze --results ~/benchmarks/lme-m
 ```
 
-**Note on top-k tuning**: `recallTopK` (100) and `contextTopK` (8) are compile-time constants in `cmd/longmemeval/run.go:23-24` — not CLI flags. Change the source and rebuild to tune them. The 8 vs 40 choice is documented in the same file (`// 40 blocks x 10KB avg = 104K tokens; 8 blocks ~21K tokens - 5x faster`).
+**Top-k tuning**: `--recall-topk` controls how many memories are fetched before trimming, and `--context-topk` controls how many context blocks go into generation. Start with `--recall-topk 100 --context-topk 8`; raise context only for targeted ablations because larger prompts reduce throughput quickly.
 
-**Checkpoint files** are written to `<out>/checkpoint-ingest.jsonl`, `<out>/checkpoint-run.jsonl`, `<out>/checkpoint-score.jsonl`. Resume is automatic — re-running any stage skips question IDs already present in the checkpoint.
+**Checkpoint files** are written to `<out>/checkpoint-ingest.jsonl`, `<out>/checkpoint-run.jsonl`, and `<out>/checkpoint-score.jsonl`. Resume is automatic. Re-running `score-efficient` is score-only reuse: it reads existing run checkpoints, preserves already-`CORRECT` rows by default, and does not ingest or generate.
 
 ### vLLM Server Launch
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -389,6 +389,27 @@ Verification:
 3. Run one short completion against `llama3.1:8b` and confirm it returns normally.
 4. Expand traffic only after the canary remains stable under a small batch.
 
+Copy-paste checks:
+
+```bash
+export OLLA_URL="${OLLA_URL:-https://olla.petersimmons.com}"
+
+# Model inventory: both the embedding model and canary chat model should appear.
+curl -fsS "${OLLA_URL}/v1/models" \
+  | jq -r '.data[].id' \
+  | grep -E '^(BAAI/bge-m3|llama3.1:8b)$'
+
+# Completion smoke: verifies the W6800 chat path can answer through Olla.
+curl -fsS "${OLLA_URL}/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"llama3.1:8b","messages":[{"role":"user","content":"Reply with W6800 canary ok."}],"max_tokens":16,"temperature":0}' \
+  | jq -r '.choices[0].message.content'
+
+# LongMemEval route discovery should select a live Olla-compatible generation route.
+go run ./cmd/longmemeval route-discover --purpose generation \
+  | jq '{llm_url, llm_model, olla_models}'
+```
+
 Rollback:
 
 1. Stop sending canary traffic to the W6800 host.

--- a/docs/superpowers/specs/2026-04-22-longmemeval-design.md
+++ b/docs/superpowers/specs/2026-04-22-longmemeval-design.md
@@ -1,7 +1,7 @@
 # LongMemEval Integration Design
 
 **Date:** 2026-04-22  
-**Status:** Approved  
+**Status:** Historical / superseded by the current `cmd/longmemeval` CLI. Keep this as design history; use `longmemeval help`, `cmd/README.md`, and `docs/lme-benchmark-learnings.md` for current commands and scoring behavior.
 **Dataset:** `longmemeval_m_cleaned` (full scale — ~500 sessions/question, 500 questions)
 
 ---


### PR DESCRIPTION
## Summary
- add `longmemeval` to the command catalog with current subcommands
- refresh the benchmark quick start for `route-discover`, `--cleanup-policy`, `--recall-topk`, `--context-topk`, `score-efficient`, and score-only reuse
- add copy-paste W6800/Olla model and chat-completion checks to runbook/deployment notes
- mark the original LongMemEval design doc as historical/superseded

Closes #890.

## Verification
- `go test ./cmd/longmemeval -count=1`
- `go test ./cmd/longmemeval -run 'TestCommandCatalogDocumentsLongMemEval|TestLMEBenchmarkLearningsQuickStartUsesCurrentFlags|TestRunbookW6800CanaryHasConcreteOllaChecks|TestDeploymentNotesW6800CanaryHasConcreteOllaChecks' -count=1`
- `golangci-lint run`
- `git diff --check`
