### PR TITLE
perf(db): raise shared pool MaxConns 50 to 75

### DIFF
--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -57,7 +57,7 @@ func configurePool(cfg *pgxpool.Config) {
 // idle. Tighter idle and health-check intervals keep the shared pool lean.
 func configureSharedPool(cfg *pgxpool.Config) {
 	cfg.MinConns = 2
-	cfg.MaxConns = 50
+	cfg.MaxConns = 75
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 3 * time.Minute
 	// 15s health-check so the pool detects dead connections within one

--- a/internal/db/postgres_shared_pool_test.go
+++ b/internal/db/postgres_shared_pool_test.go
@@ -23,8 +23,8 @@ func TestSharedPoolConfig(t *testing.T) {
 
 	configureSharedPool(cfg)
 
-	if cfg.MaxConns != 50 {
-		t.Errorf("MaxConns: got %d, want 50", cfg.MaxConns)
+	if cfg.MaxConns != 75 {
+		t.Errorf("MaxConns: got %d, want 75", cfg.MaxConns)
 	}
 	if cfg.MinConns != 2 {
 		t.Errorf("MinConns: got %d, want 2", cfg.MinConns)
@@ -145,8 +145,8 @@ func TestSharedPoolIsReusedAcrossBackends(t *testing.T) {
 
 	// Pool stat total connections must not exceed shared MaxConns.
 	stat := pool.Stat()
-	if stat.TotalConns() > 50 {
-		t.Errorf("TotalConns %d > MaxConns 50", stat.TotalConns())
+	if stat.TotalConns() > 75 {
+		t.Errorf("TotalConns %d > MaxConns 75", stat.TotalConns())
 	}
 
 	_ = b2


### PR DESCRIPTION
## Summary
- Raises `configureSharedPool` `MaxConns` from 50 to 75
- Updates `TestSharedPoolConfig` and `TestSharedPoolIsReusedAcrossBackends` to assert 75

## Context
Postgres was scaled to `max_connections=300` on 2026-05-30; the app-side pool cap of 50 became the binding constraint. 75 provides headroom while staying well under the 300-connection server ceiling.

Closes #921

## Test plan
- [ ] `go test ./internal/db/... -count=1` passes
- [ ] No regression in other pool-related tests