### PR TITLE
fix(recall): surface embed-degraded recall telemetry (#912)

### DIFF
--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -16,8 +16,10 @@ import (
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/metrics"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -360,6 +362,36 @@ func TestHandleMemoryRecall_FullMode_NoDegradation_OmitsReason(t *testing.T) {
 	require.Equal(t, false, degraded["embed"])
 	_, hasReason := degraded["reason"]
 	require.False(t, hasReason, "reason must be absent when embedder is healthy (Fix A: #634 fix#4)")
+	_, hasWarnings := out["warnings"]
+	require.False(t, hasWarnings, "warnings must be absent when recall is not degraded")
+}
+
+func TestHandleMemoryRecall_FullMode_Degraded_AddsWarningsAndMetric(t *testing.T) {
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "something",
+	}
+	cfg := testConfig()
+	cfg.RouterURL = "http://litellm:4000"
+	cfg.EmbedderHealth = NewEmbedderHealth(func(context.Context) (bool, string) {
+		return false, "litellm_unreachable"
+	}, 5*time.Second)
+
+	before := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed"))
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	warningsRaw, hasWarnings := out["warnings"]
+	require.True(t, hasWarnings, "warnings must be present when recall is degraded")
+	warnings, ok := warningsRaw.([]any)
+	require.True(t, ok)
+	require.Contains(t, warnings, recallEmbedDegradedWarning)
+
+	after := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed"))
+	require.Equal(t, before+1, after, "degraded recall counter must increment once")
 }
 
 // ── Fix B: cross-project recall→fetch (#634 primary) ─────────────────────────

--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -379,7 +379,7 @@ func TestHandleMemoryRecall_FullMode_Degraded_AddsWarningsAndMetric(t *testing.T
 		return false, "litellm_unreachable"
 	}, 5*time.Second)
 
-	before := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed"))
+	before := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("litellm_unreachable"))
 	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
 	require.NoError(t, err)
 	out := parseRecallResult(t, res)
@@ -390,7 +390,7 @@ func TestHandleMemoryRecall_FullMode_Degraded_AddsWarningsAndMetric(t *testing.T
 	require.True(t, ok)
 	require.Contains(t, warnings, recallEmbedDegradedWarning)
 
-	after := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed"))
+	after := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("litellm_unreachable"))
 	require.Equal(t, before+1, after, "degraded recall counter must increment once")
 }
 
