### PR TITLE
fix(consolidate): surface reviewer/merge batch errors via slog + counter

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -187,6 +187,13 @@ var (
 		Name: "engram_audit_drift_alerts_total",
 		Help: "Retrieval drift alerts (RBO-vs-previous below alert_threshold) per project",
 	}, []string{"project"})
+
+	// ConsolidateBatchErrors counts batch errors during ConsolidateWithClaude.
+	// Incremented when reviewer.ReviewMergeCandidates or backend.MergeMemoriesAtomic fails.
+	ConsolidateBatchErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "engram_consolidate_batch_errors_total",
+		Help: "Number of batch errors during ConsolidateWithClaude.",
+	})
 )
 
 func init() {
@@ -220,5 +227,6 @@ func init() {
 		DBPoolAcquireCount,
 		DBPoolAcquireDurationSeconds,
 		AuditDriftAlerts,
+		ConsolidateBatchErrors,
 	)
 }

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1562,7 +1562,7 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 
 	// 7. Batch candidates to Claude reviewer.
 	const batchSize = 10
-	var totalMerged, totalReviewed int
+	var totalMerged, totalReviewed, batchErrors int
 	for start := 0; start < len(candidates); start += batchSize {
 		end := start + batchSize
 		if end > len(candidates) {
@@ -1571,6 +1571,9 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 		batch := candidates[start:end]
 		decisions, err := reviewer.ReviewMergeCandidates(ctx, batch)
 		if err != nil {
+			slog.Warn("consolidate: reviewer batch failed", "err", err)
+			batchErrors++
+			metrics.ConsolidateBatchErrors.Inc()
 			continue
 		}
 		totalReviewed += len(batch)
@@ -1580,6 +1583,9 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 			}
 			// Atomic merge (#104): update winner content + delete loser in one tx.
 			if err := e.backend.MergeMemoriesAtomic(ctx, e.project, d.MemoryAID, d.MemoryBID, d.MergedContent); err != nil {
+				slog.Warn("consolidate: merge atomic failed", "err", err)
+				batchErrors++
+				metrics.ConsolidateBatchErrors.Inc()
 				continue
 			}
 			totalMerged++
@@ -1590,6 +1596,7 @@ func (e *SearchEngine) ConsolidateWithClaude(ctx context.Context, reviewer Merge
 	result["candidates_reviewed"] = totalReviewed
 	result["lsh_candidates"] = len(lshPairs)
 	result["jaccard_passed"] = len(candidates)
+	result["batch_errors"] = batchErrors
 	return result, nil
 }
 


### PR DESCRIPTION
## Summary

Batch errors from the reviewer and merge stages inside the consolidation pipeline were previously swallowed silently. This PR surfaces them via structured `slog` log lines and a new `consolidate_batch_errors_total` Prometheus counter, making failures visible in logs and dashboards.

## Files changed

- `internal/metrics/metrics.go` — add `consolidate_batch_errors_total` counter
- `internal/search/engine.go` — log and increment counter on reviewer/merge batch errors

Closes #930