### PR TITLE
fix(db): canonicalize legacy bge-m3 embedder metadata

### DIFF
--- a/internal/db/migrations/024_canonicalize_embedder_name_bge_m3.sql
+++ b/internal/db/migrations/024_canonicalize_embedder_name_bge_m3.sql
@@ -1,0 +1,10 @@
+-- 024_canonicalize_embedder_name_bge_m3.sql
+--
+-- Canonicalize historical llama.cpp GGUF model IDs in project_meta so
+-- embedder_name metadata no longer depends on runtime alias maps.
+--
+-- Safe to run multiple times: UPDATE targets only the legacy value.
+UPDATE project_meta
+SET value = 'BAAI/bge-m3'
+WHERE key = 'embedder_name'
+  AND value = 'bge-m3-Q8_0.gguf';


### PR DESCRIPTION
## Summary
- add idempotent DB migration to canonicalize legacy `project_meta.embedder_name` values from `bge-m3-Q8_0.gguf` to `BAAI/bge-m3`
- remove hidden runtime dependency on alias-map preservation for existing rows
- keep runtime aliases as safety net, but no longer load-bearing for migrated metadata

## Validation
- `go test ./...`

Closes #911
