### PR TITLE
expose embedding backlog in memory_status

### DIFF
--- a/internal/db/postgres_prune.go
+++ b/internal/db/postgres_prune.go
@@ -122,11 +122,6 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 		return nil, err
 	}
 	if err := b.pool.QueryRow(ctx, `
-		SELECT COUNT(*) FROM chunks c JOIN memories m ON m.id=c.memory_id WHERE m.project=$1 AND m.valid_to IS NULL`, project,
-	).Scan(&stats.TotalChunks); err != nil {
-		return nil, err
-	}
-	if err := b.pool.QueryRow(ctx, `
 		SELECT COUNT(*) FROM relationships WHERE project=$1`, project,
 	).Scan(&stats.TotalRelationships); err != nil {
 		return nil, err
@@ -201,13 +196,24 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 		return nil, err
 	}
 
-	pendingEmbedding, err := b.GetPendingEmbeddingCount(ctx, project)
-	if err != nil {
+	// Single-snapshot query: total and pending come from the same COUNT so
+	// ChunksEmbedded = total - pending is guaranteed non-negative even under
+	// concurrent inserts (avoids the TOCTOU race between two separate COUNTs).
+	// TotalChunks is also set from this snapshot so all three chunk-count fields
+	// are consistent with each other.
+	var chunksTotal, chunksPending int
+	if err := b.pool.QueryRow(ctx, `
+		SELECT COUNT(*) AS total,
+		       COUNT(*) FILTER (WHERE c.embedding IS NULL) AS pending
+		FROM chunks c JOIN memories m ON m.id = c.memory_id
+		WHERE m.project = $1 AND m.valid_to IS NULL`, project,
+	).Scan(&chunksTotal, &chunksPending); err != nil {
 		return nil, err
 	}
-	stats.ChunksPendingEmbedding = pendingEmbedding
-	stats.ChunksTotal = stats.TotalChunks
-	stats.ChunksEmbedded = stats.TotalChunks - pendingEmbedding
+	stats.TotalChunks = chunksTotal
+	stats.ChunksTotal = chunksTotal
+	stats.ChunksPendingEmbedding = chunksPending
+	stats.ChunksEmbedded = chunksTotal - chunksPending
 
 	return stats, nil
 }

--- a/internal/db/postgres_prune.go
+++ b/internal/db/postgres_prune.go
@@ -201,6 +201,14 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 		return nil, err
 	}
 
+	pendingEmbedding, err := b.GetPendingEmbeddingCount(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	stats.ChunksPendingEmbedding = pendingEmbedding
+	stats.ChunksTotal = stats.TotalChunks
+	stats.ChunksEmbedded = stats.TotalChunks - pendingEmbedding
+
 	return stats, nil
 }
 

