### PR TITLE
fix(mcp): use tool_timeout instead of embed_timeout for wall-clock deadline (#989)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1191,14 +1191,14 @@ func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeo
 			result, err := h(ctx, pool, req, cfg)
 			if err != nil && ctx.Err() == context.DeadlineExceeded {
 				slog.Warn("mcp tool timed out — returning degraded success to prevent false 'user denied' synthesis",
-					"tool", toolName, "timeout", toolTimeout)
+					"tool", toolName, "timeout", toolTimeout, "reason", "tool_timeout")
 				metrics.ToolRequests.WithLabelValues(toolName, "timeout").Inc()
 				degradedJSON, _ := json.Marshal(map[string]any{
 					"_engram_degraded":        true,
-					"_engram_degraded_reason": "embed_timeout",
+					"_engram_degraded_reason": "tool_timeout",
 					"_engram_tool":            toolName,
 					"status":                  "degraded",
-					"message": toolName + " ran in degraded mode (GPU saturated or backend slow) — " +
+					"message": toolName + " ran in degraded mode (tool deadline exceeded) — " +
 						"results use BM25 text search only. Memory tools remain accessible. " +
 						"Recovery is automatic when GPU pressure eases.",
 				})

--- a/internal/mcp/timeout_degraded_test.go
+++ b/internal/mcp/timeout_degraded_test.go
@@ -50,10 +50,10 @@ func simulateFixedTimeoutPath(_ context.Context, _ *EnginePool, _ Config) (*mcpg
 	const toolName = "test_slow_tool"
 	degradedJSON, _ := json.Marshal(map[string]any{
 		"_engram_degraded":        true,
-		"_engram_degraded_reason": "embed_timeout",
+		"_engram_degraded_reason": "tool_timeout",
 		"_engram_tool":            toolName,
 		"status":                  "degraded",
-		"message": toolName + " ran in degraded mode (GPU saturated) — " +
+		"message": toolName + " ran in degraded mode (tool deadline exceeded) — " +
 			"results use BM25 text search only. Memory tools remain accessible. " +
 			"Recovery is automatic when GPU pressure eases.",
 	})
@@ -135,7 +135,7 @@ func TestToolTimeout_MetricsLabel_IsTimeout(t *testing.T) {
 }
 
 // TestToolTimeout_DegradedReason_IsEmbedTimeout verifies the _engram_degraded_reason
-// field is "embed_timeout" in the fixed response.
+// field is "tool_timeout" in the fixed response.
 //
 // Currently FAILS: response is not JSON.
 func TestToolTimeout_DegradedReason_IsEmbedTimeout(t *testing.T) {
@@ -151,6 +151,6 @@ func TestToolTimeout_DegradedReason_IsEmbedTimeout(t *testing.T) {
 	require.True(t, ok)
 	var body map[string]any
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &body))
-	require.Equal(t, "embed_timeout", body["_engram_degraded_reason"],
-		"_engram_degraded_reason must be 'embed_timeout'")
+	require.Equal(t, "tool_timeout", body["_engram_degraded_reason"],
+		"_engram_degraded_reason must be 'tool_timeout'")
 }


### PR DESCRIPTION
## Summary

- `registerToolWithTimeout` in `internal/mcp/server.go`: changes `"_engram_degraded_reason"` from `"embed_timeout"` to `"tool_timeout"` and adds `"reason", "tool_timeout"` field to the WARN log
- Updates message string from "GPU saturated or backend slow" to "tool deadline exceeded"
- Updates `timeout_degraded_test.go` to assert `"tool_timeout"`

## Why

The 15-second wall-clock deadline in `registerToolWithTimeout` can fire for any tool (`memory_store`, `memory_list`, etc.), not just embed-related paths. Hardcoding `"embed_timeout"` was misleading. The embed-specific path in `tools_recall.go` was already fixed (commit `c729030`); this fixes the remaining generic location.

## Test plan

- [ ] `go test ./internal/mcp/... -count=1` pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)