### PR TITLE
chore(recall): generalize hardcoded embed_timeout reason in handle-mode WARN + MCP response (#989)

### DIFF
--- a/internal/mcp/degradation_test.go
+++ b/internal/mcp/degradation_test.go
@@ -2,12 +2,14 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/claude"
 	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/require"
@@ -85,4 +87,95 @@ func TestHandleMemoryQueryDocument_DBErrorRaisesReviewPath(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "document db stalled")
+}
+
+// ── #989: handle-mode degradation reason must reflect actual cause ─────────────
+
+// immediateErrEmbedder is an embed.Client that always returns a hard error,
+// used to inject a deterministic "embed_error" degradation reason.
+type immediateErrEmbedder struct{}
+
+func (immediateErrEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, errors.New("embedder unavailable: hard error")
+}
+func (e immediateErrEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	v, err := e.Embed(ctx, text)
+	return v, e.Name(), err
+}
+func (immediateErrEmbedder) Name() string    { return "immediate-err-test" }
+func (immediateErrEmbedder) Dimensions() int { return 384 }
+
+var _ embed.Client = immediateErrEmbedder{}
+
+// newHandleModePoolWithFailingEmbed builds an EnginePool whose embedder always
+// returns a hard error, so every recall call degrades. Suitable for testing
+// the handle-mode degradation-reason path.
+func newHandleModePoolWithFailingEmbed(t *testing.T) *EnginePool {
+	t.Helper()
+	return NewEnginePool(func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, noopBackend{}, immediateErrEmbedder{}, project,
+			"", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	})
+}
+
+// TestHandleMode_DegradedReason_IsEmbedError verifies that when a hard embed
+// error triggers degradation in handle mode, the MCP response body contains
+// reason="embed_error" — not the previously hardcoded "embed_timeout" (#989).
+func TestHandleMode_DegradedReason_IsEmbedError(t *testing.T) {
+	pool := newHandleModePoolWithFailingEmbed(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "anything",
+		"mode":    "handle",
+	}
+	cfg := testConfig()
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	text, ok := res.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &body))
+
+	degraded, ok := body["degraded"].(map[string]any)
+	require.True(t, ok, "degraded field must be a map")
+	require.Equal(t, true, degraded["embed"],
+		"degraded.embed must be true when embedder fails")
+	require.Equal(t, "embed_error", degraded["reason"],
+		"handle-mode degraded.reason must be 'embed_error' on hard embed failure, not hardcoded 'embed_timeout' (#989)")
+}
+
+// TestHandleMode_DegradedReason_Nil_WhenNoDegrade verifies that when embed
+// succeeds in handle mode, the degraded field shows embed=false with no reason.
+func TestHandleMode_DegradedReason_Nil_WhenNoDegrade(t *testing.T) {
+	pool := newTestNoopPool(t) // noopEmbedder succeeds
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "anything",
+		"mode":    "handle",
+	}
+	cfg := testConfig()
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	text, ok := res.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &body))
+
+	degraded, ok := body["degraded"].(map[string]any)
+	require.True(t, ok, "degraded field must be present")
+	require.Equal(t, false, degraded["embed"],
+		"degraded.embed must be false when embed succeeds")
+	_, hasReason := degraded["reason"]
+	require.False(t, hasReason,
+		"degraded.reason must not be present when not degraded (#634/#989)")
 }

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -374,9 +374,11 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		opts.CurrentEpisodeID = id
 	}
 
-	// Capture embedder degradation signal from RecallWithOpts.
+	// Capture embedder degradation signal and reason from RecallWithOpts (#989).
 	var embedDegraded bool
+	var embedDegradeReason string
 	opts.EmbedDegraded = &embedDegraded
+	opts.EmbedDegradedReason = &embedDegradeReason
 
 	var results []types.SearchResult
 	var eventID string
@@ -421,10 +423,10 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			"handles":    search.ToHandles(results),
 			"count":      len(results),
 			"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
-			"degraded":   degradedMap(embedDegraded, "embed_timeout"),
+			"degraded":   degradedMap(embedDegraded, embedDegradeReason),
 		}
 		if embedDegraded {
-			addRecallDegradedWarning(out, cfg.RouterURL, "embed_timeout")
+			addRecallDegradedWarning(out, cfg.RouterURL, embedDegradeReason)
 		}
 		return toolResult(out)
 	}
