### PR TITLE
feat(embed): add unified embedding gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,14 +128,12 @@ POSTGRES_PASSWORD=change_me_to_a_strong_password
 # GlobalReembedder: delay between polling iterations (default: 10s)
 # ENGRAM_REEMBED_INTERVAL=10s
 
-# Embed decoupling — issue #611 fix#2
-#
-# Controls whether Store embeds chunks inline (sync) or defers to the reembed
-# worker (async). async is the default and the correct production setting;
-# sync is provided as a rollback path for one release cycle.
-# Valid values: async | sync
-# ENGRAM_STORE_EMBED_MODE=async
-#
+# Unified Embedding Gateway (default: false). When true, background/store
+# embedding is owned by the in-process gateway with a dedicated 8-connection
+# Postgres pool, response model/dimension validation, and LISTEN/NOTIFY wakeups.
+# ENGRAM_EMBED_GW_ENABLED=false
+# ENGRAM_EMBED_GW_BATCH_SIZE=100
+
 # Maximum milliseconds the recall path waits for the embedder to respond before
 # falling back to BM25+recency. Lower values = faster degraded responses but
 # fewer vector hits under load. Default 500ms is calibrated for p99 embed

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/config"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/embedgateway"
 	"github.com/petersimmons1972/engram/internal/entity"
 	"github.com/petersimmons1972/engram/internal/ingestqueue"
 	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
@@ -161,7 +162,6 @@ func run() error {
 		return err
 	}
 
