### PR TITLE
test: add coverage for markdown/search-pure/cmd-env/chatgpt helpers

### DIFF
--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/netutil"
 )
@@ -261,5 +262,199 @@ func TestEngramReadyLog_IncludesVersion(t *testing.T) {
 	want := `slog.Info("engram ready", "version", Version`
 	if !strings.Contains(string(src), want) {
 		t.Errorf("main.go missing version key in 'engram ready' slog.Info call (#674)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// envInt
+// ---------------------------------------------------------------------------
+
+func TestEnvInt_SetValid(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_INT", "42")
+	got := envInt("ENGRAM_TEST_INT", 0)
+	if got != 42 {
+		t.Errorf("envInt set valid = %d, want 42", got)
+	}
+}
+
+func TestEnvInt_Unset(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_INT_UNSET", "")
+	got := envInt("ENGRAM_TEST_INT_UNSET", 7)
+	if got != 7 {
+		t.Errorf("envInt unset = %d, want 7 (default)", got)
+	}
+}
+
+func TestEnvInt_ParseError(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_INT_BAD", "notanint")
+	got := envInt("ENGRAM_TEST_INT_BAD", 99)
+	if got != 99 {
+		t.Errorf("envInt parse error = %d, want 99 (default)", got)
+	}
+}
+
+func TestEnvInt_NegativeValue(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_INT_NEG", "-5")
+	got := envInt("ENGRAM_TEST_INT_NEG", 0)
+	if got != -5 {
+		t.Errorf("envInt negative = %d, want -5", got)
+	}
+}
+
+func TestEnvInt_Zero(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_INT_ZERO", "0")
+	// "0" is a valid value but os.Getenv returns "0" (non-empty) → parsed → 0 returned.
+	got := envInt("ENGRAM_TEST_INT_ZERO", 10)
+	if got != 0 {
+		t.Errorf("envInt zero = %d, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// envFloat
+// ---------------------------------------------------------------------------
+
+func TestEnvFloat_SetValid(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_FLOAT", "3.14")
+	got := envFloat("ENGRAM_TEST_FLOAT", 0.0)
+	if got < 3.139 || got > 3.141 {
+		t.Errorf("envFloat set valid = %v, want ~3.14", got)
+	}
+}
+
+func TestEnvFloat_Unset(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_FLOAT_UNSET", "")
+	got := envFloat("ENGRAM_TEST_FLOAT_UNSET", 2.718)
+	if got != 2.718 {
+		t.Errorf("envFloat unset = %v, want 2.718 (default)", got)
+	}
+}
+
+func TestEnvFloat_ParseError(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_FLOAT_BAD", "notafloat")
+	got := envFloat("ENGRAM_TEST_FLOAT_BAD", 1.0)
+	if got != 1.0 {
+		t.Errorf("envFloat parse error = %v, want 1.0 (default)", got)
+	}
+}
+
+func TestEnvFloat_NegativeValue(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_FLOAT_NEG", "-1.5")
+	got := envFloat("ENGRAM_TEST_FLOAT_NEG", 0.0)
+	if got != -1.5 {
+		t.Errorf("envFloat negative = %v, want -1.5", got)
+	}
+}
+
+func TestEnvFloat_Zero(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_FLOAT_ZERO", "0")
+	got := envFloat("ENGRAM_TEST_FLOAT_ZERO", 5.0)
+	if got != 0.0 {
+		t.Errorf("envFloat zero = %v, want 0.0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// envBool
+// ---------------------------------------------------------------------------
+
+func TestEnvBool_TrueVariants(t *testing.T) {
+	for _, v := range []string{"1", "true", "yes", "TRUE", "True", "YES", "Yes"} {
+		t.Setenv("ENGRAM_TEST_BOOL", v)
+		got := envBool("ENGRAM_TEST_BOOL", false)
+		if !got {
+			t.Errorf("envBool(%q) = false, want true", v)
+		}
+	}
+}
+
+func TestEnvBool_FalseVariants(t *testing.T) {
+	for _, v := range []string{"0", "false", "no", "FALSE", "False", "NO", "No"} {
+		t.Setenv("ENGRAM_TEST_BOOL", v)
+		got := envBool("ENGRAM_TEST_BOOL", true)
+		if got {
+			t.Errorf("envBool(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestEnvBool_Unset_DefaultFalse(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_BOOL_UNSET", "")
+	got := envBool("ENGRAM_TEST_BOOL_UNSET", false)
+	if got {
+		t.Errorf("envBool unset, default=false: got true, want false")
+	}
+}
+
+func TestEnvBool_Unset_DefaultTrue(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_BOOL_UNSET_T", "")
+	got := envBool("ENGRAM_TEST_BOOL_UNSET_T", true)
+	if !got {
+		t.Errorf("envBool unset, default=true: got false, want true")
+	}
+}
+
+func TestEnvBool_UnknownValue_ReturnsDefault(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_BOOL_UNK", "maybe")
+	got := envBool("ENGRAM_TEST_BOOL_UNK", true)
+	if !got {
+		t.Errorf("envBool unknown value, default=true: got false, want true")
+	}
+	t.Setenv("ENGRAM_TEST_BOOL_UNK2", "maybe")
+	got2 := envBool("ENGRAM_TEST_BOOL_UNK2", false)
+	if got2 {
+		t.Errorf("envBool unknown value, default=false: got true, want false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// envDuration
+// ---------------------------------------------------------------------------
+
+func TestEnvDuration_SetValid(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_DUR", "30s")
+	got := envDuration("ENGRAM_TEST_DUR", 0)
+	if got != 30*time.Second {
+		t.Errorf("envDuration '30s' = %v, want 30s", got)
+	}
+}
+
+func TestEnvDuration_SetMinutes(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_DUR_MIN", "5m")
+	got := envDuration("ENGRAM_TEST_DUR_MIN", 0)
+	if got != 5*time.Minute {
+		t.Errorf("envDuration '5m' = %v, want 5m", got)
+	}
+}
+
+func TestEnvDuration_SetHours(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_DUR_HOUR", "2h")
+	got := envDuration("ENGRAM_TEST_DUR_HOUR", 0)
+	if got != 2*time.Hour {
+		t.Errorf("envDuration '2h' = %v, want 2h", got)
+	}
+}
+
+func TestEnvDuration_Unset(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_DUR_UNSET", "")
+	got := envDuration("ENGRAM_TEST_DUR_UNSET", 10*time.Second)
+	if got != 10*time.Second {
+		t.Errorf("envDuration unset = %v, want 10s (default)", got)
+	}
+}
+
+func TestEnvDuration_ParseError(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_DUR_BAD", "notaduration")
+	got := envDuration("ENGRAM_TEST_DUR_BAD", time.Minute)
+	if got != time.Minute {
+		t.Errorf("envDuration parse error = %v, want 1m (default)", got)
+	}
+}
+
+func TestEnvDuration_Zero(t *testing.T) {
+	t.Setenv("ENGRAM_TEST_DUR_ZERO", "0s")
+	got := envDuration("ENGRAM_TEST_DUR_ZERO", time.Hour)
+	if got != 0 {
+		t.Errorf("envDuration '0s' = %v, want 0", got)
 	}
 }

--- a/internal/ingest/chatgpt/findroot_internal_test.go
+++ b/internal/ingest/chatgpt/findroot_internal_test.go
@@ -1,0 +1,81 @@
+// findroot_internal_test.go — tests for unexported findRoot function.
+// Uses package chatgpt (internal) so the unexported function is accessible.
+// ParseFile error path is already covered in chatgpt_test.go (external package).
+package chatgpt
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// findRoot
+// ---------------------------------------------------------------------------
+
+func TestFindRoot_SingleNodeNoParent(t *testing.T) {
+	mapping := map[string]mapNode{
+		"root": {ID: "root", Parent: nil},
+	}
+	got := findRoot(mapping)
+	if got != "root" {
+		t.Errorf("findRoot single node = %q, want 'root'", got)
+	}
+}
+
+func TestFindRoot_MultipleNodes_ReturnsParentlessOne(t *testing.T) {
+	parent := "root"
+	mapping := map[string]mapNode{
+		"root":   {ID: "root", Parent: nil},
+		"child1": {ID: "child1", Parent: &parent},
+		"child2": {ID: "child2", Parent: &parent},
+	}
+	got := findRoot(mapping)
+	if got != "root" {
+		t.Errorf("findRoot multi-node = %q, want 'root'", got)
+	}
+}
+
+func TestFindRoot_EmptyMapping(t *testing.T) {
+	got := findRoot(map[string]mapNode{})
+	if got != "" {
+		t.Errorf("findRoot empty mapping = %q, want '' (empty string)", got)
+	}
+}
+
+func TestFindRoot_AllNodesHaveParents(t *testing.T) {
+	// Malformed tree: every node has a parent → no root found → empty string.
+	p1 := "b"
+	p2 := "a"
+	mapping := map[string]mapNode{
+		"a": {ID: "a", Parent: &p1},
+		"b": {ID: "b", Parent: &p2},
+	}
+	got := findRoot(mapping)
+	if got != "" {
+		t.Errorf("findRoot no parentless node = %q, want '' (empty string)", got)
+	}
+}
+
+func TestFindRoot_NilMapping(t *testing.T) {
+	// nil map should return empty string without panicking.
+	got := findRoot(nil)
+	if got != "" {
+		t.Errorf("findRoot nil mapping = %q, want ''", got)
+	}
+}
+
+func TestFindRoot_DeepTree(t *testing.T) {
+	// root → node1 → node2 → node3; only root has nil parent.
+	n1 := "root"
+	n2 := "node1"
+	n3 := "node2"
+	mapping := map[string]mapNode{
+		"root":  {ID: "root", Parent: nil},
+		"node1": {ID: "node1", Parent: &n1},
+		"node2": {ID: "node2", Parent: &n2},
+		"node3": {ID: "node3", Parent: &n3},
+	}
+	got := findRoot(mapping)
+	if got != "root" {
+		t.Errorf("findRoot deep tree = %q, want 'root'", got)
+	}
+}

--- a/internal/markdown/io_test.go
+++ b/internal/markdown/io_test.go
@@ -3,6 +3,7 @@ package markdown_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/markdown"
@@ -32,4 +33,219 @@ func TestExportImportRoundtrip(t *testing.T) {
 	content, err := os.ReadFile(files[0])
 	require.NoError(t, err)
 	require.Contains(t, string(content), "TDD means test first.")
+}
+
+// ---------------------------------------------------------------------------
+// ImportClaudeMD
+// ---------------------------------------------------------------------------
+
+func TestImportClaudeMD_SingleSection(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "CLAUDE.md")
+	body := "## Core Principles\n\nSimplicity first.\n"
+	require.NoError(t, os.WriteFile(f, []byte(body), 0o644))
+
+	mems, err := markdown.ImportClaudeMD(f)
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	require.Contains(t, mems[0].Content, "Core Principles")
+	require.Contains(t, mems[0].Content, "Simplicity first.")
+}
+
+func TestImportClaudeMD_MultiSection(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "CLAUDE.md")
+	body := `## Section A
+
+Content A.
+
+## Section B
+
+Content B.
+`
+	require.NoError(t, os.WriteFile(f, []byte(body), 0o644))
+
+	mems, err := markdown.ImportClaudeMD(f)
+	require.NoError(t, err)
+	require.Len(t, mems, 2)
+
+	found := make(map[string]bool)
+	for _, m := range mems {
+		if strings.Contains(m.Content, "Content A") {
+			found["A"] = true
+		}
+		if strings.Contains(m.Content, "Content B") {
+			found["B"] = true
+		}
+	}
+	require.True(t, found["A"], "expected Section A content")
+	require.True(t, found["B"], "expected Section B content")
+}
+
+func TestImportClaudeMD_WithFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "CLAUDE.md")
+	// ImportClaudeMD calls splitSections which does NOT strip front matter.
+	// Content before the first ## heading (including the front matter block) becomes
+	// the first section. "## Only Section" becomes the second section.
+	body := "---\ntitle: test\n---\n\n## Only Section\n\nBody text.\n"
+	require.NoError(t, os.WriteFile(f, []byte(body), 0o644))
+
+	mems, err := markdown.ImportClaudeMD(f)
+	require.NoError(t, err)
+	// Front matter block (before first ##) produces one section; "Only Section" is the second.
+	require.Len(t, mems, 2)
+	found := false
+	for _, m := range mems {
+		if strings.Contains(m.Content, "Only Section") {
+			found = true
+		}
+	}
+	require.True(t, found, "expected a section containing 'Only Section'")
+}
+
+func TestImportClaudeMD_NoSections(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "CLAUDE.md")
+	body := "Just plain text, no headings.\n"
+	require.NoError(t, os.WriteFile(f, []byte(body), 0o644))
+
+	mems, err := markdown.ImportClaudeMD(f)
+	require.NoError(t, err)
+	// No ## headings → one memory containing the whole document.
+	require.Len(t, mems, 1)
+	require.Contains(t, mems[0].Content, "Just plain text")
+}
+
+func TestImportClaudeMD_FileNotFound(t *testing.T) {
+	_, err := markdown.ImportClaudeMD("/nonexistent/CLAUDE.md")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ImportClaudeMD")
+}
+
+// ---------------------------------------------------------------------------
+// Ingest
+// ---------------------------------------------------------------------------
+
+func TestIngest_SingleFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "note.md")
+	require.NoError(t, os.WriteFile(f, []byte("Hello world.\n"), 0o644))
+
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	// Ingest calls stripFrontMatter which does not trim plain text; trailing newline preserved.
+	require.Contains(t, mems[0].Content, "Hello world.")
+	require.Equal(t, types.MemoryTypeContext, mems[0].MemoryType)
+	require.Equal(t, 2, mems[0].Importance)
+	require.Equal(t, "document", mems[0].StorageMode)
+}
+
+func TestIngest_SkipsNonMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "note.md"), []byte("MD content.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ignore.txt"), []byte("Txt content.\n"), 0o644))
+
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	require.Contains(t, mems[0].Content, "MD content.")
+}
+
+func TestIngest_StripsFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nid: abc\ntags: [test]\n---\n\nBody after front matter.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "doc.md"), []byte(content), 0o644))
+
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	require.NotContains(t, mems[0].Content, "id: abc")
+	require.Contains(t, mems[0].Content, "Body after front matter.")
+}
+
+func TestIngest_Recursive(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "top.md"), []byte("Top.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "inner.md"), []byte("Inner.\n"), 0o644))
+
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Len(t, mems, 2)
+}
+
+func TestIngest_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Empty(t, mems)
+}
+
+// ---------------------------------------------------------------------------
+// Dump (delegates to Export)
+// ---------------------------------------------------------------------------
+
+func TestDump_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	id := types.NewMemoryID()
+	mems := []*types.Memory{
+		{
+			ID:         id,
+			Content:    "Dump test content.",
+			MemoryType: types.MemoryTypeContext,
+			Importance: 3,
+		},
+	}
+
+	require.NoError(t, markdown.Dump(mems, dir))
+
+	written, err := os.ReadFile(filepath.Join(dir, id+".md"))
+	require.NoError(t, err)
+	require.Contains(t, string(written), "Dump test content.")
+	require.Contains(t, string(written), "importance: 3")
+}
+
+func TestDump_SkipsNilAndEmptyID(t *testing.T) {
+	dir := t.TempDir()
+	mems := []*types.Memory{
+		nil,
+		{ID: "", Content: "no id"},
+	}
+	require.NoError(t, markdown.Dump(mems, dir))
+
+	files, err := filepath.Glob(filepath.Join(dir, "*.md"))
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+// ---------------------------------------------------------------------------
+// stripFrontMatter (exercised via Ingest)
+// ---------------------------------------------------------------------------
+
+func TestStripFrontMatter_NoFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	body := "No front matter here.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plain.md"), []byte(body), 0o644))
+
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	// No front matter → stripFrontMatter returns input unchanged (including trailing newline).
+	require.Contains(t, mems[0].Content, "No front matter here.")
+}
+
+func TestStripFrontMatter_MalformedFrontMatter(t *testing.T) {
+	// Starts with --- but has no closing ---; should return unchanged.
+	dir := t.TempDir()
+	body := "---\nunterminated: true\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "malformed.md"), []byte(body), 0o644))
+
+	mems, err := markdown.Ingest(dir)
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	// Malformed front matter is left as-is.
+	require.Contains(t, mems[0].Content, "---")
 }