@@ -433,4 +433,77 @@ func TestExecFetch_CrossProjectFetch_Issue634(t *testing.T) {
 	require.NoError(t, err, "cross-project fetch must succeed after #634 fix")
 	require.Equal(t, mem.ID, out["id"], "returned id must match requested id")
 	require.Equal(t, mem.Content, out["content"], "full content must be present")
+}
+
+// ── Blocker 2: embed-timeout degradation path counter coverage ───────────────
+
+// errorEmbedder always returns an error from Embed, simulating an embed backend
+// that is unavailable or timing out. This drives the embedDegraded=true path in
+// RecallWithOpts (search/engine.go) without relying on the EmbedderHealth probe.
+type errorEmbedder struct{}
+
+func (errorEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, errors.New("embed backend unavailable")
+}
+func (errorEmbedder) EmbedWithModel(_ context.Context, _ string) ([]float32, string, error) {
+	return nil, "", errors.New("embed backend unavailable")
+}
+func (errorEmbedder) Name() string    { return "error-embedder" }
+func (errorEmbedder) Dimensions() int { return 384 }
+
+// newErrorEmbedPool builds an EnginePool backed by a noopBackend + errorEmbedder.
+// RecallWithOpts on this pool always sets embedDegraded=true.
+func newErrorEmbedPool(t *testing.T) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, noopBackend{}, errorEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+// TestHandleMemoryRecall_EmbedTimeout_IncrementsDegradedCounter verifies that
+// when RecallWithOpts sets embedDegraded=true (embed backend error path),
+// the RecallDegradedTotal counter with label "embed_timeout" increments and
+// warnings are added to the response.
+//
+// This covers the embedDegraded=true path independently of the EmbedderHealth
+// health-probe path (!ok). The embedder returns an error; the health probe
+// reports healthy — so only the timeout/error path fires.
+func TestHandleMemoryRecall_EmbedTimeout_IncrementsDegradedCounter(t *testing.T) {
+	pool := newErrorEmbedPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "embed timeout degraded path",
+	}
+	// EmbedderHealth returns healthy — only the embedDegraded=true path fires,
+	// not the !ok path. This isolates the counter increment to the embed-error branch.
+	cfg := testConfig()
+	cfg.RouterURL = "http://litellm:4000"
+
+	before := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed_timeout"))
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	// Verify warnings are present.
+	warningsRaw, hasWarnings := out["warnings"]
+	require.True(t, hasWarnings, "warnings must be present when embed backend errors")
+	warnings, ok := warningsRaw.([]any)
+	require.True(t, ok)
+	require.Contains(t, warnings, recallEmbedDegradedWarning)
+
+	// Verify the degraded field signals embed=true.
+	degradedRaw, hasDegraded := out["degraded"]
+	require.True(t, hasDegraded, "degraded key must be present")
+	degradedMap, ok := degradedRaw.(map[string]any)
+	require.True(t, ok, "degraded must be a map")
+	require.Equal(t, true, degradedMap["embed"], "degraded.embed must be true on embed error path")
+
+	// Counter must increment exactly once with label "embed_timeout".
+	after := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed_timeout"))
+	require.Equal(t, before+1, after, "RecallDegradedTotal[embed_timeout] must increment once on embed error")
 }

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -32,7 +32,7 @@ func degradedMap(embedDegraded bool, reason string) map[string]any {
 }
 
 func addRecallDegradedWarning(out map[string]any, endpoint, reason string) {
-	metrics.RecallDegradedTotal.WithLabelValues("embed").Inc()
+	metrics.RecallDegradedTotal.WithLabelValues(reason).Inc()
 	slog.Warn("memory_recall degraded: embed unavailable, using BM25 fallback",
 		"embed_endpoint", endpoint,
 		"reason", reason)

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -9,9 +9,12 @@ import (
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/claude"
+	"github.com/petersimmons1972/engram/internal/metrics"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 )
+
+const recallEmbedDegradedWarning = "recall degraded: embed unavailable, using BM25 fallback"
 
 // degradedMap builds the "degraded" response field.
 // When embed is true the reason string is included; when embed is false the
@@ -26,6 +29,14 @@ func degradedMap(embedDegraded bool, reason string) map[string]any {
 		return m
 	}
 	return map[string]any{"embed": false}
+}
+
+func addRecallDegradedWarning(out map[string]any, endpoint, reason string) {
+	metrics.RecallDegradedTotal.WithLabelValues("embed").Inc()
+	slog.Warn("memory_recall degraded: embed unavailable, using BM25 fallback",
+		"embed_endpoint", endpoint,
+		"reason", reason)
+	out["warnings"] = []string{recallEmbedDegradedWarning}
 }
 
 func execFetch(ctx context.Context, f backendFetcher, id, detail string, maxBytes int, requestedChunkIDs []string) (map[string]any, error) {
@@ -256,12 +267,16 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		}
 		if mode == "handle" {
 			ok, reason := cfg.EmbedderHealth.Snapshot(ctx)
-			return toolResult(map[string]any{
+			out := map[string]any{
 				"handles":    search.ToHandles(results),
 				"count":      len(results),
 				"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
 				"degraded":   degradedMap(!ok, reason),
-			})
+			}
+			if !ok {
+				addRecallDegradedWarning(out, cfg.RouterURL, reason)
+			}
+			return toolResult(out)
 		}
 		out := map[string]any{"results": results, "count": len(results)}
 		if includeConflicts && firstHandle != nil {
@@ -276,6 +291,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		}
 		ok, reason := cfg.EmbedderHealth.Snapshot(ctx)
 		out["degraded"] = degradedMap(!ok, reason)