-
 	if *versionFlag {
 		fmt.Printf("engram %s\n", Version)
 		os.Exit(0)
@@ -268,7 +268,7 @@ func run() error {
 	}
 	embedClient := embed.Client(embed.NewLiteLLMClientNoProbeWithCircuitBreaker(embedURL, *embedModel, litellmAPIKey, *embedDims, cbCfg))
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	probeVec, probeErr := embedClient.Embed(probeCtx, "startup probe")
+	probeVec, probeModelID, probeErr := embedClient.(embedgateway.Embedder).EmbedWithModel(probeCtx, "startup probe")
 	probeCancel()
 	if probeErr != nil {
 		slog.Warn("LiteLLM unavailable at startup — embedding degraded; server will start anyway", "error", probeErr)
@@ -276,8 +276,14 @@ func run() error {
 	} else if len(probeVec) == 0 {
 		slog.Warn("LiteLLM startup probe returned empty vector — embedding degraded")
 		embedDegraded = true
+	} else if err := embedgateway.ValidateEmbedResponse(probeVec, probeModelID); err != nil {
+		if envBool("ENGRAM_EMBED_GW_ENABLED", false) {
+			return fmt.Errorf("embed gateway startup probe rejected embed response: %w", err)
+		}
+		slog.Warn("LiteLLM startup probe does not match bge-m3 gateway contract", "err", err)
+		embedDegraded = true
 	} else {
-		slog.Info("LiteLLM embedding verified at startup", "dims", len(probeVec))
+		slog.Info("LiteLLM embedding verified at startup", "dims", len(probeVec), "model_id", probeModelID)
 	}
 
 	dsn := *databaseURL
@@ -321,21 +327,41 @@ func run() error {
 	// retentionBackend does not own the pool — do not call Close() on it.
 	go retentionBackend.StartRetentionWorker(ctx)
 
-	// GlobalReembedder processes unembedded chunks across all projects from a
-	// single goroutine, lifecycle-independent of any EnginePool entry (#359).
-	// It uses FOR UPDATE SKIP LOCKED so multiple server replicas are safe.
-	reembedBatchSize := envInt("ENGRAM_REEMBED_BATCH_SIZE", 100)
-	reembedInterval := envDuration("ENGRAM_REEMBED_INTERVAL", 10*time.Second)
-	// ENGRAM_REEMBED_BATCH_SIZE=0 disables the GlobalReembedder in this process.
-	// Use this when a dedicated engram-reembed container owns all embedding work.
-	globalReembedder := reembed.NewGlobalReembedder(pgxPool, embedClient, reembedBatchSize, reembedInterval)
-	if reembedBatchSize > 0 {
-		globalReembedder.Start(ctx)
-		slog.Info("global reembedder started", "batch_size", reembedBatchSize, "interval", reembedInterval)
+	var globalReembedder *reembed.GlobalReembedder
+	var embedGateway *embedgateway.EmbedGateway
+
+	if envBool("ENGRAM_EMBED_GW_ENABLED", false) {
+		gatewayPool, err := db.NewGatewayPool(ctx, dsn)
+		if err != nil {
+			return fmt.Errorf("embed gateway pool: %w", err)
+		}
+		defer gatewayPool.Close()
+		modelEmbedder, ok := embedClient.(embedgateway.Embedder)
+		if !ok {
+			return fmt.Errorf("embed gateway requires an embedder that reports response model IDs")
+		}
+		gatewayBatchSize := envInt("ENGRAM_EMBED_GW_BATCH_SIZE", envInt("ENGRAM_REEMBED_BATCH_SIZE", embedgateway.DefaultBatchSize))
+		embedGateway = embedgateway.New(gatewayPool, pgxPool, modelEmbedder, gatewayBatchSize)
+		embedGateway.Start(ctx)
+		defer embedGateway.Stop()
+		slog.Info("embed gateway enabled", "batch_size", gatewayBatchSize)
 	} else {
-		slog.Info("global reembedder disabled (ENGRAM_REEMBED_BATCH_SIZE=0) — reembed container owns embedding")
+		// GlobalReembedder processes unembedded chunks across all projects from a
+		// single goroutine, lifecycle-independent of any EnginePool entry (#359).
+		// It uses FOR UPDATE SKIP LOCKED so multiple server replicas are safe.
+		reembedBatchSize := envInt("ENGRAM_REEMBED_BATCH_SIZE", 100)
+		reembedInterval := envDuration("ENGRAM_REEMBED_INTERVAL", 10*time.Second)
+		// ENGRAM_REEMBED_BATCH_SIZE=0 disables the GlobalReembedder in this process.
+		// Use this when a dedicated engram-reembed container owns all embedding work.
+		globalReembedder = reembed.NewGlobalReembedder(pgxPool, embedClient, reembedBatchSize, reembedInterval)
+		if reembedBatchSize > 0 {
+			globalReembedder.Start(ctx)
+			slog.Info("global reembedder started", "batch_size", reembedBatchSize, "interval", reembedInterval)
+		} else {
+			slog.Info("global reembedder disabled (ENGRAM_REEMBED_BATCH_SIZE=0) — reembed container owns embedding")
+		}
+		defer globalReembedder.Wait()
 	}
-	defer globalReembedder.Wait()
 
 	// Audit and weight tuner workers use the shared pool directly.
 	sharedPool := pgxPool
@@ -350,7 +376,11 @@ func run() error {
 			return nil, fmt.Errorf("postgres backend for project %q: %w", project, err)
 		}
 		engine := search.New(serverCtx, backend, embedClient, project, routerURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval, *embedDims)
-		engine.SetGlobalReembedder(globalReembedder)
+		if embedGateway != nil {
+			engine.SetEmbedGateway(embedGateway)
+		} else {
+			engine.SetGlobalReembedder(globalReembedder)
+		}
 		return &internalmcp.EngineHandle{Engine: engine}, nil
 	}
 
@@ -589,6 +619,7 @@ func run() error {
 // Returns nil when:
 //   - host is loopback (any rate limit setting), OR
 //   - rate limiting is enabled (any host).
+//
 // Returns a non-nil error otherwise; caller should treat as fatal.
 func checkBindInterlock(host string, rateLimitDisable bool) error {
 	loopbacks := map[string]bool{"127.0.0.1": true, "::1": true, "localhost": true}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -268,7 +268,7 @@ func run() error {
 	}
 	embedClient := embed.Client(embed.NewLiteLLMClientNoProbeWithCircuitBreaker(embedURL, *embedModel, litellmAPIKey, *embedDims, cbCfg))
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	probeVec, probeModelID, probeErr := embedClient.(embedgateway.Embedder).EmbedWithModel(probeCtx, "startup probe")
+	probeVec, probeModelID, probeErr := embedClient.EmbedWithModel(probeCtx, "startup probe")
 	probeCancel()
 	if probeErr != nil {
 		slog.Warn("LiteLLM unavailable at startup — embedding degraded; server will start anyway", "error", probeErr)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,8 @@ This document describes the high-level structure, responsibilities, and data flo
 | `internal/db` | PostgreSQL backend interface, connection pooling, transactional storage, queries for memories, episodes, sessions |
 | `internal/search` | Semantic and BM25 hybrid search, ranking, importance decay, episode recall, memory retrieval pipeline |
 | `internal/embed` | Embedding generation via LiteLLM, model management, health probes, dimension truncation (MRL) |
+| `internal/embedgateway` | Optional unified background embedding gateway for async chunk backfill, validation, and DB backpressure |
+| `internal/embedmodel` | Machine-readable embedding model contract mirrored from `docs/EMBEDDING.md` |
 | `internal/types` | Core data types: Memory, SearchResult, Memory ID/Type, constants (MaxContentLength=500KB) |
 | `internal/claude` | HTTP client for Anthropic Messages API, advisor tool declarations, request/response marshaling |
 | `internal/chunk` | Content splitting into chunks for embedding and storage, chunk table writes |
@@ -44,11 +46,11 @@ handleMemoryStore (tools_store.go) — apply defaults, build Memory struct
   ↓
 engine.Store (search.go) — coordinate storage pipeline
   ↓
-embed.NewClient.Embed — LiteLLM embedding generation
-  ↓
 chunk.Chunker.Split — tokenize content for chunks table
   ↓
-db.Begin().Tx.StoreMemory — PostgreSQL insert
+db.Begin().Tx.StoreMemory + StoreChunks — PostgreSQL insert with NULL embeddings
+  ↓
+async: GlobalReembedder, or EmbedGateway when ENGRAM_EMBED_GW_ENABLED=true
   ↓
 async: enqueueExtractionAsync — submit for entity extraction
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -224,7 +224,9 @@ ENGRAM_CLAUDE_RERANK=false                # Use Claude to rerank results (slower
 | `POSTGRES_USER`            | `engram`             | No       | Database user (rarely needs changing)                 |
 | `ENGRAM_TRUST_PROXY_HEADERS` | `false`              | No       | Trust `X-Forwarded-For` / `X-Real-IP` for rate limiting. Set to `1` only when a trusted reverse proxy is in front. |
 | `ENGRAM_RECALL_MAX_TOP_K`  | `500`                | No       | Hard cap on results returned by `memory_recall`. Increase for bulk export use cases. |
-| `ENGRAM_REEMBED_BATCH_SIZE`| `100`                | No       | Chunks processed per GlobalReembedder iteration. Increase for faster catch-up after model changes. |
+| `ENGRAM_EMBED_GW_ENABLED` | `false`              | No       | Enable the unified embedding gateway. Default-off; when enabled it owns background embedding through a dedicated DB pool. |
+| `ENGRAM_EMBED_GW_BATCH_SIZE` | `100`             | No       | Chunks processed per embedding gateway batch. Falls back to `ENGRAM_REEMBED_BATCH_SIZE` if unset. |
+| `ENGRAM_REEMBED_BATCH_SIZE`| `100`                | No       | Chunks processed per legacy GlobalReembedder iteration. Also used as gateway batch-size fallback during rollout. |
 | `ENGRAM_REEMBED_INTERVAL`  | `10s`                | No       | Delay between GlobalReembedder polling iterations. Accepts Go duration strings (`10s`, `1m`). |
 
 ---

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -410,6 +410,34 @@ go run ./cmd/longmemeval route-discover --purpose generation \
   | jq '{llm_url, llm_model, olla_models}'
 ```
 
+## Unified Embedding Gateway
+
+The gateway is default-off. Enable it with:
+
+```bash
+ENGRAM_EMBED_GW_ENABLED=true
+ENGRAM_EMBED_GW_BATCH_SIZE=100
+```
+
+Rollback is a config-only restart with `ENGRAM_EMBED_GW_ENABLED=false`; the
+legacy `GlobalReembedder` resumes draining chunks with `embedding IS NULL`.
+Do not enable an external `reembed-rs` sidecar as the primary drain path during
+gateway rollout.
+
+Watch these metrics during canary:
+
+- `engram_chunks_pending_reembed`
+- `engram_embed_validation_rejections_total{class=...}`
+- `engram_embed_gateway_degraded_total`
+- `engram_embed_gateway_batches_total{result=...}`
+- `engram_embed_gateway_concurrency`
+
+If validation rejections climb, confirm the embedding backend is reporting an
+accepted bge-m3 alias and returning 1024 dimensions. After five consecutive
+validation rejections the gateway enters degraded hold for two minutes, leaves
+affected chunks NULL, and retries after the hold expires. Disable the gateway if
+the hold repeats after backend routing is corrected.
+
 Rollback:
 
 1. Stop sending canary traffic to the W6800 host.

--- a/internal/consolidate/consolidate_test.go
+++ b/internal/consolidate/consolidate_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testDSN(t *testing.T) string  { return testutil.DSN(t) }
+func testDSN(t *testing.T) string      { return testutil.DSN(t) }
 func uniqueProject(base string) string { return testutil.UniqueProject(base) }
 
 // fakeEmbedder returns deterministic vectors that encode similarity via a simple hash.
@@ -36,11 +36,14 @@ func (f *fakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) 
 	}
 	return vec, nil
 }
+func (f *fakeEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
+}
 func (f *fakeEmbedder) Name() string    { return "fake" }
 func (f *fakeEmbedder) Dimensions() int { return f.dims }
 
 var _ embed.Client = (*fakeEmbedder)(nil)
-
 
 // ── InferRelationships ────────────────────────────────────────────────────────
 
@@ -160,7 +163,7 @@ func TestRunAll_ReturnsStats(t *testing.T) {
 	runner := consolidate.NewRunner(backend, project, &fakeEmbedder{dims: 1024})
 
 	m := &types.Memory{
-		Content: "Sleep consolidation: infer relationships between related memories",
+		Content:    "Sleep consolidation: infer relationships between related memories",
 		MemoryType: types.MemoryTypePattern, Project: project, Importance: 2, StorageMode: "focused",
 	}
 	m.ID = types.NewMemoryID()
@@ -513,11 +516,11 @@ func storeContradictingPair(t *testing.T, ctx context.Context, backend db.Backen
 
 	// Older memory — created olderOffset in the past.
 	mOld := &types.Memory{
-		ID:         types.NewMemoryID(),
-		Content:    "PostgreSQL uses MVCC for concurrency control",
-		MemoryType: types.MemoryTypeArchitecture,
-		Project:    project,
-		Importance: 2,
+		ID:          types.NewMemoryID(),
+		Content:     "PostgreSQL uses MVCC for concurrency control",
+		MemoryType:  types.MemoryTypeArchitecture,
+		Project:     project,
+		Importance:  2,
 		StorageMode: "focused",
 	}
 	require.NoError(t, backend.StoreMemory(ctx, mOld))
@@ -530,11 +533,11 @@ func storeContradictingPair(t *testing.T, ctx context.Context, backend db.Backen
 
 	// Newer memory — created "now" (StoreMemory sets created_at=NOW()).
 	mNew := &types.Memory{
-		ID:         types.NewMemoryID(),
-		Content:    "PostgreSQL does not use MVCC for concurrency control",
-		MemoryType: types.MemoryTypeArchitecture,
-		Project:    project,
-		Importance: 2,
+		ID:          types.NewMemoryID(),
+		Content:     "PostgreSQL does not use MVCC for concurrency control",
+		MemoryType:  types.MemoryTypeArchitecture,
+		Project:     project,
+		Importance:  2,
 		StorageMode: "focused",
 	}
 	require.NoError(t, backend.StoreMemory(ctx, mNew))

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -15,8 +15,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
-	pgvector "github.com/pgvector/pgvector-go"
 	"github.com/petersimmons1972/engram/internal/types"
+	pgvector "github.com/pgvector/pgvector-go"
 )
 
 //go:embed migrations/*.sql
@@ -28,9 +28,9 @@ var projectSlugRE = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 // PostgresBackend is the PostgreSQL implementation of Backend.
 // It is safe for concurrent use from multiple goroutines.
 type PostgresBackend struct {
-	pool      *pgxpool.Pool
-	project   string // validated project slug
-	ownsPool  bool   // true only when NewPostgresBackend created the pool; false for shared-pool backends
+	pool     *pgxpool.Pool
+	project  string // validated project slug
+	ownsPool bool   // true only when NewPostgresBackend created the pool; false for shared-pool backends
 }
 
 // configurePool applies connection pool tuning for CLI tools that create a
@@ -63,6 +63,36 @@ func configureSharedPool(cfg *pgxpool.Config) {
 	// 15s health-check so the pool detects dead connections within one
 	// GlobalReembedder poll interval after a Postgres restart (#645).
 	cfg.HealthCheckPeriod = 15 * time.Second
+}
+
+func configureGatewayPool(cfg *pgxpool.Config) {
+	cfg.MinConns = 1
+	cfg.MaxConns = 8
+	cfg.MaxConnLifetime = 30 * time.Minute
+	cfg.MaxConnIdleTime = 3 * time.Minute
+	cfg.HealthCheckPeriod = 15 * time.Second
+}
+
+func NewGatewayPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DSN: %w", err)
+	}
+	if err := rejectDefaultPassword(cfg); err != nil {
+		return nil, err
+	}
+	configureGatewayPool(cfg)
+	cfg.AfterConnect = registerTypesAfterConnect
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gateway connection pool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("cannot connect gateway pool to PostgreSQL: %w", err)
+	}
+	return pool, nil
 }
 
 // registerTypesAfterConnect registers custom type codecs that every connection
@@ -492,26 +522,26 @@ func (b *PostgresBackend) SetMetaTx(ctx context.Context, tx Tx, project, key, va
 // DDL and with rowToMemory below (#112 — single point of schema knowledge).
 func rowToFTSResult(row pgx.CollectableRow) (FTSResult, error) {
 	var (
-		id, content, memType, proj string
-		tags                       []byte
-		importance, accessCount    int
+		id, content, memType, proj         string
+		tags                               []byte
+		importance, accessCount            int
 		lastAccessed, createdAt, updatedAt time.Time
-		immutable                  bool
-		expiresAt                  *time.Time
-		summary, contentHash       *string
-		storageMode                string
-		searchVector               []byte
-		validFrom, validTo         *time.Time
-		invalidationReason         *string
-		dynamicImportance          *float64
-		retrievalIntervalHrs       float64
-		nextReviewAt               *time.Time
-		timesRetrieved, timesUseful int
-		retrievalPrecision         *float64
-		episodeID                  *string
-		documentID                 *string
-		patternConfidence          *float64
-		rank                       float64
+		immutable                          bool
+		expiresAt                          *time.Time
+		summary, contentHash               *string
+		storageMode                        string
+		searchVector                       []byte
+		validFrom, validTo                 *time.Time
+		invalidationReason                 *string
+		dynamicImportance                  *float64
+		retrievalIntervalHrs               float64
+		nextReviewAt                       *time.Time
+		timesRetrieved, timesUseful        int
+		retrievalPrecision                 *float64
+		episodeID                          *string
+		documentID                         *string
+		patternConfidence                  *float64
+		rank                               float64
 	)
 	// Column order matches the live DB schema (search_vector was added between
 	// updated_at and immutable in an early migration, so it sits at position 10).

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -241,11 +241,16 @@ func (c *LiteLLMClient) Dimensions() int {
 // If a circuit breaker is configured, checks circuit state first and short-circuits
 // with errCircuitOpen if the upstream is consistently failing.
 func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, error) {
+	vec, _, err := c.EmbedWithModel(ctx, text)
+	return vec, err
+}
+
+func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
 	// Check circuit breaker before attempting request
 	if c.cb != nil {
 		if err := c.cb.Allow(); err != nil {
 			metrics.EmbedFailures.WithLabelValues("circuit_open").Inc()
-			return nil, err
+			return nil, "", err
 		}
 	}
 
@@ -258,7 +263,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("litellm embed: marshal: %w", err)
+		return nil, "", fmt.Errorf("litellm embed: marshal: %w", err)
 	}
 
 	const maxAttempts = 3
@@ -271,23 +276,23 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 			backoff := computeBackoff(attempt - 1)
 			select {
 			case <-time.After(backoff):
-				// Continue after backoff
+			// Continue after backoff
 			case <-ctx.Done():
 				// Context expired during backoff
 				metrics.EmbedFailures.WithLabelValues("non_retryable").Inc()
-				return nil, fmt.Errorf("litellm embed: context canceled during backoff: %w", ctx.Err())
+				return nil, "", fmt.Errorf("litellm embed: context canceled during backoff: %w", ctx.Err())
 			}
 		}
 
 		// Check if context is still valid before making the request
 		if ctx.Err() != nil {
 			metrics.EmbedFailures.WithLabelValues("non_retryable").Inc()
-			return nil, fmt.Errorf("litellm embed: context deadline exceeded before attempt: %w", ctx.Err())
+			return nil, "", fmt.Errorf("litellm embed: context deadline exceeded before attempt: %w", ctx.Err())
 		}
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/embeddings", bytes.NewReader(body))
 		if err != nil {
-			return nil, fmt.Errorf("litellm embed: build request: %w", err)
+			return nil, "", fmt.Errorf("litellm embed: build request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
 		if c.apiKey != "" {
@@ -305,7 +310,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 				if c.cb != nil {
 					c.cb.RecordFailure()
 				}
-				return nil, fmt.Errorf("litellm embed request: %w", err)
+				return nil, "", fmt.Errorf("litellm embed request: %w", err)
 			}
 			// Retryable error; log and retry
 			if attempt < maxAttempts-1 {
@@ -317,7 +322,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 			if c.cb != nil {
 				c.cb.RecordFailure()
 			}
-			return nil, fmt.Errorf("litellm embed request (exhausted retries): %w", err)
+			return nil, "", fmt.Errorf("litellm embed request (exhausted retries): %w", err)
 		}
 
 		defer resp.Body.Close() //nolint:errcheck
@@ -332,7 +337,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 				if c.cb != nil {
 					c.cb.RecordFailure()
 				}
-				return nil, fmt.Errorf("litellm embed: %w", statusErr)
+				return nil, "", fmt.Errorf("litellm embed: %w", statusErr)
 			}
 			// Retryable HTTP error; log and retry
 			if attempt < maxAttempts-1 {
@@ -344,12 +349,13 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 			if c.cb != nil {
 				c.cb.RecordFailure()
 			}
-			return nil, fmt.Errorf("litellm embed: %w (exhausted retries)", statusErr)
+			return nil, "", fmt.Errorf("litellm embed: %w (exhausted retries)", statusErr)
 		}
 
 		// Success: decode response
 		var result struct {
-			Data []struct {
+			Model string `json:"model"`
+			Data  []struct {
 				Embedding []float32 `json:"embedding"`
 			} `json:"data"`
 		}
@@ -359,7 +365,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 			if c.cb != nil {
 				c.cb.RecordFailure()
 			}
-			return nil, fmt.Errorf("litellm embed decode: %w", err)
+			return nil, "", fmt.Errorf("litellm embed decode: %w", err)
 		}
 		if len(result.Data) == 0 || len(result.Data[0].Embedding) == 0 {
 			// Empty response is non-retryable
@@ -367,7 +373,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 			if c.cb != nil {
 				c.cb.RecordFailure()
 			}
-			return nil, fmt.Errorf("litellm embed: empty response")
+			return nil, "", fmt.Errorf("litellm embed: empty response")
 		}
 
 		// Success!
@@ -386,7 +392,11 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 			c.cb.RecordSuccess()
 		}
 
-		return vec, nil
+		modelID := result.Model
+		if modelID == "" {
+			modelID = c.model
+		}
+		return vec, modelID, nil
 	}
 
 	// Should not reach here, but as a fallback
@@ -394,7 +404,7 @@ func (c *LiteLLMClient) Embed(ctx context.Context, text string) ([]float32, erro
 	if c.cb != nil {
 		c.cb.RecordFailure()
 	}
-	return nil, fmt.Errorf("litellm embed: exhausted %d attempts, last error: %w (status %d)", maxAttempts, lastErr, lastStatusCode)
+	return nil, "", fmt.Errorf("litellm embed: exhausted %d attempts, last error: %w (status %d)", maxAttempts, lastErr, lastStatusCode)
 }
 
 // Probe checks if the LiteLLM endpoint is healthy and advertising the configured

--- a/internal/embed/litellm_test.go
+++ b/internal/embed/litellm_test.go
@@ -55,6 +55,32 @@ func TestEmbedRetriesOn502(t *testing.T) {
 	}
 }
 
+func TestLiteLLMClient_EmbedWithModelReturnsReportedModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": "BAAI/bge-m3",
+			"data": []map[string]any{{
+				"embedding": []float32{0.1, 0.2, 0.3},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewLiteLLMClientNoProbe(server.URL, "configured-alias", "", 0)
+	vec, modelID, err := client.EmbedWithModel(context.Background(), "test text")
+	if err != nil {
+		t.Fatalf("EmbedWithModel returned error: %v", err)
+	}
+	if len(vec) != 3 {
+		t.Fatalf("len(vec) = %d, want 3", len(vec))
+	}
+	if modelID != "BAAI/bge-m3" {
+		t.Fatalf("modelID = %q, want reported model", modelID)
+	}
+}
+
 // TestEmbedNoRetryOn400 verifies that a 400 Bad Request does not retry.
 func TestEmbedNoRetryOn400(t *testing.T) {
 	t.Helper()

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -22,6 +22,8 @@ import (
 type Client interface {
 	// Embed returns a float32 vector for the given text.
 	Embed(ctx context.Context, text string) ([]float32, error)
+	// EmbedWithModel returns a vector plus the model identifier reported by the embedding backend.
+	EmbedWithModel(ctx context.Context, text string) ([]float32, string, error)
 	// Name returns the model identifier (e.g. "nomic-embed-text").
 	Name() string
 	// Dimensions returns the vector size, or 0 before the first successful embed.
@@ -184,6 +186,14 @@ func (c *OllamaClient) Embed(ctx context.Context, text string) ([]float32, error
 		return nil, fmt.Errorf("ollama embed: empty response")
 	}
 	return result.Embeddings[0], nil
+}
+
+func (c *OllamaClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := c.Embed(ctx, text)
+	if err != nil {
+		return nil, "", err
+	}
+	return vec, c.model, nil
 }
 
 func (c *OllamaClient) ensureModel(ctx context.Context) error {

--- a/internal/embedgateway/drain.go
+++ b/internal/embedgateway/drain.go
@@ -1,0 +1,122 @@
+package embedgateway
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/embedmodel"
+	"github.com/petersimmons1972/engram/internal/metrics"
+	pgvector "github.com/pgvector/pgvector-go"
+	"golang.org/x/sync/errgroup"
+)
+
+const embedTimeout = 15 * time.Second
+
+type pendingChunk struct {
+	id        string
+	chunkText string
+}
+
+func (g *EmbedGateway) drainBatch(ctx context.Context) (int, error) {
+	if g.testDrain != nil {
+		return g.testDrain(ctx)
+	}
+	if g.pool == nil || g.embedder == nil {
+		return 0, nil
+	}
+	if remaining, held := g.inDegradedHold(time.Now()); held {
+		slog.Warn("embed gateway degraded hold active; skipping drain", "remaining", remaining)
+		return 0, nil
+	}
+
+	tx, err := g.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin claim tx: %w", err)
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT c.id, c.chunk_text
+		FROM chunks c
+		WHERE c.embedding IS NULL
+		ORDER BY c.id DESC
+		LIMIT $1
+		FOR UPDATE SKIP LOCKED`, g.batchSize)
+	if err != nil {
+		_ = tx.Rollback(ctx)
+		return 0, fmt.Errorf("query pending chunks: %w", err)
+	}
+
+	var chunks []pendingChunk
+	for rows.Next() {
+		var c pendingChunk
+		if err := rows.Scan(&c.id, &c.chunkText); err != nil {
+			rows.Close()
+			_ = tx.Rollback(ctx)
+			return 0, fmt.Errorf("scan pending chunk: %w", err)
+		}
+		chunks = append(chunks, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		_ = tx.Rollback(ctx)
+		return 0, fmt.Errorf("iterate pending chunks: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit claim tx: %w", err)
+	}
+	if len(chunks) == 0 {
+		return 0, nil
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(g.throttle.Concurrency())
+	for _, chunk := range chunks {
+		chunk := chunk
+		eg.Go(func() error {
+			vec, err := g.embedAndValidate(egCtx, chunk)
+			if err != nil {
+				return nil
+			}
+			if _, err := g.pool.Exec(egCtx,
+				"UPDATE chunks SET embedding=$1 WHERE id=$2",
+				pgvector.NewVector(vec), chunk.id,
+			); err != nil {
+				slog.Warn("embed gateway: update failed", "chunk", chunk.id, "err", err)
+			}
+			return nil
+		})
+	}
+	_ = eg.Wait()
+	return len(chunks), nil
+}
+
+func (g *EmbedGateway) embedAndValidate(ctx context.Context, chunk pendingChunk) ([]float32, error) {
+	embedCtx, cancel := context.WithTimeout(ctx, embedTimeout)
+	defer cancel()
+
+	vec, modelID, err := g.embedder.EmbedWithModel(embedCtx, chunk.chunkText)
+	if err != nil {
+		metrics.WorkerErrors.WithLabelValues("embed_gateway").Inc()
+		slog.Warn("embed gateway: embed failed", "chunk", chunk.id, "err", err)
+		return nil, err
+	}
+	if err := validateEmbedResponse(vec, modelID); err != nil {
+		metrics.EmbedValidationRejections.WithLabelValues(rejectionClass(vec, modelID)).Inc()
+		slog.Error("embed response rejected", "chunk", chunk.id, "model_id", modelID, "dims", len(vec), "err", err)
+		g.noteValidationRejected(modelID, len(vec))
+		return nil, err
+	}
+	g.noteEmbedAccepted()
+	return vec, nil
+}
+
+func rejectionClass(vec []float32, modelID string) string {
+	if embedmodel.CanonicalName(modelID) != embedmodel.CanonicalBGEM3 {
+		return "wrong_model"
+	}
+	if len(vec) != embedmodel.RequiredDims {
+		return "wrong_dims"
+	}
+	return "none"
+}

--- a/internal/embedgateway/gateway.go
+++ b/internal/embedgateway/gateway.go
@@ -1,0 +1,273 @@
+package embedgateway
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/petersimmons1972/engram/internal/embedmodel"
+	"github.com/petersimmons1972/engram/internal/metrics"
+)
+
+const (
+	DefaultBatchSize      = 100
+	DefaultMaxConcurrency = 8
+	DefaultMinIdle        = 5 * time.Second
+	DefaultMaxIdle        = 300 * time.Second
+
+	consecutiveValidationThreshold = 5
+	defaultHoldDuration            = 2 * time.Minute
+)
+
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	EmbedWithModel(ctx context.Context, text string) ([]float32, string, error)
+	Name() string
+	Dimensions() int
+}
+
+type drainFunc func(context.Context) (int, error)
+
+type EmbedGateway struct {
+	pool     *pgxpool.Pool
+	userPool *pgxpool.Pool
+	embedder Embedder
+
+	batchSize int
+	minIdle   time.Duration
+	maxIdle   time.Duration
+	holdFor   time.Duration
+	throttle  *AdaptiveThrottle
+
+	stateMu                  sync.Mutex
+	holdUntil                time.Time
+	consecutiveValidationErr atomic.Int64
+
+	notify    chan struct{}
+	done      chan struct{}
+	stop      chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+
+	testDrain drainFunc
+}
+
+func New(pool, userPool *pgxpool.Pool, embedder Embedder, batchSize int) *EmbedGateway {
+	if batchSize <= 0 {
+		batchSize = DefaultBatchSize
+	}
+	return &EmbedGateway{
+		pool:      pool,
+		userPool:  userPool,
+		embedder:  embedder,
+		batchSize: batchSize,
+		minIdle:   DefaultMinIdle,
+		maxIdle:   DefaultMaxIdle,
+		holdFor:   defaultHoldDuration,
+		throttle:  NewAdaptiveThrottle(DefaultMaxConcurrency),
+		notify:    make(chan struct{}, 1),
+		done:      make(chan struct{}),
+		stop:      make(chan struct{}),
+	}
+}
+
+func NewForTest(embedder Embedder, drain drainFunc) *EmbedGateway {
+	g := New(nil, nil, embedder, 1)
+	g.minIdle = time.Hour
+	g.maxIdle = time.Hour
+	g.testDrain = drain
+	return g
+}
+
+func (g *EmbedGateway) Enqueue(chunkIDs []string) {
+	if len(chunkIDs) == 0 {
+		return
+	}
+	select {
+	case g.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (g *EmbedGateway) Start(ctx context.Context) {
+	g.startOnce.Do(func() {
+		go g.run(ctx)
+	})
+}
+
+func (g *EmbedGateway) Stop() {
+	g.stopOnce.Do(func() { close(g.stop) })
+	<-g.done
+}
+
+func (g *EmbedGateway) WaitDrained(ctx context.Context) error {
+	if g.pool == nil {
+		return nil
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var pending int
+		if err := g.pool.QueryRow(ctx, "SELECT COUNT(*) FROM chunks WHERE embedding IS NULL").Scan(&pending); err != nil {
+			return fmt.Errorf("count pending embeddings: %w", err)
+		}
+		if pending == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (g *EmbedGateway) run(ctx context.Context) {
+	defer close(g.done)
+	slog.Info("embed gateway started", "batch_size", g.batchSize)
+
+	backoff := g.minIdle
+	for {
+		if g.userPool != nil {
+			stat := g.userPool.Stat()
+			g.throttle.Update(ThrottleStats{AcquiredConns: stat.AcquiredConns(), MaxConns: stat.MaxConns()})
+			metrics.EmbedGatewayConcurrency.Set(float64(g.throttle.Concurrency()))
+		}
+		g.updatePendingGauge(ctx)
+
+		iterCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		n, err := g.drainBatch(iterCtx)
+		cancel()
+		if err != nil {
+			slog.Warn("embed gateway drain error", "err", err)
+			metrics.EmbedGatewayBatches.WithLabelValues("error").Inc()
+		} else if n > 0 {
+			metrics.EmbedGatewayBatches.WithLabelValues("work").Inc()
+		} else {
+			metrics.EmbedGatewayBatches.WithLabelValues("empty").Inc()
+		}
+		select {
+		case <-g.stop:
+			return
+		default:
+		}
+		if n > 0 {
+			backoff = g.minIdle
+			if n == g.batchSize {
+				continue
+			}
+		} else if backoff < g.maxIdle {
+			backoff = min(backoff*2, g.maxIdle)
+		}
+
+		if g.pool != nil {
+			woke, ok := g.waitForWake(ctx, backoff)
+			if !ok {
+				return
+			}
+			if woke {
+				backoff = g.minIdle
+			}
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-g.stop:
+			return
+		case <-g.notify:
+			backoff = g.minIdle
+		case <-time.After(backoff):
+		}
+	}
+}
+
+func (g *EmbedGateway) inDegradedHold(now time.Time) (time.Duration, bool) {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	if g.holdUntil.IsZero() || !now.Before(g.holdUntil) {
+		return 0, false
+	}
+	return time.Until(g.holdUntil), true
+}
+
+func (g *EmbedGateway) updatePendingGauge(ctx context.Context) {
+	if g.pool == nil {
+		return
+	}
+	countCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	var pending int
+	if err := g.pool.QueryRow(countCtx, "SELECT COUNT(*) FROM chunks WHERE embedding IS NULL").Scan(&pending); err == nil {
+		metrics.ChunksPendingReembed.Set(float64(pending))
+	}
+}
+
+func (g *EmbedGateway) noteValidationRejected(modelID string, dims int) {
+	consecutive := g.consecutiveValidationErr.Add(1)
+	if consecutive < consecutiveValidationThreshold {
+		return
+	}
+	g.stateMu.Lock()
+	g.holdUntil = time.Now().Add(g.holdFor)
+	g.stateMu.Unlock()
+
+	metrics.EmbedGatewayDegraded.Inc()
+	slog.Error("embed gateway degraded hold after repeated validation rejections",
+		"consecutive_rejections", consecutive,
+		"hold_for", g.holdFor,
+		"model_id", modelID,
+		"dims", dims)
+}
+
+func (g *EmbedGateway) noteEmbedAccepted() {
+	g.consecutiveValidationErr.Store(0)
+}
+
+func (g *EmbedGateway) waitForWake(ctx context.Context, backoff time.Duration) (woke bool, ok bool) {
+	acquireCtx, acquireCancel := context.WithTimeout(ctx, backoff)
+	conn, err := g.pool.Acquire(acquireCtx)
+	acquireCancel()
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return false, false
+		case <-g.stop:
+			return false, false
+		case <-g.notify:
+			return true, true
+		case <-time.After(backoff):
+			return false, true
+		}
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "LISTEN "+embedmodel.PGNotifyChannel); err != nil {
+		slog.Warn("embed gateway LISTEN failed", "err", err)
+		return false, true
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, backoff)
+	defer waitCancel()
+
+	_, err = conn.Conn().WaitForNotification(waitCtx)
+	if err == nil {
+		return true, true
+	}
+
+	select {
+	case <-ctx.Done():
+		return false, false
+	case <-g.stop:
+		return false, false
+	case <-g.notify:
+		return true, true
+	default:
+		return false, true
+	}
+}

--- a/internal/embedgateway/gateway_test.go
+++ b/internal/embedgateway/gateway_test.go
@@ -1,0 +1,127 @@
+package embedgateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/embedmodel"
+)
+
+type stubEmbedder struct {
+	delay   time.Duration
+	dims    int
+	modelID string
+}
+
+func (s stubEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vec, _, err := s.EmbedWithModel(ctx, text)
+	return vec, err
+}
+
+func (s stubEmbedder) EmbedWithModel(ctx context.Context, _ string) ([]float32, string, error) {
+	if s.delay > 0 {
+		select {
+		case <-time.After(s.delay):
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+	}
+	dims := s.dims
+	if dims == 0 {
+		dims = embedmodel.RequiredDims
+	}
+	modelID := s.modelID
+	if modelID == "" {
+		modelID = embedmodel.CanonicalBGEM3
+	}
+	return make([]float32, dims), modelID, nil
+}
+
+func (s stubEmbedder) Name() string    { return embedmodel.CanonicalBGEM3 }
+func (s stubEmbedder) Dimensions() int { return embedmodel.RequiredDims }
+
+func TestGateway_EnqueueWakesLoop(t *testing.T) {
+	called := make(chan struct{}, 1)
+	g := NewForTest(stubEmbedder{}, func(context.Context) (int, error) {
+		called <- struct{}{}
+		return 0, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g.Start(ctx)
+	defer g.Stop()
+
+	g.Enqueue([]string{"id1"})
+
+	select {
+	case <-called:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Enqueue did not wake drain loop within 100ms")
+	}
+}
+
+func TestGateway_AdaptiveThrottle_BacksOffUnderLoad(t *testing.T) {
+	throttle := NewAdaptiveThrottle(8)
+	throttle.Update(ThrottleStats{AcquiredConns: 9, MaxConns: 10})
+	if got := throttle.Concurrency(); got != 1 {
+		t.Fatalf("Concurrency() = %d, want 1 under >80%% utilization", got)
+	}
+}
+
+func TestGateway_AdaptiveThrottle_ScalesUpUnderLowLoad(t *testing.T) {
+	throttle := NewAdaptiveThrottle(8)
+	for range 10 {
+		throttle.Update(ThrottleStats{AcquiredConns: 1, MaxConns: 10})
+	}
+	if got := throttle.Concurrency(); got != 8 {
+		t.Fatalf("Concurrency() = %d, want max concurrency 8 under low utilization", got)
+	}
+}
+
+func TestGateway_Stop_DrainsInFlight(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	g := NewForTest(stubEmbedder{}, func(ctx context.Context) (int, error) {
+		once.Do(func() { close(started) })
+		select {
+		case <-release:
+			return 1, nil
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g.Start(ctx)
+	g.Enqueue([]string{"id1"})
+
+	select {
+	case <-started:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("drain did not start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		g.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Stop returned before in-flight drain completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Stop did not return after in-flight drain completed")
+	}
+}

--- a/internal/embedgateway/gateway_test.go
+++ b/internal/embedgateway/gateway_test.go
@@ -125,3 +125,16 @@ func TestGateway_Stop_DrainsInFlight(t *testing.T) {
 		t.Fatal("Stop did not return after in-flight drain completed")
 	}
 }
+
+func TestGateway_DegradedHoldAfterValidationRejections(t *testing.T) {
+	g := NewForTest(stubEmbedder{}, nil)
+	g.holdFor = time.Hour
+
+	for range consecutiveValidationThreshold {
+		g.noteValidationRejected("nomic-embed-text", embedmodel.RequiredDims)
+	}
+
+	if _, held := g.inDegradedHold(time.Now()); !held {
+		t.Fatal("gateway did not enter degraded hold after validation rejection threshold")
+	}
+}

--- a/internal/embedgateway/throttle.go
+++ b/internal/embedgateway/throttle.go
@@ -1,0 +1,50 @@
+package embedgateway
+
+import "sync"
+
+type ThrottleStats struct {
+	AcquiredConns int32
+	MaxConns      int32
+}
+
+type AdaptiveThrottle struct {
+	mu             sync.Mutex
+	concurrency    int
+	minConcurrency int
+	maxConcurrency int
+}
+
+func NewAdaptiveThrottle(maxConcurrency int) *AdaptiveThrottle {
+	if maxConcurrency < 1 {
+		maxConcurrency = 1
+	}
+	return &AdaptiveThrottle{
+		concurrency:    maxConcurrency,
+		minConcurrency: 1,
+		maxConcurrency: maxConcurrency,
+	}
+}
+
+func (t *AdaptiveThrottle) Update(stat ThrottleStats) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if stat.MaxConns <= 0 {
+		return
+	}
+	utilisation := float64(stat.AcquiredConns) / float64(stat.MaxConns)
+	switch {
+	case utilisation > 0.80:
+		t.concurrency = t.minConcurrency
+	case utilisation > 0.60:
+		t.concurrency = max(t.concurrency-1, t.minConcurrency)
+	case utilisation < 0.30:
+		t.concurrency = min(t.concurrency+1, t.maxConcurrency)
+	}
+}
+
+func (t *AdaptiveThrottle) Concurrency() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.concurrency
+}

--- a/internal/embedgateway/validate.go
+++ b/internal/embedgateway/validate.go
@@ -1,0 +1,22 @@
+package embedgateway
+
+import (
+	"fmt"
+
+	"github.com/petersimmons1972/engram/internal/embedmodel"
+)
+
+func ValidateEmbedResponse(vec []float32, reportedModelID string) error {
+	if embedmodel.CanonicalName(reportedModelID) != embedmodel.CanonicalBGEM3 {
+		return fmt.Errorf("embed response rejected: model %q not in bge-m3 alias set", reportedModelID)
+	}
+	if len(vec) != embedmodel.RequiredDims {
+		return fmt.Errorf("embed response rejected: got %d dims, want %d (model: %q)",
+			len(vec), embedmodel.RequiredDims, reportedModelID)
+	}
+	return nil
+}
+
+func validateEmbedResponse(vec []float32, reportedModelID string) error {
+	return ValidateEmbedResponse(vec, reportedModelID)
+}

--- a/internal/embedgateway/validate_test.go
+++ b/internal/embedgateway/validate_test.go
@@ -1,0 +1,47 @@
+package embedgateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/embedmodel"
+)
+
+func TestValidateEmbedResponse_AcceptsAllAliases(t *testing.T) {
+	vec := make([]float32, embedmodel.RequiredDims)
+	for _, alias := range embedmodel.AcceptedAliases {
+		if err := validateEmbedResponse(vec, alias); err != nil {
+			t.Fatalf("validateEmbedResponse(%q) returned error: %v", alias, err)
+		}
+	}
+}
+
+func TestValidateEmbedResponse_RejectsWrongModel(t *testing.T) {
+	err := validateEmbedResponse(make([]float32, embedmodel.RequiredDims), "nomic-embed-text")
+	if err == nil {
+		t.Fatal("validateEmbedResponse returned nil for wrong model")
+	}
+	if !strings.Contains(err.Error(), "not in bge-m3 alias set") {
+		t.Fatalf("error = %q, want alias-set rejection", err)
+	}
+}
+
+func TestValidateEmbedResponse_RejectsWrongDims(t *testing.T) {
+	err := validateEmbedResponse(make([]float32, 768), embedmodel.CanonicalBGEM3)
+	if err == nil {
+		t.Fatal("validateEmbedResponse returned nil for wrong dims")
+	}
+	if !strings.Contains(err.Error(), "got 768 dims") {
+		t.Fatalf("error = %q, want dim rejection", err)
+	}
+}
+
+func TestValidateEmbedResponse_RejectsBothWrong(t *testing.T) {
+	err := validateEmbedResponse(make([]float32, 768), "nomic-embed-text")
+	if err == nil {
+		t.Fatal("validateEmbedResponse returned nil for wrong model and dims")
+	}
+	if !strings.Contains(err.Error(), "not in bge-m3 alias set") {
+		t.Fatalf("error = %q, want model rejection first", err)
+	}
+}

--- a/internal/embedmodel/model.go
+++ b/internal/embedmodel/model.go
@@ -1,0 +1,25 @@
+package embedmodel
+
+const (
+	CanonicalBGEM3  = "BAAI/bge-m3"
+	RequiredDims    = 1024
+	PGNotifyChannel = "embed_queue"
+)
+
+var AcceptedAliases = []string{
+	"BAAI/bge-m3",
+	"bge-m3",
+	"bge-m3-Q8_0.gguf",
+	"bge-m3-Q4_K_M.gguf",
+}
+
+var aliasToCanonical = map[string]string{
+	"BAAI/bge-m3":        CanonicalBGEM3,
+	"bge-m3":             CanonicalBGEM3,
+	"bge-m3-Q8_0.gguf":   CanonicalBGEM3,
+	"bge-m3-Q4_K_M.gguf": CanonicalBGEM3,
+}
+
+func CanonicalName(modelID string) string {
+	return aliasToCanonical[modelID]
+}

--- a/internal/embedmodel/model_test.go
+++ b/internal/embedmodel/model_test.go
@@ -1,0 +1,17 @@
+package embedmodel
+
+import "testing"
+
+func TestCanonicalName_AllAliasesNormalize(t *testing.T) {
+	for _, alias := range AcceptedAliases {
+		if got := CanonicalName(alias); got != CanonicalBGEM3 {
+			t.Fatalf("CanonicalName(%q) = %q, want %q", alias, got, CanonicalBGEM3)
+		}
+	}
+}
+
+func TestCanonicalName_UnknownReturnsEmpty(t *testing.T) {
+	if got := CanonicalName("nomic-embed-text"); got != "" {
+		t.Fatalf("CanonicalName(unknown) = %q, want empty string", got)
+	}
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -242,6 +242,10 @@ type noopEmbedder struct{}
 func (noopEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, 384), nil
 }
+func (e noopEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
+}
 func (noopEmbedder) Name() string    { return "noop" }
 func (noopEmbedder) Dimensions() int { return 384 }
 

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
-	pgvector "github.com/pgvector/pgvector-go"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
+	pgvector "github.com/pgvector/pgvector-go"
 )
 
 // FlushPendingEmbeddings backfills NULL embeddings on chunks for the given
@@ -116,6 +116,10 @@ func (f *fakeTestEmbedClient) Embed(_ context.Context, text string) ([]float32, 
 		}
 	}
 	return vec, nil
+}
+func (f *fakeTestEmbedClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
 }
 func (f *fakeTestEmbedClient) Name() string    { return "fake" }
 func (f *fakeTestEmbedClient) Dimensions() int { return f.dims }

--- a/internal/mcp/ingest_export_helpers_test.go
+++ b/internal/mcp/ingest_export_helpers_test.go
@@ -55,6 +55,10 @@ type storeableNoopEmbedder struct{}
 func (storeableNoopEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, 384), nil
 }
+func (e storeableNoopEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
+}
 func (storeableNoopEmbedder) Name() string    { return "noop-store" }
 func (storeableNoopEmbedder) Dimensions() int { return 384 }
 

--- a/internal/mcp/migrate_embedder_test.go
+++ b/internal/mcp/migrate_embedder_test.go
@@ -47,6 +47,10 @@ type dimEmbedder struct {
 func (e dimEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, e.dims), nil
 }
+func (e dimEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
+}
 func (e dimEmbedder) Name() string    { return "dim-test-model" }
 func (e dimEmbedder) Dimensions() int { return e.dims }
 
@@ -171,7 +175,6 @@ type migrateReadyBackend struct{ dimBackend }
 func (b migrateReadyBackend) Begin(_ context.Context) (db.Tx, error) { return noopTx{}, nil }
 
 var _ db.Backend = migrateReadyBackend{}
-
 
 // TestHandleMemoryMigrateEmbedder_MigrateError verifies that when MigrateEmbedder
 // itself returns an error, the handler surfaces that error and does not fire

--- a/internal/mcp/tools_store_decouple_test.go
+++ b/internal/mcp/tools_store_decouple_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/stretchr/testify/require"
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
 // testDSNDecouple returns the integration-test DSN, skipping if unset.
@@ -38,6 +38,11 @@ type transientErrorEmbedder struct {
 
 func (e transientErrorEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return nil, errors.New("connection refused to embedder backend")
+}
+
+func (e transientErrorEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
 }
 
 func (e transientErrorEmbedder) Name() string    { return e.name }

--- a/internal/mcp/tools_store_permanent_test.go
+++ b/internal/mcp/tools_store_permanent_test.go
@@ -30,6 +30,11 @@ func (e permanentErrorEmbedder) Embed(_ context.Context, _ string) ([]float32, e
 	}
 }
 
+func (e permanentErrorEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
+}
+
 func (e permanentErrorEmbedder) Name() string    { return e.current }
 func (e permanentErrorEmbedder) Dimensions() int { return 384 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -75,6 +75,26 @@ var (
 		Help: "Total final embedding failures by reason",
 	}, []string{"reason"})
 
+	EmbedValidationRejections = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "engram_embed_validation_rejections_total",
+		Help: "Embedding responses rejected before storage by rejection class",
+	}, []string{"class"})
+
+	EmbedGatewayDegraded = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "engram_embed_gateway_degraded_total",
+		Help: "Times the embedding gateway entered degraded hold after repeated validation rejections",
+	})
+
+	EmbedGatewayBatches = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "engram_embed_gateway_batches_total",
+		Help: "Embedding gateway drain batches by result",
+	}, []string{"result"})
+
+	EmbedGatewayConcurrency = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "engram_embed_gateway_concurrency",
+		Help: "Current embedding gateway worker concurrency limit",
+	})
+
 	// WorkerPanics counts panics caught and recovered by background workers.
 	// Incremented by the deferred recover() in each worker's main loop.
 	WorkerPanics = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -175,6 +195,10 @@ func init() {
 		EpisodesEndedByReaperTotal,
 		EmbedRetries,
 		EmbedFailures,
+		EmbedValidationRejections,
+		EmbedGatewayDegraded,
+		EmbedGatewayBatches,
+		EmbedGatewayConcurrency,
 		WorkerPanics,
 		ExtractionDropped,
 		EmbedCircuitState,

--- a/internal/reembed/embed_fail_test.go
+++ b/internal/reembed/embed_fail_test.go
@@ -21,6 +21,10 @@ type failEmbedder struct{}
 func (f *failEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return nil, errors.New("mock embed failure")
 }
+func (f *failEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
+}
 func (f *failEmbedder) Name() string    { return "fail" }
 func (f *failEmbedder) Dimensions() int { return 0 }
 

--- a/internal/reembed/global_worker_recovery_test.go
+++ b/internal/reembed/global_worker_recovery_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/db"
-	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/petersimmons1972/engram/internal/testutil"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 // TestGlobalReembedder_ConsecutiveErrorCounterResets verifies that the
@@ -69,6 +69,10 @@ type countingEmbedder struct {
 
 func (c *countingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, c.dims), nil
+}
+func (c *countingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := c.Embed(ctx, text)
+	return vec, c.Name(), err
 }
 func (c *countingEmbedder) Name() string    { return "counting" }
 func (c *countingEmbedder) Dimensions() int { return c.dims }

--- a/internal/reembed/newest_first_test.go
+++ b/internal/reembed/newest_first_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/db"
-	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/petersimmons1972/engram/internal/testutil"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 // TestGlobalReembedder_QueryOrderIsNewestFirst_Source asserts that the
@@ -160,6 +160,10 @@ type trackingEmbedder struct {
 func (e *trackingEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
 	e.embeds = append(e.embeds, text)
 	return make([]float32, e.dims), nil
+}
+func (e *trackingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
 }
 func (e *trackingEmbedder) Name() string    { return "tracking" }
 func (e *trackingEmbedder) Dimensions() int { return e.dims }

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -19,6 +19,10 @@ type fakeEmbedder struct{ dims int }
 func (f *fakeEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, f.dims), nil
 }
+func (f *fakeEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
+}
 func (f *fakeEmbedder) Name() string    { return "fake" }
 func (f *fakeEmbedder) Dimensions() int { return f.dims }
 
@@ -308,6 +312,10 @@ func (c *concurrentEmbedder) Embed(_ context.Context, _ string) ([]float32, erro
 	<-c.release
 	return make([]float32, c.dims), nil
 }
+func (c *concurrentEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := c.Embed(ctx, text)
+	return vec, c.Name(), err
+}
 func (c *concurrentEmbedder) Name() string    { return "concurrent-fake" }
 func (c *concurrentEmbedder) Dimensions() int { return c.dims }
 
@@ -348,6 +356,10 @@ func (d *deadlineInspectEmbedder) Embed(ctx context.Context, _ string) ([]float3
 	}
 	d.mu.Unlock()
 	return make([]float32, d.dims), nil
+}
+func (d *deadlineInspectEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := d.Embed(ctx, text)
+	return vec, d.Name(), err
 }
 func (d *deadlineInspectEmbedder) Name() string    { return "inspect-fake" }
 func (d *deadlineInspectEmbedder) Dimensions() int { return d.dims }
