### PR TITLE
fix(embed): bound ollama pull error body reads

### DIFF
--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -255,7 +255,7 @@ func (c *OllamaClient) pullModel(ctx context.Context) error {
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return fmt.Errorf("ollama pull: HTTP %d: %s", resp.StatusCode, string(body))
 	}
 


### PR DESCRIPTION
## Summary
- Limit non-200 Ollama pull response body reads to 1024 bytes to prevent unbounded allocations on oversized/malicious error payloads.
- Keeps behavior consistent with other bounded embed error handling paths.

Refs #928