### PR TITLE
hygiene(ops): surface dropped reviewer batches in consolidate

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,12 @@ var (
 		Help: "Chunks with NULL embedding_vec awaiting reembedding",
 	})
 
+	// ReembedPoolResets counts pgx pool reset events triggered by the reembed worker.
+	ReembedPoolResets = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "engram_reembed_pool_resets_total",
+		Help: "Total reembed worker pool reset events after repeated consecutive errors",
+	})
+
 	// IngestQueueDepth is the current number of async ingestion jobs queued but not yet started.
 	IngestQueueDepth = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "engram_ingest_queue_depth",
@@ -196,6 +202,7 @@ func init() {
 		WorkerTicks,
 		WorkerErrors,
 		ChunksPendingReembed,
+		ReembedPoolResets,
 		IngestQueueDepth,
 		EpisodesStartedTotal,
 		EpisodesEndedCleanTotal,

--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -145,6 +145,7 @@ func (g *GlobalReembedder) run(ctx context.Context) {
 					if consecutive >= consecutiveErrorThreshold {
 						slog.Warn("global reembedder: resetting pool after repeated errors — possible Postgres restart",
 							"consecutive_errors", consecutive)
+						metrics.ReembedPoolResets.Inc()
 						g.pool.Reset()
 					}
 					break

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1562,7 +1562,7 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 
 	// 7. Batch candidates to Claude reviewer.
 	const batchSize = 10
-	var totalMerged, totalReviewed int
+	var totalMerged, totalReviewed, totalDropped int
 	for start := 0; start < len(candidates); start += batchSize {
 		end := start + batchSize
 		if end > len(candidates) {
@@ -1571,6 +1571,8 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 		batch := candidates[start:end]
 		decisions, err := reviewer.ReviewMergeCandidates(ctx, batch)
 		if err != nil {
+			slog.Warn("consolidate: reviewer batch failed", "batch_start", start, "err", err)
+			totalDropped += len(batch)
 			continue
 		}
 		totalReviewed += len(batch)
@@ -1588,6 +1590,7 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 
 	result["merged_memories"] = totalMerged
 	result["candidates_reviewed"] = totalReviewed
+	result["batches_dropped"] = totalDropped
 	result["lsh_candidates"] = len(lshPairs)
 	result["jaccard_passed"] = len(candidates)
 	return result, nil

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -35,6 +35,14 @@ func (f *fakeClient) EmbedWithModel(ctx context.Context, text string) ([]float32
 func (f *fakeClient) Name() string    { return "fake" }
 func (f *fakeClient) Dimensions() int { return f.dims }
 
+type failingMergeReviewer struct {
+	err error
+}
+
+func (f *failingMergeReviewer) ReviewMergeCandidates(context.Context, []search.MergeCandidate) ([]search.MergeDecision, error) {
+	return nil, f.err
+}
+
 // compile-time check that fakeClient satisfies embed.Client.
 var _ embed.Client = (*fakeClient)(nil)
 
@@ -622,4 +630,54 @@ func TestSearchEngine_EmbedderNameAliasesAreCompatible(t *testing.T) {
 		require.True(t, errors.As(err, &pe))
 		require.Equal(t, "embedder_mismatch", pe.Code)
 	})
+}
+
+func TestSearchEngine_ConsolidateWithClaude_ReviewerBatchFailuresIncrementDroppedCounter(t *testing.T) {
+	project := uniqueProject("test-consolidate-reviewer-failure")
+	engine := newTestEngine(t, project)
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	m1 := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "Consolidation test memory A. This memory is intentionally verbose to pass length checks and is used to verify dropped batch accounting in reviewer failures.",
+		MemoryType:  types.MemoryTypePattern,
+		Importance:  1,
+		StorageMode: "focused",
+	}
+	m2 := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "Consolidation test memory B. This memory is intentionally verbose to pass length checks and is used to verify dropped batch accounting in reviewer failures.",
+		MemoryType:  types.MemoryTypePattern,
+		Importance:  1,
+		StorageMode: "focused",
+	}
+	require.NoError(t, engine.Store(ctx, m1))
+	require.NoError(t, engine.Store(ctx, m2))
+
+	chunks1, err := engine.Backend().GetChunksForMemory(ctx, m1.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, chunks1, "first memory must have stored chunks")
+	chunks2, err := engine.Backend().GetChunksForMemory(ctx, m2.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, chunks2, "second memory must have stored chunks")
+
+	vector := make([]float32, 1024)
+	for i := range vector {
+		vector[i] = 0.01 * float32(i%11)
+	}
+
+	for _, c := range append(chunks1, chunks2...) {
+		updated, err := engine.Backend().UpdateChunkEmbedding(ctx, c.ID, vector)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, updated, 1)
+	}
+
+	reviewer := &failingMergeReviewer{err: errors.New("claude reviewer unavailable")}
+	result, err := engine.ConsolidateWithClaude(ctx, reviewer)
+	require.NoError(t, err)
+
+	batchesDropped, ok := result["batches_dropped"].(int)
+	require.True(t, ok, "result should expose batches_dropped as int")
+	require.Equal(t, 1, batchesDropped)
 }


### PR DESCRIPTION
## Summary

- Add warning log on each failed  reviewer batch call.
- Track dropped batch size in result map as .
- Add regression test covering reviewer failure path with deterministic seeded embeddings.

Closes #930