+		if !ok {
+			addRecallDegradedWarning(out, cfg.RouterURL, reason)
+		}
 		return toolResult(out)
 	}
 
@@ -343,12 +361,16 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 
 	if mode == "handle" {
-		return toolResult(map[string]any{
+		out := map[string]any{
 			"handles":    search.ToHandles(results),
 			"count":      len(results),
 			"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
 			"degraded":   degradedMap(embedDegraded, "embed_timeout"),
-		})
+		}
+		if embedDegraded {
+			addRecallDegradedWarning(out, cfg.RouterURL, "embed_timeout")
+		}
+		return toolResult(out)
 	}
 	out := map[string]any{"results": results, "count": len(results)}
 	if eventID != "" {
@@ -362,7 +384,14 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 	// Add embedder health status to response.
 	ok, reason := cfg.EmbedderHealth.Snapshot(ctx)
-	out["degraded"] = degradedMap(embedDegraded || !ok, reason)
+	isDegraded := embedDegraded || !ok
+	out["degraded"] = degradedMap(isDegraded, reason)
+	if isDegraded {
+		if reason == "" && embedDegraded {
+			reason = "embed_timeout"
+		}
+		addRecallDegradedWarning(out, cfg.RouterURL, reason)
+	}
 	return toolResult(out)
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -141,6 +141,13 @@ var (
 		Help: "memory_recall calls that exceeded embed timeout and fell back to BM25+recency",
 	})
 
+	// RecallDegradedTotal counts memory_recall calls that returned degraded
+	// results due to embed backend unavailability/fallback.
+	RecallDegradedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "engram_recall_degraded_total",
+		Help: "memory_recall degraded responses by reason",
+	}, []string{"reason"})
+
 	// #673: pgxpool connection pool gauges. Operators need visibility into
 	// pool saturation — until now /health Ping succeeded even when the pool
 	// was fully acquired with callers blocking on Acquire.
@@ -205,6 +212,7 @@ func init() {
 		EmbedCircuitTransitions,
 		StoreEmbedAsyncTotal,
 		RecallEmbedTimeoutTotal,
+		RecallDegradedTotal,
 		DBPoolAcquiredConns,
 		DBPoolIdleConns,
 		DBPoolTotalConns,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -17,7 +17,7 @@ func TestMetricsRegistered(t *testing.T) {
 	WorkerTicks.WithLabelValues("reembed").Inc()
 	WorkerErrors.WithLabelValues("reembed").Inc()
 	ChunksPendingReembed.Set(5)
-	RecallDegradedTotal.WithLabelValues("embed").Inc()
+	RecallDegradedTotal.WithLabelValues("embed_timeout").Inc()
 
 	names := []string{
 		"engram_tool_requests_total",

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -17,6 +17,7 @@ func TestMetricsRegistered(t *testing.T) {
 	WorkerTicks.WithLabelValues("reembed").Inc()
 	WorkerErrors.WithLabelValues("reembed").Inc()
 	ChunksPendingReembed.Set(5)
+	RecallDegradedTotal.WithLabelValues("embed").Inc()
 
 	names := []string{
 		"engram_tool_requests_total",
@@ -24,6 +25,7 @@ func TestMetricsRegistered(t *testing.T) {
 		"engram_worker_ticks_total",
 		"engram_worker_errors_total",
 		"engram_chunks_pending_reembed",
+		"engram_recall_degraded_total",
 	}
 	for _, name := range names {
 		mfs, err := prometheus.DefaultGatherer.Gather()


### PR DESCRIPTION
Salvaged from a stranded Codex worktree (claude-codex#12 silent-drop): commit ac77720 was complete with tests but never pushed. Draft for review.

Closes #912