### PR TITLE
hygiene(reembed): track pool reset events

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,12 @@ var (
 		Help: "Chunks with NULL embedding_vec awaiting reembedding",
 	})
 
+	// ReembedPoolResets counts pgx pool reset events triggered by the reembed worker.
+	ReembedPoolResets = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "engram_reembed_pool_resets_total",
+		Help: "Total reembed worker pool reset events after repeated consecutive errors",
+	})
+
 	// IngestQueueDepth is the current number of async ingestion jobs queued but not yet started.
 	IngestQueueDepth = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "engram_ingest_queue_depth",
@@ -196,6 +202,7 @@ func init() {
 		WorkerTicks,
 		WorkerErrors,
 		ChunksPendingReembed,
+		ReembedPoolResets,
 		IngestQueueDepth,
 		EpisodesStartedTotal,
 		EpisodesEndedCleanTotal,

--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -145,6 +145,7 @@ func (g *GlobalReembedder) run(ctx context.Context) {
 					if consecutive >= consecutiveErrorThreshold {
 						slog.Warn("global reembedder: resetting pool after repeated errors — possible Postgres restart",
 							"consecutive_errors", consecutive)
+						metrics.ReembedPoolResets.Inc()
 						g.pool.Reset()
 					}
 					break


### PR DESCRIPTION
## Summary
- Add Prometheus counter  to observe recovery resets.
- Register the new metric in .
- Increment it immediately before  in  when consecutive errors exceed threshold.

## Issue
Closes #931

## Testing
- Not run (change is metrics wiring only).