@@ -446,7 +448,8 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	out["degraded"] = degradedMap(isDegraded, reason)
 	if isDegraded {
 		if reason == "" && embedDegraded {
-			reason = "embed_timeout"
+			// Use the actual degradation reason surfaced by the engine (#989).
+			reason = embedDegradeReason
 		}
 		addRecallDegradedWarning(out, cfg.RouterURL, reason)
 	}

--- a/internal/search/embed_deadline_test.go
+++ b/internal/search/embed_deadline_test.go
@@ -320,6 +320,71 @@ func TestNoDoubleCount_RecallWithOpts_MCPLayer(t *testing.T) {
 		"engram_recall_degraded_total{reason=embed_error} must increment exactly once (engine is sole owner)")
 }
 
+// ── #989: EmbedDegradedReason must reflect actual cause, not hardcoded string ──
+
+// TestEmbedDegradedReason_Timeout verifies that when the embed deadline fires,
+// RecallWithOpts populates EmbedDegradedReason with "embed_timeout" — not the
+// hardcoded literal that the MCP layer used to supply (#989).
+func TestEmbedDegradedReason_Timeout(t *testing.T) {
+	proj := uniqueProject("degraded-reason-timeout")
+	// Embedder blocks for 60s — far longer than the 500ms default deadline.
+	eng := newEngineWithEmbedder(t, proj, &blockingClient{dims: 768, holdFor: 60 * time.Second})
+
+	callerCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var degraded bool
+	var reason string
+	opts := search.RecallOpts{EmbedDegraded: &degraded, EmbedDegradedReason: &reason}
+	_, err := eng.RecallWithOpts(callerCtx, "test query", 5, "summary", opts)
+
+	require.NoError(t, err, "timeout degradation must not return an error")
+	require.True(t, degraded, "EmbedDegraded must be true on embed timeout")
+	require.Equal(t, "embed_timeout", reason,
+		"EmbedDegradedReason must be 'embed_timeout' when the embed deadline fires (#989)")
+}
+
+// TestEmbedDegradedReason_HardError verifies that when the embedder returns a
+// hard synchronous error (not a context cancellation), RecallWithOpts populates
+// EmbedDegradedReason with "embed_error" — allowing operators to distinguish
+// backend saturation from model crashes (#989).
+func TestEmbedDegradedReason_HardError(t *testing.T) {
+	proj := uniqueProject("degraded-reason-error")
+	eng := newEngineWithEmbedder(t, proj, &immediateErrorEmbedder{dims: 768})
+
+	callerCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var degraded bool
+	var reason string
+	opts := search.RecallOpts{EmbedDegraded: &degraded, EmbedDegradedReason: &reason}
+	_, err := eng.RecallWithOpts(callerCtx, "test query", 5, "summary", opts)
+
+	require.NoError(t, err, "hard embed error must degrade gracefully, not return error")
+	require.True(t, degraded, "EmbedDegraded must be true on hard embed error")
+	require.Equal(t, "embed_error", reason,
+		"EmbedDegradedReason must be 'embed_error' on hard embed failure, not 'embed_timeout' (#989)")
+}
+
+// TestEmbedDegradedReason_NoDegrade verifies that when the embed succeeds,
+// EmbedDegradedReason is left empty and EmbedDegraded is false.
+func TestEmbedDegradedReason_NoDegrade(t *testing.T) {
+	proj := uniqueProject("degraded-reason-nodeg")
+	eng := newEngineWithEmbedder(t, proj, &fakeClient{dims: 768})
+
+	callerCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var degraded bool
+	var reason string
+	opts := search.RecallOpts{EmbedDegraded: &degraded, EmbedDegradedReason: &reason}
+	_, err := eng.RecallWithOpts(callerCtx, "test query", 5, "summary", opts)
+
+	require.NoError(t, err)
+	require.False(t, degraded, "EmbedDegraded must be false when embed succeeds")
+	require.Empty(t, reason, "EmbedDegradedReason must be empty when embed succeeds (#989)")
+}
+
 // ── #973 Blocker 2: ENGRAM_EMBED_RECALL_TIMEOUT_MS=0 via New() ───────────────
 
 // TestEnvVarZero_DisablesDeadline_RecallWithOpts verifies that when

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -71,6 +71,12 @@ type RecallOpts struct {
 	// non-nil pointer. It is set to true if the embed operation timed out or
 	// returned an error, causing fallback to BM25+recency. Nil = do not populate.
 	EmbedDegraded *bool
+	// EmbedDegradedReason receives the actual degradation cause when a non-nil
+	// pointer is provided. Populated alongside EmbedDegraded; values are
+	// "embed_timeout" (the embed deadline fired) or "embed_error" (hard failure
+	// such as model crash or connection refused). Empty string when not degraded.
+	// Nil = do not populate. (#989)
+	EmbedDegradedReason *string
 	// DateSince and DateBefore scope retrieval by memory valid_from timestamps.
 	// Nil bounds leave that side unbounded.
 	DateSince  *time.Time
@@ -605,6 +611,7 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	defer embedCancel()
 	queryVec, err := e.getEmbedder().Embed(embedCtx, query)
 	embedDegraded := false
+	embedDegradeReason := ""
 	if err != nil {
 		// Distinguish a deadline-exceeded embed (backend saturated or slow) from a
 		// hard embed error (model crash, connection refused). Saturation is the
@@ -623,12 +630,17 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			"reason", degradeReason, "err", err)
 		queryVec = nil
 		embedDegraded = true
+		embedDegradeReason = degradeReason
 		metrics.RecallEmbedTimeoutTotal.Inc()
 		metrics.RecallDegradedTotal.WithLabelValues(degradeReason).Inc()
 	}
 	// Populate the caller's embed degradation signal if they provided a pointer.
 	if opts.EmbedDegraded != nil {
 		*opts.EmbedDegraded = embedDegraded
+	}
+	// Populate the caller's degradation reason if they provided a pointer (#989).
+	if opts.EmbedDegradedReason != nil {
+		*opts.EmbedDegradedReason = embedDegradeReason
 	}
 
 	// ANN vector search via pgvector HNSW index — skipped when embed degraded.


