### PR TITLE
hygiene(embed): warn on unrecognized ENGRAM_EMBED_MODEL token fallback

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -439,15 +439,15 @@ func run() error {
 			}
 			return "closed"
 		},
-		DegradedErrorMode:        envOr("ENGRAM_DEGRADED_ERROR_MODE", ""),
-		SessionDB:                retentionBackend, // retentionBackend satisfies db.SessionRegistry
-		IngestQueue:              ingestQ,
-		RateLimitRPS:             *rateLimitRPS,
-		RateLimitBurst:           *rateLimitBurst,
-		RateLimitDisable:         *rateLimitDisable,
-		SessionRehydrateWindow:   sessionRehydrateWindow,
-		EmbedRatePerSecond:       *embedRatePerSecond,
-		LogLevelVar:              logLevelVar,
+		DegradedErrorMode:      envOr("ENGRAM_DEGRADED_ERROR_MODE", ""),
+		SessionDB:              retentionBackend, // retentionBackend satisfies db.SessionRegistry
+		IngestQueue:            ingestQ,
+		RateLimitRPS:           *rateLimitRPS,
+		RateLimitBurst:         *rateLimitBurst,
+		RateLimitDisable:       *rateLimitDisable,
+		SessionRehydrateWindow: sessionRehydrateWindow,
+		EmbedRatePerSecond:     *embedRatePerSecond,
+		LogLevelVar:            logLevelVar,
 	}
 	// Default EpisodeTTL to 24 h; set ENGRAM_EPISODE_TTL=0 to disable the sweeper.
 	if cfg.EpisodeTTL == 0 {
@@ -753,11 +753,35 @@ type auditRecallerAdapter struct {
 // model name. Model upgrades are operational changes as long as they preserve
 // that dimension.
 func validateEmbedConfig(model string, dims int) string {
-	if dims == 1024 {
+	var issues []string
+
+	fallbackTokens := embed.ModelMaxTokens("")
+	if !isRecognizedEmbedModel(model) && embed.ModelMaxTokens(model) == fallbackTokens {
+		issues = append(issues, fmt.Sprintf(
+			"configured embed model %q is not in SuggestedModels — using default %d-token window",
+			model, fallbackTokens,
+		))
+	}
+
+	if dims != 1024 {
+		issues = append(issues, "the embedding index expects ENGRAM_EMBED_DIMENSIONS=1024; current value ("+
+			fmt.Sprintf("%d", dims)+") will cause dimension mismatch errors")
+	}
+
+	if len(issues) == 0 {
 		return ""
 	}
-	return "the embedding index expects ENGRAM_EMBED_DIMENSIONS=1024; current value (" +
-		fmt.Sprintf("%d", dims) + ") will cause dimension mismatch errors"
+
+	return strings.Join(issues, "; ")
+}
+
+func isRecognizedEmbedModel(model string) bool {
+	for _, candidate := range embed.SuggestedModels {
+		if candidate.Name == model {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *auditRecallerAdapter) Recall(ctx context.Context, project, query string, topK int) ([]string, error) {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"bytes"
-	"log/slog"
-	"os"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -96,10 +96,11 @@ func TestValidateEmbedConfig(t *testing.T) {
 		wantWarn     bool
 		warnContains string
 	}{
-		{"any-model", 0, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
-		{"any-model", 512, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
-		{"any-model", 768, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
-		{"any-model", 1024, false, ""},
+		{"BAAI/bge-m3", 1024, false, ""},
+		{"BAAI/bge-m3", 0, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
+		{"some-model", 1024, true, "not in SuggestedModels"},
+		{"some-model", 512, true, "not in SuggestedModels"},
+		{"nomic-embed-text", 0, true, "ENGRAM_EMBED_DIMENSIONS=1024"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- Added startup validation warning in `validateEmbedConfig` when `ENGRAM_EMBED_MODEL` is not present in `internal/embed.SuggestedModels`.
- The warning now fires when the resolved token window is from the unknown-model fallback path, making silent `ModelMaxTokens` fallback explicit in logs.
- Existing embedding dimension consistency warning is preserved in the same startup path.
- Added/updated validation tests in `cmd/engram/main_test.go` to assert:
  - recognized models with correct dims produce no warning,
  - recognized models with mismatched dims warn,
  - unknown models always emit a warning that they are not in `SuggestedModels` (even when dims are 1024).

Closes #933