### PR TITLE
fix(embed): hygiene — ollama read cap, pool-reset metric, max-tokens default, GPU-hang gate doc (#928 #931 #933 #934)

### DIFF
--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -518,10 +518,10 @@ func InfinityQueueCheck(ctx context.Context, httpClient *http.Client, baseURL st
 
 	for _, m := range modelsResp.Data {
 		s := m.Stats
-		// All three conditions required to avoid false positives:
-		// - QueueFraction > 1 alone can occur during normal burst load
-		// - ResultsPending == 0 with QueueFraction > 1 is the definitive hang
-		// - QueueAbsolute > 0 guards against zero-value structs (non-Infinity servers)
+		// GPU hang: ResultsPending == 0 means the GPU has stopped processing entirely
+		// (queue drained with no output). High-load cases where ResultsPending > 0
+		// are intentionally NOT flagged — backpressure without stall is normal.
+		// See TestInfinityQueueCheck_HighLoadNotHung (litellm_test.go).
 		if s.QueueFraction > 1.0 && s.ResultsPending == 0 && s.QueueAbsolute > 0 {
 			return false, fmt.Sprintf(
 				"infinity_queue_check: GPU thread hung (model=%s queue_fraction=%.4f results_pending=%d queue_absolute=%d)",

--- a/internal/embed/models.go
+++ b/internal/embed/models.go
@@ -11,7 +11,7 @@ type ModelSpec struct {
 }
 
 // defaultModelMaxTokens is the safe fallback for unknown models.
-const defaultModelMaxTokens = 512
+const defaultModelMaxTokens = 8192
 
 // ModelMaxTokens returns the context window limit for the named model.
 // Falls back to defaultModelMaxTokens for unknown model names.

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -255,7 +255,7 @@ func (c *OllamaClient) pullModel(ctx context.Context) error {
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		return fmt.Errorf("ollama pull: HTTP %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/embed/truncate_test.go
+++ b/internal/embed/truncate_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 // TestModelMaxTokensKnownModels verifies that the curated models have correct
-// max-token values — mxbai-embed-large and nomic-embed-text cap at 512 tokens.
+// max-token values — mxbai-embed-large and nomic-embed-text cap at 512 tokens;
+// unrecognised short names fall through to the default (8192 for bge-m3 era).
 func TestModelMaxTokensKnownModels(t *testing.T) {
 	cases := []struct {
 		model string
@@ -15,7 +16,9 @@ func TestModelMaxTokensKnownModels(t *testing.T) {
 	}{
 		{"mxbai-embed-large", 512},
 		{"nomic-embed-text", 512},
-		{"bge-m3", 512},
+		// "bge-m3" is not a registered name (SuggestedModels uses "BAAI/bge-m3");
+		// it falls through to defaultModelMaxTokens, which is 8192 since #933.
+		{"bge-m3", 8192},
 	}
 	for _, tc := range cases {
 		t.Run(tc.model, func(t *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,6 +30,13 @@ var (
 		Help: "Background worker error count",
 	}, []string{"worker"})
 
+	// WorkerPoolResets counts the number of times the embed worker pool has been reset.
+	// A pool reset closes stale connections after repeated errors (e.g. Postgres restart).
+	WorkerPoolResets = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "engram_worker_pool_resets_total",
+		Help: "Number of times the embed worker pool has been reset.",
+	}, []string{"worker"})
+
 	// ChunksPendingReembed is the current number of chunks with NULL embedding_vec.
 	ChunksPendingReembed = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "engram_chunks_pending_reembed",
@@ -195,6 +202,7 @@ func init() {
 		ToolDuration,
 		WorkerTicks,
 		WorkerErrors,
+		WorkerPoolResets,
 		ChunksPendingReembed,
 		IngestQueueDepth,
 		EpisodesStartedTotal,

--- a/internal/reembed/global_worker.go
+++ b/internal/reembed/global_worker.go
@@ -146,6 +146,7 @@ func (g *GlobalReembedder) run(ctx context.Context) {
 						slog.Warn("global reembedder: resetting pool after repeated errors — possible Postgres restart",
 							"consecutive_errors", consecutive)
 						g.pool.Reset()
+						metrics.WorkerPoolResets.WithLabelValues("global_reembed").Inc()
 					}
 					break
 				}


### PR DESCRIPTION
## Summary

Closes #928, #931, #933, #934.

- **#928** — Cap Ollama HTTP response read to guard against unbounded allocations on large model outputs.
- **#931** — Add `pool_reset_total` Prometheus metric to surface embed-pool reset events for observability.
- **#933** — Raise default `max_tokens` for embed calls; prior value was undersized for large context requests.
- **#934** — Comment-only clarification: documents the GPU-hang detection gate in the embed health-check path. No logic change.

## Notes

- #934 is a **comment-only** change — no runtime behaviour altered.
- All four issues are independent embed-layer hygiene items; grouped for review efficiency.
- Tests pass locally (`go test ./... -count=1 -race` green on all affected packages).

## Review needed

This PR requires a **3-round adversarial review** (correctness → coverage → structural) per the `ai-generated` label policy before merge. Do NOT merge without completing the review sweep.