### PR TITLE
fix(errhandling): rate-limiter goroutine ctx + reembed zero-row surface + migration-flag timeout

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -962,10 +962,11 @@ func isLoopbackIP(ip string) bool {
 }
 
 // setupTokenTOFUHandler returns the /setup-token handler with TOFU (Trust On
-// First Use) logic. It creates an internal rate limiter with default parameters.
+// First Use) logic. It creates an internal rate limiter whose eviction goroutine
+// is bound to ctx so it stops when the server shuts down (prevents goroutine leak).
 // Use setupTokenTOFUHandlerWithLimiter in tests to inject a pre-exhausted limiter.
-func (s *Server) setupTokenTOFUHandler(apiKey string) http.Handler {
-	return s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(context.Background()))
+func (s *Server) setupTokenTOFUHandler(ctx context.Context, apiKey string) http.Handler {
+	return s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(ctx))
 }
 
 // setupTokenTOFUHandlerWithLimiter returns the /setup-token handler using the

--- a/internal/mcp/setup_token_tofu_test.go
+++ b/internal/mcp/setup_token_tofu_test.go
@@ -29,9 +29,8 @@ func newTOFUTestServer(t *testing.T, apiKey string) *Server {
 }
 
 // buildSetupTokenTOFUHandler returns the TOFU-aware handler for /setup-token.
-// Will FAIL TO COMPILE until Server.setupTokenTOFUHandler is implemented.
 func buildSetupTokenTOFUHandler(s *Server, apiKey string) http.Handler {
-	return s.setupTokenTOFUHandler(apiKey) // method doesn't exist yet
+	return s.setupTokenTOFUHandler(context.Background(), apiKey)
 }
 
 // TestSetupToken_TOFUFirstLocalhostSucceeds verifies that the very first

--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -255,11 +255,13 @@ func (g *GlobalReembedder) runBatch(ctx context.Context) (int, error) {
 				metrics.WorkerErrors.WithLabelValues("global_reembed").Inc()
 				return nil // non-fatal: skip chunk, retry on next tick
 			}
-			if _, err := g.pool.Exec(egCtx,
+			if tag, err := g.pool.Exec(egCtx,
 				"UPDATE chunks SET embedding=$1 WHERE id=$2",
 				pgvector.NewVector(vec), c.id,
 			); err != nil {
 				slog.Warn("global reembedder: update failed", "chunk", c.id, "err", err)
+			} else if tag.RowsAffected() == 0 {
+				slog.Warn("global reembedder: update matched zero rows — chunk may have been deleted between fetch and update", "chunk", c.id)
 			}
 			return nil
 		})

--- a/internal/reembed/worker.go
+++ b/internal/reembed/worker.go
@@ -158,7 +158,7 @@ func (w *Worker) run(ctx context.Context) {
 		}
 		if batchDone && !migrationCleared {
 			slog.Info("reembed: backfill pass complete", "project", w.project)
-			flagCtx, flagCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			flagCtx, flagCancel := context.WithTimeout(ctx, 10*time.Second)
 			if err := w.backend.SetMeta(flagCtx, w.project, "embedding_migration_in_progress", "false"); err != nil {
 				slog.Warn("reembed: failed to clear migration flag", "project", w.project, "err", err)
 				metrics.WorkerErrors.WithLabelValues("reembed").Inc()
@@ -224,8 +224,10 @@ func (w *Worker) runBatch(ctx context.Context) bool {
 				slog.Warn("reembed embed failed", "chunk", c.ID, "err", err)
 				return nil // non-fatal: let other goroutines continue
 			}
-			if n, err := w.backend.UpdateChunkEmbedding(egCtx, c.ID, vec); err != nil || n == 0 {
-				slog.Warn("reembed update failed or chunk deleted", "chunk", c.ID)
+			if n, err := w.backend.UpdateChunkEmbedding(egCtx, c.ID, vec); err != nil {
+				slog.Warn("reembed update failed", "chunk", c.ID, "err", err)
+			} else if n == 0 {
+				slog.Warn("reembed update matched zero rows — chunk may have been deleted between fetch and update", "chunk", c.ID)
 			}
 			return nil
 		})


### PR DESCRIPTION
## Summary

Three error-handling defects from a discovery sweep, in files disjoint from active work on `cmd/longmemeval`.

### M1 — `internal/mcp/server.go` ~L967-968: goroutine leak in `setupTokenTOFUHandler`

`newRateLimiter(context.Background())` spawned an `evictLoop` goroutine bound to `Background` that never stops. Fixed by threading `ctx context.Context` through `setupTokenTOFUHandler` so the evict goroutine is tied to the caller's lifecycle. Test helper updated to pass `context.Background()` explicitly.

### M3 — `internal/reembed/worker.go` ~L227-228 and `internal/reembed/global_worker.go` ~L258-263: zero-rows update silently treated as success

The combined `err != nil || n == 0` branch collapsed both error and zero-rows cases into the same `slog.Warn`, so a chunk that failed to update (zero rows matched) was logged identically to an error — and was then marked done and never retried. Split into distinct branches: `err != nil` logs the error, `n == 0` emits a separate `slog.Warn` with the chunk ID calling out that the chunk may have been deleted between fetch and update.

### L1 — `internal/reembed/worker.go` ~L161: migration-flag `SetMeta` uses `context.Background()`

`flagCtx` was derived from `context.Background()`, so worker shutdown could not abort the `SetMeta` call. Changed to `context.WithTimeout(ctx, 10*time.Second)` using the worker's own `ctx`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/mcp/... ./internal/reembed/...` — clean
- [x] `go test ./internal/mcp/... ./internal/reembed/... -race -count=1 -timeout 120s` — both packages pass
- [ ] CI green (block on required checks; re-run once if known flake #975)

## Files touched

- `internal/mcp/server.go`
- `internal/mcp/setup_token_tofu_test.go` (test helper signature update)
- `internal/reembed/worker.go`
- `internal/reembed/global_worker.go`

`cmd/longmemeval/run.go` — NOT touched (deferred wave, under active edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)