### PR TITLE
fix(embed): resolve four pre-gateway blockers (#924 #925 #926 #927)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -429,6 +429,16 @@ func run() error {
 		EmbedDimensions:          *embedDims,
 		PgPool:                   sharedPool,
 		EmbedDegraded:            embedDegraded,
+		// Wire circuit breaker state into /health via a closure over the concrete client. (#926)
+		CircuitStateFunc: func() string {
+			type circuitStater interface {
+				CircuitState() embed.CircuitState
+			}
+			if cs, ok := embedClient.(circuitStater); ok {
+				return cs.CircuitState().String()
+			}
+			return "closed"
+		},
 		DegradedErrorMode:        envOr("ENGRAM_DEGRADED_ERROR_MODE", ""),
 		SessionDB:                retentionBackend, // retentionBackend satisfies db.SessionRegistry
 		IngestQueue:              ingestQ,

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -394,9 +394,11 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			// so cosine similarity remains meaningful at the reduced dimension.
 			vec = L2Normalize(vec[:c.targetDims])
 		}
-		if c.dims.Load() == 0 {
-			c.dims.Store(int32(len(vec)))
-		}
+		// CompareAndSwap is more explicit than the check-then-Store idiom: it
+		// atomically sets dims to the observed vector size only when dims is still
+		// 0, preventing a redundant store on subsequent calls. Functionally
+		// equivalent but makes the intent clear.
+		c.dims.CompareAndSwap(0, int32(len(vec)))
 
 		// Record success in circuit breaker and return
 		if c.cb != nil {

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -221,7 +221,7 @@ func (c *LiteLLMClient) Name() string { return c.model }
 
 // CircuitState returns the current circuit breaker state for this client.
 // Returns StateClosed when circuit breaking is disabled (c.cb == nil) so
-// callers can safely call String() on the result without a nil check. (#926)
+// callers can safely call String() on the result without a nil check (#926).
 func (c *LiteLLMClient) CircuitState() CircuitState {
 	if c.cb == nil {
 		return StateClosed

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/metrics"
@@ -25,7 +26,7 @@ type LiteLLMClient struct {
 	baseURL    string
 	model      string
 	apiKey     string
-	dims       int
+	dims       atomic.Int32
 	targetDims int
 	http       *http.Client
 	cb         *CircuitBreaker
@@ -103,7 +104,7 @@ func NewLiteLLMClient(ctx context.Context, baseURL, model, apiKey string, target
 	if err != nil {
 		return nil, fmt.Errorf("litellm startup probe: %w", err)
 	}
-	c.dims = len(vec)
+	c.dims.Store(int32(len(vec)))
 	return c, nil
 }
 
@@ -218,12 +219,22 @@ func computeBackoff(attempt int) time.Duration {
 
 func (c *LiteLLMClient) Name() string { return c.model }
 
+// CircuitState returns the current circuit breaker state for this client.
+// Returns StateClosed when circuit breaking is disabled (c.cb == nil) so
+// callers can safely call String() on the result without a nil check. (#926)
+func (c *LiteLLMClient) CircuitState() CircuitState {
+	if c.cb == nil {
+		return StateClosed
+	}
+	return c.cb.State()
+}
+
 // Dimensions returns the known vector size. Before the first successful Embed
 // call, falls back to targetDims so the dimension guard in checkEmbedderMeta
 // does not falsely report a mismatch on startup.
 func (c *LiteLLMClient) Dimensions() int {
-	if c.dims > 0 {
-		return c.dims
+	if d := c.dims.Load(); d > 0 {
+		return int(d)
 	}
 	return c.targetDims
 }
@@ -383,8 +394,8 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			// so cosine similarity remains meaningful at the reduced dimension.
 			vec = L2Normalize(vec[:c.targetDims])
 		}
-		if c.dims == 0 {
-			c.dims = len(vec)
+		if c.dims.Load() == 0 {
+			c.dims.Store(int32(len(vec)))
 		}
 
 		// Record success in circuit breaker and return

--- a/internal/embed/litellm_test.go
+++ b/internal/embed/litellm_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -543,4 +544,48 @@ func TestInfinityQueueCheck_HighLoadNotHung(t *testing.T) {
 	if !ok {
 		t.Errorf("expected ok=true for high-load-but-processing queue, got ok=false reason=%q", reason)
 	}
+}
+
+// TestDimsRace_ConcurrentEmbedAndDimensions exercises concurrent Embed/EmbedWithModel
+// calls and concurrent Dimensions() reads. Run with -race; the unfixed plain-int version
+// of dims triggers the Go race detector. (#924)
+func TestDimsRace_ConcurrentEmbedAndDimensions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always return a valid 3-dim embedding.
+		encodeEmbeddingResponse(w, []float32{0.1, 0.2, 0.3})
+	}))
+	defer srv.Close()
+
+	client := NewLiteLLMClientNoProbe(srv.URL, "test-model", "", 0)
+	ctx := context.Background()
+
+	const goroutines = 20
+	const callsPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2) // writers + readers
+
+	// Writers: call Embed concurrently (triggers dims write on first success).
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsPerGoroutine; j++ {
+				if _, err := client.Embed(ctx, "text"); err != nil {
+					t.Errorf("Embed error: %v", err)
+				}
+			}
+		}()
+	}
+
+	// Readers: call Dimensions() concurrently.
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsPerGoroutine; j++ {
+				_ = client.Dimensions()
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/mcp/health_test.go
+++ b/internal/mcp/health_test.go
@@ -19,9 +19,10 @@ import (
 
 // healthResponse is the shape returned by handleHealth.
 type healthResponse struct {
-	Status   string `json:"status"`
-	Postgres string `json:"postgres"`
-	Ollama   string `json:"ollama"`
+	Status       string `json:"status"`
+	Postgres     string `json:"postgres"`
+	Ollama       string `json:"ollama"`
+	CircuitState string `json:"circuit_state"`
 }
 
 // newHealthServer builds a Server configured with a fake Ollama URL pointing
@@ -286,5 +287,94 @@ func TestHealth_InfinityHealthyStats(t *testing.T) {
 	}
 	if resp.Ollama != "ok" {
 		t.Errorf("expected ollama=ok for healthy queue, got %q", resp.Ollama)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #926 — circuit_state surfaced in /health response
+// ---------------------------------------------------------------------------
+
+// TestHealth_CircuitStateClosed verifies that /health includes circuit_state="closed"
+// when no CircuitStateFunc is configured (default/nil path → closed).
+func TestHealth_CircuitStateClosed(t *testing.T) {
+	ollamaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  0.10,
+						"queue_absolute":  6,
+						"results_pending": 2,
+						"batch_size":      64,
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ollamaServer.Close()
+
+	// No CircuitStateFunc → defaults to "closed".
+	s := newHealthServer(ollamaServer.URL)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.CircuitState != "closed" {
+		t.Errorf("circuit_state: expected %q, got %q", "closed", resp.CircuitState)
+	}
+}
+
+// TestHealth_CircuitStateOpen verifies that /health reflects circuit_state="open"
+// when the CircuitStateFunc reports an open circuit breaker. (#926)
+func TestHealth_CircuitStateOpen(t *testing.T) {
+	ollamaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  0.10,
+						"queue_absolute":  6,
+						"results_pending": 2,
+						"batch_size":      64,
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ollamaServer.Close()
+
+	s := &Server{
+		cfg: Config{
+			RouterURL: ollamaServer.URL,
+			// CircuitStateFunc simulates an open breaker.
+			CircuitStateFunc: func() string { return "open" },
+		},
+		embedDegraded: &atomic.Bool{},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	s.handleHealth(w, req)
+
+	var resp healthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.CircuitState != "open" {
+		t.Errorf("circuit_state: expected %q, got %q", "open", resp.CircuitState)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1428,9 +1428,10 @@ func (s *Server) registerTools() {
 // Unauthenticated — suitable as a K8s readiness probe.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	type result struct {
-		Status   string `json:"status"`
-		Postgres string `json:"postgres"`
-		Ollama   string `json:"ollama"`
+		Status       string `json:"status"`
+		Postgres     string `json:"postgres"`
+		Ollama       string `json:"ollama"`
+		CircuitState string `json:"circuit_state"`
 	}
 
 	pgStatus := "ok"
@@ -1486,10 +1487,16 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Resolve circuit breaker state for the response.
+	circuitState := "closed"
+	if s.cfg.CircuitStateFunc != nil {
+		circuitState = s.cfg.CircuitStateFunc()
+	}
 	res := result{
-		Status:   "ok",
-		Postgres: pgStatus,
-		Ollama:   ollamaStatus,
+		Status:       "ok",
+		Postgres:     pgStatus,
+		Ollama:       ollamaStatus,
+		CircuitState: circuitState,
 	}
 	statusCode := http.StatusOK
 	// Return 503 only for hard failures: Postgres down, or LiteLLM down when it was

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -84,6 +84,10 @@ type Config struct {
 	// server continued anyway. /health returns 200 with "ollama":"degraded"
 	// rather than 503, because the server itself is operational.
 	EmbedDegraded bool
+	// CircuitStateFunc, when non-nil, is called by the /health handler to
+	// surface the current circuit-breaker state in the response. It must
+	// return one of "closed", "half-open", or "open". (#926)
+	CircuitStateFunc func() string
 	// PgPool is the PostgreSQL connection pool, used by audit and weight tools.
 	// When nil, audit/weight tools return an error.
 	PgPool *pgxpool.Pool

--- a/internal/search/embed_deadline_test.go
+++ b/internal/search/embed_deadline_test.go
@@ -76,22 +76,23 @@ func TestEmbedDeadline_RecallWithOpts(t *testing.T) {
 		"RecallWithOpts must return within 1s when embed times out (500ms deadline); got %s", elapsed)
 }
 
-// TestEmbedDeadline_RecallWithinMemory verifies that RecallWithinMemory fails
-// fast (within 3s) when Ollama is unavailable. Document chunk search is
-// vector-only so an error is correct — but it must not hang.
+// TestEmbedDeadline_RecallWithinMemory verifies that RecallWithinMemory degrades
+// to keyword search (not an error) when Ollama is unavailable, and returns
+// within the embed deadline window (not 15s+).
 func TestEmbedDeadline_RecallWithinMemory(t *testing.T) {
 	proj := uniqueProject("embed-deadline-within")
+	// Embedder blocks for 60s — far longer than the 500ms embed deadline.
 	eng := newEngineWithEmbedder(t, proj, &blockingClient{dims: 768, holdFor: 60 * time.Second})
 
 	callerCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	start := time.Now()
-	_, err := eng.RecallWithinMemory(callerCtx, "test query", "some-memory-id", 5, "summary")
+	results, err := eng.RecallWithinMemory(callerCtx, "test query", "some-memory-id", 5, "summary")
 	elapsed := time.Since(start)
 
-	require.Error(t, err, "RecallWithinMemory must return error when embed fails (no BM25 fallback for document search)")
-	require.ErrorContains(t, err, "embed query", "error should wrap embed failure")
+	require.NoError(t, err, "RecallWithinMemory must degrade to keyword search on embed failure, not return an error")
+	require.NotNil(t, results, "results slice must be non-nil even when degraded")
 	require.Less(t, elapsed, 1*time.Second,
-		"RecallWithinMemory must fail within 1s (500ms embed deadline); got %s", elapsed)
+		"RecallWithinMemory must return within 1s when embed times out (500ms deadline); got %s", elapsed)
 }

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -983,6 +983,12 @@ func (e *SearchEngine) RecallWithinMemory(ctx context.Context, query string, mem
 	defer embedCancel()
 	queryVec, embedErr := e.getEmbedder().Embed(embedCtx, query)
 	if embedErr != nil {
+		// If the PARENT ctx was cancelled or expired (not just the embed child ctx),
+		// propagate the parent error rather than silently degrading to BM25 results.
+		// Only degrade when the embed itself failed while the parent ctx is still alive.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		metrics.RecallEmbedTimeoutTotal.Inc()
 		slog.Info("RecallWithinMemory embed failed, degrading to keyword search",
 			"memory_id", memoryID, "timeout_ms", embedTimeout.Milliseconds(), "err", embedErr)

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1014,6 +1014,8 @@ var embedderAliases = map[string]string{
 	"bge-m3-Q4_K_M.gguf": "BAAI/bge-m3",
 	"bge-m3":             "BAAI/bge-m3",
 	"BAAI/bge-m3":        "BAAI/bge-m3",
+	"bge-m3:latest":      "BAAI/bge-m3",
+	"BAAI/bge-m3:latest": "BAAI/bge-m3",
 }
 
 // canonicalEmbedderName returns the canonical model identifier for s.

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"strconv"
 	"sync"
 	"time"
@@ -972,18 +973,20 @@ func (e *SearchEngine) RecallWithinMemory(ctx context.Context, query string, mem
 	}
 
 	// Embed call bounded by embedRecallTimeout, consistent with RecallWithOpts.
-	// RecallWithinMemory has no BM25 fallback (document chunk search is
-	// vector-only), so it returns an error on embed failure.
+	// On embed timeout or error, degrade to keyword-scored chunk search using
+	// GetChunksForMemory — mirrors the BM25+recency fallback in RecallWithOpts.
 	embedTimeout := e.embedRecallTimeout
 	if embedTimeout <= 0 {
 		embedTimeout = defaultEmbedRecallTimeoutMS * time.Millisecond
 	}
 	embedCtx, embedCancel := context.WithTimeout(ctx, embedTimeout)
 	defer embedCancel()
-	queryVec, err := e.getEmbedder().Embed(embedCtx, query)
-	if err != nil {
+	queryVec, embedErr := e.getEmbedder().Embed(embedCtx, query)
+	if embedErr != nil {
 		metrics.RecallEmbedTimeoutTotal.Inc()
-		return nil, fmt.Errorf("embed query: %w", err)
+		slog.Info("RecallWithinMemory embed failed, degrading to keyword search",
+			"memory_id", memoryID, "timeout_ms", embedTimeout.Milliseconds(), "err", embedErr)
+		return e.recallWithinMemoryKeywordFallback(ctx, query, memoryID, topK)
 	}
 	chunks, err := e.backend.SearchChunksWithinMemory(ctx, queryVec, memoryID, topK)
 	if err != nil {
@@ -996,6 +999,74 @@ func (e *SearchEngine) RecallWithinMemory(ctx context.Context, query string, mem
 			ID:      c.MemoryID,
 			Content: c.ChunkText,
 			Project: c.Project,
+		})
+	}
+	return out, nil
+}
+
+// recallWithinMemoryKeywordFallback is the degraded-signal path for
+// RecallWithinMemory when the embedder is unavailable. It fetches all chunks
+// for the memory and ranks them by simple term-overlap against the query
+// (case-insensitive unigrams), returning up to topK results. This preserves
+// usefulness of the document-query tool even when the vector index is cold.
+func (e *SearchEngine) recallWithinMemoryKeywordFallback(ctx context.Context, query, memoryID string, topK int) ([]*types.Memory, error) {
+	all, err := e.backend.GetChunksForMemory(ctx, memoryID)
+	if err != nil {
+		return nil, err
+	}
+	if len(all) == 0 {
+		return []*types.Memory{}, nil
+	}
+
+	// Build query term set (lowercase unigrams, ignore single-char tokens).
+	queryTerms := make(map[string]struct{})
+	for _, tok := range strings.Fields(strings.ToLower(query)) {
+		tok = strings.Trim(tok, ".,;:!?\"'()[]{}") // strip punctuation
+		if len(tok) > 1 {
+			queryTerms[tok] = struct{}{}
+		}
+	}
+
+	type scored struct {
+		chunk *types.Chunk
+		score float64
+	}
+	scoredChunks := make([]scored, 0, len(all))
+	for _, c := range all {
+		if len(queryTerms) == 0 {
+			scoredChunks = append(scoredChunks, scored{chunk: c, score: 0})
+			continue
+		}
+		text := strings.ToLower(c.ChunkText)
+		var hits int
+		for term := range queryTerms {
+			if strings.Contains(text, term) {
+				hits++
+			}
+		}
+		scoredChunks = append(scoredChunks, scored{
+			chunk: c,
+			score: float64(hits) / float64(len(queryTerms)),
+		})
+	}
+
+	// Sort descending by score, then ascending by chunk_index for ties.
+	sort.SliceStable(scoredChunks, func(i, j int) bool {
+		if scoredChunks[i].score != scoredChunks[j].score {
+			return scoredChunks[i].score > scoredChunks[j].score
+		}
+		return scoredChunks[i].chunk.ChunkIndex < scoredChunks[j].chunk.ChunkIndex
+	})
+
+	if topK > 0 && len(scoredChunks) > topK {
+		scoredChunks = scoredChunks[:topK]
+	}
+	out := make([]*types.Memory, 0, len(scoredChunks))
+	for _, s := range scoredChunks {
+		out = append(out, &types.Memory{
+			ID:      s.chunk.MemoryID,
+			Content: s.chunk.ChunkText,
+			Project: s.chunk.Project,
 		})
 	}
 	return out, nil

--- a/internal/search/engine_alias_test.go
+++ b/internal/search/engine_alias_test.go
@@ -1,0 +1,17 @@
+package search
+
+import "testing"
+
+func TestCanonicalEmbedderName_InfinityVariants(t *testing.T) {
+	t.Helper()
+	for input, want := range map[string]string{
+		"bge-m3:latest":      "BAAI/bge-m3",
+		"BAAI/bge-m3:latest": "BAAI/bge-m3",
+	} {
+		t.Run(input, func(t *testing.T) {
+			if got := canonicalEmbedderName(input); got != want {
+				t.Fatalf("expected %s, got %s", want, got)
+			}
+		})
+	}
+}

--- a/internal/search/recall_within_memory_fallback_test.go
+++ b/internal/search/recall_within_memory_fallback_test.go
@@ -165,3 +165,199 @@ func TestRecallWithinMemory_EmbedError_EmptyChunks_ReturnsEmpty(t *testing.T) {
 	require.NotNil(t, results)
 	require.Empty(t, results, "no chunks means no results")
 }
+
+// ── Concern 1: parent-ctx cancellation must NOT be swallowed (#927) ───────────
+
+// TestRecallWithinMemory_ParentCtxCancelled_PropagatesError verifies that when
+// the PARENT context is cancelled (not just the embed child ctx), RecallWithinMemory
+// returns the cancellation error rather than silently degrading to BM25 results.
+func TestRecallWithinMemory_ParentCtxCancelled_PropagatesError(t *testing.T) {
+	proj := uniqueProject("rwm-parent-cancel")
+	memID := "mem-doc-cancel"
+
+	chunks := []*types.Chunk{
+		{
+			ID:         "chunk-c001",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "Some content that would match any query.",
+			ChunkIndex: 0,
+		},
+	}
+
+	// Use a hanging embedder so embed blocks until its (child) ctx is cancelled.
+	// We will cancel the PARENT ctx ourselves before calling RecallWithinMemory.
+	emb := &hangingEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	// Cancel parent before the call.
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	parentCancel()
+
+	results, err := eng.RecallWithinMemory(parentCtx, "any query", memID, 5, "summary")
+
+	// Must propagate the context cancellation error, NOT return keyword results.
+	require.Error(t, err, "cancelled parent ctx must yield an error, not keyword fallback results")
+	require.ErrorIs(t, err, context.Canceled,
+		"error must wrap context.Canceled; got: %v", err)
+	require.Nil(t, results, "results must be nil when parent ctx is cancelled")
+}
+
+// TestRecallWithinMemory_ParentDeadlineExceeded_PropagatesError verifies the
+// DeadlineExceeded variant: when the parent deadline has already expired before
+// the call, the error is propagated rather than swallowed into BM25 fallback.
+func TestRecallWithinMemory_ParentDeadlineExceeded_PropagatesError(t *testing.T) {
+	proj := uniqueProject("rwm-parent-deadline")
+	memID := "mem-doc-deadline"
+
+	chunks := []*types.Chunk{
+		{
+			ID:         "chunk-d001",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "Content for deadline test.",
+			ChunkIndex: 0,
+		},
+	}
+
+	emb := &hangingEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	// Parent deadline already expired.
+	parentCtx, parentCancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer parentCancel()
+	time.Sleep(5 * time.Millisecond) // ensure deadline has passed
+
+	results, err := eng.RecallWithinMemory(parentCtx, "deadline query", memID, 5, "summary")
+
+	require.Error(t, err, "expired parent deadline must yield an error, not keyword fallback")
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"error must wrap context.DeadlineExceeded; got: %v", err)
+	require.Nil(t, results, "results must be nil when parent ctx deadline exceeded")
+}
+
+// TestRecallWithinMemory_EmbedOwnTimeout_StillFallsBackToBM25 verifies the
+// complementary case: when the embed child ctx times out but the PARENT ctx
+// is still alive, fallback to BM25 results must still occur (no regression).
+func TestRecallWithinMemory_EmbedOwnTimeout_StillFallsBackToBM25(t *testing.T) {
+	proj := uniqueProject("rwm-embed-timeout-fallback")
+	memID := "mem-doc-embed-timeout"
+
+	chunks := []*types.Chunk{
+		{
+			ID:         "chunk-e001",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "Python is a dynamically typed interpreted language.",
+			ChunkIndex: 0,
+		},
+		{
+			ID:         "chunk-e002",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "Go is a statically typed compiled language created at Google.",
+			ChunkIndex: 1,
+		},
+	}
+
+	// hangingEmbedder blocks until its context is cancelled (embed child ctx
+	// will be cancelled by the 500ms embed deadline; parent ctx has 10s).
+	emb := &hangingEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	parentCtx, parentCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer parentCancel()
+
+	results, err := eng.RecallWithinMemory(parentCtx, "Go compiled language", memID, 5, "summary")
+
+	// Must NOT error — embed child timeout with alive parent → BM25 fallback.
+	require.NoError(t, err, "embed child timeout with alive parent must fall back to BM25, not error")
+	require.NotNil(t, results)
+	require.NotEmpty(t, results, "fallback must return keyword results when parent ctx is alive")
+	// Parent ctx must still be alive.
+	require.NoError(t, parentCtx.Err(), "parent ctx must remain alive after embed timeout")
+}
+
+// ── Concern 2: unit tests for recallWithinMemoryKeywordFallback ───────────────
+
+// TestKeywordFallback_TopKSlicing verifies that results are capped at topK.
+func TestKeywordFallback_TopKSlicing(t *testing.T) {
+	proj := uniqueProject("rwm-topk")
+	memID := "mem-topk"
+
+	// 6 chunks, all matching the query with varying scores.
+	chunks := make([]*types.Chunk, 6)
+	for i := range chunks {
+		chunks[i] = &types.Chunk{
+			ID:         "chunk-topk-" + string(rune('0'+i)),
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "The quick brown fox jumps",
+			ChunkIndex: i,
+		}
+	}
+
+	emb := &immediateErrorEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	// topK=3 must return exactly 3 results even though 6 chunks match.
+	results, err := eng.RecallWithinMemory(context.Background(), "quick brown fox", memID, 3, "full")
+	require.NoError(t, err)
+	require.Len(t, results, 3, "results must be capped at topK=3")
+}
+
+// TestKeywordFallback_ScoringOrder verifies that higher term-overlap chunks rank
+// above lower-overlap chunks, and that chunk_index breaks ties ascending.
+func TestKeywordFallback_ScoringOrder(t *testing.T) {
+	proj := uniqueProject("rwm-scoring")
+	memID := "mem-scoring"
+
+	// chunk-high: 3 matching terms (highest score)
+	// chunk-mid:  1 matching term
+	// chunk-low:  0 matching terms (lowest score)
+	// chunk-tie-a/b: same score, ordered by chunk_index
+	chunks := []*types.Chunk{
+		{ID: "chunk-low", MemoryID: memID, Project: proj,
+			ChunkText: "completely unrelated content here", ChunkIndex: 0},
+		{ID: "chunk-tie-b", MemoryID: memID, Project: proj,
+			ChunkText: "golang programming", ChunkIndex: 2},
+		{ID: "chunk-high", MemoryID: memID, Project: proj,
+			ChunkText: "golang is a compiled statically typed language", ChunkIndex: 3},
+		{ID: "chunk-tie-a", MemoryID: memID, Project: proj,
+			ChunkText: "golang programming", ChunkIndex: 1},
+		{ID: "chunk-mid", MemoryID: memID, Project: proj,
+			ChunkText: "programming in many languages", ChunkIndex: 4},
+	}
+
+	emb := &immediateErrorEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	results, err := eng.RecallWithinMemory(context.Background(), "golang compiled statically typed", memID, 10, "full")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	// First result must be chunk-high (matches "golang", "compiled", "statically", "typed").
+	require.Equal(t, "golang is a compiled statically typed language", results[0].Content,
+		"highest term-overlap chunk must rank first")
+
+	// chunk-tie-a must appear before chunk-tie-b (both match "golang programming";
+	// chunk_index=1 < chunk_index=2).
+	var tieAIdx, tieBIdx int = -1, -1
+	for i, r := range results {
+		if r.Content == "golang programming" {
+			if tieAIdx == -1 {
+				tieAIdx = i
+			} else {
+				tieBIdx = i
+			}
+		}
+	}
+	require.GreaterOrEqual(t, tieAIdx, 0, "tie-a chunk must appear in results")
+	require.GreaterOrEqual(t, tieBIdx, 0, "tie-b chunk must appear in results")
+	require.Less(t, tieAIdx, tieBIdx, "tie-a (chunk_index=1) must rank before tie-b (chunk_index=2)")
+
+	// Last result: among zero-overlap chunks, chunk-mid (chunk_index=4) ranks
+	// after chunk-low (chunk_index=0) due to ascending chunk_index tie-break.
+	require.Equal(t, "programming in many languages", results[len(results)-1].Content,
+		"highest chunk_index zero-overlap chunk must rank last (tie-break ascending)")
+}

--- a/internal/search/recall_within_memory_fallback_test.go
+++ b/internal/search/recall_within_memory_fallback_test.go
@@ -342,7 +342,7 @@ func TestKeywordFallback_ScoringOrder(t *testing.T) {
 
 	// chunk-tie-a must appear before chunk-tie-b (both match "golang programming";
 	// chunk_index=1 < chunk_index=2).
-	var tieAIdx, tieBIdx int = -1, -1
+	tieAIdx, tieBIdx := -1, -1
 	for i, r := range results {
 		if r.Content == "golang programming" {
 			if tieAIdx == -1 {

--- a/internal/search/recall_within_memory_fallback_test.go
+++ b/internal/search/recall_within_memory_fallback_test.go
@@ -1,0 +1,167 @@
+package search_test
+
+// recall_within_memory_fallback_test.go — #925 regression tests.
+//
+// RecallWithinMemory must degrade to keyword-ranked chunk results when the
+// embedder errors or times out, instead of returning an error. This mirrors
+// the BM25+recency fallback already present in RecallWithOpts.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// chunkFallbackBackend is a stubBackend variant that returns pre-loaded chunks
+// for GetChunksForMemory and returns nothing for vector search.
+type chunkFallbackBackend struct {
+	*stubBackend
+	chunks []*types.Chunk
+}
+
+func (b *chunkFallbackBackend) SearchChunksWithinMemory(_ context.Context, _ []float32, _ string, _ int) ([]*types.Chunk, error) {
+	// vector search must not be reached when embed degraded
+	return nil, errors.New("SearchChunksWithinMemory must not be called when embed is degraded")
+}
+
+func (b *chunkFallbackBackend) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
+	return b.chunks, nil
+}
+
+// immediateErrorEmbedder returns an error immediately.
+type immediateErrorEmbedder struct {
+	dims int
+}
+
+func (e *immediateErrorEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, errors.New("embedder unavailable")
+}
+func (e *immediateErrorEmbedder) EmbedWithModel(_ context.Context, text string) ([]float32, string, error) {
+	v, err := e.Embed(context.Background(), text)
+	return v, e.Name(), err
+}
+func (e *immediateErrorEmbedder) Name() string    { return "immediate-error-fake" }
+func (e *immediateErrorEmbedder) Dimensions() int { return e.dims }
+
+var _ embed.Client = (*immediateErrorEmbedder)(nil)
+
+// newChunkFallbackEngine builds a *search.SearchEngine backed by
+// chunkFallbackBackend with the given chunks and the given embedder.
+func newChunkFallbackEngine(t *testing.T, proj string, chunks []*types.Chunk, emb embed.Client) *search.SearchEngine {
+	t.Helper()
+	backend := &chunkFallbackBackend{
+		stubBackend: newStubBackend(0, 0),
+		chunks:      chunks,
+	}
+	eng := search.New(context.Background(), backend, emb, proj,
+		"http://ollama:11434", "llama3.2", false, nil, 0)
+	t.Cleanup(func() { eng.Close() })
+	return eng
+}
+
+// TestRecallWithinMemory_EmbedError_ReturnsBM25Results verifies that when the
+// embedder returns an error immediately, RecallWithinMemory degrades to keyword
+// search across the memory's chunks and returns non-empty results (not an error).
+func TestRecallWithinMemory_EmbedError_ReturnsBM25Results(t *testing.T) {
+	proj := uniqueProject("rwm-fallback-error")
+	memID := "mem-doc-001"
+
+	chunks := []*types.Chunk{
+		{
+			ID:         "chunk-001",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "The capital city of France is Paris.",
+			ChunkIndex: 0,
+		},
+		{
+			ID:         "chunk-002",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "Mount Everest is the tallest mountain in the world.",
+			ChunkIndex: 1,
+		},
+		{
+			ID:         "chunk-003",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "The Eiffel Tower is located in Paris, France.",
+			ChunkIndex: 2,
+		},
+	}
+
+	emb := &immediateErrorEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	results, err := eng.RecallWithinMemory(context.Background(), "Paris France capital", memID, 5, "summary")
+
+	// Must NOT return an error — degrade to keyword fallback.
+	require.NoError(t, err, "RecallWithinMemory must NOT error on embed failure; should degrade to keyword search")
+	require.NotNil(t, results, "results must be non-nil even on embed failure")
+	require.NotEmpty(t, results, "keyword search must return at least one result for query 'Paris France capital'")
+
+	// The Paris-related chunks should rank above the mountain chunk.
+	var parisFound bool
+	for _, r := range results {
+		if r.Content == chunks[0].ChunkText || r.Content == chunks[2].ChunkText {
+			parisFound = true
+		}
+	}
+	require.True(t, parisFound, "at least one Paris-related chunk should appear in fallback results")
+}
+
+// TestRecallWithinMemory_EmbedTimeout_ReturnsBM25Results verifies that when the
+// embedder hangs (times out), RecallWithinMemory still returns keyword results.
+func TestRecallWithinMemory_EmbedTimeout_ReturnsBM25Results(t *testing.T) {
+	proj := uniqueProject("rwm-fallback-timeout")
+	memID := "mem-doc-002"
+
+	chunks := []*types.Chunk{
+		{
+			ID:         "chunk-t001",
+			MemoryID:   memID,
+			Project:    proj,
+			ChunkText:  "Golang is a statically typed compiled language.",
+			ChunkIndex: 0,
+		},
+	}
+
+	// hangingEmbedder is defined in recall_fallback_test.go (same package).
+	emb := &hangingEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, chunks, emb)
+
+	callerCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	results, err := eng.RecallWithinMemory(callerCtx, "Golang compiled language", memID, 5, "summary")
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "RecallWithinMemory must NOT error on embed timeout; degrade to keyword search")
+	require.NotNil(t, results, "results must be non-nil on embed timeout")
+	// Must complete well within caller deadline (embed timeout is ~500ms).
+	require.Less(t, elapsed, 1500*time.Millisecond,
+		"RecallWithinMemory must return quickly after embed timeout; got %s", elapsed)
+}
+
+// TestRecallWithinMemory_EmbedError_EmptyChunks_ReturnsEmpty verifies the
+// edge case: embed fails AND the memory has no chunks — must return empty, no error.
+func TestRecallWithinMemory_EmbedError_EmptyChunks_ReturnsEmpty(t *testing.T) {
+	proj := uniqueProject("rwm-fallback-empty")
+	memID := "mem-doc-003"
+
+	emb := &immediateErrorEmbedder{dims: 768}
+	eng := newChunkFallbackEngine(t, proj, []*types.Chunk{}, emb)
+
+	results, err := eng.RecallWithinMemory(context.Background(), "any query", memID, 5, "summary")
+
+	require.NoError(t, err, "empty-chunks fallback must not error")
+	require.NotNil(t, results)
+	require.Empty(t, results, "no chunks means no results")
+}


### PR DESCRIPTION
Resolves the four severity/blocker embed-hardening issues that a prior Codex session claimed but never landed (see #935).

- #924: guard LiteLLMClient.dims against data race (atomic.Int32)
- #925: BM25 fallback in RecallWithinMemory on embed timeout/failure (no more hard-error)
- #926: surface circuit_state in /health response (CircuitState() on LiteLLMClient)
- #927: complete embedderAliases for :latest-tagged Infinity model names

All four fresh from origin/main. go test ./internal/embed/... ./internal/mcp/... ./internal/search/... -race PASS.

Closes #924
Closes #925
Closes #926
Closes #927