### PR DESCRIPTION
## Summary

- **#973** — Already satisfied by PR #988 (merged 2026-06-02). `SetEmbedRecallTimeout(0)` on `origin/main` correctly maps `0` to the `noEmbedTimeout` sentinel via the `else if ms == 0` branch added in #988. The CLI flag path (`main.go:380` calls `engine.SetEmbedRecallTimeout(*embedRecallTimeoutMS)`) passes `0` through unchanged, which is now handled correctly. No code change required.
- **#989** — Genuinely open. Three places in `tools_recall.go` hardcoded `"embed_timeout"` as the degradation reason in the handle-mode WARN log and MCP response body, even though the engine already computed the correct reason (`"embed_timeout"` vs `"embed_error"`). Fixed by threading the reason through `RecallOpts.EmbedDegradedReason`.

## Changes

- `internal/search/engine.go`: Add `EmbedDegradedReason *string` to `RecallOpts`; populate it in `RecallWithOpts` alongside the existing `EmbedDegraded` bool
- `internal/mcp/tools_recall.go`: Capture `EmbedDegradedReason` from opts; use the dynamic value in handle-mode `degradedMap`, `addRecallDegradedWarning`, and the non-handle-mode fallback (replaces 3 hardcoded `"embed_timeout"` literals)
- `internal/search/embed_deadline_test.go`: 3 new tests for `EmbedDegradedReason` (timeout reason, hard-error reason, no-degrade stays empty)
- `internal/mcp/degradation_test.go`: 2 new integration tests verifying the handle-mode response carries the dynamic reason

## Verification

- `go build -buildvcs=false ./...` — clean
- `go test -buildvcs=false ./cmd/engram/... ./internal/search/... ./internal/mcp/... -count=1 -race` — all pass
- `golangci-lint run ./internal/search/... ./internal/mcp/... ./cmd/engram/...` — 0 issues

## Review

3-round adversarial review required per AI-PR policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)