### PR TITLE
fix(embed): background probe recovers stuck-open circuit breaker (#1000)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -320,6 +320,15 @@ func run() error {
 		liteLLMClient.StartBackgroundProbe(ctx, *embedCircuitOpenDuration)
 		slog.Info("embed circuit breaker background probe started",
 			"interval", *embedCircuitOpenDuration)
+	} else {
+		// If the embed client is ever wrapped or swapped, the background probe
+		// silently would not start and circuit-breaker recovery would again
+		// depend entirely on demand traffic — the exact 18-hour stuck-open
+		// failure #1000 fixes. Log loudly so this regression is never silent.
+		slog.Warn("embed circuit breaker background probe NOT started: "+
+			"embed client is not *embed.LiteLLMClient — recovery from an OPEN "+
+			"circuit will depend on demand-path traffic only (#1000)",
+			"embed_client_type", fmt.Sprintf("%T", embedClient))
 	}
 
 	dsn := *databaseURL

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -306,6 +306,22 @@ func run() error {
 		slog.Info("LiteLLM embedding verified at startup", "dims", len(probeVec), "model_id", probeModelID)
 	}
 
+	// Wire background probe goroutine so the circuit breaker can recover from
+	// an Open state independently of query load (#1000).  A just-restarted GPU
+	// answers GET /v1/models (used by Probe) well within 5 s even when
+	// embeddings take longer than the 500 ms recall budget, breaking the
+	// ping-pong loop that kept the breaker open for 18+ hours.
+	//
+	// The probe runs on the server root context (ctx) so it stops on SIGTERM.
+	// The interval is set to the circuit OpenDuration so at most one tick
+	// fires per backoff window — we do not probe faster than the breaker
+	// is configured to allow demand-driven probes.
+	if liteLLMClient, ok := embedClient.(*embed.LiteLLMClient); ok {
+		liteLLMClient.StartBackgroundProbe(ctx, *embedCircuitOpenDuration)
+		slog.Info("embed circuit breaker background probe started",
+			"interval", *embedCircuitOpenDuration)
+	}
+
 	dsn := *databaseURL
 	routerURLVal := *routerURL
 	sumModel := *summarizeModel

--- a/internal/embed/background_probe_test.go
+++ b/internal/embed/background_probe_test.go
@@ -2,11 +2,13 @@ package embed
 
 // background_probe_test.go — deterministic tests for StartBackgroundProbe.
 //
-// Design notes:
-//   - No real time.Sleep; all timing is controlled via the injected cb.now func.
-//   - Probe behaviour is controlled via a stubbed probeFunc injected through
-//     runProbeLoop (a test helper that mirrors the production loop logic).
-//   - Goroutine-leak safety is verified via a done-channel / WaitGroup pattern.
+// Design:
+//   - Tests drive the REAL StartBackgroundProbe loop (no mirror helper). The
+//     loop's probe call is injected via the unexported probeFunc field so no
+//     network is needed.
+//   - Synchronization uses channels signaled by the probe stub — never
+//     time.Sleep as an ordering barrier. The only timed constructs are
+//     bounded negative-assertion guards (proving an event does NOT happen).
 //   - All tests are safe under -race.
 
 import (
@@ -17,57 +19,28 @@ import (
 	"time"
 )
 
-// runProbeLoop is the deterministic core of the background probe logic used
-// in tests. It mirrors StartBackgroundProbe but accepts an explicit tick
-// channel and probeFunc so tests can drive each tick deterministically.
-//
-// Returns a done channel that closes when the loop exits (context cancelled).
-func runProbeLoop(
-	ctx context.Context,
-	cb *CircuitBreaker,
-	probeTimeout time.Duration,
-	tick <-chan time.Time,
-	probeFunc func(ctx context.Context) (bool, string),
-) <-chan struct{} {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-tick:
-				// Mirror production StartBackgroundProbe: only probe when Open,
-				// then gate through Allow() for the Open->HalfOpen transition,
-				// nextProbeAt enforcement, and probeInFlight guard.
-				if cb.State() != StateOpen {
-					continue
-				}
-				if err := cb.Allow(); err != nil {
-					continue
-				}
-
-				// Run probe with a dedicated timeout context.
-				probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-				ok, _ := probeFunc(probeCtx)
-				cancel()
-
-				if ok {
-					cb.RecordSuccess()
-				} else {
-					cb.RecordFailure()
-				}
-			}
-		}
-	}()
-	return done
+// newProbeTestClient builds a LiteLLMClient with a circuit breaker and an
+// injectable probe stub, plus a controllable injected clock.
+func newProbeTestClient(t *testing.T, cfg CircuitConfig, now func() time.Time, probe func(context.Context) (bool, string)) *LiteLLMClient {
+	t.Helper()
+	c := NewLiteLLMClientNoProbeWithCircuitBreaker("http://127.0.0.1:1", "test-model", "", 0, cfg)
+	c.cb.now = now
+	c.probeFunc = probe
+	return c
 }
 
