### PR TITLE
docs: restore Codex protocol pointer + document ENGRAM_STORE_EMBED_MODE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,14 @@ POSTGRES_PASSWORD=change_me_to_a_strong_password
 # ENGRAM_EMBED_GW_ENABLED=false
 # ENGRAM_EMBED_GW_BATCH_SIZE=100
 
+# Embed decoupling — issue #611 fix#2
+#
+# Controls whether Store embeds chunks inline (sync) or defers to the reembed
+# worker (async). async is the default and the correct production setting;
+# sync is provided as a rollback path for one release cycle.
+# Valid values: async | sync
+# ENGRAM_STORE_EMBED_MODE=async
+
 # Maximum milliseconds the recall path waits for the embedder to respond before
 # falling back to BM25+recency. Lower values = faster degraded responses but
 # fewer vector hits under load. Default 500ms is calibrated for p99 embed

--- a/docs/codex/onboarding.md
+++ b/docs/codex/onboarding.md
@@ -1,3 +1,5 @@
+> **Global Claude↔Codex loop, QA, and protocol:** petersimmons1972/claude-codex/AGENTS.md — repo-specific notes below.
+
 # Codex Onboarding — engram-go
 
 ## Role


### PR DESCRIPTION
docs-only PR recovered during a local-main resync. (1) Re-adds the global Claude↔Codex protocol pointer to docs/codex/onboarding.md. (2) Adds ENGRAM_STORE_EMBED_MODE documentation to .env.example, ADDITIVELY (origin's ENGRAM_EMBED_GW_ENABLED gateway docs are preserved — both env vars are live). No code changes.