### PR TITLE
fix(db): partial index for reembedder NULL-embedding scan

### DIFF
--- a/internal/db/migrations/024_reembed_null_partial_index.sql
+++ b/internal/db/migrations/024_reembed_null_partial_index.sql
@@ -1,0 +1,5 @@
+-- Partial index to make the global reembedder's NULL-embedding SELECT efficient
+-- under large backlogs. Replaces a full-table sort+scan with a pure index scan.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunks_null_embed_id_desc
+    ON chunks (id DESC)
+    WHERE embedding IS NULL;

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -326,9 +326,9 @@ func (b *PostgresBackend) runMigrations(ctx context.Context) error {
 
 		// 003_pgvector.sql starts with CREATE EXTENSION which cannot run
 		// inside a transaction in most PostgreSQL configurations.
-		// 023_null_embed_covering_idx.sql uses CREATE INDEX CONCURRENTLY,
-		// which also must run outside a transaction block.
-		if name == "003_pgvector.sql" || name == "023_null_embed_covering_idx.sql" {
+		// 023_null_embed_covering_idx.sql and 024_reembed_null_partial_index.sql
+		// use CREATE INDEX CONCURRENTLY, which also must run outside a transaction block.
+		if name == "003_pgvector.sql" || name == "023_null_embed_covering_idx.sql" || name == "024_reembed_null_partial_index.sql" {
 			if _, err := b.pool.Exec(ctx, string(sql)); err != nil {
 				return fmt.Errorf("apply migration %s: %w", name, err)
 			}


### PR DESCRIPTION
## Summary

Adds a partial index (`WHERE embedding IS NULL`) on the memories table so the reembedder's scan for un-embedded rows hits an index rather than a full sequential scan. Without this index, the reembedder performs a seqscan that degrades O(n) with table size even when the NULL set is tiny.

## Implementation notes

- Migration `024_reembed_null_partial_index.sql` creates the index using `CREATE INDEX CONCURRENTLY` so it does not block writes during application.
- `internal/db/postgres.go` — the migration filename has been added to the non-transactional allowlist so the concurrent index creation is not wrapped in an explicit transaction (which would cause a Postgres error).

## Follow-up (not in this PR)

Keyset pagination for the reembedder is a further improvement on top of this index, deferring re-scan of already-processed rows entirely.

Closes #913