### PR TITLE
test(longmemeval): stop TestGenerateOpus 600s hang (#954, #950)

### DIFF
--- a/internal/longmemeval/claude_additions_test.go
+++ b/internal/longmemeval/claude_additions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
@@ -62,7 +63,14 @@ func TestGenerateOpus_InvalidModel_NotTriggered(t *testing.T) {
 	// GenerateOpus passes "opus" which IS in the allowlist. The call will fail
 	// because there is no real claude binary in CI, but the error must NOT be
 	// the model-rejection sentinel.
-	ctx := context.Background()
+	//
+	// Use a 2s deadline so the test completes quickly on machines where a real
+	// `claude` binary is on PATH. The deadline does not affect what we're
+	// testing: the model-allowlist check in runClaude is synchronous and happens
+	// before any exec, so ErrDisallowedModel (if it were returned) arrives in
+	// well under 1 ms regardless of the deadline. (#954)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	_, err := longmemeval.GenerateOpus(ctx, "prompt", 0)
 	if err != nil && strings.Contains(err.Error(), "disallowed model") {
 		t.Errorf("GenerateOpus should use an allowed model but got: %v", err)


### PR DESCRIPTION
## Summary

- Fixes #954 (duplicate: #950): `TestGenerateOpus_InvalidModel_NotTriggered` blocked up to 600 s on any machine where the real `claude` binary is on `PATH`, because `context.Background()` propagated into `runClaude`'s 600 s hard-capped deadline.
- Fix: add `context.WithTimeout(context.Background(), 2*time.Second)` in the test. The model-allowlist check in `runClaude` is **synchronous and pre-exec** — `ErrDisallowedModel` is returned in <1 ms regardless of the deadline — so the 2 s timeout does not change what the test validates, only how long it is willing to wait for `claude --print` to respond.
- No production code changed; test file only.

## Approach chosen

Short-deadline context (`2*time.Second`). This is correct because:
1. The intent of the test is to assert `ErrDisallowedModel` is *not* returned for `"opus"` (an allowed model alias). That assertion is satisfied synchronously before any `exec.Cmd` is launched.
2. If `claude` is not on PATH, `cmd.Output()` returns immediately with `exec.ErrNotFound`; test still passes.
3. If `claude` is on PATH, the 2 s deadline fires, returning a `context.DeadlineExceeded`-wrapped error — which does not contain `"disallowed model"` — so the test still passes.

## Test plan

- [x] `go test ./internal/longmemeval/ -run TestGenerateOpus -count=1 -timeout 30s -v` — passes in ~2 s (2 s deadline fires, no hang)
- [x] `go build ./...` — clean
- [x] `go vet ./internal/longmemeval/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)