### PR TITLE
fix(lme): replace stale result-local wrappers with maintained scripts

### DIFF
--- a/docs/lme-benchmark-learnings.md
+++ b/docs/lme-benchmark-learnings.md
@@ -314,6 +314,20 @@ export LME_LLM_MODEL="$(jq -r .llm_model /tmp/lme-route.json)"
 
 **Checkpoint files** are written to `<out>/checkpoint-ingest.jsonl`, `<out>/checkpoint-run.jsonl`, and `<out>/checkpoint-score.jsonl`. Resume is automatic. Re-running `score-efficient` is score-only reuse: it reads existing run checkpoints, preserves already-`CORRECT` rows by default, and does not ingest or generate.
 
+### Maintained Wrappers
+
+Use tracked wrappers under `scripts/` for reproducible runs:
+
+```bash
+# Full ingest -> run -> score-efficient pipeline (captures route-discover output when enabled).
+ROUTE_DISCOVER=1 OUT=~/benchmarks/lme-m scripts/longmemeval-pipeline.sh
+
+# Resume run/score with optional route discovery and optional RUN_PID wait.
+ROUTE_DISCOVER=1 OUT=~/benchmarks/lme-m scripts/longmemeval-resume.sh
+```
+
+Result-local scripts inside `results/**` are historical run artifacts and are not maintained entrypoints.
+
 ### vLLM Server Launch
 
 ```bash

--- a/scripts/longmemeval-pipeline.sh
+++ b/scripts/longmemeval-pipeline.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Maintained LongMemEval pipeline wrapper.
+# This script replaces ad-hoc result-local wrappers in ignored results trees.
+
+REPO=${REPO:-/home/psimmons/projects/engram-go}
+BIN=${BIN:-$REPO/longmemeval}
+DATA=${DATA:-$REPO/testdata/longmemeval/longmemeval_m_cleaned.json}
+OUT=${OUT:-$REPO/results/longmemeval}
+RUN_ID=${RUN_ID:-}
+WORKERS=${WORKERS:-1}
+RECALL_TOPK=${RECALL_TOPK:-100}
+CONTEXT_TOPK=${CONTEXT_TOPK:-15}
+GEN_URL=${GEN_URL:-}
+GEN_MODEL=${GEN_MODEL:-}
+SCORER_URL=${SCORER_URL:-}
+SCORER_MODEL=${SCORER_MODEL:-}
+ROUTE_DISCOVER=${ROUTE_DISCOVER:-0}
+
+log() { echo "$(date '+%Y/%m/%d %H:%M:%S') $*"; }
+
+if [[ ! -x "$BIN" ]]; then
+  log "ERROR: binary not found or not executable: $BIN"
+  exit 1
+fi
+
+mkdir -p "$OUT"
+
+if [[ "$ROUTE_DISCOVER" == "1" ]]; then
+  route_path="$OUT/route-discover.json"
+  go run "$REPO/cmd/longmemeval" route-discover --purpose generation > "$route_path"
+  GEN_URL=$(jq -r '.llm_url' "$route_path")
+  GEN_MODEL=$(jq -r '.llm_model' "$route_path")
+  log "route-discover captured at $route_path"
+fi
+
+if [[ -z "$GEN_URL" || -z "$GEN_MODEL" ]]; then
+  log "ERROR: GEN_URL and GEN_MODEL are required (or set ROUTE_DISCOVER=1)"
+  exit 1
+fi
+
+if [[ -z "$SCORER_URL" ]]; then
+  SCORER_URL="$GEN_URL"
+fi
+if [[ -z "$SCORER_MODEL" ]]; then
+  SCORER_MODEL="$GEN_MODEL"
+fi
+
+run_flags=(
+  --data "$DATA"
+  --out "$OUT"
+  --workers "$WORKERS"
+  --recall-topk "$RECALL_TOPK"
+  --context-topk "$CONTEXT_TOPK"
+  --llm-url "$GEN_URL"
+  --llm-model "$GEN_MODEL"
+  --cleanup-policy never
+)
+if [[ -n "$RUN_ID" ]]; then
+  run_flags+=(--run-id "$RUN_ID")
+fi
+
+ingest_flags=(--data "$DATA" --out "$OUT" --workers "$WORKERS" --cleanup-policy never)
+if [[ -n "$RUN_ID" ]]; then
+  ingest_flags+=(--run-id "$RUN_ID")
+fi
+
+score_flags=(
+  --data "$DATA"
+  --out "$OUT"
+  --scorer-url "$SCORER_URL"
+  --scorer-model "$SCORER_MODEL"
+  --workers "$WORKERS"
+  --preserve-correct
+)
+
+log "=== ingest ==="
+"$BIN" ingest "${ingest_flags[@]}"
+
+log "=== run ==="
+"$BIN" run "${run_flags[@]}"
+
+log "=== score-efficient ==="
+"$BIN" score-efficient "${score_flags[@]}"
+
+log "complete: $OUT"

--- a/scripts/longmemeval-resume.sh
+++ b/scripts/longmemeval-resume.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Maintained resume wrapper for run/score stages.
+# Optional RUN_PID waits for a running "longmemeval run" process before scoring.
+
+REPO=${REPO:-/home/psimmons/projects/engram-go}
+BIN=${BIN:-$REPO/longmemeval}
+DATA=${DATA:-$REPO/testdata/longmemeval/longmemeval_m_cleaned.json}
+OUT=${OUT:-$REPO/results/longmemeval}
+LLM_URL=${LLM_URL:-}
+LLM_MODEL=${LLM_MODEL:-}
+WORKERS=${WORKERS:-1}
+RUN_INGEST=${RUN_INGEST:-0}
+SKIP_SCORE=${SKIP_SCORE:-0}
+RUN_PID=${RUN_PID:-}
+ROUTE_DISCOVER=${ROUTE_DISCOVER:-0}
+
+if [[ "$ROUTE_DISCOVER" == "1" ]]; then
+  route_path="$OUT/route-discover.json"
+  mkdir -p "$OUT"
+  go run "$REPO/cmd/longmemeval" route-discover --purpose generation > "$route_path"
+  LLM_URL=$(jq -r '.llm_url' "$route_path")
+  LLM_MODEL=$(jq -r '.llm_model' "$route_path")
+  echo "route-discover: $route_path"
+fi
+
+if [[ -z "$LLM_URL" || -z "$LLM_MODEL" ]]; then
+  echo "ERROR: LLM_URL and LLM_MODEL are required (or set ROUTE_DISCOVER=1)"
+  exit 1
+fi
+
+mkdir -p "$OUT"
+
+if [[ "$RUN_INGEST" == "1" && ! -s "$OUT/checkpoint-ingest.jsonl" ]]; then
+  "$BIN" ingest --data "$DATA" --out "$OUT" --workers "$WORKERS" --cleanup-policy never 2>&1 | tee "$OUT/ingest.log"
+fi
+
+"$BIN" run \
+  --data "$DATA" \
+  --out "$OUT" \
+  --llm-url "$LLM_URL" \
+  --llm-model "$LLM_MODEL" \
+  --workers "$WORKERS" \
+  --cleanup-policy never \
+  2>&1 | tee -a "$OUT/run.log"
+
+if [[ "$SKIP_SCORE" == "1" ]]; then
+  exit 0
+fi
+
+while [[ -n "$RUN_PID" ]] && kill -0 "$RUN_PID" 2>/dev/null; do
+  sleep 30
+done
+
+"$BIN" score \
+  --data "$DATA" \
+  --out "$OUT" \
+  --llm-url "$LLM_URL" \
+  --llm-model "$LLM_MODEL" \
+  --workers "$WORKERS" \
+  2>&1 | tee "$OUT/score.log"


### PR DESCRIPTION
## Summary
- add tracked maintained wrappers: scripts/longmemeval-pipeline.sh and scripts/longmemeval-resume.sh
- wrappers avoid stale flags and historical worktree binaries, and default to current repo binary paths
- add optional route discovery capture into output directories via ROUTE_DISCOVER=1
- document maintained wrappers in docs/lme-benchmark-learnings.md
- explicitly mark result-local scripts under results/** as historical artifacts, not maintained entrypoints

## Why
Closes #883 by moving maintained benchmark entrypoints out of ignored result trees and into tracked scripts with reproducible defaults.

## Verification
- bash -n scripts/longmemeval-pipeline.sh scripts/longmemeval-resume.sh