@@ -463,6 +475,10 @@ func (b *blockingEmbedder) Embed(ctx context.Context, _ string) ([]float32, erro
 	<-ctx.Done()
 	close(b.cancelled)
 	return nil, ctx.Err()
+}
+func (b *blockingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := b.Embed(ctx, text)
+	return vec, b.Name(), err
 }
 func (b *blockingEmbedder) Name() string    { return "blocking" }
 func (b *blockingEmbedder) Dimensions() int { return b.dims }

--- a/internal/search/async_embed_test.go
+++ b/internal/search/async_embed_test.go
@@ -21,6 +21,10 @@ func (c *callCountingClient) Embed(_ context.Context, _ string) ([]float32, erro
 	c.calls++
 	return make([]float32, 4), nil
 }
+func (c *callCountingClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := c.Embed(ctx, text)
+	return vec, c.Name(), err
+}
 func (c *callCountingClient) Name() string    { return "counting" }
 func (c *callCountingClient) Dimensions() int { return 4 }
 

--- a/internal/search/embed_deadline_test.go
+++ b/internal/search/embed_deadline_test.go
@@ -34,6 +34,10 @@ func (b *blockingClient) Embed(ctx context.Context, _ string) ([]float32, error)
 		return nil, errors.New("blockingClient: timeout simulated")
 	}
 }
