### PR TITLE
fix(recall): embed-timeout 0-semantics (#973) + degradation observability (#917)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -158,7 +158,7 @@ func run() error {
 	embedCircuitOpenDuration := fs.Duration("embed-circuit-open-duration", envDuration("ENGRAM_EMBED_CIRCUIT_OPEN_DURATION", 30*time.Second), "Initial cooldown when circuit opens")
 	embedCircuitBackoffMultiplier := fs.Float64("embed-circuit-backoff-multiplier", envFloat("ENGRAM_EMBED_CIRCUIT_BACKOFF_MULTIPLIER", 2.0), "Exponential backoff multiplier for consecutive opens")
 	embedCircuitBackoffCap := fs.Duration("embed-circuit-backoff-cap", envDuration("ENGRAM_EMBED_CIRCUIT_BACKOFF_CAP", 5*time.Minute), "Maximum cooldown duration (cap on exponential backoff)")
-	embedRecallTimeoutMS := fs.Int("embed-recall-timeout-ms", envInt("ENGRAM_EMBED_RECALL_TIMEOUT_MS", 500), "Embed call budget during recall before degrading to BM25+recency (ms; 0 = no timeout)")
+	embedRecallTimeoutMS := fs.Int("embed-recall-timeout-ms", envInt("ENGRAM_EMBED_RECALL_TIMEOUT_MS", 500), "Embed call budget during recall before degrading to BM25+recency (ms; 0 = no embed deadline, parent context governs — caller must supply a bounded context)")
 
 	// Token bucket rate limiter (#611): per-project embed call budget to prevent GPU saturation.
 	embedRatePerSecond := fs.Float64("embed-rate-per-second", envFloat("ENGRAM_EMBED_RATE_PER_SECOND", 0), "Per-project embed call rate limit in calls/s (0 = disabled)")

--- a/internal/search/embed_degradation_observability_test.go
+++ b/internal/search/embed_degradation_observability_test.go
@@ -1,0 +1,106 @@
+package search_test
+
+// embed_degradation_observability_test.go — #917: silent degradation
+// observability increment.
+//
+// Verifies that:
+//   1. RecallWithOpts sets EmbedDegraded=true via RecallOpts when the embed
+//      call fails (timeout or immediate error).
+//   2. metrics.RecallEmbedTimeoutTotal is incremented on each degraded recall.
+//
+// These tests cover the clearly-safe observability increment shipped in this
+// PR.  The larger #917 architectural fix (adaptive back-pressure / dedicated
+// GPU lane / concurrency throttle) is teed up via the opus-advisor
+// recommendation in the PR description and tracked in issue #917.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/metrics"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbedDegradedFlag_SetOnTimeout verifies that RecallOpts.EmbedDegraded
+// is set to true when the embed call times out (hanging embedder + 100ms
+// budget).
+func TestEmbedDegradedFlag_SetOnTimeout(t *testing.T) {
+	proj := uniqueProject("embed-degraded-flag-timeout")
+	eng := newEngineWithEmbedder(t, proj, &hangingEmbedder{dims: 768})
+	eng.SetEmbedRecallTimeout(100) // short budget to force a quick timeout
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var degraded bool
+	results, err := eng.RecallWithOpts(parentCtx, "test", 5, "summary",
+		search.RecallOpts{EmbedDegraded: &degraded})
+
+	require.NoError(t, err, "RecallWithOpts must degrade gracefully, not error, on embed timeout")
+	require.NotNil(t, results)
+	require.True(t, degraded, "EmbedDegraded must be true when embed timed out")
+}
+
+// TestEmbedDegradedFlag_SetOnImmediateError verifies that EmbedDegraded is set
+// to true when the embedder returns an error immediately (no timeout needed).
+func TestEmbedDegradedFlag_SetOnImmediateError(t *testing.T) {
+	proj := uniqueProject("embed-degraded-flag-error")
+	eng := newEngineWithEmbedder(t, proj,
+		&errorEmbedder{dims: 768, err: errors.New("simulated embed failure")})
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var degraded bool
+	results, err := eng.RecallWithOpts(parentCtx, "test", 5, "summary",
+		search.RecallOpts{EmbedDegraded: &degraded})
+
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.True(t, degraded, "EmbedDegraded must be true when embedder returns error immediately")
+}
+
+// TestEmbedDegradedFlag_NotSetOnSuccess verifies that EmbedDegraded is false
+// when the embed call succeeds (no degradation).
+func TestEmbedDegradedFlag_NotSetOnSuccess(t *testing.T) {
+	proj := uniqueProject("embed-degraded-flag-success")
+	// syncCountingEmbedder returns a real (zero) vector immediately — no error.
+	eng := newEngineWithEmbedder(t, proj, &syncCountingEmbedder{dims: 768})
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var degraded bool
+	_, err := eng.RecallWithOpts(parentCtx, "test", 5, "summary",
+		search.RecallOpts{EmbedDegraded: &degraded})
+
+	// err may be non-nil for dimension mismatch or vector search issues, but
+	// degraded must be false.
+	_ = err
+	require.False(t, degraded, "EmbedDegraded must be false when embed succeeds")
+}
+
+// TestRecallEmbedTimeoutMetric_IncrementedOnDegradation verifies that
+// metrics.RecallEmbedTimeoutTotal is incremented when recall degrades due
+// to embed failure (#917 observability increment).
+func TestRecallEmbedTimeoutMetric_IncrementedOnDegradation(t *testing.T) {
+	proj := uniqueProject("embed-timeout-metric")
+	eng := newEngineWithEmbedder(t, proj,
+		&errorEmbedder{dims: 768, err: errors.New("embed backend down")})
+
+	before := testutil.ToFloat64(metrics.RecallEmbedTimeoutTotal)
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := eng.RecallWithOpts(parentCtx, "test", 5, "summary", search.RecallOpts{})
+	require.NoError(t, err, "must degrade gracefully")
+
+	after := testutil.ToFloat64(metrics.RecallEmbedTimeoutTotal)
+	require.Equal(t, before+1, after,
+		"RecallEmbedTimeoutTotal must be incremented by 1 on embed-degraded recall")
+}

--- a/internal/search/embed_timeout_zero_test.go
+++ b/internal/search/embed_timeout_zero_test.go
@@ -1,0 +1,99 @@
+package search_test
+
+// embed_timeout_zero_test.go — #973: SetEmbedRecallTimeout(0) semantics.
+//
+// Verifies that passing ms==0 to SetEmbedRecallTimeout disables the
+// engine-level embed deadline, so the parent context governs directly.
+// This is the "Option A" behaviour selected by the ADV.5 advisory gate.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetEmbedRecallTimeout_ZeroDisablesDeadline verifies that when
+// SetEmbedRecallTimeout(0) is called the engine no longer applies a
+// 500ms embed-specific deadline.  Instead the parent context deadline
+// governs: a 200ms parent deadline cancels the hanging embed after ≈200ms,
+// not 500ms.
+func TestSetEmbedRecallTimeout_ZeroDisablesDeadline(t *testing.T) {
+	proj := uniqueProject("embed-timeout-zero")
+	// Use a hanging embedder so we can see exactly when the embed unblocks.
+	eng := newEngineWithEmbedder(t, proj, &hangingEmbedder{dims: 768})
+	// Disable the engine-level embed deadline (#973).
+	eng.SetEmbedRecallTimeout(0)
+
+	// Parent context with a 200ms deadline.  With the old code (ms==0 →
+	// preserve 500ms default) the embed would unblock at ~500ms and the call
+	// would succeed (degraded).  With the new code (ms==0 → no extra deadline)
+	// the embed is cancelled by the parent at 200ms, at which point ctx.Err()
+	// is non-nil, so RecallWithOpts propagates context.DeadlineExceeded — the
+	// call must return within ~250ms.
+	parentCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := eng.RecallWithOpts(parentCtx, "test query", 5, "summary", search.RecallOpts{})
+	elapsed := time.Since(start)
+
+	// The parent ctx expired before the embed could finish: the error must be
+	// context.DeadlineExceeded (propagated because ctx.Err() != nil).
+	require.Error(t, err, "RecallWithOpts must return error when parent ctx expires with no embed deadline")
+	require.Less(t, elapsed, 350*time.Millisecond,
+		"RecallWithOpts must return within ~350ms when parent ctx has 200ms deadline; got %s", elapsed)
+	// Critically: must complete BEFORE the old 500ms default would have fired.
+	require.Less(t, elapsed, 450*time.Millisecond,
+		"elapsed %s ≥ 450ms — indicates the 500ms default deadline was applied instead of the parent ctx", elapsed)
+}
+
+// TestSetEmbedRecallTimeout_ZeroVsPositive contrasts zero vs a short positive
+// value to confirm the two paths are distinct.
+//
+// - ms>0: engine applies a short embed deadline; embed times out early and
+//   RecallWithOpts degrades to BM25 (no error) within that budget.
+// - ms==0: engine applies no embed deadline; a bounded parent ctx is required
+//   or the caller will block.  This test gives a 150ms parent so the parent
+//   expiry propagates as an error.
+func TestSetEmbedRecallTimeout_ZeroVsPositive(t *testing.T) {
+	t.Run("positive_ms_applies_budget", func(t *testing.T) {
+		proj := uniqueProject("embed-timeout-pos")
+		eng := newEngineWithEmbedder(t, proj, &hangingEmbedder{dims: 768})
+		eng.SetEmbedRecallTimeout(100) // 100ms budget
+
+		parentCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		start := time.Now()
+		results, err := eng.RecallWithOpts(parentCtx, "query", 5, "summary", search.RecallOpts{})
+		elapsed := time.Since(start)
+
+		require.NoError(t, err, "positive ms: must degrade gracefully, not error")
+		require.NotNil(t, results)
+		require.Less(t, elapsed, 400*time.Millisecond,
+			"positive ms=100: must return within ~400ms; got %s", elapsed)
+		// Parent must still be alive — the 100ms embed deadline must not bleed.
+		require.NoError(t, parentCtx.Err())
+	})
+
+	t.Run("zero_ms_no_embed_deadline", func(t *testing.T) {
+		proj := uniqueProject("embed-timeout-zero2")
+		eng := newEngineWithEmbedder(t, proj, &hangingEmbedder{dims: 768})
+		eng.SetEmbedRecallTimeout(0) // no embed deadline
+
+		// Short parent forces a bounded call.
+		parentCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err := eng.RecallWithOpts(parentCtx, "query", 5, "summary", search.RecallOpts{})
+		elapsed := time.Since(start)
+
+		require.Error(t, err, "zero ms: parent deadline must propagate as error")
+		require.Less(t, elapsed, 300*time.Millisecond,
+			"zero ms: must return within ~300ms when parent has 100ms deadline; got %s", elapsed)
+	})
+}


### PR DESCRIPTION
## Summary

- **#973 (closed by this PR):** `SetEmbedRecallTimeout(0)` previously preserved the 500 ms default while the flag help claimed `0 = no timeout`. This PR implements the correct semantics: ms == 0 disables the engine-level embed deadline so the parent context governs directly.
- **#917 (stays open — architectural fix teed up):** Adds the clearly-safe observability increment: `slog.Info` → `slog.Warn` on both embed-degradation log lines, plus tests that assert `EmbedDegraded=true` and `engram_recall_embed_timeout_total` increments on degraded recall.

## #973 — Option A selected (ADV.5 advisory gate)

**Decision fork:** Option A = implement the escape hatch; Option B = docs-only fix.

**Advisory reasoning (ADV.5):** The MCP server's `registerToolWithTimeout` wraps every tool call with a bounded parent context — confirmed in `internal/mcp/server.go:1185`. This makes "no embed deadline, rely on parent ctx" safe in production. Option A was chosen: operators running slow-but-reliable local embed backends gain a real escape hatch without resorting to an arbitrarily large ms value.

**Implementation:**
- `SetEmbedRecallTimeout(0)` stores sentinel `-1` on `e.embedRecallTimeout`
- Both `RecallWithOpts` and `GetContextForMemory`/`RecallWithinMemory` check for the sentinel and skip `context.WithTimeout`, passing parent ctx directly
- Callers using ms == 0 **must** supply a bounded parent context (documented in flag help and code comments)
- Flag help updated: `"0 = no embed deadline (parent context governs — caller must supply a bounded context)"`

**Tests:** `embed_timeout_zero_test.go` — two tests covering ms==0 vs ms>0 path divergence and confirming the parent deadline governs when the sentinel is active.

## #917 — Observability increment (architectural fix deferred)

**Shipped in this PR (clearly-safe):**
- `slog.Info` → `slog.Warn` for both embed-degraded log lines (`RecallWithOpts` + `RecallWithinMemory`)
- Tests in `embed_degradation_observability_test.go`: `EmbedDegraded` flag set on timeout, immediate error, and not set on success; `RecallEmbedTimeoutTotal` incremented on degraded recall

**NOT shipped (requires architectural decision):**

The #917 architectural fix requires choosing between three approaches with meaningfully different long-term consequences:

1. **Dedicated fast GPU lane** — separate embed pool/endpoint for recall queries, bypassing the shared inference queue. Highest throughput gain but requires infrastructure changes and adds a new service dependency.

2. **Adaptive back-pressure-aware timeout** — the embed deadline auto-adjusts based on rolling p95 latency of recent embed calls. Self-tuning, no infrastructure needed, but adds complexity to the engine and a new state machine.

3. **Reembed concurrency throttle** — cap in-flight embed calls per project/globally so the reembed worker doesn't saturate the GPU while recall queries are waiting. Simplest, but doesn't help when the embed backend is intrinsically slow.

**Opus-advisor recommendation (verbal summary):** Approach 2 (adaptive back-pressure-aware timeout) is the preferred first step. It requires no infrastructure changes, is reversible, and directly addresses the root cause (static timeout doesn't adapt to embed backend load). It should be implemented with a circuit-breaker pattern: if the rolling p95 exceeds a threshold, the timeout tightens; if the backend recovers, it widens. Approach 3 is a complementary safeguard, not a substitute. Approach 1 is the long-term target for high-traffic deployments but should not be the first architectural move.

Issue #917 stays open for the Approach 2 implementation. This PR's observability increment makes that work easier: operators can now see degradation rate in Prometheus and correlate with embed latency.

## Test plan

- [x] `go build ./internal/search/... ./cmd/engram/...` — clean
- [x] `go vet ./internal/search/... ./cmd/engram/...` — clean
- [x] `go test ./internal/search/... ./cmd/engram/... -count=1 -race -timeout 120s` — all pass (DB integration tests skip cleanly without `TEST_DATABASE_URL`)
- [x] Push to `fix/917-973-embed-recall-timeout`, branch verified on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)