### PR TITLE
feat(lme): add RUN_STATUS.json stage lifecycle artifact

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -421,20 +421,32 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	switch subcommand {
 	case "ingest":
-		runIngest(cfg)
+		return runStageWithStatus(cfg, subcommand, args, func() int {
+			runIngest(cfg)
+			return 0
+		})
 	case "run":
 		// #703: surface non-zero exit when runRun reports any errors.
-		if exit := runRun(cfg); exit != 0 {
-			return exit
-		}
+		return runStageWithStatus(cfg, subcommand, args, func() int {
+			return runRun(cfg)
+		})
 	case "score":
-		if exit := runScore(cfg); exit != 0 {
-			return exit
-		}
+		return runStageWithStatus(cfg, subcommand, args, func() int {
+			return runScore(cfg)
+		})
 	case "all":
-		return runAll(cfg)
+		return runStageWithStatus(cfg, subcommand, args, func() int {
+			return runAll(cfg)
+		})
 	}
 	return 0
+}
+
+func runStageWithStatus(cfg *Config, stage string, commandLine []string, run func() int) int {
+	startedAt := time.Now().UTC()
+	exitCode := run()
+	writeRunStatus(cfg, stage, startedAt, time.Now().UTC(), exitCode, commandLine)
+	return exitCode
 }
 
 func newRunID() string {

--- a/cmd/longmemeval/manifest.go
+++ b/cmd/longmemeval/manifest.go
@@ -23,6 +23,13 @@ type scoreCompleteness struct {
 	Complete            bool
 }
 
+type runStatusSnapshot struct {
+	Completeness   scoreCompleteness
+	IngestRowTotal int
+	RunRowTotal    int
+	ScoreRowTotal  int
+}
+
 func scoreCompletenessFromScores(scores []longmemeval.ScoreEntry) scoreCompleteness {
 	scoreDone, scoreErrors := scoreOutcomeCounts(scores)
 	total := scoreDone + scoreErrors
@@ -127,6 +134,157 @@ func writeRunManifest(
 		return
 	}
 	log.Printf("wrote %s", path)
+}
+
+func writeRunStatus(cfg *Config, stage string, startedAt, endedAt time.Time, exitCode int, commandLine []string) {
+	snapshot := collectRunStatusSnapshot(cfg)
+	exe, _ := os.Executable()
+	status := map[string]any{
+		"run_id":                cfg.RunID,
+		"stage":                 stage,
+		"started_at":            startedAt.UTC().Format(time.RFC3339),
+		"ended_at":              endedAt.UTC().Format(time.RFC3339),
+		"exit_code":             exitCode,
+		"pid":                   os.Getpid(),
+		"expected_total":        snapshot.Completeness.ExpectedTotal,
+		"ingest_done_total":     snapshot.Completeness.IngestDoneTotal,
+		"completed_run_total":   snapshot.Completeness.CompletedRunTotal,
+		"completed_score_total": snapshot.Completeness.CompletedScoreTotal,
+		"run_error_total":       snapshot.Completeness.RunErrorTotal,
+		"score_error_total":     snapshot.Completeness.ScoreErrorTotal,
+		"complete":              snapshot.Completeness.Complete,
+		"ingest_row_total":      snapshot.IngestRowTotal,
+		"run_row_total":         snapshot.RunRowTotal,
+		"score_row_total":       snapshot.ScoreRowTotal,
+		"binary_path":           exe,
+		"command_line":          commandLine,
+		"git_sha":               bestEffortGit("rev-parse", "HEAD"),
+		"git_dirty":             bestEffortGitDirty(),
+		"server_url":            redactURL(cfg.ServerURL),
+		"llm_url":               redactURL(cfg.LLMBaseURL),
+		"llm_model":             cfg.LLMModel,
+		"scorer_url":            redactURL(cfg.ScorerURL),
+		"scorer_model":          cfg.ScorerModel,
+		"lock_file":             statusLockFile(cfg),
+		"cleanup_policy":        cfg.CleanupPolicy,
+		"recall_topk":           cfg.RecallTopK,
+		"context_topk":          cfg.ContextTopKOverride,
+		"route_snapshot": map[string]any{
+			"server_url":   redactURL(cfg.ServerURL),
+			"llm_url":      redactURL(cfg.LLMBaseURL),
+			"llm_model":    cfg.LLMModel,
+			"scorer_url":   redactURL(cfg.ScorerURL),
+			"scorer_model": cfg.ScorerModel,
+		},
+	}
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		log.Printf("WARN marshal RUN_STATUS.json: %v", err)
+		return
+	}
+	path := filepath.Join(cfg.OutDir, "RUN_STATUS.json")
+	if err := os.WriteFile(path, data, privateArtifactFileMode); err != nil {
+		log.Printf("WARN write RUN_STATUS.json: %v", err)
+		return
+	}
+	if err := os.Chmod(path, privateArtifactFileMode); err != nil {
+		log.Printf("WARN chmod RUN_STATUS.json: %v", err)
+		return
+	}
+	log.Printf("wrote %s", path)
+}
+
+func collectRunStatusSnapshot(cfg *Config) runStatusSnapshot {
+	itemMap := loadItemMapForStatus(cfg.DataFile)
+	ingestEntries := readIngestEntriesForStatus(cfg.OutDir)
+	runEntries := readRunEntriesForStatus(cfg.OutDir)
+	scoreEntries := readScoreEntriesForStatus(cfg.OutDir)
+
+	ingestMap := make(map[string]longmemeval.IngestEntry, len(ingestEntries))
+	for _, entry := range ingestEntries {
+		if entry.QuestionID == "" {
+			continue
+		}
+		if entry.Status == "done" {
+			ingestMap[entry.QuestionID] = entry
+			continue
+		}
+		delete(ingestMap, entry.QuestionID)
+	}
+	runMap := make(map[string]longmemeval.RunEntry, len(runEntries))
+	for _, entry := range runEntries {
+		if entry.QuestionID == "" {
+			continue
+		}
+		runMap[entry.QuestionID] = entry
+	}
+	return runStatusSnapshot{
+		Completeness:   scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scoreEntries),
+		IngestRowTotal: len(ingestEntries),
+		RunRowTotal:    len(runEntries),
+		ScoreRowTotal:  len(scoreEntries),
+	}
+}
+
+func loadItemMapForStatus(path string) map[string]longmemeval.Item {
+	itemMap := make(map[string]longmemeval.Item)
+	if path == "" {
+		return itemMap
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("WARN RUN_STATUS.json: read data file %q: %v", path, err)
+		return itemMap
+	}
+	var items []longmemeval.Item
+	if err := json.Unmarshal(data, &items); err != nil {
+		log.Printf("WARN RUN_STATUS.json: parse data file %q: %v", path, err)
+		return itemMap
+	}
+	for _, item := range items {
+		if item.QuestionID != "" {
+			itemMap[item.QuestionID] = item
+		}
+	}
+	return itemMap
+}
+
+func readIngestEntriesForStatus(outDir string) []longmemeval.IngestEntry {
+	entries, err := longmemeval.ReadAllIngest(filepath.Join(outDir, "checkpoint-ingest.jsonl"))
+	if err != nil {
+		log.Printf("WARN RUN_STATUS.json: read checkpoint-ingest.jsonl: %v", err)
+		return nil
+	}
+	return entries
+}
+
+func readRunEntriesForStatus(outDir string) []longmemeval.RunEntry {
+	entries, err := longmemeval.ReadAllRun(filepath.Join(outDir, "checkpoint-run.jsonl"))
+	if err != nil {
+		log.Printf("WARN RUN_STATUS.json: read checkpoint-run.jsonl: %v", err)
+		return nil
+	}
+	return entries
+}
+
+func readScoreEntriesForStatus(outDir string) []longmemeval.ScoreEntry {
+	entries, err := longmemeval.ReadAllScore(filepath.Join(outDir, "checkpoint-score.jsonl"))
+	if err != nil {
+		log.Printf("WARN RUN_STATUS.json: read checkpoint-score.jsonl: %v", err)
+		return nil
+	}
+	return entries
+}
+
+func statusLockFile(cfg *Config) string {
+	if !cfg.ExclusiveBackend || cfg.LLMBaseURL == "" {
+		return ""
+	}
+	dir := cfg.BackendLockDir
+	if dir == "" {
+		dir = defaultLockDir()
+	}
+	return backendLockPath(dir, cfg.LLMBaseURL)
 }
 
 func bestEffortGit(args ...string) string {

--- a/cmd/longmemeval/orchestration_test.go
+++ b/cmd/longmemeval/orchestration_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -239,6 +240,108 @@ func TestRunScore_WritesRunManifest(t *testing.T) {
 	}
 	if complete, ok := manifest["complete"].(bool); !ok || !complete {
 		t.Fatalf("complete = %v (%T), want true", manifest["complete"], manifest["complete"])
+	}
+}
+
+func TestDispatchScoreWritesRunStatus(t *testing.T) {
+	dir := t.TempDir()
+
+	items := []longmemeval.Item{
+		{QuestionID: "q001", QuestionType: "single-session-user", Question: "?", Answer: "A"},
+	}
+	data, _ := json.Marshal(items)
+	dataPath := filepath.Join(dir, "data.json")
+	if err := os.WriteFile(dataPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q001", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q001", Hypothesis: "A", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q001", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	exit := dispatch([]string{
+		"longmemeval",
+		"score",
+		"--data", dataPath,
+		"--out", dir,
+		"--workers", "1",
+		"--run-id", "status-run",
+		"--llm-url", "http://user:pass@localhost:8000/v1?token=secret",
+		"--llm-model", "test-model",
+		"--score-output", "quiet",
+	}, &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("dispatch exit = %d, want 0; stderr=%s", exit, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "RUN_STATUS.json"))
+	if err != nil {
+		t.Fatalf("read RUN_STATUS.json: %v", err)
+	}
+	var status map[string]any
+	if err := json.Unmarshal(data, &status); err != nil {
+		t.Fatalf("parse RUN_STATUS.json: %v", err)
+	}
+	if status["run_id"] != "status-run" {
+		t.Fatalf("run_id = %v, want status-run", status["run_id"])
+	}
+	if status["stage"] != "score" {
+		t.Fatalf("stage = %v, want score", status["stage"])
+	}
+	if got := int(status["exit_code"].(float64)); got != 0 {
+		t.Fatalf("exit_code = %d, want 0", got)
+	}
+	if got := int(status["expected_total"].(float64)); got != 1 {
+		t.Fatalf("expected_total = %d, want 1", got)
+	}
+	if got := int(status["completed_run_total"].(float64)); got != 1 {
+		t.Fatalf("completed_run_total = %d, want 1", got)
+	}
+	if got := int(status["completed_score_total"].(float64)); got != 1 {
+		t.Fatalf("completed_score_total = %d, want 1", got)
+	}
+	if got := int(status["ingest_row_total"].(float64)); got != 1 {
+		t.Fatalf("ingest_row_total = %d, want 1", got)
+	}
+	if got := int(status["run_row_total"].(float64)); got != 1 {
+		t.Fatalf("run_row_total = %d, want 1", got)
+	}
+	if got := int(status["score_row_total"].(float64)); got != 1 {
+		t.Fatalf("score_row_total = %d, want 1", got)
+	}
+	if _, ok := status["pid"].(float64); !ok {
+		t.Fatalf("pid missing or not numeric: %v", status["pid"])
+	}
+	if _, ok := status["started_at"].(string); !ok {
+		t.Fatalf("started_at missing or not a string: %v", status["started_at"])
+	}
+	if _, ok := status["ended_at"].(string); !ok {
+		t.Fatalf("ended_at missing or not a string: %v", status["ended_at"])
+	}
+	if _, ok := status["binary_path"].(string); !ok {
+		t.Fatalf("binary_path missing or not a string: %v", status["binary_path"])
+	}
+	if _, ok := status["command_line"].([]any); !ok {
+		t.Fatalf("command_line missing or not an array: %v", status["command_line"])
+	}
+	if _, ok := status["git_dirty"].(bool); !ok {
+		t.Fatalf("git_dirty missing or not a bool: %v", status["git_dirty"])
+	}
+	route, ok := status["route_snapshot"].(map[string]any)
+	if !ok {
+		t.Fatalf("route_snapshot missing or not a map: %v", status["route_snapshot"])
+	}
+	if route["llm_url"] != "http://localhost:8000/v1" {
+		t.Fatalf("route_snapshot.llm_url = %v, want redacted URL", route["llm_url"])
+	}
+	if status["lock_file"] == "" {
+		t.Fatalf("lock_file missing")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add RUN_STATUS.json written at end of ingest, run, score, and all command lifecycles
- include lifecycle and provenance fields: started_at, ended_at, exit_code, pid, binary_path, command_line, and git metadata
- include completeness counters and checkpoint row totals to make partial runs explicit
- include redacted route snapshot fields (server_url, llm_url, scorer_url) and backend lock file path when exclusive locking is enabled
- add CLI integration test that verifies score writes RUN_STATUS.json with expected fields and URL redaction

## Why
Closes #884 by ensuring each run publishes a deterministic status artifact with denominator-safe completeness and provenance context.

## Verification
- go test ./cmd/longmemeval -run TestDispatchScoreWritesRunStatus -count=1
- go test ./cmd/longmemeval -count=1
- golangci-lint run