--- a/internal/db/postgres_stats_test.go
+++ b/internal/db/postgres_stats_test.go
@@ -9,6 +9,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetStats_ZeroChunks(t *testing.T) {
+	ctx := context.Background()
+	project := uniqueProject("stats-zero-chunks")
+	testDSN(t)
+
+	backend := newTestBackend(t, project)
+	// No chunks stored — all three embedding-backlog fields must be zero.
+	stats, err := backend.GetStats(ctx, project)
+	require.NoError(t, err)
+	require.Equal(t, 0, stats.ChunksTotal)
+	require.Equal(t, 0, stats.ChunksEmbedded)
+	require.Equal(t, 0, stats.ChunksPendingEmbedding)
+}
+
+func TestGetStats_AllEmbedded(t *testing.T) {
+	ctx := context.Background()
+	project := uniqueProject("stats-all-embedded")
+	testDSN(t)
+
+	backend := newTestBackend(t, project)
+	mem := storeMemory(t, backend, project, "all-embedded test")
+
+	// Use a minimal non-nil embedding so the DB accepts the vector.
+	vec := []float32{0.1, 0.2, 0.3}
+	err := backend.StoreChunks(ctx, []*types.Chunk{
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk a",
+			ChunkHash: "chunk-hash-a",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: vec,
+		},
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk b",
+			ChunkHash: "chunk-hash-b",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: vec,
+		},
+	})
+	require.NoError(t, err)
+
+	stats, err := backend.GetStats(ctx, project)
+	require.NoError(t, err)
+	require.Equal(t, 2, stats.ChunksTotal)
+	require.Equal(t, 0, stats.ChunksPendingEmbedding)
+	require.Equal(t, stats.ChunksTotal, stats.ChunksEmbedded)
+}
+
 func TestGetStats_ReportsEmbeddingBacklog(t *testing.T) {
 	ctx := context.Background()
 	project := uniqueProject("stats-embedding-backlog")

--- a/internal/db/postgres_stats_test.go
+++ b/internal/db/postgres_stats_test.go
@@ -1,0 +1,69 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStats_ReportsEmbeddingBacklog(t *testing.T) {
+	ctx := context.Background()
+	project := uniqueProject("stats-embedding-backlog")
+	dsn := testDSN(t)
+
+	backend := newTestBackend(t, project)
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	mem := storeMemory(t, backend, project, "embedding backlog test")
+	err = backend.StoreChunks(ctx, []*types.Chunk{
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk 1",
+			ChunkHash: "chunk-hash-1",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: nil,
+		},
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk 2",
+			ChunkHash: "chunk-hash-2",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: nil,
+		},
+		{
+			ID:        types.NewMemoryID(),
+			MemoryID:  mem.ID,
+			ChunkText: "chunk 3",
+			ChunkHash: "chunk-hash-3",
+			Project:   project,
+			ChunkType: "sentence_window",
+			Embedding: nil,
+		},
+	})
+	require.NoError(t, err)
+
+	stats, err := backend.GetStats(ctx, project)
+	require.NoError(t, err)
+	require.Equal(t, 3, stats.TotalChunks)
+	require.Equal(t, 3, stats.ChunksTotal)
+	require.Equal(t, 0, stats.ChunksEmbedded)
+	require.Equal(t, 3, stats.ChunksPendingEmbedding)
+
+	var dbCount int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM chunks c
+		JOIN memories m ON m.id = c.memory_id
+		WHERE m.project=$1 AND m.valid_to IS NULL AND c.embedding IS NULL`, project).Scan(&dbCount)
+	require.NoError(t, err)
+	require.Equal(t, dbCount, stats.ChunksPendingEmbedding)
+}

--- a/internal/db/postgres_stats_test.go
+++ b/internal/db/postgres_stats_test.go
@@ -31,28 +31,37 @@ func TestGetStats_AllEmbedded(t *testing.T) {
 	backend := newTestBackend(t, project)
 	mem := storeMemory(t, backend, project, "all-embedded test")
 
-	// Use a minimal non-nil embedding so the DB accepts the vector.
-	vec := []float32{0.1, 0.2, 0.3}
-	err := backend.StoreChunks(ctx, []*types.Chunk{
-		{
-			ID:        types.NewMemoryID(),
-			MemoryID:  mem.ID,
-			ChunkText: "chunk a",
-			ChunkHash: "chunk-hash-a",
-			Project:   project,
-			ChunkType: "sentence_window",
-			Embedding: vec,
-		},
-		{
-			ID:        types.NewMemoryID(),
-			MemoryID:  mem.ID,
-			ChunkText: "chunk b",
-			ChunkHash: "chunk-hash-b",
-			Project:   project,
-			ChunkType: "sentence_window",
-			Embedding: vec,
-		},
-	})
+	// Store chunks with nil embeddings first, then update them so the DB
+	// vector dimension constraint is satisfied (migration 018 sets vector(1024)).
+	chunkA := &types.Chunk{
+		ID:        types.NewMemoryID(),
+		MemoryID:  mem.ID,
+		ChunkText: "chunk a",
+		ChunkHash: "chunk-hash-a",
+		Project:   project,
+		ChunkType: "sentence_window",
+		Embedding: nil,
+	}
+	chunkB := &types.Chunk{
+		ID:        types.NewMemoryID(),
+		MemoryID:  mem.ID,
+		ChunkText: "chunk b",
+		ChunkHash: "chunk-hash-b",
+		Project:   project,
+		ChunkType: "sentence_window",
+		Embedding: nil,
+	}
+	err := backend.StoreChunks(ctx, []*types.Chunk{chunkA, chunkB})
+	require.NoError(t, err)
+
+	// Populate embeddings using the proper 1024-dim vector.
+	vec := make([]float32, 1024)
+	for i := range vec {
+		vec[i] = float32(i) / 1024.0
+	}
+	_, err = backend.UpdateChunkEmbedding(ctx, chunkA.ID, vec)
+	require.NoError(t, err)
+	_, err = backend.UpdateChunkEmbedding(ctx, chunkB.ID, vec)
 	require.NoError(t, err)
 
 	stats, err := backend.GetStats(ctx, project)

--- a/internal/mcp/issue629_handler_test.go
+++ b/internal/mcp/issue629_handler_test.go
@@ -40,7 +40,13 @@ func newIssue629Pool(t *testing.T) *EnginePool {
 	t.Helper()
 	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
 		engine := search.New(ctx, issue629Backend{
-			stats:    &types.MemoryStats{TotalMemories: 3},
+			stats: &types.MemoryStats{
+				TotalMemories:          3,
+				TotalChunks:            6,
+				ChunksTotal:            6,
+				ChunksEmbedded:         4,
+				ChunksPendingEmbedding: 2,
+			},
 			projects: []string{"alpha", "beta"},
 			episode:  &types.Episode{ID: "ep-1", Project: project},
 			memories: []*types.Memory{{ID: "m-1", Project: project}},
@@ -87,6 +93,7 @@ func TestIssue629_EpisodeHandlersAndAdminHandlers(t *testing.T) {
 	res, err = handleMemoryStatus(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
 	require.NoError(t, err)
 	require.Equal(t, float64(3), decodeToolResult(t, res)["total_memories"])
+	require.Equal(t, float64(2), decodeToolResult(t, res)["chunks_pending_embedding"])
 
 	res, err = handleMemoryDiagnose(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj", "question": "what happened?"}}})
 	require.NoError(t, err)

--- a/internal/mcp/issue629_handler_test.go
+++ b/internal/mcp/issue629_handler_test.go
@@ -92,8 +92,11 @@ func TestIssue629_EpisodeHandlersAndAdminHandlers(t *testing.T) {
 
 	res, err = handleMemoryStatus(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
 	require.NoError(t, err)
-	require.Equal(t, float64(3), decodeToolResult(t, res)["total_memories"])
-	require.Equal(t, float64(2), decodeToolResult(t, res)["chunks_pending_embedding"])
+	statusResult := decodeToolResult(t, res)
+	require.Equal(t, float64(3), statusResult["total_memories"])
+	require.Equal(t, float64(6), statusResult["chunks_total"])
+	require.Equal(t, float64(4), statusResult["chunks_embedded"])
+	require.Equal(t, float64(2), statusResult["chunks_pending_embedding"])
 
 	res, err = handleMemoryDiagnose(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj", "question": "what happened?"}}})
 	require.NoError(t, err)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -32,10 +32,10 @@ const (
 	RelTypeContradicts = "contradicts" // set by sleep consolidation daemon
 
 	// Semantic types from open-brain vocabulary (additive merge, v3.x).
-	RelTypeSupports    = "supports"      // one memory strengthens another's evidence
-	RelTypeDerivedFrom = "derived_from"  // citation chain — memory derived from source
-	RelTypePartOf      = "part_of"       // hierarchical containment
-	RelTypeFollows     = "follows"       // temporal or sequential ordering
+	RelTypeSupports    = "supports"     // one memory strengthens another's evidence
+	RelTypeDerivedFrom = "derived_from" // citation chain — memory derived from source
+	RelTypePartOf      = "part_of"      // hierarchical containment
+	RelTypeFollows     = "follows"      // temporal or sequential ordering
 )
 
 // MemoryVersionChangeType constants for memory_versions.change_type.
@@ -175,16 +175,16 @@ type Memory struct {
 	// and you want chunks to be built from the full body. Store() passes
 	// m.RawBody to StoreWithRawBody, eliminating the magic-value "" sentinel.
 	// When RawBody is empty (normal memories), behaviour is unchanged.
-	RawBody string `json:"-"`
-	MemoryType  string    `json:"memory_type"`
-	Project     string    `json:"project"`
-	Tags        []string  `json:"tags"`
-	Importance  int       `json:"importance"`
-	AccessCount int       `json:"access_count"`
+	RawBody      string    `json:"-"`
+	MemoryType   string    `json:"memory_type"`
+	Project      string    `json:"project"`
+	Tags         []string  `json:"tags"`
+	Importance   int       `json:"importance"`
+	AccessCount  int       `json:"access_count"`
 	LastAccessed time.Time `json:"last_accessed"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	Immutable   bool      `json:"immutable"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Immutable    bool      `json:"immutable"`
 
 	// ExpiresAt is nil when the memory does not expire.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
@@ -356,27 +356,30 @@ type ConnectedMemory struct {
 type Handle struct {
 	ID          string  `json:"id"`
 	Project     string  `json:"project"`
-	Summary     string  `json:"summary"`       // "" if not yet summarized
+	Summary     string  `json:"summary"` // "" if not yet summarized
 	Score       float64 `json:"score"`
 	StorageMode string  `json:"storage_mode"`
-	ChunkCount  int     `json:"chunk_count"`   // 0 if unknown at recall time
-	Bytes       int     `json:"bytes"`         // len(content)
-	IsHandle    bool    `json:"is_handle"`     // always true; signals paged-out result
-	FetchHint   string  `json:"fetch_hint"`    // human-readable usage hint
+	ChunkCount  int     `json:"chunk_count"` // 0 if unknown at recall time
+	Bytes       int     `json:"bytes"`       // len(content)
+	IsHandle    bool    `json:"is_handle"`   // always true; signals paged-out result
+	FetchHint   string  `json:"fetch_hint"`  // human-readable usage hint
 }
 
 // MemoryStats summarizes the contents of the store. Returned by the status endpoint.
 type MemoryStats struct {
-	TotalMemories       int            `json:"total_memories"`
-	TotalChunks         int            `json:"total_chunks"`
-	TotalRelationships  int            `json:"total_relationships"`
-	ByType              map[string]int `json:"by_type"`
-	ByImportance        map[string]int `json:"by_importance"`
-	Oldest              *string        `json:"oldest,omitempty"`
-	Newest              *string        `json:"newest,omitempty"`
-	DBSizeBytes         int64          `json:"db_size_bytes"`
-	PendingSummarization int           `json:"pending_summarization"`
-	Summarization       map[string]any `json:"summarization"`
+	TotalMemories          int            `json:"total_memories"`
+	TotalChunks            int            `json:"total_chunks"`
+	ChunksTotal            int            `json:"chunks_total"`
+	ChunksEmbedded         int            `json:"chunks_embedded"`
+	ChunksPendingEmbedding int            `json:"chunks_pending_embedding"`
+	TotalRelationships     int            `json:"total_relationships"`
+	ByType                 map[string]int `json:"by_type"`
+	ByImportance           map[string]int `json:"by_importance"`
+	Oldest                 *string        `json:"oldest,omitempty"`
+	Newest                 *string        `json:"newest,omitempty"`
+	DBSizeBytes            int64          `json:"db_size_bytes"`
+	PendingSummarization   int            `json:"pending_summarization"`
+	Summarization          map[string]any `json:"summarization"`
 }
 
 // FTSResult is an intermediate result from the full-text search layer, before
@@ -393,8 +396,8 @@ type FTSResult struct {
 type ConflictingResult struct {
 	Memory        *Memory `json:"memory"`
 	ContradictsID string  `json:"contradicts_id"` // ID of the recalled memory this contradicts
-	Strength      float64 `json:"strength"`        // contradiction edge strength
-	MatchedChunk  string  `json:"matched_chunk"`   // first 500 bytes of content
+	Strength      float64 `json:"strength"`       // contradiction edge strength
+	MatchedChunk  string  `json:"matched_chunk"`  // first 500 bytes of content
 }
 
 // AggregateRow is one bucket in an aggregate query result.
@@ -404,4 +407,3 @@ type AggregateRow struct {
 	Oldest time.Time `json:"oldest"`
 	Newest time.Time `json:"newest"`
 }
-

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -32,10 +32,10 @@ const (
 	RelTypeContradicts = "contradicts" // set by sleep consolidation daemon
 
 	// Semantic types from open-brain vocabulary (additive merge, v3.x).
-	RelTypeSupports    = "supports"     // one memory strengthens another's evidence
-	RelTypeDerivedFrom = "derived_from" // citation chain — memory derived from source
-	RelTypePartOf      = "part_of"      // hierarchical containment
-	RelTypeFollows     = "follows"      // temporal or sequential ordering
+	RelTypeSupports    = "supports"      // one memory strengthens another's evidence
+	RelTypeDerivedFrom = "derived_from"  // citation chain — memory derived from source
+	RelTypePartOf      = "part_of"       // hierarchical containment
+	RelTypeFollows     = "follows"       // temporal or sequential ordering
 )
 
 // MemoryVersionChangeType constants for memory_versions.change_type.
@@ -175,16 +175,16 @@ type Memory struct {
 	// and you want chunks to be built from the full body. Store() passes
 	// m.RawBody to StoreWithRawBody, eliminating the magic-value "" sentinel.
 	// When RawBody is empty (normal memories), behaviour is unchanged.
-	RawBody      string    `json:"-"`
-	MemoryType   string    `json:"memory_type"`
-	Project      string    `json:"project"`
-	Tags         []string  `json:"tags"`
-	Importance   int       `json:"importance"`
-	AccessCount  int       `json:"access_count"`
+	RawBody string `json:"-"`
+	MemoryType  string    `json:"memory_type"`
+	Project     string    `json:"project"`
+	Tags        []string  `json:"tags"`
+	Importance  int       `json:"importance"`
+	AccessCount int       `json:"access_count"`
 	LastAccessed time.Time `json:"last_accessed"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
