### PR TITLE
fix(mcp): unblock prewarm cancellation and add null-embed covering index (#918)

### DIFF
--- a/internal/db/migrations/023_null_embed_covering_idx.sql
+++ b/internal/db/migrations/023_null_embed_covering_idx.sql
@@ -1,0 +1,9 @@
+-- 023_null_embed_covering_idx.sql — cover null-embedding scans by project/time.
+--
+-- Reembed workers claim pending rows using FOR UPDATE SKIP LOCKED where
+-- embedding IS NULL. At high row counts, this partial covering index avoids
+-- broad scans on the chunks table and reduces lock contention with warmup.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunks_null_embed_proj_created
+    ON chunks (project, created_at)
+    WHERE embedding IS NULL;

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -87,7 +87,7 @@ func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, er
 	// factory for a given project at a time. All concurrent callers for the
 	// same project share the result, preventing TOCTOU races and duplicate
 	// backend connection pools.
-	v, err, _ := p.sfg.Do(project, func() (any, error) {
+	resCh := p.sfg.DoChan(project, func() (any, error) {
 		// Re-check under read lock in case a previous singleflight call (from
 		// before pool startup) already inserted this project.
 		p.mu.RLock()
@@ -126,10 +126,16 @@ func (p *EnginePool) Get(ctx context.Context, project string) (*EngineHandle, er
 		p.engines[project] = entry
 		return h, nil
 	})
-	if err != nil {
-		return nil, err
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-resCh:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return res.Val.(*EngineHandle), nil //nolint:errcheck
 	}
-	return v.(*EngineHandle), nil //nolint:errcheck
 }
 
 // evictLRULocked removes the engine with the oldest lastAccess time.

--- a/internal/mcp/pool_warmup_test.go
+++ b/internal/mcp/pool_warmup_test.go
@@ -81,6 +81,46 @@ func TestWarmProjects_CancelledContext_ExitsCleanly(t *testing.T) {
 	}
 }
 
+// TestPrewarm_ContextCancel_Unblocks verifies that cancelling the warm context
+// after warmup has already started unblocks WarmProjects quickly, even when the
+// underlying factory is stuck and ignores context cancellation.
+func TestPrewarm_ContextCancel_Unblocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	var startedOnce sync.Once
+
+	pool := NewEnginePool(func(_ context.Context, project string) (*EngineHandle, error) {
+		startedOnce.Do(func() {
+			close(started)
+		})
+		select {}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool.WarmProjects(ctx, []string{"a", "b", "c"}, 1)
+	}()
+
+	select {
+	case <-started:
+		// A warmup Get is now blocked in factory.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WarmProjects never started the blocking factory")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+		// WarmProjects should unblock promptly after cancellation.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WarmProjects did not unblock within 500ms after warm context cancellation")
+	}
+}
+
 // TestWarmProjects_EmptyList_IsNoop verifies that passing nil or an empty slice
 // is a safe no-op — no panic, no hang.
 func TestWarmProjects_EmptyList_IsNoop(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `TestPrewarm_ContextCancel_Unblocks` regression coverage for warmup cancellation behavior
- fix `EnginePool.Get` to use `singleflight.DoChan` and return on `ctx.Done()` while factory work is still blocked
- add migration `023_null_embed_covering_idx.sql` with concurrent partial index for NULL embeddings

## Validation
- `go test ./internal/mcp/... -count=1 -race -run TestPrewarm`
- `go test ./internal/mcp/... -count=1 -race`
- `go test ./... -count=1 -race`

Closes #918
