### PR TITLE
fix(engram-setup): default to k8s ingress URL (https://engram.petersimmons.com)

### DIFF
--- a/cmd/engram-setup/engram_setup_test.go
+++ b/cmd/engram-setup/engram_setup_test.go
@@ -268,3 +268,57 @@ func TestConfigFormatFlag(t *testing.T) {
 		t.Skip("--format flag recognition verified in run() logic")
 	})
 }
+
+// TestDefaultEndpointIsK8s verifies that the default server URL points to the
+// k8s ingress, not the retired local Docker address (#engram-setup-k8s).
+func TestDefaultEndpointIsK8s(t *testing.T) {
+	if defaultServerURL != "https://engram.petersimmons.com" {
+		t.Errorf("defaultServerURL = %q, want %q", defaultServerURL, "https://engram.petersimmons.com")
+	}
+}
+
+// TestPortFlagOverridesURL verifies that --port builds a localhost base URL and
+// takes precedence over --url / the k8s default.
+func TestPortFlagOverridesURL(t *testing.T) {
+	oldArgs := os.Args
+	oldCommandLine := flag.CommandLine
+	defer func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldCommandLine
+	}()
+
+	// Point --port at the httptest server so the health-check succeeds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/setup-token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"token":    "test-token-abcdefghijklmnop",
+				"endpoint": r.Host + "/mcp",
+				"name":     "engram",
+			})
+		}
+	}))
+	defer srv.Close()
+
+	// Extract port from httptest server URL.
+	srvParts := strings.Split(srv.URL, ":")
+	srvPort := srvParts[len(srvParts)-1]
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	flag.CommandLine = flag.NewFlagSet("engram-setup", flag.ContinueOnError)
+	os.Args = []string{"engram-setup", "--port", srvPort, "--dry-run"}
+
+	// run() should succeed: --port overrides the k8s default to localhost,
+	// health-check passes, setup-token returns a token, dry-run prints without writing.
+	if err := run(); err != nil {
+		t.Fatalf("run() with --port override returned error: %v", err)
+	}
+}

--- a/cmd/engram-setup/main.go
+++ b/cmd/engram-setup/main.go
@@ -21,9 +21,10 @@
 //
 // Usage:
 //
-//	go run ./cmd/engram-setup              # configure with defaults
+//	go run ./cmd/engram-setup              # configure with defaults (k8s ingress)
 //	go run ./cmd/engram-setup --dry-run    # preview changes without writing
-//	go run ./cmd/engram-setup --port 9000  # non-default port
+//	go run ./cmd/engram-setup --url http://127.0.0.1:8788  # local Docker override
+//	go run ./cmd/engram-setup --port 9000  # local port override (sets base to http://127.0.0.1:<port>)
 package main
 
 import (
@@ -49,8 +50,13 @@ func main() {
 	}
 }
 
