### PR TITLE
fix(errhandling): GetStats cursors + last-matched error + embed body drain

### DIFF
--- a/internal/db/postgres_prune.go
+++ b/internal/db/postgres_prune.go
@@ -132,31 +132,35 @@ func (b *PostgresBackend) GetStats(ctx context.Context, project string) (*types.
 	if err != nil {
 		return nil, err
 	}
+	defer typeRows.Close()
 	for typeRows.Next() {
 		var mt string
 		var c int
 		if err := typeRows.Scan(&mt, &c); err != nil {
-			typeRows.Close()
 			return nil, err
 		}
 		stats.ByType[mt] = c
 	}
-	typeRows.Close()
+	if err := typeRows.Err(); err != nil {
+		return nil, err
+	}
 
 	impRows, err := b.pool.Query(ctx,
 		"SELECT importance, COUNT(*) FROM memories WHERE project=$1 AND valid_to IS NULL GROUP BY importance", project)
 	if err != nil {
 		return nil, err
 	}
+	defer impRows.Close()
 	for impRows.Next() {
 		var imp, c int
 		if err := impRows.Scan(&imp, &c); err != nil {
-			impRows.Close()
 			return nil, err
 		}
 		stats.ByImportance[fmt.Sprintf("%d", imp)] = c
 	}
-	impRows.Close()
+	if err := impRows.Err(); err != nil {
+		return nil, err
+	}
 
 	var oldest, newest *time.Time
 	if err := b.pool.QueryRow(ctx, "SELECT MIN(created_at) FROM memories WHERE project=$1 AND valid_to IS NULL", project).Scan(&oldest); err != nil {

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -380,6 +380,7 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			return nil, "", fmt.Errorf("litellm embed decode: %w", err)
 		}
 		if len(result.Data) == 0 || len(result.Data[0].Embedding) == 0 {
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close() //nolint:errcheck
 			// Empty response is non-retryable
 			metrics.EmbedFailures.WithLabelValues("non_retryable").Inc()
@@ -389,6 +390,7 @@ func (c *LiteLLMClient) EmbedWithModel(ctx context.Context, text string) ([]floa
 			return nil, "", fmt.Errorf("litellm embed: empty response")
 		}
 
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close() //nolint:errcheck
 		// Success!
 		vec := result.Data[0].Embedding

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -969,7 +969,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		// are skipped via the chunkID check. This is a strict improvement over
 		// the prior code, which would have called UpdateChunkLastMatched("").
 		if hit, ok := bestHits[r.Memory.ID]; ok && hit.chunkID != "" {
-			_ = e.backend.UpdateChunkLastMatched(ctx, hit.chunkID)
+			if err := e.backend.UpdateChunkLastMatched(ctx, hit.chunkID); err != nil {
+				slog.Warn("recall: update last-matched failed", "err", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Error-handling discovery sweep — three HIGH-severity defects, all mechanical hardening, no behavior change on happy path.

### H1 — `internal/db/postgres_prune.go` · `GetStats` (~L130–159)

**Before:** `typeRows` and `impRows` cursors iterated with no `defer rows.Close()` and no `rows.Err()` check after the loop. A mid-cursor DB error returned a silently-truncated stats map; if the connection was recycled the cursor could also leak.

**After:** Added `defer typeRows.Close()` immediately after its Query err-check; `defer impRows.Close()` after its err-check; and `if err := typeRows.Err(); err != nil { return nil, err }` / `if err := impRows.Err(); err != nil { return nil, err }` after each loop body. Matches the rows-handling pattern used in `PruneStaleMemories`, `PruneColdDocuments`, `ListAllProjects`, and `FTSSearch` in the same file.

Also removed the now-redundant manual `typeRows.Close()` / `impRows.Close()` calls inside the Scan error branches (defer covers them).

### H2 — `internal/search/engine.go` · recall hot path (~L972)

**Before:** `_ = e.backend.UpdateChunkLastMatched(ctx, hit.chunkID)` — blank-discarded the error. A transient DB hiccup silently lost the last-matched timestamp update, corrupting decay/access data used for memory scoring.

**After:**
```go
if err := e.backend.UpdateChunkLastMatched(ctx, hit.chunkID); err != nil {
    slog.Warn("recall: update last-matched failed", "err", err)
}
```
`slog` was already imported. Non-fatal by design (recall still succeeds), but the error is now observable.

### H3 — `internal/embed/litellm.go` · success + empty-response paths (~L383/392)

**Before:** `resp.Body` was closed without draining on the success path (L392) and the empty-response path (L383). Trailing bytes in the body prevented HTTP keep-alive connection reuse (`MaxIdleConnsPerHost`), forcing a new TCP handshake on every embedding call under load.

**After:** Added `_, _ = io.Copy(io.Discard, resp.Body)` before `resp.Body.Close()` on both paths. `io` was already imported. The error path (~L342) already uses `io.LimitReader` and is unchanged. Complements the #965 explicit-Close fix rather than conflicting with it.

## Test plan

- [x] `go test ./internal/db/... ./internal/search/... ./internal/embed/... -race -count=1 -timeout 120s` — all pass (`ok` for all three packages)
- [x] `go build ./...` — clean
- [x] `go vet ./internal/db/... ./internal/search/... ./internal/embed/...` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)