### PR TITLE
fix(skills): unify engram-ingest/consolidate/episodes into one routed skill (#951)

### DIFF
--- a/skills/engram/SKILL.md
+++ b/skills/engram/SKILL.md
@@ -1,0 +1,36 @@
+---
+description: Hidden Engram ops: bulk ingest from files/exports, memory consolidation/sleep/summarize, and episode lifecycle (start/end/list/recall).
+---
+
+# engram
+
+Access hidden Engram MCP tools that are intentionally excluded from `tools/list`
+to prevent accidental triggering during normal recall/store workflows. All calls
+go directly to the MCP JSON-RPC endpoint via `xh`.
+
+## Routing
+
+Identify which operation category applies, then read the matching reference file:
+
+- Bulk ingest from files, directories, or exports → [reference/ingest.md](reference/ingest.md)
+- Memory consolidation, sleep, summarize, resummarize → [reference/consolidate.md](reference/consolidate.md)
+- Episode start, end, list, recall → [reference/episodes.md](reference/episodes.md)
+
+## Common Setup
+
+All calls use:
+
+```bash
+xh POST "${ENGRAM_BASE_URL:-http://localhost:8788}/mcp" \
+  "Authorization: Bearer $ENGRAM_API_KEY" \
+  Content-Type:application/json \
+  jsonrpc=2.0 id:=1 method=tools/call \
+  params:='{"name":"<tool>","arguments":{...}}'
+```
+
+If `ENGRAM_API_KEY` is not set: halt and tell the user to set the variable
+before retrying.
+
+If the server is unreachable: stage a note in
+`~/.claude/projects/-home-psimmons/memory/fallback.md` and retry when Engram
+reconnects.

--- a/skills/engram/reference/consolidate.md
+++ b/skills/engram/reference/consolidate.md
@@ -1,13 +1,7 @@
----
-description: Compress and prune Engram memory after long sessions or when the store feels cluttered
----
-
-# engram-consolidate
+# Consolidation Operations
 
 Run memory maintenance operations against the Engram MCP server. These tools
-are hidden from the normal tools/list to keep context lean. This skill calls
-them directly via HTTP so you can trigger consolidation without bloating the
-active tool roster.
+are hidden from the normal tools/list to keep context lean.
 
 ## When to Use
 
@@ -20,8 +14,7 @@ active tool roster.
 ## How to Use
 
 Identify which operation the user wants, then issue the matching `xh` call
-below. All calls go to the MCP JSON-RPC endpoint. Capture the response and
-report the result (or error) to the user.
+below. Capture the response and report the result (or error) to the user.
 
 ### 1. Quick consolidation — prune stale entries, decay edges, merge near-duplicates
 
@@ -78,12 +71,12 @@ regenerate all of them within approximately 60 seconds.
 
 ## Tools Available
 
-| Tool | Arguments | Effect |
-|------|-----------|--------|
-| `memory_consolidate` | `project` (string) | Prune stale memories, decay graph edges, merge near-duplicates. Fast. |
-| `memory_sleep` | `project` (string) | Full consolidation cycle with relationship inference. Slow but thorough. |
-| `memory_summarize` | `id` (string) | Immediately summarize a single memory by ID. |
-| `memory_resummarize` | `project` (string) | Clear all summaries for a project so they regenerate fresh. |
+| Tool                  | Arguments           | Effect |
+|-----------------------|---------------------|--------|
+| `memory_consolidate`  | `project` (string)  | Prune stale memories, decay graph edges, merge near-duplicates. Fast. |
+| `memory_sleep`        | `project` (string)  | Full consolidation cycle with relationship inference. Slow but thorough. |
+| `memory_summarize`    | `id` (string)       | Immediately summarize a single memory by ID. |
+| `memory_resummarize`  | `project` (string)  | Clear all summaries for a project so they regenerate fresh. |
 
 ## Decision Order
 

--- a/skills/engram/reference/episodes.md
+++ b/skills/engram/reference/episodes.md
@@ -1,8 +1,4 @@
----
-description: Start, end, list, and recall named work session episodes in Engram memory
----
-
-# engram-episodes
+# Episode Operations
 
 Group memories into named episodes so you can recall everything that happened
 during a discrete work session. Episodes give Engram a timeline structure —
@@ -84,12 +80,12 @@ during a past session, brief a new agent, or produce a session summary report.
 
 ## Tools Available
 
-| Tool | Arguments | Effect |
-|------|-----------|--------|
-| `memory_episode_start` | `project` (string), `description` (string) | Open a new episode; returns `id` |
-| `memory_episode_end` | `id` (string), `project` (string), `summary` (string, optional) | Close the episode |
-| `memory_episode_list` | `project` (string), `limit` (int, default 10) | List recent episodes |
-| `memory_episode_recall` | `id` (string), `project` (string) | Retrieve all memories in the episode in order |
+| Tool                   | Arguments                                              | Effect |
+|------------------------|--------------------------------------------------------|--------|
+| `memory_episode_start` | `project` (string), `description` (string)            | Open a new episode; returns `id` |
+| `memory_episode_end`   | `id` (string), `project` (string), `summary` (string, optional) | Close the episode |
+| `memory_episode_list`  | `project` (string), `limit` (int, default 10)         | List recent episodes |
+| `memory_episode_recall`| `id` (string), `project` (string)                     | Retrieve all memories in the episode in order |
 
 ## Typical Full-Session Workflow
 

--- a/skills/engram/reference/ingest.md
+++ b/skills/engram/reference/ingest.md
@@ -1,16 +1,9 @@
----
-description: Bulk-load files, directories, or exported chat histories into Engram; export memories to markdown
----
-
-# engram-ingest
+# Ingest Operations
 
 Load large volumes of content into Engram memory without hand-crafting
 individual `memory_store` calls. Supports local files and directories, exported
 chat histories from Slack, Claude, and ChatGPT, and full memory exports for
 backup.
-
-These tools are hidden from the normal tools/list. This skill calls them
-directly via HTTP.
 
 ## When to Use
 
@@ -91,10 +84,10 @@ off memory content to another system.
 
 | Tool | Arguments | Effect |
 |------|-----------|--------|
-| `memory_ingest` | `path` (string), `project` (string) | Ingest local file or directory; returns `job_id` |
+| `memory_ingest`        | `path` (string), `project` (string) | Ingest local file or directory; returns `job_id` |
 | `memory_ingest_export` | `path` (string), `project` (string), `source` ("slack"\|"claude"\|"chatgpt") | Parse exported chat history; returns `job_id` |
 | `memory_ingest_status` | `job_id` (string) | Check async job status and progress |
-| `memory_export_all` | `project` (string), `output_dir` (string) | Export all project memories to markdown files |
+| `memory_export_all`    | `project` (string), `output_dir` (string) | Export all project memories to markdown files |
 
 ## Typical Ingest Workflow
 


### PR DESCRIPTION
Materializes the #951 skill unification onto engram-go \`main\` so that \`make install-skills\` (which runs \`cp -r skills/* ~/.claude/skills/\`) no longer clobbers the live unified \`engram\` skill back to the old split layout.

## What changed
Replaces the three separate skill dirs (\`engram-ingest/\`, \`engram-consolidate/\`, \`engram-episodes/\`) with a single routed skill:
- \`skills/engram/SKILL.md\` — new router (new file)
- \`skills/engram/reference/ingest.md\` — git rename of \`engram-ingest/SKILL.md\` (90% similarity)
- \`skills/engram/reference/consolidate.md\` — git rename of \`engram-consolidate/SKILL.md\` (77% similarity)
- \`skills/engram/reference/episodes.md\` — git rename of \`engram-episodes/SKILL.md\` (86% similarity)

Each reference file retains its \`## Error Handling\` section referencing \`fallback.md\` per the [R6] requirement.

## Scope / safety
- Touches **ZERO Go code** — diff is SKILL.md + reference markdown only (4 files, +55/-37).
- \`skills/engram-diagnose/\` is untouched.
- Content is **byte-identical** to the already-reviewed #951 skill in the live load path (verified via \`diff -rq\` against \`~/.claude/skills/engram\`, no differences).

Refs #951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)