-// makeOpenBreaker creates a circuit breaker already in StateOpen with
-// nextProbeAt in the past (using the injected now func).
-func makeOpenBreaker(t *testing.T, now func() time.Time) *CircuitBreaker {
-	t.Helper()
-	cfg := CircuitConfig{
+// forceOpen drives the breaker directly into StateOpen with nextProbeAt in the
+// past (relative to the injected clock) so the next probe fires immediately.
+func forceOpen(cb *CircuitBreaker, now time.Time) {
+	cb.mu.Lock()
+	cb.state = StateOpen
+	cb.consecutiveOpens = 1
+	cb.nextProbeAt = now.Add(-1 * time.Second)
+	cb.mu.Unlock()
+}
+
+func defaultCfg() CircuitConfig {
+	return CircuitConfig{
 		Enabled:           true,
 		FailureThreshold:  1,
 		FailureWindow:     30 * time.Second,
@@ -75,50 +48,38 @@ func makeOpenBreaker(t *testing.T, now func() time.Time) *CircuitBreaker {
 		BackoffMultiplier: 2.0,
 		BackoffCap:        5 * time.Minute,
 	}
-	cb := NewCircuitBreaker(cfg)
-	cb.now = now
-	// Force Open state directly.
-	cb.mu.Lock()
-	cb.state = StateOpen
-	cb.consecutiveOpens = 1
-	// Set nextProbeAt 1 second in the past so the probe fires immediately.
-	cb.nextProbeAt = now().Add(-1 * time.Second)
-	cb.mu.Unlock()
-	return cb
 }
 
-// TestBackgroundProbe_OpenSucceeds verifies:
-//
-//	Open breaker + now past nextProbeAt + probe success → transitions to Closed,
-//	failures cleared, consecutiveOpens reset.
+// TestBackgroundProbe_OpenSucceeds: Open + past nextProbeAt + probe success ->
+// Closed, failures cleared, consecutiveOpens reset.
 func TestBackgroundProbe_OpenSucceeds(t *testing.T) {
 	fixedNow := time.Now()
-	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+	probed := make(chan struct{}, 1)
+	c := newProbeTestClient(t, defaultCfg(), func() time.Time { return fixedNow },
+		func(context.Context) (bool, string) {
+			probed <- struct{}{}
+			return true, ""
+		})
+	forceOpen(c.cb, fixedNow)
 
-	probeFunc := func(_ context.Context) (bool, string) { return true, "" }
-	tick := make(chan time.Time, 1)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+	c.StartBackgroundProbe(ctx, time.Millisecond)
 
-	// Fire one tick.
-	tick <- fixedNow
-
-	// Wait long enough for the goroutine to process.
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-	<-done
-
-	if got := cb.State(); got != StateClosed {
-		t.Errorf("expected StateClosed after successful probe, got %v", got)
+	// Wait for the probe to actually run (channel barrier, not a sleep).
+	select {
+	case <-probed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe never ran")
 	}
 
-	cb.mu.Lock()
-	co := cb.consecutiveOpens
-	fl := len(cb.failures)
-	cb.mu.Unlock()
+	// Wait for the breaker to reach Closed (RecordSuccess runs after probe).
+	waitForState(t, c.cb, StateClosed, 2*time.Second)
+	cancel()
 
+	c.cb.mu.Lock()
+	co, fl := c.cb.consecutiveOpens, len(c.cb.failures)
+	c.cb.mu.Unlock()
 	if co != 0 {
 		t.Errorf("consecutiveOpens = %d, want 0", co)
 	}
@@ -127,40 +88,59 @@ func TestBackgroundProbe_OpenSucceeds(t *testing.T) {
 	}
 }
 
-// TestBackgroundProbe_OpenFails verifies:
-//
-//	Open breaker + probe fails -> stays Open, consecutiveOpens++, nextProbeAt advances.
+// TestBackgroundProbe_OpenFails: Open + probe fails -> stays Open,
+// consecutiveOpens++, nextProbeAt advances.
 func TestBackgroundProbe_OpenFails(t *testing.T) {
 	fixedNow := time.Now()
-	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+	probed := make(chan struct{}, 1)
+	c := newProbeTestClient(t, defaultCfg(), func() time.Time { return fixedNow },
+		func(context.Context) (bool, string) {
+			probed <- struct{}{}
+			return false, "connection refused"
+		})
+	forceOpen(c.cb, fixedNow)
 
-	// Capture initial nextProbeAt.
-	cb.mu.Lock()
-	initialNextProbeAt := cb.nextProbeAt
-	initialConsecutiveOpens := cb.consecutiveOpens
-	cb.mu.Unlock()
+	c.cb.mu.Lock()
+	initialNextProbeAt := c.cb.nextProbeAt
+	initialConsecutiveOpens := c.cb.consecutiveOpens
+	c.cb.mu.Unlock()
 
-	probeFunc := func(_ context.Context) (bool, string) { return false, "connection refused" }
-	tick := make(chan time.Time, 1)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+	c.StartBackgroundProbe(ctx, time.Millisecond)
 
-	tick <- fixedNow
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-	<-done
-
-	if got := cb.State(); got != StateOpen {
-		t.Errorf("expected StateOpen after failed probe, got %v", got)
+	select {
+	case <-probed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe never ran")
 	}
+	// After a failed probe the breaker re-opens. Wait for that transition by
+	// polling for consecutiveOpens to advance (RecordFailure runs after probe).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c.cb.mu.Lock()
+		co := c.cb.consecutiveOpens
+		st := c.cb.state
+		c.cb.mu.Unlock()
+		if co > initialConsecutiveOpens && st == StateOpen {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("breaker did not re-open: state=%v consecutiveOpens=%d", st, co)
+		}
+		runtimeYield()
+	}
+	cancel()
 
-	cb.mu.Lock()
-	newConsecutiveOpens := cb.consecutiveOpens
-	newNextProbeAt := cb.nextProbeAt
-	cb.mu.Unlock()
+	c.cb.mu.Lock()
+	newConsecutiveOpens := c.cb.consecutiveOpens
+	newNextProbeAt := c.cb.nextProbeAt
+	st := c.cb.state
+	c.cb.mu.Unlock()
 
+	if st != StateOpen {
+		t.Errorf("expected StateOpen after failed probe, got %v", st)
+	}
 	if newConsecutiveOpens <= initialConsecutiveOpens {
 		t.Errorf("consecutiveOpens did not increase: before=%d after=%d", initialConsecutiveOpens, newConsecutiveOpens)
 	}
@@ -169,240 +149,355 @@ func TestBackgroundProbe_OpenFails(t *testing.T) {
 	}
 }
 
-// TestBackgroundProbe_ClosedIsNoOp verifies:
-//
-//	When breaker is Closed, background tick does NOT call the probe func.
+// TestBackgroundProbe_ClosedIsNoOp: when Closed, ticks never call the probe.
 func TestBackgroundProbe_ClosedIsNoOp(t *testing.T) {
 	fixedNow := time.Now()
-	cfg := CircuitConfig{
-		Enabled:           true,
-		FailureThreshold:  5,
-		FailureWindow:     30 * time.Second,
-		OpenDuration:      10 * time.Second,
-		BackoffMultiplier: 2.0,
-		BackoffCap:        5 * time.Minute,
-	}
-	cb := NewCircuitBreaker(cfg)
-	cb.now = func() time.Time { return fixedNow }
-
-	// Confirm state is Closed.
-	if cb.State() != StateClosed {
-		t.Fatalf("expected StateClosed, got %v", cb.State())
-	}
-
 	var probeCalled atomic.Int64
-	probeFunc := func(_ context.Context) (bool, string) {
-		probeCalled.Add(1)
-		return true, ""
+	cfg := defaultCfg()
+	cfg.FailureThreshold = 5
+	c := newProbeTestClient(t, cfg, func() time.Time { return fixedNow },
+		func(context.Context) (bool, string) {
+			probeCalled.Add(1)
+			return true, ""
+		})
+	// Leave breaker in its default Closed state.
+	if c.cb.State() != StateClosed {
+		t.Fatalf("expected StateClosed, got %v", c.cb.State())
 	}
-	tick := make(chan time.Time, 3)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+	// Fast interval so many ticks fire during the observation window.
+	c.StartBackgroundProbe(ctx, time.Millisecond)
 
-	// Send three ticks -- none should invoke probeFunc because state is Closed.
-	tick <- fixedNow
-	tick <- fixedNow
-	tick <- fixedNow
-	time.Sleep(50 * time.Millisecond)
+	// Negative assertion: over a bounded window with many ticks, the probe must
+	// never be called on a Closed breaker. The window is a guard, not an
+	// ordering barrier — a single missed probe would still be caught given the
+	// 1ms interval fires ~100+ times here.
+	time.Sleep(120 * time.Millisecond)
 	cancel()
-	<-done
 
 	if n := probeCalled.Load(); n != 0 {
 		t.Errorf("probe was called %d times on a Closed breaker, want 0", n)
 	}
 }
 
-// TestBackgroundProbe_ContextCancelExits verifies:
-//
-//	Cancelling the context causes the goroutine to exit cleanly (no leak).
+// TestBackgroundProbe_ContextCancelExits: cancelling ctx exits the goroutine.
 func TestBackgroundProbe_ContextCancelExits(t *testing.T) {
 	fixedNow := time.Now()
-	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+	probeEntered := make(chan struct{}, 1)
+	c := newProbeTestClient(t, defaultCfg(), func() time.Time { return fixedNow },
+		func(pctx context.Context) (bool, string) {
+			select {
+			case probeEntered <- struct{}{}:
+			default:
+			}
+			<-pctx.Done() // block until the probe context is cancelled
+			return false, "cancelled"
+		})
+	forceOpen(c.cb, fixedNow)
 
-	probeFunc := func(ctx context.Context) (bool, string) {
-		// Block until context cancelled.
-		<-ctx.Done()
-		return false, "cancelled"
-	}
-	tick := make(chan time.Time)
-
+	// Track goroutine completion via a wrapper: StartBackgroundProbe does not
+	// expose a done channel, so we assert exit indirectly — after cancel, a
+	// subsequent probe must never fire. We confirm the loop was running first.
 	ctx, cancel := context.WithCancel(context.Background())
-	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
-
-	// Cancel immediately -- no ticks needed.
-	cancel()
+	c.StartBackgroundProbe(ctx, time.Millisecond)
 
 	select {
-	case <-done:
-		// Good: goroutine exited.
+	case <-probeEntered:
 	case <-time.After(2 * time.Second):
-		t.Fatal("goroutine did not exit within 2s after context cancel")
+		t.Fatal("probe loop never started")
+	}
+
+	// Cancel: this cancels the probe context (unblocking the stub) and the loop.
+	cancel()
+
+	// After cancel, drain probeEntered and assert no NEW probe starts within a
+	// bounded guard window. If the goroutine leaked, a 1ms ticker would refire.
+	// First probe re-opened the breaker via RecordFailure (ctx.Err guard path
+	// or probe-fail path), so a leaked loop would re-enter.
+	time.Sleep(80 * time.Millisecond)
+	select {
+	case <-probeEntered:
+		t.Fatal("probe fired after context cancel — goroutine leaked")
+	default:
 	}
 }
 
-// TestBackgroundProbe_OnlyOneProbeInFlight verifies:
-//
-//	probeInFlight flag prevents concurrent probes; second tick while first
-//	probe is running is a no-op.
+// TestBackgroundProbe_OnlyOneProbeInFlight: a second tick while a probe is in
+// flight is a no-op (probeInFlight respected).
 func TestBackgroundProbe_OnlyOneProbeInFlight(t *testing.T) {
 	fixedNow := time.Now()
-	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
-
 	var probeCalled atomic.Int64
-	// Block the first probe call until we've sent the second tick.
-	firstProbeStarted := make(chan struct{}, 1)
-	firstProbeUnblock := make(chan struct{})
+	firstStarted := make(chan struct{}, 1)
+	unblock := make(chan struct{})
+	c := newProbeTestClient(t, defaultCfg(), func() time.Time { return fixedNow },
+		func(pctx context.Context) (bool, string) {
+			probeCalled.Add(1)
+			select {
+			case firstStarted <- struct{}{}:
+			default:
+			}
+			select {
+			case <-unblock:
+			case <-pctx.Done():
+			}
+			return true, ""
+		})
+	forceOpen(c.cb, fixedNow)
 
-	probeFunc := func(ctx context.Context) (bool, string) {
-		probeCalled.Add(1)
-		select {
-		case firstProbeStarted <- struct{}{}:
-		default:
-		}
-		select {
-		case <-firstProbeUnblock:
-		case <-ctx.Done():
-		}
-		return true, ""
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// 1ms interval: many ticks fire while the first probe is blocked.
+	c.StartBackgroundProbe(ctx, time.Millisecond)
+
+	// Wait for the first probe to start and block.
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first probe never started")
 	}
 
-	tick := make(chan time.Time, 2)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
-
-	// Fire first tick -- probe will block.
-	tick <- fixedNow
-	<-firstProbeStarted
-
-	// Fire second tick while first probe is in flight.
-	tick <- fixedNow
-	time.Sleep(30 * time.Millisecond)
-
-	// Unblock the first probe.
-	close(firstProbeUnblock)
+	// Let many ticks fire while the first probe holds the slot. Because the
+	// breaker is HalfOpen with probeInFlight=true, AllowProbe rejects them all.
 	time.Sleep(50 * time.Millisecond)
-	cancel()
-	<-done
 
-	// Only one probe should have run (second tick was a no-op due to probeInFlight).
+	// Exactly one probe should have run so far.
 	if n := probeCalled.Load(); n != 1 {
-		t.Errorf("probe called %d times, want exactly 1", n)
+		t.Errorf("probe called %d times while one in flight, want exactly 1", n)
+	}
+
+	// Release; the probe succeeds and the breaker closes. No further probe runs
+	// because a Closed breaker is a no-op.
+	close(unblock)
+	waitForState(t, c.cb, StateClosed, 2*time.Second)
+	cancel()
+}
+
+// TestBackgroundProbe_NeverProbesClosedUnderRace is the regression guard for the
+// TOCTOU BLOCKER (#1000 review finding #1). The original loop used a two-step
+// gate — `State() == Open` then `Allow()` — across two separate lock
+// acquisitions. Between them a concurrent path could drive the breaker to
+// Closed, after which the second-step Allow() returns nil on Closed and the
+// loop fires a SPURIOUS probe against a healthy upstream (verified: a buggy
+// two-step gate grants on Closed dozens of times under this hammering).
+//
+// AllowProbe() decides atomically under a single lock and returns errCircuitOpen
+// for Closed, so it must NEVER grant a probe on a Closed breaker — no matter how
+// a demand-path Allow() interleaves. We drive the breaker Open<->Closed rapidly
+// while many goroutines call AllowProbe() (background) and Allow() (demand)
+// concurrently, and assert AllowProbe never granted a slot while Closed.
+func TestBackgroundProbe_NeverProbesClosedUnderRace(t *testing.T) {
+	fixedNow := time.Now()
+	cfg := defaultCfg()
+	cb := NewCircuitBreaker(cfg)
+	cb.now = func() time.Time { return fixedNow }
+
+	var probeGrants atomic.Int64        // AllowProbe() returned nil
+	var probeGrantsOnClosed atomic.Int64 // ...and breaker was Closed at grant time (the bug)
+
+	runProbeGate := func() {
+		if err := cb.AllowProbe(); err != nil {
+			return
+		}
+		probeGrants.Add(1)
+		cb.mu.Lock()
+		spurious := cb.state == StateClosed
+		cb.mu.Unlock()
+		if spurious {
+			probeGrantsOnClosed.Add(1)
+		}
+		cb.RecordSuccess() // closes HalfOpen, releases the slot
+	}
+	// Demand path: Allow() granting on Closed is a normal embed, not a probe, so
+	// it is fine. We run it purely to create the interleaving pressure.
+	runDemandGate := func() {
+		if err := cb.Allow(); err != nil {
+			return
+		}
+		cb.RecordSuccess()
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Driver flips the breaker Open<->Closed to maximize the TOCTOU window. It
+	// only mutates while no probe slot is held, so it never stomps an in-flight
+	// probe.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			cb.mu.Lock()
+			if !cb.probeInFlight {
+				if cb.state == StateClosed {
+					cb.state = StateOpen
+					cb.consecutiveOpens = 1
+					cb.nextProbeAt = fixedNow.Add(-1 * time.Second)
+				} else {
+					cb.state = StateClosed
+				}
+			}
+			cb.mu.Unlock()
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20000; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				runProbeGate()
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20000; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				runDemandGate()
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if n := probeGrantsOnClosed.Load(); n != 0 {
+		t.Fatalf("AllowProbe granted a probe on a Closed breaker %d times — TOCTOU spurious-probe race is OPEN", n)
+	}
+	// Vacuity guard: the test must have actually granted probes, otherwise the
+	// assertion above could never fail.
+	if probeGrants.Load() == 0 {
+		t.Fatal("no probe was ever granted — test is vacuous")
 	}
 }
 
-// TestBackgroundProbe_ConcurrentSafe verifies that the probe loop and the
-// circuit breaker's Allow/RecordFailure paths are race-free under -race.
+// TestBackgroundProbe_PanicSafe verifies a panicking probe does not wedge the
+// breaker: the slot is released (RecordFailure runs) and the loop keeps going.
+func TestBackgroundProbe_PanicSafe(t *testing.T) {
+	fixedNow := time.Now()
+	var calls atomic.Int64
+	recovered := make(chan struct{}, 1)
+	c := newProbeTestClient(t, defaultCfg(), func() time.Time { return fixedNow },
+		func(context.Context) (bool, string) {
+			n := calls.Add(1)
+			if n == 1 {
+				panic("simulated probe panic")
+			}
+			select {
+			case recovered <- struct{}{}:
+			default:
+			}
+			return false, "after panic"
+		})
+	forceOpen(c.cb, fixedNow)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.StartBackgroundProbe(ctx, time.Millisecond)
+
+	// The first probe panics; the deferred recover records a failure (releasing
+	// the slot). The breaker re-opens, nextProbeAt advances by backoff. To let
+	// a second probe fire we must move the clock past the new nextProbeAt.
+	// Wait for the panic to be handled first (breaker leaves probeInFlight).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c.cb.mu.Lock()
+		pif := c.cb.probeInFlight
+		c.cb.mu.Unlock()
+		if !pif && calls.Load() >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("breaker stayed wedged (probeInFlight) after probe panic")
+		}
+		runtimeYield()
+	}
+	cancel()
+	// Success criterion: the breaker was not wedged — probeInFlight cleared and
+	// at least one probe ran. (A wedged breaker would fail the loop above.)
+	if calls.Load() < 1 {
+		t.Fatal("probe never ran")
+	}
+}
+
+// TestBackgroundProbe_ConcurrentSafe exercises the loop and breaker paths
+// concurrently under -race.
 func TestBackgroundProbe_ConcurrentSafe(t *testing.T) {
 	fixedNow := time.Now()
 	cfg := CircuitConfig{
 		Enabled:           true,
 		FailureThreshold:  3,
 		FailureWindow:     30 * time.Second,
-		OpenDuration:      1 * time.Second,
+		OpenDuration:      time.Millisecond,
 		BackoffMultiplier: 1.5,
-		BackoffCap:        10 * time.Second,
+		BackoffCap:        10 * time.Millisecond,
 	}
-	cb := NewCircuitBreaker(cfg)
-
-	// Drive now forward so nextProbeAt is periodically past.
-	var nowOffset atomic.Int64
-	cb.now = func() time.Time { return fixedNow.Add(time.Duration(nowOffset.Load())) }
-
-	// Alternate probe success/fail.
 	var probeCount atomic.Int64
-	probeFunc := func(_ context.Context) (bool, string) {
-		n := probeCount.Add(1)
-		if n%2 == 0 {
-			return true, ""
-		}
-		return false, "simulated fail"
-	}
+	c := newProbeTestClient(t, cfg, func() time.Time { return fixedNow },
+		func(context.Context) (bool, string) {
+			n := probeCount.Add(1)
+			return n%2 == 0, "x"
+		})
+	forceOpen(c.cb, fixedNow)
 
-	tick := make(chan time.Time, 32)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
+	c.StartBackgroundProbe(ctx, time.Millisecond)
 
-	done := runProbeLoop(ctx, cb, 100*time.Millisecond, tick, probeFunc)
-
-	// Concurrent Allow/RecordFailure goroutines.
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 50; j++ {
-				if err := cb.Allow(); err == nil {
-					cb.RecordFailure()
+			for j := 0; j < 200; j++ {
+				if err := c.cb.Allow(); err == nil {
+					c.cb.RecordFailure()
 				}
-				nowOffset.Add(int64(100 * time.Millisecond))
 			}
 		}()
 	}
-
-	// Concurrently send ticks.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 200; i++ {
-			select {
-			case tick <- fixedNow:
-			default:
-			}
-			nowOffset.Add(int64(50 * time.Millisecond))
-			time.Sleep(time.Millisecond)
-		}
-	}()
-
 	wg.Wait()
-	cancel()
-	<-done
-	// No assertion on final state -- test passes if -race detects no races.
+	<-ctx.Done()
+	// Passes if -race reports no data races.
 }
 
-// TestStartBackgroundProbe_IntegrationSmoke verifies the exported method
-// StartBackgroundProbe on a real *LiteLLMClient (no network), exercising
-// the lifecycle wiring at the method level.
-func TestStartBackgroundProbe_IntegrationSmoke(t *testing.T) {
-	// Build a LiteLLMClient with a circuit breaker but no real HTTP server.
-	cbCfg := CircuitConfig{
-		Enabled:           true,
-		FailureThreshold:  1,
-		FailureWindow:     30 * time.Second,
-		OpenDuration:      10 * time.Second,
-		BackoffMultiplier: 2.0,
-		BackoffCap:        5 * time.Minute,
+// waitForState polls the breaker until it reaches want or the deadline passes.
+func waitForState(t *testing.T, cb *CircuitBreaker, want CircuitState, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if cb.State() == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("breaker did not reach %v within %v (current %v)", want, within, cb.State())
+		}
+		runtimeYield()
 	}
-	c := NewLiteLLMClientNoProbeWithCircuitBreaker("http://127.0.0.1:1", "test-model", "", 0, cbCfg)
+}
 
-	fixedNow := time.Now()
-	c.cb.now = func() time.Time { return fixedNow }
-
-	// Force breaker Open with nextProbeAt in the past.
-	c.cb.mu.Lock()
-	c.cb.state = StateOpen
-	c.cb.consecutiveOpens = 1
-	c.cb.nextProbeAt = fixedNow.Add(-1 * time.Second)
-	c.cb.mu.Unlock()
-
-	// Start the background probe with a short interval.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	// StartBackgroundProbe is the production method under test.
-	// If it does not exist yet, compilation fails (TDD red phase).
-	c.StartBackgroundProbe(ctx, 10*time.Millisecond)
-
-	// Give the goroutine time to run at least one probe cycle.
-	// The real probe will fail (no server at 127.0.0.1:1) -- that's acceptable;
-	// we're testing that the method exists, starts without panic, and the
-	// goroutine exits cleanly when ctx is cancelled.
-	time.Sleep(150 * time.Millisecond)
-	cancel()
-
-	// Allow time for goroutine exit.
-	time.Sleep(50 * time.Millisecond)
-	// Test passes if no panic and no deadlock.
+// runtimeYield yields the scheduler without a meaningful wall-clock delay; used
+// only to widen race windows and avoid busy-spin starvation, never as an
+// ordering barrier for correctness assertions.
+func runtimeYield() {
+	time.Sleep(time.Microsecond)
 }

--- a/internal/embed/background_probe_test.go
+++ b/internal/embed/background_probe_test.go
@@ -1,0 +1,408 @@
+package embed
+
+// background_probe_test.go — deterministic tests for StartBackgroundProbe.
+//
+// Design notes:
+//   - No real time.Sleep; all timing is controlled via the injected cb.now func.
+//   - Probe behaviour is controlled via a stubbed probeFunc injected through
+//     runProbeLoop (a test helper that mirrors the production loop logic).
+//   - Goroutine-leak safety is verified via a done-channel / WaitGroup pattern.
+//   - All tests are safe under -race.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// runProbeLoop is the deterministic core of the background probe logic used
+// in tests. It mirrors StartBackgroundProbe but accepts an explicit tick
+// channel and probeFunc so tests can drive each tick deterministically.
+//
+// Returns a done channel that closes when the loop exits (context cancelled).
+func runProbeLoop(
+	ctx context.Context,
+	cb *CircuitBreaker,
+	probeTimeout time.Duration,
+	tick <-chan time.Time,
+	probeFunc func(ctx context.Context) (bool, string),
+) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick:
+				// Mirror production StartBackgroundProbe: only probe when Open,
+				// then gate through Allow() for the Open->HalfOpen transition,
+				// nextProbeAt enforcement, and probeInFlight guard.
+				if cb.State() != StateOpen {
+					continue
+				}
+				if err := cb.Allow(); err != nil {
+					continue
+				}
+
+				// Run probe with a dedicated timeout context.
+				probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+				ok, _ := probeFunc(probeCtx)
+				cancel()
+
+				if ok {
+					cb.RecordSuccess()
+				} else {
+					cb.RecordFailure()
+				}
+			}
+		}
+	}()
+	return done
+}
+
+// makeOpenBreaker creates a circuit breaker already in StateOpen with
+// nextProbeAt in the past (using the injected now func).
+func makeOpenBreaker(t *testing.T, now func() time.Time) *CircuitBreaker {
+	t.Helper()
+	cfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  1,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      10 * time.Second,
+		BackoffMultiplier: 2.0,
+		BackoffCap:        5 * time.Minute,
+	}
+	cb := NewCircuitBreaker(cfg)
+	cb.now = now
+	// Force Open state directly.
+	cb.mu.Lock()
+	cb.state = StateOpen
+	cb.consecutiveOpens = 1
+	// Set nextProbeAt 1 second in the past so the probe fires immediately.
+	cb.nextProbeAt = now().Add(-1 * time.Second)
+	cb.mu.Unlock()
+	return cb
+}
+
+// TestBackgroundProbe_OpenSucceeds verifies:
+//
+//	Open breaker + now past nextProbeAt + probe success → transitions to Closed,
+//	failures cleared, consecutiveOpens reset.
+func TestBackgroundProbe_OpenSucceeds(t *testing.T) {
+	fixedNow := time.Now()
+	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+
+	probeFunc := func(_ context.Context) (bool, string) { return true, "" }
+	tick := make(chan time.Time, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+
+	// Fire one tick.
+	tick <- fixedNow
+
+	// Wait long enough for the goroutine to process.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := cb.State(); got != StateClosed {
+		t.Errorf("expected StateClosed after successful probe, got %v", got)
+	}
+
+	cb.mu.Lock()
+	co := cb.consecutiveOpens
+	fl := len(cb.failures)
+	cb.mu.Unlock()
+
+	if co != 0 {
+		t.Errorf("consecutiveOpens = %d, want 0", co)
+	}
+	if fl != 0 {
+		t.Errorf("failures len = %d, want 0", fl)
+	}
+}
+
+// TestBackgroundProbe_OpenFails verifies:
+//
+//	Open breaker + probe fails -> stays Open, consecutiveOpens++, nextProbeAt advances.
+func TestBackgroundProbe_OpenFails(t *testing.T) {
+	fixedNow := time.Now()
+	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+
+	// Capture initial nextProbeAt.
+	cb.mu.Lock()
+	initialNextProbeAt := cb.nextProbeAt
+	initialConsecutiveOpens := cb.consecutiveOpens
+	cb.mu.Unlock()
+
+	probeFunc := func(_ context.Context) (bool, string) { return false, "connection refused" }
+	tick := make(chan time.Time, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+
+	tick <- fixedNow
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := cb.State(); got != StateOpen {
+		t.Errorf("expected StateOpen after failed probe, got %v", got)
+	}
+
+	cb.mu.Lock()
+	newConsecutiveOpens := cb.consecutiveOpens
+	newNextProbeAt := cb.nextProbeAt
+	cb.mu.Unlock()
+
+	if newConsecutiveOpens <= initialConsecutiveOpens {
+		t.Errorf("consecutiveOpens did not increase: before=%d after=%d", initialConsecutiveOpens, newConsecutiveOpens)
+	}
+	if !newNextProbeAt.After(initialNextProbeAt) {
+		t.Errorf("nextProbeAt did not advance: before=%v after=%v", initialNextProbeAt, newNextProbeAt)
+	}
+}
+
+// TestBackgroundProbe_ClosedIsNoOp verifies:
+//
+//	When breaker is Closed, background tick does NOT call the probe func.
+func TestBackgroundProbe_ClosedIsNoOp(t *testing.T) {
+	fixedNow := time.Now()
+	cfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  5,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      10 * time.Second,
+		BackoffMultiplier: 2.0,
+		BackoffCap:        5 * time.Minute,
+	}
+	cb := NewCircuitBreaker(cfg)
+	cb.now = func() time.Time { return fixedNow }
+
+	// Confirm state is Closed.
+	if cb.State() != StateClosed {
+		t.Fatalf("expected StateClosed, got %v", cb.State())
+	}
+
+	var probeCalled atomic.Int64
+	probeFunc := func(_ context.Context) (bool, string) {
+		probeCalled.Add(1)
+		return true, ""
+	}
+	tick := make(chan time.Time, 3)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+
+	// Send three ticks -- none should invoke probeFunc because state is Closed.
+	tick <- fixedNow
+	tick <- fixedNow
+	tick <- fixedNow
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if n := probeCalled.Load(); n != 0 {
+		t.Errorf("probe was called %d times on a Closed breaker, want 0", n)
+	}
+}
+
+// TestBackgroundProbe_ContextCancelExits verifies:
+//
+//	Cancelling the context causes the goroutine to exit cleanly (no leak).
+func TestBackgroundProbe_ContextCancelExits(t *testing.T) {
+	fixedNow := time.Now()
+	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+
+	probeFunc := func(ctx context.Context) (bool, string) {
+		// Block until context cancelled.
+		<-ctx.Done()
+		return false, "cancelled"
+	}
+	tick := make(chan time.Time)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+
+	// Cancel immediately -- no ticks needed.
+	cancel()
+
+	select {
+	case <-done:
+		// Good: goroutine exited.
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit within 2s after context cancel")
+	}
+}
+
+// TestBackgroundProbe_OnlyOneProbeInFlight verifies:
+//
+//	probeInFlight flag prevents concurrent probes; second tick while first
+//	probe is running is a no-op.
+func TestBackgroundProbe_OnlyOneProbeInFlight(t *testing.T) {
+	fixedNow := time.Now()
+	cb := makeOpenBreaker(t, func() time.Time { return fixedNow })
+
+	var probeCalled atomic.Int64
+	// Block the first probe call until we've sent the second tick.
+	firstProbeStarted := make(chan struct{}, 1)
+	firstProbeUnblock := make(chan struct{})
+
+	probeFunc := func(ctx context.Context) (bool, string) {
+		probeCalled.Add(1)
+		select {
+		case firstProbeStarted <- struct{}{}:
+		default:
+		}
+		select {
+		case <-firstProbeUnblock:
+		case <-ctx.Done():
+		}
+		return true, ""
+	}
+
+	tick := make(chan time.Time, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := runProbeLoop(ctx, cb, 5*time.Second, tick, probeFunc)
+
+	// Fire first tick -- probe will block.
+	tick <- fixedNow
+	<-firstProbeStarted
+
+	// Fire second tick while first probe is in flight.
+	tick <- fixedNow
+	time.Sleep(30 * time.Millisecond)
+
+	// Unblock the first probe.
+	close(firstProbeUnblock)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Only one probe should have run (second tick was a no-op due to probeInFlight).
+	if n := probeCalled.Load(); n != 1 {
+		t.Errorf("probe called %d times, want exactly 1", n)
+	}
+}
+
+// TestBackgroundProbe_ConcurrentSafe verifies that the probe loop and the
+// circuit breaker's Allow/RecordFailure paths are race-free under -race.
+func TestBackgroundProbe_ConcurrentSafe(t *testing.T) {
+	fixedNow := time.Now()
+	cfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  3,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      1 * time.Second,
+		BackoffMultiplier: 1.5,
+		BackoffCap:        10 * time.Second,
+	}
+	cb := NewCircuitBreaker(cfg)
+
+	// Drive now forward so nextProbeAt is periodically past.
+	var nowOffset atomic.Int64
+	cb.now = func() time.Time { return fixedNow.Add(time.Duration(nowOffset.Load())) }
+
+	// Alternate probe success/fail.
+	var probeCount atomic.Int64
+	probeFunc := func(_ context.Context) (bool, string) {
+		n := probeCount.Add(1)
+		if n%2 == 0 {
+			return true, ""
+		}
+		return false, "simulated fail"
+	}
+
+	tick := make(chan time.Time, 32)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := runProbeLoop(ctx, cb, 100*time.Millisecond, tick, probeFunc)
+
+	// Concurrent Allow/RecordFailure goroutines.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if err := cb.Allow(); err == nil {
+					cb.RecordFailure()
+				}
+				nowOffset.Add(int64(100 * time.Millisecond))
+			}
+		}()
+	}
+
+	// Concurrently send ticks.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			select {
+			case tick <- fixedNow:
+			default:
+			}
+			nowOffset.Add(int64(50 * time.Millisecond))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+	cancel()
+	<-done
+	// No assertion on final state -- test passes if -race detects no races.
+}
+
+// TestStartBackgroundProbe_IntegrationSmoke verifies the exported method
+// StartBackgroundProbe on a real *LiteLLMClient (no network), exercising
+// the lifecycle wiring at the method level.
+func TestStartBackgroundProbe_IntegrationSmoke(t *testing.T) {
+	// Build a LiteLLMClient with a circuit breaker but no real HTTP server.
+	cbCfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  1,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      10 * time.Second,
+		BackoffMultiplier: 2.0,
+		BackoffCap:        5 * time.Minute,
+	}
+	c := NewLiteLLMClientNoProbeWithCircuitBreaker("http://127.0.0.1:1", "test-model", "", 0, cbCfg)
+
+	fixedNow := time.Now()
+	c.cb.now = func() time.Time { return fixedNow }
+
+	// Force breaker Open with nextProbeAt in the past.
+	c.cb.mu.Lock()
+	c.cb.state = StateOpen
+	c.cb.consecutiveOpens = 1
+	c.cb.nextProbeAt = fixedNow.Add(-1 * time.Second)
+	c.cb.mu.Unlock()
+
+	// Start the background probe with a short interval.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// StartBackgroundProbe is the production method under test.
+	// If it does not exist yet, compilation fails (TDD red phase).
+	c.StartBackgroundProbe(ctx, 10*time.Millisecond)
+
+	// Give the goroutine time to run at least one probe cycle.
+	// The real probe will fail (no server at 127.0.0.1:1) -- that's acceptable;
+	// we're testing that the method exists, starts without panic, and the
+	// goroutine exits cleanly when ctx is cancelled.
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	// Allow time for goroutine exit.
+	time.Sleep(50 * time.Millisecond)
+	// Test passes if no panic and no deadlock.
+}

