### PR TITLE
fix(hookdaemon): ENGRAM_URL env override + api_key file fallback for token (#396)

### DIFF
--- a/cmd/engram/hook.go
+++ b/cmd/engram/hook.go
@@ -50,10 +50,7 @@ func runHookDaemon(args []string) error {
 // newHookDaemon assembles the daemon with its production adapters.
 func newHookDaemon() (*hookdaemon.Daemon, error) {
 	home, _ := os.UserHomeDir()
-	base := fmt.Sprintf("http://127.0.0.1:%d", config.DefaultPort)
-	if p := os.Getenv("ENGRAM_TEST_PORT"); p != "" {
-		base = "http://127.0.0.1:" + p
-	}
+	base := hookBaseURL()
 	memDir := memoryDir(home)
 	return hookdaemon.New(hookdaemon.Config{
 		Engram:        hookdaemon.NewHTTPEngramClient(base),
@@ -62,6 +59,28 @@ func newHookDaemon() (*hookdaemon.Daemon, error) {
 		Fallback:      hookdaemon.NewFileFallbackStore(filepath.Join(memDir, "fallback.md")),
 		RecallProject: inferEngramProject(),
 	})
+}
+
+// hookBaseURL resolves the Engram API base URL the daemon should call. The
+// production shell scripts point at a remote endpoint (e.g.
+// https://engram.petersimmons.com), so the daemon must honour the same
+// override or it will silently call the wrong host. Precedence (highest first):
+//
+//	ENGRAM_TEST_PORT — test-only loopback override (kept for the test harness)
+//	ENGRAM_URL       — explicit base URL
+//	ENGRAM_BASE_URL  — the name the shell scripts already export
+//	http://127.0.0.1:<DefaultPort> — local default
+func hookBaseURL() string {
+	if p := os.Getenv("ENGRAM_TEST_PORT"); p != "" {
+		return "http://127.0.0.1:" + p
+	}
+	if u := os.Getenv("ENGRAM_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	if u := os.Getenv("ENGRAM_BASE_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d", config.DefaultPort)
 }
 
 // memoryDir returns the directory holding MEMORY.md / fallback.md for the

--- a/cmd/engram/hook_test.go
+++ b/cmd/engram/hook_test.go
@@ -14,6 +14,34 @@ func TestHookSocketPath(t *testing.T) {
 	}
 }
 
+func TestHookBaseURL(t *testing.T) {
+	// Default: localhost on the configured port.
+	t.Setenv("ENGRAM_TEST_PORT", "")
+	t.Setenv("ENGRAM_URL", "")
+	t.Setenv("ENGRAM_BASE_URL", "")
+	if got := hookBaseURL(); !strings.HasPrefix(got, "http://127.0.0.1:") {
+		t.Fatalf("default base URL should be loopback, got %q", got)
+	}
+
+	// ENGRAM_BASE_URL is honoured (trailing slash trimmed).
+	t.Setenv("ENGRAM_BASE_URL", "https://engram.petersimmons.com/")
+	if got := hookBaseURL(); got != "https://engram.petersimmons.com" {
+		t.Fatalf("ENGRAM_BASE_URL not honoured, got %q", got)
+	}
+
+	// ENGRAM_URL takes precedence over ENGRAM_BASE_URL.
+	t.Setenv("ENGRAM_URL", "https://primary.example.com")
+	if got := hookBaseURL(); got != "https://primary.example.com" {
+		t.Fatalf("ENGRAM_URL should win over ENGRAM_BASE_URL, got %q", got)
+	}
+
+	// ENGRAM_TEST_PORT overrides everything (test harness escape hatch).
+	t.Setenv("ENGRAM_TEST_PORT", "9999")
+	if got := hookBaseURL(); got != "http://127.0.0.1:9999" {
+		t.Fatalf("ENGRAM_TEST_PORT should take top precedence, got %q", got)
+	}
+}
+
 func TestClaudeProjectSlug(t *testing.T) {
 	cases := map[string]string{
 		"/home/psimmons":  "-home-psimmons",

--- a/internal/hookdaemon/adapters.go
+++ b/internal/hookdaemon/adapters.go
@@ -141,19 +141,52 @@ func readAllLimited(r interface{ Read([]byte) (int, error) }, max int64) ([]byte
 	}
 }
 
-// mcpTokenStore reads/writes the Engram bearer token in mcp_servers.json.
+// mcpTokenStore reads/writes the Engram bearer token in mcp_servers.json. When
+// that file yields an empty token, Load falls back to a plain-text key file
+// (typically ~/.config/engram/api_key) — the source the shell scripts use, so
+// the daemon and scripts cannot silently diverge (#396).
 type mcpTokenStore struct {
-	path string
+	path    string
+	keyPath string // plain-text api_key fallback; "" disables the fallback
 }
 
 // NewMCPTokenStore returns a TokenStore backed by the given mcp_servers.json
-// path (typically ~/.claude/mcp_servers.json).
-func NewMCPTokenStore(path string) TokenStore { return &mcpTokenStore{path: path} }
+// path (typically ~/.claude/mcp_servers.json). It also falls back to the
+// plain-text key file at ~/.config/engram/api_key when mcp_servers.json yields
+// an empty token.
+func NewMCPTokenStore(path string) TokenStore {
+	keyPath := ""
+	if home, err := os.UserHomeDir(); err == nil {
+		keyPath = filepath.Join(home, ".config", "engram", "api_key")
+	}
+	return &mcpTokenStore{path: path, keyPath: keyPath}
+}
+
+// newMCPTokenStore builds the store with both paths supplied explicitly. It
+// exists so tests can point the api_key fallback at a temp file instead of the
+// real ~/.config/engram/api_key.
+func newMCPTokenStore(path, keyPath string) *mcpTokenStore {
+	return &mcpTokenStore{path: path, keyPath: keyPath}
+}
 
 func (s *mcpTokenStore) Load() (string, error) {
+	token := s.loadFromMCP()
+	// If mcp_servers.json is absent, malformed, or carries no engram token, fall
+	// back to the plain-text api_key file the shell scripts read.
+	if token == "" && s.keyPath != "" {
+		if data, err := os.ReadFile(s.keyPath); err == nil {
+			token = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(data)), "Bearer "))
+		}
+	}
+	return token, nil
+}
+
+// loadFromMCP returns the engram bearer token from mcp_servers.json, or "" if
+// the file is missing, malformed, or has no engram authorization header.
+func (s *mcpTokenStore) loadFromMCP() string {
 	b, err := os.ReadFile(s.path)
 	if err != nil {
-		return "", err
+		return ""
 	}
 	var cfg struct {
 		MCPServers map[string]struct {
@@ -163,10 +196,10 @@ func (s *mcpTokenStore) Load() (string, error) {
 		} `json:"mcpServers"`
 	}
 	if err := json.Unmarshal(b, &cfg); err != nil {
-		return "", err
+		return ""
 	}
 	auth := cfg.MCPServers["engram"].Headers.Authorization
-	return strings.TrimSpace(strings.TrimPrefix(auth, "Bearer ")), nil
+	return strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
 }
 
 // Store writes the token back into mcp_servers.json atomically, preserving all

--- a/internal/hookdaemon/adapters_test.go
+++ b/internal/hookdaemon/adapters_test.go
@@ -50,6 +50,67 @@ func TestMCPTokenStore_LoadAndStore(t *testing.T) {
 	}
 }
 
+func TestMCPTokenStore_FallsBackToAPIKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	mcpPath := filepath.Join(dir, "mcp_servers.json")
+	keyPath := filepath.Join(dir, "api_key")
+
+	// mcp_servers.json has an engram entry but an empty Authorization header.
+	mcp := `{"mcpServers":{"engram":{"headers":{"Authorization":""}}}}`
+	if err := os.WriteFile(mcpPath, []byte(mcp), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("  file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newMCPTokenStore(mcpPath, keyPath)
+	tok, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if tok != "file-token" {
+		t.Fatalf("expected api_key fallback to yield file-token, got %q", tok)
+	}
+}
+
+func TestMCPTokenStore_FallbackWhenMCPMissing(t *testing.T) {
+	dir := t.TempDir()
+	mcpPath := filepath.Join(dir, "does-not-exist.json")
+	keyPath := filepath.Join(dir, "api_key")
+	if err := os.WriteFile(keyPath, []byte("Bearer key-with-prefix\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newMCPTokenStore(mcpPath, keyPath)
+	tok, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if tok != "key-with-prefix" {
+		t.Fatalf("expected key-with-prefix when mcp file absent, got %q", tok)
+	}
+}
+
+func TestMCPTokenStore_PrefersMCPToken(t *testing.T) {
+	dir := t.TempDir()
+	mcpPath := filepath.Join(dir, "mcp_servers.json")
+	keyPath := filepath.Join(dir, "api_key")
+	mcp := `{"mcpServers":{"engram":{"headers":{"Authorization":"Bearer mcp-token"}}}}`
+	if err := os.WriteFile(mcpPath, []byte(mcp), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newMCPTokenStore(mcpPath, keyPath)
+	tok, _ := s.Load()
+	if tok != "mcp-token" {
+		t.Fatalf("expected mcp-token to win over api_key file, got %q", tok)
+	}
+}
+
 func TestFileMemoryWriter_ReplacesRecallSection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "MEMORY.md")
 	os.WriteFile(path, []byte("# Memory\n\nbody text\n\n## Engram Session Recall\n\nold stuff\n"), 0o600)


### PR DESCRIPTION
## Summary

- `cmd/engram/hook.go`: new `hookBaseURL()` reads `ENGRAM_URL` → `ENGRAM_BASE_URL` → `localhost:<port>` (was hardcoded localhost)
- `internal/hookdaemon/adapters.go`: `mcpTokenStore.Load()` falls back to `~/.config/engram/api_key` when `mcp_servers.json` yields empty token

## Why

Two blockers prevented the hook daemon from working in production:
1. Daemon connected to `localhost:8788` but live Engram is at `https://engram.petersimmons.com`
2. Live system writes tokens to `~/.config/engram/api_key`; daemon only read `mcp_servers.json`

## Test plan

- [ ] `go test ./internal/hookdaemon/... -race` pass (confirmed locally)
- [ ] `go test ./cmd/engram/... -race` pass (confirmed locally)
- [ ] Smoke test: daemon starts, handles SessionStart, MEMORY.md populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)