### PR TITLE
expose memory_status embedding backlog metrics

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -120,6 +120,7 @@ func run() error {
 	exploreMaxIters := fs.Int("explore-max-iters", envInt("ENGRAM_EXPLORE_MAX_ITERS", 5), "Maximum iterations for explore_context")
 	exploreMaxWorkers := fs.Int("explore-max-workers", envInt("ENGRAM_EXPLORE_MAX_WORKERS", 8), "Maximum parallel workers for explore_context")
 	exploreTokenBudget := fs.Int("explore-token-budget", envInt("ENGRAM_EXPLORE_TOKEN_BUDGET", 20000), "Token budget for explore_context")
+	embedRecallTimeoutMS := fs.Int("embed-recall-timeout-ms", envInt("ENGRAM_EMBED_RECALL_TIMEOUT_MS", 500), "Per-recall embedding timeout in milliseconds")
 	maxDocumentBytes := fs.Int("max-document-bytes", envInt("ENGRAM_MAX_DOCUMENT_BYTES", 8*1024*1024), "Maximum document size for ingest operations")
 	rawDocumentMaxBytes := fs.Int("raw-document-max-bytes", envInt("ENGRAM_RAW_DOCUMENT_MAX_BYTES", 50*1024*1024), "Maximum raw document size before rejection")
 	ragMaxTokens := fs.Int("rag-max-tokens", envInt("ENGRAM_RAG_MAX_TOKENS", 4096), "Maximum tokens for RAG context assembly")
@@ -375,7 +376,7 @@ func run() error {
 		if err != nil {
 			return nil, fmt.Errorf("postgres backend for project %q: %w", project, err)
 		}
-		engine := search.New(serverCtx, backend, embedClient, project, routerURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval, *embedDims)
+		engine := search.New(serverCtx, backend, embedClient, project, routerURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval, *embedDims, *embedRecallTimeoutMS)
 		if embedGateway != nil {
 			engine.SetEmbedGateway(embedGateway)
 		} else {

--- a/docs/proposed-fixes/2026-06-01-engram-go-branch-reconciliation.md
+++ b/docs/proposed-fixes/2026-06-01-engram-go-branch-reconciliation.md
@@ -1,0 +1,32 @@
+# Engram-Go Branch Reconciliation Triage (2026-05-31 snapshot)
+
+Context: this note records the decision for stale and rescued branches identified in
+[`#942`](https://github.com/petersimmons1972/engram-go/issues/942), aligned with the
+reconciliation snapshot taken 2026-05-31.
+
+## Action decisions
+
+| Branch | Ahead | Behind | Tip commit | Decision | Notes |
+| --- | ---: | ---: | --- | --- | --- |
+| `lme-campaign-2026-05-19` | +10 | -33 | `feat(lme-scorer): add --scorer-api-key flag` | KEEP | Preserved for review; contains partial campaign wiring and is not ready for merge as-is. |
+| `fix/temporal-retrieval-f1-f2` | +2 | -33 | `fix(search): F1 — rank-normalize recency decay` | KEEP | Useful scoring experiment; continue running with reconciliation checks before merge. |
+| `codex/agent-p0p1-engram` | +2 | -21 | `Merge remote-tracking origin/main into branch` | KEEP | Utility branch used for Codex-side merge-work; retain to avoid losing unresolved diff context. |
+| `codex/lme-codex-execution-20260530` | +2 | -3 | `chore(docs): add global protocol pointer to Codex onboarding` | KEEP | Mostly documentation/process updates with light drift; keep for possible merge in next tidy-up. |
+| `chore/rename-litellm-to-engram-router` | +1 | -37 | `chore: rename LITELLM_URL → ENGRAM_ROUTER_URL (closes #636)` | MERGE | Explicit merge-needed rename consolidation; this branch was consolidated from duplicated worktree branches. |
+| `rescue/pr920-startup-probe-guard` | +3 | -2 | `fix(embed): guard startup probe EmbedWithModel type assertion` | KEEP | Rescue branch should be retained to preserve fix until main branch merge target is ready. |
+| `rescue/verify-881-ops-truth` | +2 | -19 | `wip(rescue): verify-881 working tree (ops status truth + longmemeval)` | KEEP | Rescue branch contains ops-trace recovery notes; keep for continuity. |
+| `rescue/verify-commit-881-score-checkpoint` | +2 | -19 | `fix(lme): fail closed on score checkpoint failures` | KEEP | Keep as a working recovery branch while score-checkpoint fixes stabilize. |
+| `rescue/orphan-8c23223-docker-heredoc` | n/a | n/a | `8c2322336dc33cfb7dc91e46b03db7c660914014` | KEEP | Preserved orphaned commit branch; should be reviewed for docs/ops utility. |
+| `rescue/orphan-46da1f5-db-unique-ids` | n/a | n/a | `46da1f578571b6219cb6c8c9cd48070fda528b6b` | KEEP | Preserved orphaned commit branch; review before deciding merge/rebase. |
+
+## Notes
+
+- No branches were marked `ABANDON` in this triage pass.
+- `chore/rename-litellm-to-engram-router` is the only branch assigned `MERGE` and should be pulled into the next feature batch.
+- Rescue and orphaned branches are retained per the issue correction note because they are now pinned and were previously at risk of GC.
+
+## Recommended follow-ups
+
+1. Resolve merge prerequisites for `chore/rename-litellm-to-engram-router` (including conflict check).
+2. Re-run a fresh snapshot after merge PRs from this pass are accepted or abandoned.
+3. For any branch still marked `KEEP` after 14 days, force a second checkpoint with a new `KEEP/MERGE/ABANDON` decision.

--- a/internal/db/postgres_prune.go
+++ b/internal/db/postgres_prune.go
@@ -201,6 +201,14 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 		return nil, err
 	}
 
+	pendingEmbedding, err := b.GetPendingEmbeddingCount(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	stats.ChunksPendingEmbedding = pendingEmbedding
+	stats.ChunksTotal = stats.TotalChunks
+	stats.ChunksEmbedded = stats.TotalChunks - pendingEmbedding
+
 	return stats, nil
 }
 

--- a/internal/db/postgres_stats_test.go
+++ b/internal/db/postgres_stats_test.go
@@ -1,0 +1,69 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStats_ReportsEmbeddingBacklog(t *testing.T) {
+	ctx := context.Background()
+	project := uniqueProject("stats-embedding-backlog")
+	dsn := testDSN(t)
+
+	backend := newTestBackend(t, project)
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	mem := storeMemory(t, backend, project, "embedding backlog test")
+	err = backend.StoreChunks(ctx, []*types.Chunk{
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk 1",
+			ChunkHash: "chunk-hash-1",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: nil,
+		},
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk 2",
+			ChunkHash: "chunk-hash-2",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: nil,
+		},
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk 3",
+			ChunkHash: "chunk-hash-3",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: nil,
+		},
+	})
+	require.NoError(t, err)
+
+	stats, err := backend.GetStats(ctx, project)
+	require.NoError(t, err)
+	require.Equal(t, 3, stats.TotalChunks)
+	require.Equal(t, 3, stats.ChunksTotal)
+	require.Equal(t, 0, stats.ChunksEmbedded)
+	require.Equal(t, 3, stats.ChunksPendingEmbedding)
+
+	var dbCount int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM chunks c
+		JOIN memories m ON m.id = c.memory_id
+		WHERE m.project=$1 AND m.valid_to IS NULL AND c.embedding IS NULL`, project).Scan(&dbCount)
+	require.NoError(t, err)
+	require.Equal(t, dbCount, stats.ChunksPendingEmbedding)
+}

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -336,11 +336,11 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			return nil, "", fmt.Errorf("litellm embed request (exhausted retries): %w", err)
 		}
 
-		defer resp.Body.Close() //nolint:errcheck
 		lastStatusCode = resp.StatusCode
 
 		if resp.StatusCode != http.StatusOK {
 			rb, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			_ = resp.Body.Close() //nolint:errcheck
 			statusErr := fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(rb)))
 
 			if !isRetryableError(statusErr, resp.StatusCode) {
@@ -371,6 +371,7 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			} `json:"data"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			_ = resp.Body.Close() //nolint:errcheck
 			// Decode error is non-retryable
 			metrics.EmbedFailures.WithLabelValues("non_retryable").Inc()
 			if c.cb != nil {
@@ -379,6 +380,7 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			return nil, "", fmt.Errorf("litellm embed decode: %w", err)
 		}
 		if len(result.Data) == 0 || len(result.Data[0].Embedding) == 0 {
+			_ = resp.Body.Close() //nolint:errcheck
 			// Empty response is non-retryable
 			metrics.EmbedFailures.WithLabelValues("non_retryable").Inc()
 			if c.cb != nil {
@@ -387,6 +389,7 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			return nil, "", fmt.Errorf("litellm embed: empty response")
 		}
 
+		_ = resp.Body.Close() //nolint:errcheck
 		// Success!
 		vec := result.Data[0].Embedding
 		if c.targetDims > 0 && len(vec) > c.targetDims {

--- a/internal/embed/litellm_test.go
+++ b/internal/embed/litellm_test.go
@@ -546,6 +546,42 @@ func TestInfinityQueueCheck_HighLoadNotHung(t *testing.T) {
 	}
 }
 
+// TestInfinityQueueCheck_FullQueueWithInflight verifies that queue_fraction == 1.0
+// with in-flight work is not treated as hung.
+func TestInfinityQueueCheck_FullQueueWithInflight(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			encodeModelsResponse(w, "BAAI/bge-m3", 1.0, 800, 12)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if !ok {
+		t.Errorf("expected ok=true for full queue with in-flight work, got ok=false reason=%q", reason)
+	}
+}
+
+// TestInfinityQueueCheck_ExactlyOneNoInflight verifies that queue_fraction == 1.0
+// with no in-flight work and an empty absolute queue is not treated as hung.
+func TestInfinityQueueCheck_ExactlyOneNoInflight(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			encodeModelsResponse(w, "BAAI/bge-m3", 1.0, 0, 0)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ok, reason := InfinityQueueCheck(context.Background(), http.DefaultClient, srv.URL)
+	if !ok {
+		t.Errorf("expected ok=true for empty absolute queue even at exact capacity, got ok=false reason=%q", reason)
+	}
+}
+
 // TestDimsRace_ConcurrentEmbedAndDimensions exercises concurrent Embed/EmbedWithModel
 // calls and concurrent Dimensions() reads. Run with -race; the unfixed plain-int version
 // of dims triggers the Go race detector. (#924)

--- a/internal/embed/litellm_test.go
+++ b/internal/embed/litellm_test.go
@@ -56,6 +56,53 @@ func TestEmbedRetriesOn502(t *testing.T) {
 	}
 }
 
+// TestEmbed_NoConnectionLeakOnRetry verifies that response bodies are closed on
+// each retry attempt before the next request is issued. With MaxConnsPerHost set
+// to 1 and oversized error bodies, this would otherwise block subsequent retry
+// requests when close is deferred inside the loop.
+func TestEmbed_NoConnectionLeakOnRetry(t *testing.T) {
+	t.Helper()
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(strings.Repeat("x", 2048)))
+			return
+		}
+		encodeEmbeddingResponse(w, []float32{0.1, 0.2, 0.3})
+	}))
+	defer server.Close()
+
+	client := NewLiteLLMClientNoProbe(server.URL, "test-model", "", 3)
+	client.http = &http.Client{
+		Transport: &http.Transport{
+			MaxConnsPerHost:     1,
+			MaxIdleConnsPerHost: 1,
+			IdleConnTimeout:     30 * time.Second,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	vec, err := client.Embed(ctx, "test text")
+	if err != nil {
+		t.Fatalf("expected retry to recover successfully, got error: %v", err)
+	}
+	if len(vec) != 3 {
+		t.Fatalf("len(vec) = %d, want 3", len(vec))
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatalf("expected retries to complete without transport starvation, got %s", time.Since(start))
+	}
+}
+
 func TestLiteLLMClient_EmbedWithModelReturnsReportedModel(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/mcp/issue629_handler_test.go
+++ b/internal/mcp/issue629_handler_test.go
@@ -40,7 +40,13 @@ func newIssue629Pool(t *testing.T) *EnginePool {
 	t.Helper()
 	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
 		engine := search.New(ctx, issue629Backend{
-			stats:    &types.MemoryStats{TotalMemories: 3},
+			stats: &types.MemoryStats{
+				TotalMemories:          3,
+				TotalChunks:            6,
+				ChunksTotal:            6,
+				ChunksEmbedded:         4,
+				ChunksPendingEmbedding: 2,
+			},
 			projects: []string{"alpha", "beta"},
 			episode:  &types.Episode{ID: "ep-1", Project: project},
 			memories: []*types.Memory{{ID: "m-1", Project: project}},
@@ -87,6 +93,7 @@ func TestIssue629_EpisodeHandlersAndAdminHandlers(t *testing.T) {
 	res, err = handleMemoryStatus(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
 	require.NoError(t, err)
 	require.Equal(t, float64(3), decodeToolResult(t, res)["total_memories"])
+	require.Equal(t, float64(2), decodeToolResult(t, res)["chunks_pending_embedding"])
 
 	res, err = handleMemoryDiagnose(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj", "question": "what happened?"}}})
 	require.NoError(t, err)

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -14,7 +14,6 @@ import (
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/embedmodel"
-	"github.com/petersimmons1972/engram/internal/envconf"
 	"github.com/petersimmons1972/engram/internal/metrics"
 	"github.com/petersimmons1972/engram/internal/minhash"
 	"github.com/petersimmons1972/engram/internal/reembed"
@@ -196,7 +195,12 @@ func (e *SearchEngine) SetEmbedGateway(g embedGateway) {
 // New constructs a SearchEngine and starts background workers (summarize, reembed,
 // and spaced-repetition importance decay). claudeClient may be nil, in which case
 // summarization falls back to Ollama. decayInterval controls how often the decay
-// pass runs; pass 0 to use the default (8 hours).
+// pass 0 to use the default (8 hours).
+//
+// Optional variadic args:
+// targetDims[0]  -> target embedding dimensions override (or 0 = native output)
+// targetDims[1]  -> recall timeout in milliseconds for per-recall embedding calls
+//                   (defaults to defaultEmbedRecallTimeoutMS when omitted)
 func New(ctx context.Context, backend db.Backend, embedder embed.Client, project string,
 	ollamaURL, summarizeModel string, summarizeEnabled bool,
 	claudeClient summarize.ClaudeCompleter, decayInterval time.Duration, targetDims ...int) *SearchEngine {
@@ -226,7 +230,10 @@ func New(ctx context.Context, backend db.Backend, embedder embed.Client, project
 	if len(targetDims) > 0 {
 		dims = targetDims[0]
 	}
-	recallTimeoutMS := envconf.Int("ENGRAM_EMBED_RECALL_TIMEOUT_MS", defaultEmbedRecallTimeoutMS)
+	recallTimeoutMS := defaultEmbedRecallTimeoutMS
+	if len(targetDims) > 1 {
+		recallTimeoutMS = targetDims[1]
+	}
 
 	return &SearchEngine{
 		backend:             backend,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -32,10 +32,10 @@ const (
 	RelTypeContradicts = "contradicts" // set by sleep consolidation daemon
 
 	// Semantic types from open-brain vocabulary (additive merge, v3.x).
-	RelTypeSupports    = "supports"      // one memory strengthens another's evidence
-	RelTypeDerivedFrom = "derived_from"  // citation chain — memory derived from source
-	RelTypePartOf      = "part_of"       // hierarchical containment
-	RelTypeFollows     = "follows"       // temporal or sequential ordering
+	RelTypeSupports    = "supports"     // one memory strengthens another's evidence
+	RelTypeDerivedFrom = "derived_from" // citation chain — memory derived from source
+	RelTypePartOf      = "part_of"      // hierarchical containment
+	RelTypeFollows     = "follows"      // temporal or sequential ordering
 )
 
 // MemoryVersionChangeType constants for memory_versions.change_type.
@@ -175,16 +175,16 @@ type Memory struct {
 	// and you want chunks to be built from the full body. Store() passes
 	// m.RawBody to StoreWithRawBody, eliminating the magic-value "" sentinel.
 	// When RawBody is empty (normal memories), behaviour is unchanged.
-	RawBody string `json:"-"`
-	MemoryType  string    `json:"memory_type"`
-	Project     string    `json:"project"`
-	Tags        []string  `json:"tags"`
-	Importance  int       `json:"importance"`
-	AccessCount int       `json:"access_count"`
+	RawBody      string    `json:"-"`
+	MemoryType   string    `json:"memory_type"`
+	Project      string    `json:"project"`
+	Tags         []string  `json:"tags"`
+	Importance   int       `json:"importance"`
+	AccessCount  int       `json:"access_count"`
 	LastAccessed time.Time `json:"last_accessed"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	Immutable   bool      `json:"immutable"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Immutable    bool      `json:"immutable"`
 
 	// ExpiresAt is nil when the memory does not expire.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
@@ -356,27 +356,30 @@ type ConnectedMemory struct {
 type Handle struct {
 	ID          string  `json:"id"`
 	Project     string  `json:"project"`
-	Summary     string  `json:"summary"`       // "" if not yet summarized
+	Summary     string  `json:"summary"` // "" if not yet summarized
 	Score       float64 `json:"score"`
 	StorageMode string  `json:"storage_mode"`
-	ChunkCount  int     `json:"chunk_count"`   // 0 if unknown at recall time
-	Bytes       int     `json:"bytes"`         // len(content)
-	IsHandle    bool    `json:"is_handle"`     // always true; signals paged-out result
-	FetchHint   string  `json:"fetch_hint"`    // human-readable usage hint
+	ChunkCount  int     `json:"chunk_count"` // 0 if unknown at recall time
+	Bytes       int     `json:"bytes"`       // len(content)
+	IsHandle    bool    `json:"is_handle"`   // always true; signals paged-out result
+	FetchHint   string  `json:"fetch_hint"`  // human-readable usage hint
 }
 
 // MemoryStats summarizes the contents of the store. Returned by the status endpoint.
 type MemoryStats struct {
-	TotalMemories       int            `json:"total_memories"`
-	TotalChunks         int            `json:"total_chunks"`
-	TotalRelationships  int            `json:"total_relationships"`
-	ByType              map[string]int `json:"by_type"`
-	ByImportance        map[string]int `json:"by_importance"`
-	Oldest              *string        `json:"oldest,omitempty"`
-	Newest              *string        `json:"newest,omitempty"`
-	DBSizeBytes         int64          `json:"db_size_bytes"`
-	PendingSummarization int           `json:"pending_summarization"`
-	Summarization       map[string]any `json:"summarization"`
+	TotalMemories          int            `json:"total_memories"`
+	TotalChunks            int            `json:"total_chunks"`
+	ChunksTotal            int            `json:"chunks_total"`
+	ChunksEmbedded         int            `json:"chunks_embedded"`
+	ChunksPendingEmbedding int            `json:"chunks_pending_embedding"`
+	TotalRelationships     int            `json:"total_relationships"`
+	ByType                 map[string]int `json:"by_type"`
+	ByImportance           map[string]int `json:"by_importance"`
+	Oldest                 *string        `json:"oldest,omitempty"`
+	Newest                 *string        `json:"newest,omitempty"`
+	DBSizeBytes            int64          `json:"db_size_bytes"`
+	PendingSummarization   int            `json:"pending_summarization"`
+	Summarization          map[string]any `json:"summarization"`
 }
 
 // FTSResult is an intermediate result from the full-text search layer, before
@@ -393,8 +396,8 @@ type FTSResult struct {
 type ConflictingResult struct {
 	Memory        *Memory `json:"memory"`
 	ContradictsID string  `json:"contradicts_id"` // ID of the recalled memory this contradicts
-	Strength      float64 `json:"strength"`        // contradiction edge strength
-	MatchedChunk  string  `json:"matched_chunk"`   // first 500 bytes of content
+	Strength      float64 `json:"strength"`       // contradiction edge strength
+	MatchedChunk  string  `json:"matched_chunk"`  // first 500 bytes of content
 }
 
 // AggregateRow is one bucket in an aggregate query result.
@@ -404,4 +407,3 @@ type AggregateRow struct {
 	Oldest time.Time `json:"oldest"`
 	Newest time.Time `json:"newest"`
 }
-


### PR DESCRIPTION
## Summary
- Added chunk embedding backlog metrics to  via  (, , ).
- Populated these metrics from  by calling existing .
- Added tests:
  - : verifies  response includes .
  - : verifies  matches  fixture query.

## Issue
Closes #936