+func (b *blockingClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := b.Embed(ctx, text)
+	return vec, b.Name(), err
+}
 func (b *blockingClient) Name() string    { return "blocking-fake" }
 func (b *blockingClient) Dimensions() int { return b.dims }
 

--- a/internal/search/embed_decouple_test.go
+++ b/internal/search/embed_decouple_test.go
@@ -1,10 +1,10 @@
 package search_test
 
-// embed_decouple_test.go — issue #611 fix#2: env-var config and metrics coverage.
+// embed_decouple_test.go — store and recall embedding decoupling coverage.
 //
 // Tests:
 //   T1: ENGRAM_EMBED_RECALL_TIMEOUT_MS shortens the recall embed budget.
-//   T2: ENGRAM_STORE_EMBED_MODE=sync embeds inline (embedder called during Store).
+//   T2: legacy ENGRAM_STORE_EMBED_MODE=sync no longer embeds inline.
 //   T3: ENGRAM_STORE_EMBED_MODE=async (default) does NOT call embedder during Store.
 
 import (
@@ -32,6 +32,10 @@ func (e *countingBlockingEmbedder) Embed(ctx context.Context, _ string) ([]float
 	<-ctx.Done()
 	return nil, ctx.Err()
 }
+func (e *countingBlockingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
+}
 func (e *countingBlockingEmbedder) Name() string    { return "counting-blocking" }
 func (e *countingBlockingEmbedder) Dimensions() int { return e.dims }
 
@@ -46,6 +50,10 @@ type syncCountingEmbedder struct {
 func (e *syncCountingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	e.calls.Add(1)
 	return make([]float32, e.dims), nil
+}
+func (e *syncCountingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
 }
 func (e *syncCountingEmbedder) Name() string    { return "sync-counting" }
 func (e *syncCountingEmbedder) Dimensions() int { return e.dims }
@@ -96,12 +104,12 @@ func TestRecallEmbedTimeout_ShortBudget(t *testing.T) {
 		"parent context must not be cancelled by the embed timeout")
 }
 
-// TestStoreEmbedMode_Sync verifies that ENGRAM_STORE_EMBED_MODE=sync causes
-// Store to call the embedder inline. The embedder call count must be > 0
-// after Store returns.
+// TestStoreEmbedMode_SyncIgnored verifies that legacy ENGRAM_STORE_EMBED_MODE=sync
+// no longer calls the embedder inline. Store must remain async so the gateway
+// remains the single background/store embedding path.
 //
 // Integration: requires TEST_DATABASE_URL.
-func TestStoreEmbedMode_Sync(t *testing.T) {
+func TestStoreEmbedMode_SyncIgnored(t *testing.T) {
 	proj := uniqueProject("embed-decouple-sync")
 	t.Setenv("ENGRAM_STORE_EMBED_MODE", "sync")
 
@@ -110,15 +118,16 @@ func TestStoreEmbedMode_Sync(t *testing.T) {
 
 	m := &types.Memory{
 		ID:          types.NewMemoryID(),
-		Content:     "Sync mode: embedding must be computed inline during Store.",
+		Content:     "Legacy sync mode must not embed inline during Store.",
 		MemoryType:  types.MemoryTypeContext,
 		Importance:  2,
 		StorageMode: "focused",
 	}
 	require.NoError(t, eng.Store(context.Background(), m))
 
-	assert.Greater(t, int(counter.calls.Load()), 0,
-		"ENGRAM_STORE_EMBED_MODE=sync: embedder must be called inline during Store; got 0 calls")
+	assert.Equal(t, int64(0), counter.calls.Load(),
+		"legacy ENGRAM_STORE_EMBED_MODE=sync must not call embedder during Store; got %d calls",
+		counter.calls.Load())
 }
 
 // TestStoreEmbedMode_Async verifies that ENGRAM_STORE_EMBED_MODE=async (default)

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/chunk"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/embedmodel"
 	"github.com/petersimmons1972/engram/internal/envconf"
 	"github.com/petersimmons1972/engram/internal/metrics"
 	"github.com/petersimmons1972/engram/internal/minhash"
@@ -25,6 +26,10 @@ import (
 // (avoiding an import cycle) and tests can supply a stub.
 type globalNotifier interface {
 	Notify()
+}
+
+type embedGateway interface {
+	Enqueue(chunkIDs []string)
 }
 
 // MergeReviewer reviews candidate near-duplicate pairs and returns merge decisions.
@@ -155,14 +160,11 @@ type SearchEngine struct {
 	decayer             *DecayWorker
 	weightCache         *WeightCache        // nil when no pgxpool available (pre-migration or test)
 	globalReembedder    globalNotifier      // non-nil after SetGlobalReembedder; woken on chunk store
+	embedGateway        embedGateway        // non-nil when ENGRAM_EMBED_GW_ENABLED=true
 	PreferenceExtractor PreferenceExtractor // nil = extraction disabled; default PatternPreferenceExtractor{}
 	// embedRecallTimeout is the bounded embed deadline for recall. Read from
 	// ENGRAM_EMBED_RECALL_TIMEOUT_MS at engine construction; default 500ms.
 	embedRecallTimeout time.Duration
-	// storeEmbedSync, when true, embeds chunks inline during Store rather than
-	// deferring to the reembed worker. Controlled by ENGRAM_STORE_EMBED_MODE=sync.
-	// Default (false) is async: Store returns immediately after the DB write.
-	storeEmbedSync bool
 }
 
 // getEmbedder safely reads the current embedder. Use this instead of e.embedder
@@ -184,6 +186,10 @@ func (e *SearchEngine) Embedder() embed.Client {
 // constructing the engine in main; nil is safe (Notify is skipped).
 func (e *SearchEngine) SetGlobalReembedder(n globalNotifier) {
 	e.globalReembedder = n
+}
+
+func (e *SearchEngine) SetEmbedGateway(g embedGateway) {
+	e.embedGateway = g
 }
 
 // New constructs a SearchEngine and starts background workers (summarize, reembed,
@@ -220,7 +226,6 @@ func New(ctx context.Context, backend db.Backend, embedder embed.Client, project
 		dims = targetDims[0]
 	}
 	recallTimeoutMS := envconf.Int("ENGRAM_EMBED_RECALL_TIMEOUT_MS", defaultEmbedRecallTimeoutMS)
-	storeEmbedSync := envconf.String("ENGRAM_STORE_EMBED_MODE", "async") == "sync"
 
 	return &SearchEngine{
 		backend:             backend,
@@ -235,7 +240,6 @@ func New(ctx context.Context, backend db.Backend, embedder embed.Client, project
 		weightCache:         wc,
 		PreferenceExtractor: PatternPreferenceExtractor{}, // default; swap for Ollama-backed impl without changing callers
 		embedRecallTimeout:  time.Duration(recallTimeoutMS) * time.Millisecond,
-		storeEmbedSync:      storeEmbedSync,
 	}
 }
 
@@ -255,11 +259,9 @@ func (e *SearchEngine) Backend() db.Backend { return e.backend }
 // Project returns the project slug this engine is scoped to.
 func (e *SearchEngine) Project() string { return e.project }
 
-// storeChunksForMemory chunks content, embeds each chunk, and returns the new
-// chunk records ready for storage. It is used by both Store (new memories) and
-// Correct (re-chunking after a content change). Embedding is done outside any
-// transaction because it is slow; callers are responsible for writing the
-// returned chunks inside a transaction.
+// storeChunksForMemory chunks content and returns records with NULL embeddings.
+// It is used by both Store (new memories) and Correct (re-chunking after a
+// content change). Background workers fill vectors after callers commit chunks.
 func (e *SearchEngine) storeChunksForMemory(ctx context.Context, m *types.Memory, rawBody string) ([]*types.Chunk, error) {
 	// A4 Tier-1 synopsis support: when rawBody is non-empty, chunks are built
 	// from the full document body rather than the memory's (synopsis) Content.
@@ -313,11 +315,8 @@ func (e *SearchEngine) storeChunksForMemory(ctx context.Context, m *types.Memory
 		return nil, nil
 	}
 
-	// Build chunk records. In async mode (default), embeddings are left nil and the
-	// reembed worker fills them in — this keeps Store fully decoupled from Ollama
-	// and eliminates the 48-minute hang caused by Ollama blocking the MCP call.
-	// In sync mode (ENGRAM_STORE_EMBED_MODE=sync), embeddings are computed inline
-	// for callers that require immediate vector availability (e.g. migration scripts).
+	// Build chunk records with nil embeddings. Background embedding is handled by
+	// GlobalReembedder or EmbedGateway; Store must never block on the embedder.
 	chunks := make([]*types.Chunk, len(pending))
 	for j, p := range pending {
 		ch := &types.Chunk{
@@ -333,16 +332,6 @@ func (e *SearchEngine) storeChunksForMemory(ctx context.Context, m *types.Memory
 		if p.candidate.HasHeading {
 			heading := p.candidate.SectionHeading
 			ch.SectionHeading = &heading
-		}
-		if e.storeEmbedSync {
-			// Sync mode: embed inline. Errors are non-fatal — the chunk is stored
-			// with a nil embedding and the reembed worker will backfill it.
-			if vec, embedErr := e.getEmbedder().Embed(ctx, p.candidate.Text); embedErr == nil {
-				ch.Embedding = vec
-			} else {
-				slog.Warn("storeChunksForMemory: inline embed failed, chunk stored without embedding",
-					"project", e.project, "chunk_idx", p.idx, "err", embedErr)
-			}
 		}
 		chunks[j] = ch
 	}
@@ -424,8 +413,7 @@ func (e *SearchEngine) StoreWithRawBody(ctx context.Context, m *types.Memory, ra
 		return err
 	}
 	if len(chunks) > 0 {
-		// Async path: enqueue chunks for reembed worker. In sync mode, embeddings
-		// were already computed inline; the worker will skip them (no NULL embedding).
+		// Enqueue chunks for the enabled background embedding path.
 		chunkIDs := make([]string, len(chunks))
 		for i, c := range chunks {
 			chunkIDs[i] = c.ID
@@ -434,15 +422,18 @@ func (e *SearchEngine) StoreWithRawBody(ctx context.Context, m *types.Memory, ra
 			// Log but do not fail — reembed worker will find chunks via NULL embedding.
 			slog.Warn("failed to enqueue chunk leases", "count", len(chunkIDs), "err", err)
 		}
-		e.reembedder.Notify()
-		if e.globalReembedder != nil {
+		if e.embedGateway != nil {
+			e.embedGateway.Enqueue(chunkIDs)
+			e.notifyEmbedQueue(ctx)
+		} else {
+			e.reembedder.Notify()
+		}
+		if e.globalReembedder != nil && e.embedGateway == nil {
 			e.globalReembedder.Notify()
 		}
 	}
-	if !e.storeEmbedSync {
-		// Count each store call that returned before embedding completed.
-		metrics.StoreEmbedAsyncTotal.Inc()
-	}
+	// Count each store call that returned before embedding completed.
+	metrics.StoreEmbedAsyncTotal.Inc()
 	return nil
 }
 
@@ -515,16 +506,19 @@ func (e *SearchEngine) StoreBatch(ctx context.Context, memories []*types.Memory)
 			// Log but do not fail — reembed worker will find chunks via NULL embedding.
 			slog.Warn("failed to enqueue batch chunk leases", "count", len(allChunkIDs), "err", err)
 		}
-		e.reembedder.Notify()
-		if e.globalReembedder != nil {
+		if e.embedGateway != nil {
+			e.embedGateway.Enqueue(allChunkIDs)
+			e.notifyEmbedQueue(ctx)
+		} else {
+			e.reembedder.Notify()
+		}
+		if e.globalReembedder != nil && e.embedGateway == nil {
 			e.globalReembedder.Notify()
 		}
 	}
-	if !e.storeEmbedSync {
-		// Count each store-batch call that returned before embedding completed.
-		// One increment per StoreBatch call (not per memory) — tracks call volume.
-		metrics.StoreEmbedAsyncTotal.Inc()
-	}
+	// Count each store-batch call that returned before embedding completed.
+	// One increment per StoreBatch call (not per memory) — tracks call volume.
+	metrics.StoreEmbedAsyncTotal.Inc()
 	return nil
 }
 
@@ -1025,10 +1019,27 @@ var embedderAliases = map[string]string{
 // canonicalEmbedderName returns the canonical model identifier for s.
 // If s has no alias entry, it is returned unchanged.
 func canonicalEmbedderName(s string) string {
+	if c := embedmodel.CanonicalName(s); c != "" {
+		return c
+	}
 	if c, ok := embedderAliases[s]; ok {
 		return c
 	}
 	return s
+}
+
+func (e *SearchEngine) notifyEmbedQueue(ctx context.Context) {
+	pgb, ok := e.backend.(pgPooler)
+	if !ok || pgb.PgxPool() == nil {
+		return
+	}
+	go func() {
+		notifyCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		if _, err := pgb.PgxPool().Exec(notifyCtx, "SELECT pg_notify($1, '')", embedmodel.PGNotifyChannel); err != nil {
+			slog.Warn("failed to notify embed queue", "err", err)
+		}
+	}()
 }
 
 // checkEmbedderMeta ensures the stored embedder name matches the current client,
@@ -1195,6 +1206,24 @@ func (e *SearchEngine) Correct(ctx context.Context, id string, content *string, 
 		if err := tx.Commit(ctx); err != nil {
 			return nil, err
 		}
+		if len(chunks) > 0 {
+			chunkIDs := make([]string, len(chunks))
+			for i, c := range chunks {
+				chunkIDs[i] = c.ID
+			}
+			if err := e.backend.EnqueueChunkLeases(ctx, chunkIDs); err != nil {
+				slog.Warn("failed to enqueue corrected chunk leases", "count", len(chunkIDs), "err", err)
+			}
+			if e.embedGateway != nil {
+				e.embedGateway.Enqueue(chunkIDs)
+				e.notifyEmbedQueue(ctx)
+			} else {
+				e.reembedder.Notify()
+			}
+			if e.globalReembedder != nil && e.embedGateway == nil {
+				e.globalReembedder.Notify()
+			}
+		}
 	}
 
 	return mem, nil
@@ -1334,6 +1363,16 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err
+	}
+
+	if e.embedGateway != nil {
+		e.embedGateway.Enqueue([]string{"migration"})
+		e.notifyEmbedQueue(ctx)
+		return map[string]any{
+			"chunks_nulled": nulled,
+			"new_model":     newModel,
+			"status":        "migration queued — embed gateway will drain NULL embeddings",
+		}, nil
 	}
 
 	// Stop old reembed worker and create a new one with the new model.

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -28,6 +28,10 @@ func (f *fakeClient) Embed(_ context.Context, text string) ([]float32, error) {
 	}
 	return vec, nil
 }
+func (f *fakeClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
+}
 func (f *fakeClient) Name() string    { return "fake" }
 func (f *fakeClient) Dimensions() int { return f.dims }
 
@@ -379,6 +383,10 @@ func (f *fakeClientWithName) Embed(_ context.Context, text string) ([]float32, e
 		vec[i] = float32(i) / float32(f.dims)
 	}
 	return vec, nil
+}
+func (f *fakeClientWithName) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
 }
 func (f *fakeClientWithName) Name() string    { return f.name }
 func (f *fakeClientWithName) Dimensions() int { return f.dims }

--- a/internal/search/recall_fallback_test.go
+++ b/internal/search/recall_fallback_test.go
@@ -27,6 +27,10 @@ func (h *hangingEmbedder) Embed(ctx context.Context, _ string) ([]float32, error
 	<-ctx.Done()
 	return nil, ctx.Err()
 }
+func (h *hangingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := h.Embed(ctx, text)
+	return vec, h.Name(), err
+}
 func (h *hangingEmbedder) Name() string    { return "hanging-fake" }
 func (h *hangingEmbedder) Dimensions() int { return h.dims }
 
@@ -40,6 +44,10 @@ type errorEmbedder struct {
 
 func (e *errorEmbedder) Embed(ctx context.Context, _ string) ([]float32, error) {
 	return nil, e.err
+}
+func (e *errorEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
 }
 func (e *errorEmbedder) Name() string    { return "error-fake" }
 func (e *errorEmbedder) Dimensions() int { return e.dims }

--- a/tests/integration/embedder_failure_test.go
+++ b/tests/integration/embedder_failure_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/mcp"
@@ -32,7 +33,6 @@ import (
 	"github.com/petersimmons1972/engram/internal/testutil"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/require"
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
 // testDSN returns the TEST_DATABASE_URL environment variable, skipping t if unset.
@@ -62,6 +62,11 @@ func (f *fakeClientWithName) Embed(_ context.Context, text string) ([]float32, e
 	return vec, nil
 }
 
+func (f *fakeClientWithName) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := f.Embed(ctx, text)
+	return vec, f.Name(), err
+}
+
 func (f *fakeClientWithName) Name() string    { return f.name }
 func (f *fakeClientWithName) Dimensions() int { return f.dims }
 
@@ -75,6 +80,11 @@ type transientErrorEmbedder struct {
 
 func (e *transientErrorEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return nil, errors.New("connection refused to embedder backend")
+}
+
+func (e *transientErrorEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, e.Name(), err
 }
 
 func (e *transientErrorEmbedder) Name() string    { return e.name }
@@ -91,6 +101,11 @@ type hangingEmbedder struct {
 func (h *hangingEmbedder) Embed(ctx context.Context, _ string) ([]float32, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()
+}
+
+func (h *hangingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := h.Embed(ctx, text)
+	return vec, h.Name(), err
 }
 
 func (h *hangingEmbedder) Name() string    { return "hanging-fake" }


### PR DESCRIPTION
## Summary
- add `internal/embedmodel` and `internal/embedgateway` with alias-aware response validation, LISTEN/NOTIFY wakeups, degraded hold, pending metrics, and adaptive concurrency
- add default-off `ENGRAM_EMBED_GW_ENABLED` startup wiring with a dedicated gateway pool and async store enqueue path
- extend embedding clients with `EmbedWithModel` while leaving recall-time `Embed()` behavior unchanged
- document enablement, rollback, and gateway metrics

Closes #920

## Validation
- `go test ./... -count=1 -timeout=20m`
- `go test ./internal/longmemeval -run TestRecall_RetryReconnectsOnError -count=1 -v`
- `go test ./internal/longmemeval -count=1`
- `gofmt -l $(git diff --name-only -- "*.go") && git diff --check`
- `(cd reembed-rs && cargo test)`
- `(cd reembed-rs && cargo clippy --all-targets --all-features -- -D warnings)`

## Notes
- The first default-timeout full-suite run hit Go's 10m package timeout in `internal/longmemeval`; the targeted retry test and package both passed, and the full suite passed with `-timeout=20m`.
- Database-backed gateway integration tests continue to require a configured test DB; unit coverage exercises alias validation, enqueue wakeup, throttle behavior, stop draining, and validation rejection paths.