+// defaultServerURL is the k8s ingress endpoint for the engram MCP server.
+// Override with --url for local Docker development, or --port for a local port.
+const defaultServerURL = "https://engram.petersimmons.com"
+
 func run() error {
-	port := flag.Int("port", 8788, "engram server port")
+	serverURL := flag.String("url", defaultServerURL, "engram server base URL (overrides --port)")
+	port := flag.Int("port", 0, "local port override: sets base URL to http://127.0.0.1:<port> (deprecated; use --url)")
 	name := flag.String("name", "engram", "MCP server name to write in Claude config files")
 	dryRun := flag.Bool("dry-run", false, "print the MCP config diff without writing any files")
 	offline := flag.Bool("offline", false, "preview-only: skip /setup-token call and require --dry-run")
@@ -70,7 +76,11 @@ func run() error {
 		os.Exit(0)
 	}
 
-	base := fmt.Sprintf("http://127.0.0.1:%d", *port)
+	// --port is a legacy local-only shorthand. When set, it overrides --url.
+	base := *serverURL
+	if *port != 0 {
+		base = fmt.Sprintf("http://127.0.0.1:%d", *port)
+	}
 
 	if *offline && !*dryRun {
 		return fmt.Errorf("--offline is preview-only and must be combined with --dry-run")
@@ -81,8 +91,9 @@ func run() error {
 		if err := healthCheck(base); err != nil {
 			return fmt.Errorf(
 				"engram server not reachable at %s/health\n\n"+
-					"  Is it running?  →  docker compose up -d\n"+
-					"  Check logs?     →  make logs\n\n"+
+					"  K8s deployment?  →  kubectl rollout status deploy/engram -n engram\n"+
+					"  Check logs?      →  kubectl logs -n engram deploy/engram --tail=50\n"+
+					"  Local override?  →  go run ./cmd/engram-setup --url http://127.0.0.1:8788\n\n"+
 					"  (original error: %w)", base, err)
 		}
 
@@ -129,7 +140,7 @@ func run() error {
 					fmt.Fprintf(os.Stderr,
 						"engram-setup: /setup-token unavailable (%v) — recovered key from %s\n",
 						setupErr, c.label)
-					stub := &setupResponse{Token: key, Endpoint: fmt.Sprintf("http://127.0.0.1:%d/mcp", *port)}
+					stub := &setupResponse{Token: key, Endpoint: base + "/mcp"}
 					return configureWithSetup(base, *name, *dryRun, *format, stub)
 				}
 			}
@@ -146,7 +157,7 @@ func run() error {
 	stubSetup := &setupResponse{
 		// #693: stable placeholder so dry-run output is idempotent (was: timestamp suffix made every dry-run diff differently).
 		Token:    "stub-offline-token-PLACEHOLDER",
-		Endpoint: fmt.Sprintf("http://127.0.0.1:%d/mcp", *port),
+		Endpoint: base + "/mcp",
 		Name:     *name,
 	}
 	return configureWithSetup(base, *name, *dryRun, *format, stubSetup)


### PR DESCRIPTION
## Problem

`engram-go` is now deployed exclusively as a k8s workload; the local Docker container at `http://127.0.0.1:8788` no longer exists. Before this change, `make setup` (which calls `go run ./cmd/engram-setup`) contacted a dead address, received a connection-refused error, and — depending on the fallback path — either exited with an error or wrote a stale token into the Claude Code MCP config. Either way, Claude started sessions without a valid token.

The root cause is that the default URL was hardcoded in three places, all as `fmt.Sprintf("http://127.0.0.1:%d", *port)`:
1. The main `base` variable (line 73)
2. The disk-key fallback stub endpoint (line 132)
3. The `--offline` mode stub endpoint (line 149)

## Fix

- Add a `--url` flag with default `https://engram.petersimmons.com` (the k8s ingress).
- Keep `--port` as a legacy local override: when non-zero, `--port` builds `http://127.0.0.1:<port>` and takes precedence over `--url`. This preserves backward compat for local development.
- All three endpoint constructions now derive from `base`, which flows from `--url` or `--port`.
- Updated the stale "docker compose up -d" error hint to k8s `kubectl` equivalents.

## Tests

Two new tests added:
- `TestDefaultEndpointIsK8s` — asserts `defaultServerURL == "https://engram.petersimmons.com"`
- `TestPortFlagOverridesURL` — runs `run()` end-to-end with `--port <httptest-port> --dry-run`, verifying the local override path still works

All 22 tests pass (`go test ./cmd/engram-setup/... -count=1 -race`).

## Test plan

- [ ] `go test ./cmd/engram-setup/... -count=1 -race` passes
- [ ] `go build ./cmd/engram-setup/...` compiles clean
- [ ] `go run ./cmd/engram-setup --dry-run` shows `https://engram.petersimmons.com/mcp` as the endpoint
- [ ] `go run ./cmd/engram-setup --port 8788 --dry-run` shows `http://127.0.0.1:8788/mcp` (local override preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)