-	Immutable    bool      `json:"immutable"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Immutable   bool      `json:"immutable"`
 
 	// ExpiresAt is nil when the memory does not expire.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
@@ -356,19 +356,24 @@ type ConnectedMemory struct {
 type Handle struct {
 	ID          string  `json:"id"`
 	Project     string  `json:"project"`
-	Summary     string  `json:"summary"` // "" if not yet summarized
+	Summary     string  `json:"summary"`       // "" if not yet summarized
 	Score       float64 `json:"score"`
 	StorageMode string  `json:"storage_mode"`
-	ChunkCount  int     `json:"chunk_count"` // 0 if unknown at recall time
-	Bytes       int     `json:"bytes"`       // len(content)
-	IsHandle    bool    `json:"is_handle"`   // always true; signals paged-out result
-	FetchHint   string  `json:"fetch_hint"`  // human-readable usage hint
+	ChunkCount  int     `json:"chunk_count"`   // 0 if unknown at recall time
+	Bytes       int     `json:"bytes"`         // len(content)
+	IsHandle    bool    `json:"is_handle"`     // always true; signals paged-out result
+	FetchHint   string  `json:"fetch_hint"`    // human-readable usage hint
 }
 
 // MemoryStats summarizes the contents of the store. Returned by the status endpoint.
 type MemoryStats struct {
-	TotalMemories          int            `json:"total_memories"`
-	TotalChunks            int            `json:"total_chunks"`
+	TotalMemories int `json:"total_memories"`
+	// TotalChunks is the legacy name for the total chunk count (json: "total_chunks").
+	// For embedding-backlog consumers, prefer the embedding-view fields below.
+	TotalChunks int `json:"total_chunks"`
+	// ChunksTotal mirrors TotalChunks in the embedding-backlog view.
+	// Invariant: chunks_total == chunks_embedded + chunks_pending_embedding.
+	// Both keys are returned to satisfy consumers that rely on either name.
 	ChunksTotal            int            `json:"chunks_total"`
 	ChunksEmbedded         int            `json:"chunks_embedded"`
 	ChunksPendingEmbedding int            `json:"chunks_pending_embedding"`
@@ -396,8 +401,8 @@ type FTSResult struct {
 type ConflictingResult struct {
 	Memory        *Memory `json:"memory"`
 	ContradictsID string  `json:"contradicts_id"` // ID of the recalled memory this contradicts
-	Strength      float64 `json:"strength"`       // contradiction edge strength
-	MatchedChunk  string  `json:"matched_chunk"`  // first 500 bytes of content
+	Strength      float64 `json:"strength"`        // contradiction edge strength
+	MatchedChunk  string  `json:"matched_chunk"`   // first 500 bytes of content
 }
 
 // AggregateRow is one bucket in an aggregate query result.


### PR DESCRIPTION
## Summary
- Added embedding backlog metrics to `MemoryStats` and `memory_status` (`chunks_total`, `chunks_embedded`, `chunks_pending_embedding`).
- Populated those fields in `PostgresBackend.GetStats` using `GetPendingEmbeddingCount`.
- Added tests:
  - `internal/mcp/issue629_handler_test.go`: verifies `memory_status` returns `chunks_pending_embedding`.
  - `internal/db/postgres_stats_test.go`: verifies `chunks_pending_embedding` matches `SELECT ... WHERE embedding IS NULL`.

Closes #936