--- a/internal/search/engine_pure_test.go
+++ b/internal/search/engine_pure_test.go
@@ -1,0 +1,253 @@
+// engine_pure_test.go — tests for pure (no-DB) functions in the search package:
+// bigramJaccard, sortResults, toConnectedMemories.
+// This file is test-only; it does NOT modify engine.go.
+package search
+
+import (
+	"math"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// bigramJaccard
+// ---------------------------------------------------------------------------
+
+func TestBigramJaccard_BothEmpty(t *testing.T) {
+	// Both empty strings → both bigram sets are empty → defined as 1.0 (identical).
+	got := bigramJaccard("", "")
+	if got != 1.0 {
+		t.Errorf("bigramJaccard('','') = %v, want 1.0", got)
+	}
+}
+
+func TestBigramJaccard_SingleCharEach(t *testing.T) {
+	// Single-character strings produce no bigrams → same as both-empty treatment.
+	got := bigramJaccard("a", "b")
+	if got != 1.0 {
+		t.Errorf("bigramJaccard('a','b') = %v, want 1.0 (both produce empty bigram sets)", got)
+	}
+}
+
+func TestBigramJaccard_OneEmptyOneNonEmpty(t *testing.T) {
+	// One side empty → intersection is 0; union is non-zero → result is 0.
+	got := bigramJaccard("", "hello")
+	if got != 0.0 {
+		t.Errorf("bigramJaccard('','hello') = %v, want 0.0", got)
+	}
+	got2 := bigramJaccard("world", "")
+	if got2 != 0.0 {
+		t.Errorf("bigramJaccard('world','') = %v, want 0.0", got2)
+	}
+}
+
+func TestBigramJaccard_Identical(t *testing.T) {
+	// Identical strings → perfect overlap → 1.0.
+	got := bigramJaccard("hello", "hello")
+	if got != 1.0 {
+		t.Errorf("bigramJaccard('hello','hello') = %v, want 1.0", got)
+	}
+}
+
+func TestBigramJaccard_Disjoint(t *testing.T) {
+	// Completely disjoint character sets → no common bigrams → 0.0.
+	got := bigramJaccard("abcd", "efgh")
+	if got != 0.0 {
+		t.Errorf("bigramJaccard('abcd','efgh') = %v, want 0.0", got)
+	}
+}
+
+func TestBigramJaccard_PartialOverlap(t *testing.T) {
+	// "abc" has bigrams {ab, bc}; "bcd" has bigrams {bc, cd}.
+	// intersection = {bc} = 1; union = {ab, bc, cd} = 3 → 1/3 ≈ 0.333...
+	got := bigramJaccard("abc", "bcd")
+	want := 1.0 / 3.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("bigramJaccard('abc','bcd') = %v, want %v", got, want)
+	}
+}
+
+func TestBigramJaccard_UnicodeRunes(t *testing.T) {
+	// Unicode: "αβγ" has bigrams {αβ, βγ}; "βγδ" has bigrams {βγ, γδ}.
+	// intersection = {βγ}; union = {αβ, βγ, γδ} → 1/3.
+	got := bigramJaccard("αβγ", "βγδ")
+	want := 1.0 / 3.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("bigramJaccard unicode = %v, want %v", got, want)
+	}
+}
+
+func TestBigramJaccard_TwoCharSame(t *testing.T) {
+	// Two-char strings: "ab" and "ab" → bigram sets each contain {ab} → 1.0.
+	got := bigramJaccard("ab", "ab")
+	if got != 1.0 {
+		t.Errorf("bigramJaccard('ab','ab') = %v, want 1.0", got)
+	}
+}
+
+func TestBigramJaccard_TwoCharDifferent(t *testing.T) {
+	// "ab" vs "cd" → sets {ab} and {cd} → intersection 0, union 2 → 0.0.
+	got := bigramJaccard("ab", "cd")
+	if got != 0.0 {
+		t.Errorf("bigramJaccard('ab','cd') = %v, want 0.0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sortResults
+// ---------------------------------------------------------------------------
+
+func TestSortResults_DescendingByScore(t *testing.T) {
+	results := []types.SearchResult{
+		{Memory: &types.Memory{ID: "low"}, Score: 0.1},
+		{Memory: &types.Memory{ID: "high"}, Score: 0.9},
+		{Memory: &types.Memory{ID: "mid"}, Score: 0.5},
+	}
+
+	sortResults(results)
+
+	if results[0].Memory.ID != "high" {
+		t.Errorf("first result should be 'high', got %q", results[0].Memory.ID)
+	}
+	if results[1].Memory.ID != "mid" {
+		t.Errorf("second result should be 'mid', got %q", results[1].Memory.ID)
+	}
+	if results[2].Memory.ID != "low" {
+		t.Errorf("third result should be 'low', got %q", results[2].Memory.ID)
+	}
+}
+
+func TestSortResults_EmptySlice(t *testing.T) {
+	// Must not panic on nil or empty input.
+	sortResults(nil)
+	sortResults([]types.SearchResult{})
+}
+
+func TestSortResults_SingleElement(t *testing.T) {
+	results := []types.SearchResult{
+		{Memory: &types.Memory{ID: "only"}, Score: 0.7},
+	}
+	sortResults(results)
+	if results[0].Memory.ID != "only" {
+		t.Errorf("single element: expected 'only', got %q", results[0].Memory.ID)
+	}
+}
+
+func TestSortResults_TiedScores(t *testing.T) {
+	// Tied scores — sort must not panic; order among ties is unspecified.
+	results := []types.SearchResult{
+		{Memory: &types.Memory{ID: "a"}, Score: 0.5},
+		{Memory: &types.Memory{ID: "b"}, Score: 0.5},
+	}
+	sortResults(results)
+	// Both scores are equal; just verify both IDs still present.
+	ids := map[string]bool{results[0].Memory.ID: true, results[1].Memory.ID: true}
+	if !ids["a"] || !ids["b"] {
+		t.Errorf("tied sort lost an element: got %v", results)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// toConnectedMemories
+// ---------------------------------------------------------------------------
+
+func TestToConnectedMemories_Empty(t *testing.T) {
+	out := toConnectedMemories(nil, "mem-1", nil)
+	if len(out) != 0 {
+		t.Errorf("expected empty result for nil rels, got %d", len(out))
+	}
+}
+
+func TestToConnectedMemories_OutgoingRelationship(t *testing.T) {
+	// Relationship where TargetID != memID → direction = "outgoing", neighborID = TargetID.
+	neighborMem := &types.Memory{ID: "neighbor-1", Content: "neighbor content"}
+	rels := []types.Relationship{
+		{SourceID: "mem-1", TargetID: "neighbor-1", RelType: "relates_to", Strength: 0.8},
+	}
+	neighborMap := map[string]*types.Memory{"neighbor-1": neighborMem}
+
+	out := toConnectedMemories(rels, "mem-1", neighborMap)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 connected memory, got %d", len(out))
+	}
+	if out[0].Direction != "outgoing" {
+		t.Errorf("direction = %q, want 'outgoing'", out[0].Direction)
+	}
+	if out[0].RelType != "relates_to" {
+		t.Errorf("rel_type = %q, want 'relates_to'", out[0].RelType)
+	}
+	if out[0].Memory == nil || out[0].Memory.ID != "neighbor-1" {
+		t.Errorf("expected neighbor memory ID 'neighbor-1', got %v", out[0].Memory)
+	}
+	if out[0].Strength != 0.8 {
+		t.Errorf("strength = %v, want 0.8", out[0].Strength)
+	}
+}
+
+func TestToConnectedMemories_IncomingRelationship(t *testing.T) {
+	// Relationship where TargetID == memID → direction = "incoming", neighborID = SourceID.
+	neighborMem := &types.Memory{ID: "source-1"}
+	rels := []types.Relationship{
+		{SourceID: "source-1", TargetID: "mem-1", RelType: "supports", Strength: 0.5},
+	}
+	neighborMap := map[string]*types.Memory{"source-1": neighborMem}
+
+	out := toConnectedMemories(rels, "mem-1", neighborMap)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 connected memory, got %d", len(out))
+	}
+	if out[0].Direction != "incoming" {
+		t.Errorf("direction = %q, want 'incoming'", out[0].Direction)
+	}
+	if out[0].Memory == nil || out[0].Memory.ID != "source-1" {
+		t.Errorf("expected source memory ID 'source-1', got %v", out[0].Memory)
+	}
+}
+
+func TestToConnectedMemories_NeighborMissing(t *testing.T) {
+	// Neighbor not in neighborMap → Memory field is nil (best-effort).
+	rels := []types.Relationship{
+		{SourceID: "mem-1", TargetID: "missing-1", RelType: "relates_to", Strength: 1.0},
+	}
+	neighborMap := map[string]*types.Memory{} // empty
+
+	out := toConnectedMemories(rels, "mem-1", neighborMap)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 result even for missing neighbor, got %d", len(out))
+	}
+	if out[0].Memory != nil {
+		t.Errorf("expected nil Memory for missing neighbor, got %v", out[0].Memory)
+	}
+}
+
+func TestToConnectedMemories_MixedDirections(t *testing.T) {
+	m1 := &types.Memory{ID: "out-neighbor"}
+	m2 := &types.Memory{ID: "in-source"}
+	rels := []types.Relationship{
+		{SourceID: "mem-1", TargetID: "out-neighbor", RelType: "r1", Strength: 1.0},
+		{SourceID: "in-source", TargetID: "mem-1", RelType: "r2", Strength: 0.9},
+	}
+	neighborMap := map[string]*types.Memory{
+		"out-neighbor": m1,
+		"in-source":    m2,
+	}
+
+	out := toConnectedMemories(rels, "mem-1", neighborMap)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 connected memories, got %d", len(out))
+	}
+
+	dirs := map[string]string{}
+	for _, c := range out {
+		if c.Memory != nil {
+			dirs[c.Memory.ID] = c.Direction
+		}
+	}
+	if dirs["out-neighbor"] != "outgoing" {
+		t.Errorf("out-neighbor direction = %q, want 'outgoing'", dirs["out-neighbor"])
+	}
+	if dirs["in-source"] != "incoming" {
+		t.Errorf("in-source direction = %q, want 'incoming'", dirs["in-source"])
+	}
+}


### PR DESCRIPTION
## Summary

- **WI-2** `internal/markdown/io_test.go`: tests for `ImportClaudeMD`, `Ingest`, `Dump`, `stripFrontMatter`, `splitSections` — package statement coverage 22.5% → **90.1%**
- **WI-3** `internal/search/engine_pure_test.go` (new file): pure-function tests for `bigramJaccard` (empty/single-char/identical/disjoint/partial/Unicode edge cases), `sortResults`, `toConnectedMemories` — all three functions at **94–100%** statement coverage
- **WI-6** `cmd/engram/main_test.go`: `envInt`, `envFloat`, `envBool`, `envDuration` helpers — all reach **100%** statement coverage; mirrors the cmd/instinct pattern
- **WI-7** `internal/ingest/chatgpt/findroot_internal_test.go` (new file): `findRoot` — single-node, multi-node, empty map, no-parentless-node, nil map, deep tree — **100%** statement coverage; `ParseFile` os.Open error path already covered by existing `TestParseFile_NotFound`

## Notes

- Tests only — no production code modified
- Lint: `golangci-lint run ./...` = 0 issues
- All 4 packages pass `go test -count=1`
- Needs 3-round review before merge per ai-generated policy

## Test plan

- [ ] `go test ./internal/markdown/... ./internal/search/... ./cmd/engram/... ./internal/ingest/chatgpt/... -count=1` passes
- [ ] `golangci-lint run ./...` = 0 issues
- [ ] Reviewer confirms no production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)