--- a/internal/embed/background_probe_test.go
+++ b/internal/embed/background_probe_test.go
@@ -274,43 +274,98 @@ func TestBackgroundProbe_OnlyOneProbeInFlight(t *testing.T) {
 	cancel()
 }
 
-// TestBackgroundProbe_NeverProbesClosedUnderRace is the regression guard for the
-// TOCTOU BLOCKER (#1000 review finding #1). The original loop used a two-step
-// gate — `State() == Open` then `Allow()` — across two separate lock
-// acquisitions. Between them a concurrent path could drive the breaker to
-// Closed, after which the second-step Allow() returns nil on Closed and the
-// loop fires a SPURIOUS probe against a healthy upstream (verified: a buggy
-// two-step gate grants on Closed dozens of times under this hammering).
+// TestAllowProbe_NeverGrantsOnClosed is the DETERMINISTIC contract guard for the
+// TOCTOU BLOCKER (#1000 review finding #1): AllowProbe() must never return nil
+// when the breaker is Closed at the instant of the call. Because AllowProbe
+// decides atomically under a single lock, we can prove this single-threaded —
+// no concurrent post-read (which would itself be racy) is needed.
 //
-// AllowProbe() decides atomically under a single lock and returns errCircuitOpen
-// for Closed, so it must NEVER grant a probe on a Closed breaker — no matter how
-// a demand-path Allow() interleaves. We drive the breaker Open<->Closed rapidly
-// while many goroutines call AllowProbe() (background) and Allow() (demand)
-// concurrently, and assert AllowProbe never granted a slot while Closed.
-func TestBackgroundProbe_NeverProbesClosedUnderRace(t *testing.T) {
+// We also demonstrate, in the same deterministic frame, that the ORIGINAL buggy
+// two-step gate (State()==Open then Allow()) WOULD grant a probe on a Closed
+// breaker when the two steps straddle a transition — so this guard is not
+// vacuous: it distinguishes the correct atomic path from the bug it replaced.
+func TestAllowProbe_NeverGrantsOnClosed(t *testing.T) {
 	fixedNow := time.Now()
 	cfg := defaultCfg()
 	cb := NewCircuitBreaker(cfg)
 	cb.now = func() time.Time { return fixedNow }
 
-	var probeGrants atomic.Int64        // AllowProbe() returned nil
-	var probeGrantsOnClosed atomic.Int64 // ...and breaker was Closed at grant time (the bug)
+	// 1) Closed breaker: AllowProbe denies, atomically, every time.
+	if cb.State() != StateClosed {
+		t.Fatalf("expected Closed, got %v", cb.State())
+	}
+	for i := 0; i < 100; i++ {
+		if err := cb.AllowProbe(); err != errCircuitOpen {
+			t.Fatalf("AllowProbe on Closed = %v, want errCircuitOpen (iter %d)", err, i)
+		}
+		if cb.State() != StateClosed {
+			t.Fatalf("AllowProbe perturbed Closed state -> %v (iter %d)", cb.State(), i)
+		}
+	}
+
+	// 2) Non-vacuity: the bug AllowProbe replaced is the two-step gate. Reproduce
+	//    the exact straddle deterministically — read Open, transition to Closed,
+	//    then the buggy second step (Allow on Closed) returns nil = spurious grant.
+	cb.mu.Lock()
+	cb.state = StateOpen
+	cb.consecutiveOpens = 1
+	cb.nextProbeAt = fixedNow.Add(-1 * time.Second)
+	cb.mu.Unlock()
+
+	buggyStateRead := cb.State() // reads Open (step 1 of the buggy gate)
+	if buggyStateRead != StateOpen {
+		t.Fatalf("setup: expected Open, got %v", buggyStateRead)
+	}
+	// A concurrent path drives the breaker Closed between the two steps.
+	cb.mu.Lock()
+	cb.state = StateClosed
+	cb.probeInFlight = false
+	cb.mu.Unlock()
+	// Buggy step 2: Allow() on the now-Closed breaker returns nil — a SPURIOUS
+	// probe grant against a healthy upstream. This is exactly what the old loop
+	// did and what AllowProbe fixes.
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("buggy two-step proof broken: Allow on Closed = %v, want nil", err)
+	}
+	// And AllowProbe, given the identical Closed state, would NOT have granted:
+	cb.mu.Lock()
+	cb.state = StateClosed
+	cb.probeInFlight = false
+	cb.mu.Unlock()
+	if err := cb.AllowProbe(); err != errCircuitOpen {
+		t.Fatalf("AllowProbe on Closed = %v, want errCircuitOpen — bug present", err)
+	}
+}
+
+// TestAllowProbe_ConcurrentNoRaceStillGrants is the concurrency guard. It runs
+// AllowProbe() (background) and Allow() (demand) against the breaker from many
+// goroutines while a driver flips it Open<->Closed, and asserts only two things:
+//   - the run is data-race clean (the value of this test is under `-race`), and
+//   - legitimate Open-state probes are still granted (probeGrants > 0), so the
+//     concurrent path is exercised, not starved.
+//
+// Crucially it does NOT attempt a "was the breaker Closed at grant time"
+// post-read: that determination cannot be made atomically with the grant from
+// outside the breaker, so a separate-lock read after AllowProbe returns is
+// inherently racy and produces false positives. The Closed-grant contract is
+// proven deterministically in TestAllowProbe_NeverGrantsOnClosed instead.
+func TestAllowProbe_ConcurrentNoRaceStillGrants(t *testing.T) {
+	fixedNow := time.Now()
+	cfg := defaultCfg()
+	cb := NewCircuitBreaker(cfg)
+	cb.now = func() time.Time { return fixedNow }
+
+	var probeGrants atomic.Int64
 
 	runProbeGate := func() {
 		if err := cb.AllowProbe(); err != nil {
 			return
 		}
 		probeGrants.Add(1)
-		cb.mu.Lock()
-		spurious := cb.state == StateClosed
-		cb.mu.Unlock()
-		if spurious {
-			probeGrantsOnClosed.Add(1)
-		}
-		cb.RecordSuccess() // closes HalfOpen, releases the slot
+		// Release the slot the real way. No post-read of state here — that would
+		// be racy (see doc comment).
+		cb.RecordSuccess()
 	}
-	// Demand path: Allow() granting on Closed is a normal embed, not a probe, so
-	// it is fine. We run it purely to create the interleaving pressure.
 	runDemandGate := func() {
 		if err := cb.Allow(); err != nil {
 			return
@@ -321,9 +376,8 @@ func TestBackgroundProbe_NeverProbesClosedUnderRace(t *testing.T) {
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
 
-	// Driver flips the breaker Open<->Closed to maximize the TOCTOU window. It
-	// only mutates while no probe slot is held, so it never stomps an in-flight
-	// probe.
+	// Driver flips Open<->Closed only while no probe slot is held, so it never
+	// stomps an in-flight probe.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -380,13 +434,8 @@ func TestBackgroundProbe_NeverProbesClosedUnderRace(t *testing.T) {
 	close(stop)
 	wg.Wait()
 
-	if n := probeGrantsOnClosed.Load(); n != 0 {
-		t.Fatalf("AllowProbe granted a probe on a Closed breaker %d times — TOCTOU spurious-probe race is OPEN", n)
-	}
-	// Vacuity guard: the test must have actually granted probes, otherwise the
-	// assertion above could never fail.
 	if probeGrants.Load() == 0 {
-		t.Fatal("no probe was ever granted — test is vacuous")
+		t.Fatal("no probe was ever granted under concurrency — path starved/vacuous")
 	}
 }
 

--- a/internal/embed/circuit_breaker.go
+++ b/internal/embed/circuit_breaker.go
@@ -104,6 +104,56 @@ func (cb *CircuitBreaker) Allow() error {
 	return errCircuitOpen
 }
 
+// AllowProbe is the background-recovery counterpart to Allow. It atomically
+// decides whether the caller may run a recovery probe, returning nil only when
+// the circuit is degraded and a probe slot is available:
+//
+//   - Closed: returns errCircuitOpen — a healthy circuit needs no background
+//     probe (this is what makes a Closed-state tick a no-op).
+//   - Open and past nextProbeAt: transitions to HalfOpen, claims the probe
+//     slot, returns nil.
+//   - Open within the backoff window: returns errCircuitOpen.
+//   - HalfOpen with no probe in flight: claims the probe slot, returns nil.
+//   - HalfOpen with a probe already in flight: returns errCircuitOpen.
+//
+// Unlike Allow, AllowProbe never returns nil for a Closed circuit. This single
+// lock acquisition replaces the racy State()+Allow() two-step in the background
+// probe loop, eliminating the TOCTOU window where a demand-path Allow could
+// interleave and trigger a second concurrent probe.
+func (cb *CircuitBreaker) AllowProbe() error {
+	if !cb.cfg.Enabled {
+		return errCircuitOpen
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := cb.now()
+
+	switch cb.state {
+	case StateClosed:
+		// Healthy: no background probe needed.
+		return errCircuitOpen
+
+	case StateOpen:
+		if now.After(cb.nextProbeAt) {
+			cb.transitionTo(StateHalfOpen)
+			cb.probeInFlight = true
+			return nil
+		}
+		return errCircuitOpen
+
+	case StateHalfOpen:
+		if cb.probeInFlight {
+			return errCircuitOpen
+		}
+		cb.probeInFlight = true
+		return nil
+	}
+
+	return errCircuitOpen
+}
+
 // RecordSuccess records a successful request. Transitions to Closed if in HalfOpen.
 func (cb *CircuitBreaker) RecordSuccess() {
 	if !cb.cfg.Enabled {
@@ -152,18 +202,22 @@ func (cb *CircuitBreaker) RecordFailure() {
 	if len(cb.failures) >= cb.cfg.FailureThreshold {
 		switch cb.state {
 		case StateClosed:
-			// Transition to Open
-			cb.transitionTo(StateOpen)
+			// Compute backoff state BEFORE transitionTo so the OPEN log line
+			// reports the freshly-computed next_probe_at rather than a stale
+			// (here: zero) value (#1000 review).
 			cb.openedAt = now
 			cb.consecutiveOpens = 1
 			cb.updateNextProbeTime()
+			cb.transitionTo(StateOpen)
 
 		case StateHalfOpen:
-			// Probe failed; reopen with exponential backoff
-			cb.transitionTo(StateOpen)
+			// Probe failed; reopen with exponential backoff. Compute backoff
+			// state BEFORE transitionTo so the OPEN log reports the fresh
+			// next_probe_at (#1000 review).
 			cb.openedAt = now
 			cb.consecutiveOpens++
 			cb.updateNextProbeTime()
+			cb.transitionTo(StateOpen)
 			cb.failures = make([]time.Time, 0) // reset window
 		}
 	}

--- a/internal/embed/circuit_breaker.go
+++ b/internal/embed/circuit_breaker.go
@@ -31,6 +31,12 @@ func (s CircuitState) String() string {
 
 var errCircuitOpen = errors.New("circuit breaker is open")
 
+// errProbeDisabled is returned by AllowProbe when circuit breaking is
+// disabled (cfg.Enabled == false). It is distinct from errCircuitOpen so the
+// "feature off" case is not conflated with "circuit currently open". The
+// background-probe loop discards the specific error; this is for clarity.
+var errProbeDisabled = errors.New("circuit breaker probing disabled")
+
 // CircuitConfig holds configuration for the circuit breaker.
 type CircuitConfig struct {
 	Enabled           bool
@@ -122,7 +128,7 @@ func (cb *CircuitBreaker) Allow() error {
 // interleave and trigger a second concurrent probe.
 func (cb *CircuitBreaker) AllowProbe() error {
 	if !cb.cfg.Enabled {
-		return errCircuitOpen
+		return errProbeDisabled
 	}
 
 	cb.mu.Lock()

--- a/internal/embed/circuit_breaker_log_test.go
+++ b/internal/embed/circuit_breaker_log_test.go
@@ -2,9 +2,11 @@ package embed
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestCircuitBreaker_LogsTransitions — #676: every state transition produces
@@ -48,6 +50,67 @@ func TestCircuitBreaker_LogsTransitions(t *testing.T) {
 	cb.transitionTo(StateClosed)
 	if buf.Len() != 0 {
 		t.Errorf("same-state transition should be silent; got: %s", buf.String())
+	}
+}
+
+// TestCircuitBreaker_OpenLogReportsFreshNextProbeAt is the regression guard for
+// #1000 review finding #4: RecordFailure must compute updateNextProbeTime()
+// BEFORE transitionTo(StateOpen) so the OPEN log line reports the freshly
+// computed next_probe_at, not a stale/zero value.
+func TestCircuitBreaker_OpenLogReportsFreshNextProbeAt(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	fixedNow := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	cfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  1,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      30 * time.Second,
+		BackoffMultiplier: 2.0,
+		BackoffCap:        5 * time.Minute,
+	}
+	cb := NewCircuitBreaker(cfg)
+	cb.now = func() time.Time { return fixedNow }
+
+	// Closed -> Open via RecordFailure (the real path).
+	cb.Allow()
+	cb.RecordFailure()
+
+	// Parse the OPEN log line and assert next_probe_at == now + OpenDuration,
+	// i.e. the fresh value — not the zero time the stale ordering would log.
+	var sawOpen bool
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		msg, _ := rec["msg"].(string)
+		if !strings.HasPrefix(msg, "embed circuit breaker OPEN") {
+			continue
+		}
+		sawOpen = true
+		npa, _ := rec["next_probe_at"].(string)
+		if npa == "" {
+			t.Fatalf("OPEN log missing next_probe_at; line: %s", line)
+		}
+		got, err := time.Parse(time.RFC3339, npa)
+		if err != nil {
+			t.Fatalf("next_probe_at not RFC3339: %q (%v)", npa, err)
+		}
+		want := fixedNow.Add(cfg.OpenDuration)
+		if !got.Equal(want) {
+			t.Errorf("OPEN log next_probe_at = %v, want fresh %v (stale-ordering bug logs zero time)", got, want)
+		}
+		// Explicitly reject the stale zero-time value.
+		if got.IsZero() {
+			t.Error("OPEN log next_probe_at is the zero time — stale-ordering bug present")
+		}
+	}
+	if !sawOpen {
+		t.Fatalf("no OPEN log line emitted; buffer: %s", buf.String())
 	}
 }
 

--- a/internal/embed/circuit_breaker_test.go
+++ b/internal/embed/circuit_breaker_test.go
@@ -431,3 +431,92 @@ func TestCircuitBreakerHalfOpenOnlyAllowsOneProbe(t *testing.T) {
 		t.Errorf("expected Allow to succeed after probe complete, got %v", err)
 	}
 }
+
+// TestAllowProbe_ClosedReturnsError verifies the core difference between
+// AllowProbe and Allow: AllowProbe never grants a probe on a healthy (Closed)
+// circuit, so a background tick is a no-op when nothing is wrong (#1000).
+func TestAllowProbe_ClosedReturnsError(t *testing.T) {
+	cfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  5,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      30 * time.Second,
+		BackoffMultiplier: 2.0,
+		BackoffCap:        5 * time.Minute,
+	}
+	cb := NewCircuitBreaker(cfg)
+
+	if cb.State() != StateClosed {
+		t.Fatalf("expected Closed, got %v", cb.State())
+	}
+	if err := cb.AllowProbe(); err != errCircuitOpen {
+		t.Errorf("AllowProbe on Closed = %v, want errCircuitOpen", err)
+	}
+	// Allow, by contrast, grants on Closed.
+	if err := cb.Allow(); err != nil {
+		t.Errorf("Allow on Closed = %v, want nil", err)
+	}
+}
+
+// TestAllowProbe_OpenTransitionsHalfOpen verifies AllowProbe drives the same
+// Open->HalfOpen transition as Allow and enforces nextProbeAt + one-probe.
+func TestAllowProbe_OpenTransitionsHalfOpen(t *testing.T) {
+	now := time.Now()
+	cfg := CircuitConfig{
+		Enabled:           true,
+		FailureThreshold:  1,
+		FailureWindow:     30 * time.Second,
+		OpenDuration:      10 * time.Second,
+		BackoffMultiplier: 2.0,
+		BackoffCap:        5 * time.Minute,
+	}
+	cb := NewCircuitBreaker(cfg)
+	cb.now = func() time.Time { return now }
+
+	// Force Open with nextProbeAt in the future: within backoff, AllowProbe denies.
+	cb.mu.Lock()
+	cb.state = StateOpen
+	cb.consecutiveOpens = 1
+	cb.nextProbeAt = now.Add(10 * time.Second)
+	cb.mu.Unlock()
+	if err := cb.AllowProbe(); err != errCircuitOpen {
+		t.Errorf("AllowProbe within backoff = %v, want errCircuitOpen", err)
+	}
+	if cb.State() != StateOpen {
+		t.Errorf("state changed during denied probe: %v", cb.State())
+	}
+
+	// Move past nextProbeAt: AllowProbe grants and transitions to HalfOpen.
+	cb.mu.Lock()
+	cb.nextProbeAt = now.Add(-1 * time.Second)
+	cb.mu.Unlock()
+	if err := cb.AllowProbe(); err != nil {
+		t.Fatalf("AllowProbe past nextProbeAt = %v, want nil", err)
+	}
+	if cb.State() != StateHalfOpen {
+		t.Errorf("expected HalfOpen after AllowProbe, got %v", cb.State())
+	}
+
+	// Second AllowProbe while a probe is in flight is denied.
+	if err := cb.AllowProbe(); err != errCircuitOpen {
+		t.Errorf("second AllowProbe in HalfOpen = %v, want errCircuitOpen", err)
+	}
+
+	// After RecordSuccess (slot released, breaker Closed), AllowProbe denies again.
+	cb.RecordSuccess()
+	if cb.State() != StateClosed {
+		t.Fatalf("expected Closed after RecordSuccess, got %v", cb.State())
+	}
+	if err := cb.AllowProbe(); err != errCircuitOpen {
+		t.Errorf("AllowProbe after recovery (Closed) = %v, want errCircuitOpen", err)
+	}
+}
+
+// TestAllowProbe_DisabledReturnsError verifies a disabled breaker never grants
+// a background probe (no point probing when circuit breaking is off).
+func TestAllowProbe_DisabledReturnsError(t *testing.T) {
+	cb := NewCircuitBreaker(CircuitConfig{Enabled: false})
+	if err := cb.AllowProbe(); err != errCircuitOpen {
+		t.Errorf("AllowProbe when disabled = %v, want errCircuitOpen", err)
+	}
+}

--- a/internal/embed/circuit_breaker_test.go
+++ b/internal/embed/circuit_breaker_test.go
@@ -516,7 +516,7 @@ func TestAllowProbe_OpenTransitionsHalfOpen(t *testing.T) {
 // a background probe (no point probing when circuit breaking is off).
 func TestAllowProbe_DisabledReturnsError(t *testing.T) {
 	cb := NewCircuitBreaker(CircuitConfig{Enabled: false})
-	if err := cb.AllowProbe(); err != errCircuitOpen {
-		t.Errorf("AllowProbe when disabled = %v, want errCircuitOpen", err)
+	if err := cb.AllowProbe(); err != errProbeDisabled {
+		t.Errorf("AllowProbe when disabled = %v, want errProbeDisabled", err)
 	}
 }

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -470,6 +470,60 @@ func (c *LiteLLMClient) Probe(ctx context.Context) (ok bool, reason string) {
 	return false, fmt.Sprintf("embed_probe: model %q not advertised by /v1/models", c.model)
 }
 
+// StartBackgroundProbe launches a goroutine that periodically probes the
+// LiteLLM endpoint when the circuit breaker is Open and past its nextProbeAt
+// cooldown.  This decouples recovery from query load — the probe uses a
+// dedicated 5 s timeout instead of the 500 ms recall budget, so a warming
+// MI50 GPU can answer the lightweight GET /v1/models check even when it cannot
+// serve embeddings within the recall deadline.
+//
+// The goroutine exits when ctx is cancelled (wire to the server root context
+// so it stops on shutdown).  interval controls the ticker period; callers
+// should use a value on the order of the OpenDuration config (e.g., 10 s).
+//
+// No-op when the client has no circuit breaker configured.
+func (c *LiteLLMClient) StartBackgroundProbe(ctx context.Context, interval time.Duration) {
+	if c.cb == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		const probeTimeout = 5 * time.Second
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// Only fire when Open. This prevents unnecessary probe calls during
+				// normal (Closed) operation and avoids perturbing the HalfOpen
+				// state from a previous demand-driven Allow() call.
+				if c.cb.State() != StateOpen {
+					continue
+				}
+				// Allow() handles the Open→HalfOpen transition, enforces
+				// nextProbeAt, and guards the one-probe-at-a-time invariant.
+				if err := c.cb.Allow(); err != nil {
+					// Not ready: probeInFlight or still within backoff window.
+					continue
+				}
+
+				// Run the cheap GET /v1/models probe with a dedicated timeout
+				// that is independent of the recall budget.
+				probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+				ok, _ := c.Probe(probeCtx)
+				cancel()
+
+				if ok {
+					c.cb.RecordSuccess()
+				} else {
+					c.cb.RecordFailure()
+				}
+			}
+		}
+	}()
+}
+
 // InfinityModelStats holds per-model GPU queue statistics from the Infinity
 // /v1/models response. These fields are Infinity-specific and absent from
 // standard OpenAI-compatible servers (zero value is safe: QueueAbsolute == 0

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -564,8 +564,10 @@ func (c *LiteLLMClient) runProbe(ctx context.Context, probeTimeout time.Duration
 		probe = c.Probe
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	// Deferred so the timeout context is released even if record() panics; the
+	// recover() defer above still runs (defers are LIFO, both fire). #1000 review.
+	defer cancel()
 	ok, _ := probe(probeCtx)
-	cancel()
 	record(ok)
 }
 

--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"math/rand"
 	"net"
@@ -30,6 +31,10 @@ type LiteLLMClient struct {
 	targetDims int
 	http       *http.Client
 	cb         *CircuitBreaker
+	// probeFunc performs the recovery health check. Defaults to c.Probe (a
+	// real GET /v1/models). Overridable in tests so the background-probe loop
+	// can be driven deterministically without a network or wall-clock sleeps.
+	probeFunc func(ctx context.Context) (ok bool, reason string)
 }
 
 // newLiteLLMHTTPClient builds a *http.Client for the LiteLLM/olla endpoint.
@@ -495,33 +500,73 @@ func (c *LiteLLMClient) StartBackgroundProbe(ctx context.Context, interval time.
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				// Only fire when Open. This prevents unnecessary probe calls during
-				// normal (Closed) operation and avoids perturbing the HalfOpen
-				// state from a previous demand-driven Allow() call.
-				if c.cb.State() != StateOpen {
-					continue
+				// Guard shutdown BEFORE claiming a probe slot: if ctx is already
+				// cancelled, deriving a probe context from it would fail
+				// immediately and record a spurious failure that inflates
+				// backoff on the way down. Checking first means we neither claim
+				// the slot nor record anything — we just exit. Mirrors the
+				// EmbedWithModel ctx guard. #1000 review.
+				if ctx.Err() != nil {
+					return
 				}
-				// Allow() handles the Open→HalfOpen transition, enforces
-				// nextProbeAt, and guards the one-probe-at-a-time invariant.
-				if err := c.cb.Allow(); err != nil {
-					// Not ready: probeInFlight or still within backoff window.
+
+				// AllowProbe() makes the whole decision atomically under one
+				// lock: it returns nil only when the circuit is degraded (Open
+				// past cooldown, or HalfOpen with a free slot) and claims the
+				// probe slot in the same critical section. This closes the
+				// TOCTOU window a State()+Allow() two-step would open, where a
+				// demand-path Allow could interleave and launch a second probe.
+				if err := c.cb.AllowProbe(); err != nil {
+					// Not degraded, within backoff, or a probe is already in
+					// flight. Nothing to do this tick.
 					continue
 				}
 
-				// Run the cheap GET /v1/models probe with a dedicated timeout
-				// that is independent of the recall budget.
-				probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-				ok, _ := c.Probe(probeCtx)
-				cancel()
-
-				if ok {
-					c.cb.RecordSuccess()
-				} else {
-					c.cb.RecordFailure()
-				}
+				// runProbe isolates the probe call so a panic can never leave
+				// the breaker wedged in HalfOpen with probeInFlight=true: the
+				// deferred recover guarantees exactly one of
+				// RecordSuccess/RecordFailure runs. #1000 review.
+				c.runProbe(ctx, probeTimeout)
 			}
 		}
 	}()
+}
+
+// runProbe executes a single background recovery probe and records the result
+// on the circuit breaker. It is panic-safe: if c.Probe panics, the deferred
+// recover records a failure so the probe slot (probeInFlight) is always
+// released and the breaker cannot wedge in HalfOpen.
+func (c *LiteLLMClient) runProbe(ctx context.Context, probeTimeout time.Duration) {
+	recorded := false
+	record := func(ok bool) {
+		if recorded {
+			return
+		}
+		recorded = true
+		if ok {
+			c.cb.RecordSuccess()
+		} else {
+			c.cb.RecordFailure()
+		}
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("embed background probe panicked — recording failure", "panic", r)
+			record(false)
+		}
+	}()
+
+	// Run the cheap GET /v1/models probe with a dedicated timeout that is
+	// independent of the recall budget. probeFunc defaults to c.Probe; tests
+	// override it to drive this real loop deterministically.
+	probe := c.probeFunc
+	if probe == nil {
+		probe = c.Probe
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	ok, _ := probe(probeCtx)
+	cancel()
+	record(ok)
 }
 
 // InfinityModelStats holds per-model GPU queue statistics from the Infinity


### PR DESCRIPTION
## Problem
The embed circuit breaker (`internal/embed/circuit_breaker.go`) sat OPEN on all 3 engram-go replicas for ~18h (since 2026-06-01 ~13:50 UTC). Every `memory_recall` silently fell back to BM25 + recency — no vector similarity — surfacing as `degraded.embed: true` / `reason: embed_timeout`.

## Root cause
The three-state breaker's half-open recovery was **demand-driven**: it only transitioned Open→HalfOpen when a live recall arrived, and that path runs under a 500ms timeout (`internal/search/engine.go`). A just-restarted/warming MI50 embed backend (`precision:8007`, bge-m3 on llama.cpp/ROCm gfx906) answers slower than 500ms, so each probe embed timed out → `RecordFailure` → re-open → exponential backoff pinned at the 5-min cap, ping-ponging indefinitely. The breaker was starved of a probe path with a sane timeout.

## Fix
Add `LiteLLMClient.StartBackgroundProbe(ctx, interval)` — a bounded ticker goroutine that, while the breaker is Open and past `nextProbeAt`, calls the existing cheap `c.Probe()` (`GET /v1/models`, designed to survive short timeouts) under a dedicated 5s timeout and drives `RecordSuccess`/`RecordFailure`. Recovery is decoupled from query load and from the 500ms recall budget. Wired in `cmd/engram/main.go` on the server root context (stops on shutdown), with a WARN else-branch if `embedClient` isn't a `*LiteLLMClient`.

Key correctness detail: probe admission uses a new single-lock `CircuitBreaker.AllowProbe()` (returns `errCircuitOpen` on Closed) rather than a `State()`-then-`Allow()` two-step, which would be a TOCTOU race granting a spurious probe on a healthy breaker.

## Testing
- TDD throughout. New deterministic tests for background-probe recovery, no-op-when-Closed, context-cancel exit, single-probe-in-flight, panic-safety, and a non-vacuous `AllowProbe` contract test (reproduces the buggy two-step gate granting on Closed).
- `go vet ./...` clean; `go test -race -count=10 ./internal/embed/...` green (84.9s); 30 consecutive green on the previously-flaky path; dependent packages (cmd, search, reembed, embedgateway) green.

## Scope / follow-ups
- Interim production unblock already applied out-of-band: `kubectl rollout restart deploy/engram-go -n engram` (fresh pods start Closed; recall verified `degraded.embed: false` with vector scores).
- Follow-up #1003: pre-existing demand-path wedge where a cancelled HalfOpen call can leave `probeInFlight=true` without `RecordFailure`. Out of scope here.
- Out of scope: reembed startup retry loop, olla graceful drain, MCP degraded-recall notification, distributed breaker state.

Closes #1000.