### PR TITLE
feat(search): cross-encoder reranker via TEI endpoint (LME Lever-2, flag-gated)

### DIFF
--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -371,6 +371,12 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if claudeRerankEnabled && rerank && cfg.claudeClient != nil {
 		opts.Reranker = &claudeRerankAdapter{client: cfg.claudeClient}
 	}
+	// Cross-encoder reranker (LEVER-2): flag-gated via ENGRAM_CROSS_ENCODER_RERANK=true.
+	// When enabled, replaces any other reranker — cross-encoder is the stronger signal.
+	// ENGRAM_CROSS_ENCODER_URL must be set to the TEI /rerank endpoint.
+	if ceReranker := search.NewCrossEncoderRerankerFromEnv(); ceReranker != nil {
+		opts.Reranker = ceReranker
+	}
 	// Inject current session episode for same-session score boosting (Phase 3).
 	if id, ok := episodeIDFromContext(ctx); ok {
 		opts.CurrentEpisodeID = id

--- a/internal/search/cross_encoder_reranker.go
+++ b/internal/search/cross_encoder_reranker.go
@@ -1,0 +1,234 @@
+package search
+
+// cross_encoder_reranker.go — TEI cross-encoder reranker (LME LEVER-2).
+//
+// # Design
+//
+// After candidate retrieval (any method), this reranker re-scores the top-K
+// candidates using a cross-encoder model (e.g. bge-reranker-v2-m3) that
+// JOINTLY encodes (query, chunk) rather than using independent bi-encoder
+// cosine similarity. This directly addresses the "compilation bottleneck":
+// SmartSearch oracle analysis shows ~22.5% of gold evidence is lost to
+// truncation, and cross-encoder reranking is the dominant SOTA lever
+// (arXiv 2603.15599, +8–14pp).
+//
+// The implementation calls a TEI (Text Embeddings Inference) compatible
+// /rerank endpoint:
+//
+//	POST /rerank
+//	{"query": "...", "texts": ["chunk1", "chunk2", ...]}
+//	→ [{"index": 0, "score": 0.92}, {"index": 1, "score": 0.31}, ...]
+//
+// This API is supported by:
+//   - HuggingFace Text Embeddings Inference (TEI) — CPU build
+//   - Infinity (SentenceTransformers serving)
+//   - Any compatible endpoint
+//
+// # Hosting decision (ADV.1 resolved 2026-06-02)
+//
+// Option B was selected: configurable HTTP endpoint via ENGRAM_CROSS_ENCODER_URL.
+// Rationale:
+//   - Avoids re-saturating the MI50 GPU embed path (circuit breaker history #917/#1000)
+//   - Decoupled from Olla's unknown /v1/rerank capability surface
+//   - Operator defers standing up the sidecar until after interface is validated
+//   - Default docker run: docker run -p 6006:80
+//       ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
+//       --model-id BAAI/bge-reranker-v2-m3
+//
+// # Flag
+//
+// Feature-gated by ENGRAM_CROSS_ENCODER_RERANK=true|1 (default OFF).
+// The endpoint URL is configured via ENGRAM_CROSS_ENCODER_URL.
+// When the URL is empty, the reranker is disabled even if the flag is on.
+//
+// Set RecallOpts.Reranker = NewCrossEncoderRerankerFromEnv() at the call site;
+// when the flag is off (or URL unset), the function returns nil and the hook
+// is a no-op — baseline scores and ordering are unchanged.
+//
+// # Ablation bench command
+//
+//	ENGRAM_CROSS_ENCODER_RERANK=true \
+//	ENGRAM_CROSS_ENCODER_URL=http://localhost:6006/rerank \
+//	./longmemeval run \
+//	  --data ~/path/to/longmemeval_m_cleaned.json \
+//	  --url http://localhost:8788 \
+//	  --llm-url "${LME_LLM_URL}" \
+//	  --llm-model "${LME_LLM_MODEL}" \
+//	  --workers 8 \
+//	  --out ~/benchmarks/lme-lever2-cross-encoder \
+//	  --recall-topk 100 \
+//	  --context-topk 8 \
+//	  --run-id lever2-$(date +%Y%m%dT%H%M%S)
+//
+// Use a fresh run_id. Never re-use run_id 7a87fd (golden baseline).
+// Compare against golden-snapshot-20260602T1810Z/ (367/566 CORRECT).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultCrossEncoderTimeout is the per-call HTTP timeout for the rerank endpoint.
+	// 8 candidates × ~25ms each ≈ 200ms typical; 2s gives ample headroom for
+	// a cold CPU sidecar without blocking the recall path excessively.
+	defaultCrossEncoderTimeout = 2 * time.Second
+)
+
+// teiRerankRequest is the payload sent to the TEI /rerank endpoint.
+type teiRerankRequest struct {
+	Query string   `json:"query"`
+	Texts []string `json:"texts"`
+}
+
+// teiRerankResponse is one scored entry from the TEI /rerank response.
+type teiRerankResponse struct {
+	Index int     `json:"index"`
+	Score float64 `json:"score"`
+}
+
+// CrossEncoderReranker implements ResultReranker using a TEI-compatible
+// /rerank HTTP endpoint. The reranker jointly encodes (query, chunk) pairs
+// rather than using independent bi-encoder cosine similarity.
+//
+// Instantiate via NewCrossEncoderReranker or NewCrossEncoderRerankerFromEnv.
+type CrossEncoderReranker struct {
+	endpoint string
+	timeout  time.Duration
+	client   *http.Client
+}
+
+// NewCrossEncoderReranker returns a CrossEncoderReranker that calls the given
+// TEI /rerank endpoint URL. endpoint must be the full path including /rerank,
+// e.g. "http://localhost:6006/rerank".
+func NewCrossEncoderReranker(endpoint string) *CrossEncoderReranker {
+	return &CrossEncoderReranker{
+		endpoint: endpoint,
+		timeout:  defaultCrossEncoderTimeout,
+		client:   &http.Client{Timeout: defaultCrossEncoderTimeout},
+	}
+}
+
+// IsCrossEncoderRerankerEnabled returns true when ENGRAM_CROSS_ENCODER_RERANK
+// is set to "true" or "1" (case-insensitive). Default is OFF.
+//
+// Evaluated at call time (not cached) so t.Setenv works in tests and the
+// flag can be toggled at runtime without restart.
+func IsCrossEncoderRerankerEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_CROSS_ENCODER_RERANK")))
+	return v == "true" || v == "1"
+}
+
+// NewCrossEncoderRerankerFromEnv returns a *CrossEncoderReranker when:
+//   - ENGRAM_CROSS_ENCODER_RERANK is "true" or "1", AND
+//   - ENGRAM_CROSS_ENCODER_URL is non-empty.
+//
+// Returns nil (no-op) when either condition is not met. Assign directly to
+// RecallOpts.Reranker:
+//
+//	opts := search.RecallOpts{
+//	    Reranker: search.NewCrossEncoderRerankerFromEnv(),
+//	}
+//
+// When nil, RecallWithOpts skips re-ranking entirely — baseline unchanged.
+func NewCrossEncoderRerankerFromEnv() ResultReranker {
+	if !IsCrossEncoderRerankerEnabled() {
+		return nil
+	}
+	url := strings.TrimSpace(os.Getenv("ENGRAM_CROSS_ENCODER_URL"))
+	if url == "" {
+		slog.Warn("cross-encoder rerank enabled but ENGRAM_CROSS_ENCODER_URL is empty — skipping")
+		return nil
+	}
+	return NewCrossEncoderReranker(url)
+}
+
+// RerankResults calls the TEI /rerank endpoint with the query and item summaries,
+// then maps the cross-encoder scores back to RerankResult by item ID.
+//
+// The TEI endpoint receives items in the same order they appear in items[];
+// the response assigns scores by index. This mapping is stable regardless of
+// what score order the endpoint returns results in.
+//
+// On HTTP or parse error, the error is returned and the caller falls through
+// to the existing bi-encoder ordering (engine.go: error from Reranker is
+// logged and the original results are used unchanged).
+func (r *CrossEncoderReranker) RerankResults(
+	ctx context.Context,
+	query string,
+	items []RerankItem,
+) ([]RerankResult, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	texts := make([]string, len(items))
+	for i, it := range items {
+		texts[i] = it.Summary
+	}
+
+	reqBody, err := json.Marshal(teiRerankRequest{Query: query, Texts: texts})
+	if err != nil {
+		return nil, fmt.Errorf("cross-encoder: marshal request: %w", err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(callCtx, http.MethodPost, r.endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("cross-encoder: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cross-encoder: HTTP request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cross-encoder: endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cross-encoder: read response: %w", err)
+	}
+
+	var teiResults []teiRerankResponse
+	if err := json.Unmarshal(body, &teiResults); err != nil {
+		return nil, fmt.Errorf("cross-encoder: parse response: %w", err)
+	}
+
+	// Map index → cross-encoder score.
+	scoreByIndex := make(map[int]float64, len(teiResults))
+	for _, tr := range teiResults {
+		scoreByIndex[tr.Index] = tr.Score
+	}
+
+	results := make([]RerankResult, len(items))
+	for i, it := range items {
+		score, ok := scoreByIndex[i]
+		if !ok {
+			// Index missing from response: fall back to original score.
+			slog.Warn("cross-encoder: missing index in response, using original score",
+				"index", i, "id", it.ID)
+			score = it.Score
+		}
+		results[i] = RerankResult{ID: it.ID, Score: score}
+	}
+
+	return results, nil
+}
+
+// Compile-time check: CrossEncoderReranker satisfies ResultReranker.
+var _ ResultReranker = (*CrossEncoderReranker)(nil)

--- a/internal/search/cross_encoder_reranker_test.go
+++ b/internal/search/cross_encoder_reranker_test.go
@@ -1,0 +1,189 @@
+package search_test
+
+// cross_encoder_reranker_test.go — TDD tests for the TEI cross-encoder reranker.
+//
+// Test strategy: all tests use a stub HTTP server — no live model required.
+// The stub simulates the TEI /rerank response so unit tests are deterministic
+// and run offline.
+//
+// Covered behaviours:
+//   1. Flag OFF  -> NewCrossEncoderRerankerFromEnv returns nil (no-op in RecallOpts)
+//   2. Flag ON, URL empty  -> returns nil (no-op; URL not configured yet)
+//   3. Stub server: reranker promotes a jointly-relevant chunk that bi-encoder
+//      ranked below cutoff -- verifies the rerank order changes
+//   4. Stub server returns error -> RerankResults surfaces the error
+//   5. Empty items slice -> nil, nil returned without HTTP call
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/search"
+)
+
+// teiRerankItem mirrors the TEI /rerank response entry.
+type teiRerankItem struct {
+	Index int     `json:"index"`
+	Score float64 `json:"score"`
+}
+
+// newTEIStub starts an httptest.Server that serves fixed scores for the items
+// it receives. scores maps item-index to cross-encoder score. Items not in the
+// map get score 0.0.
+func newTEIStub(t *testing.T, scores map[int]float64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rerank" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Query string   `json:"query"`
+			Texts []string `json:"texts"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		results := make([]teiRerankItem, len(req.Texts))
+		for i := range req.Texts {
+			s := 0.0
+			if v, ok := scores[i]; ok {
+				s = v
+			}
+			results[i] = teiRerankItem{Index: i, Score: s}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(results)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Test 1: flag OFF -> NewCrossEncoderRerankerFromEnv returns nil.
+func TestCrossEncoderRerankerFromEnv_FlagOff(t *testing.T) {
+	t.Setenv("ENGRAM_CROSS_ENCODER_RERANK", "false")
+	t.Setenv("ENGRAM_CROSS_ENCODER_URL", "http://localhost:9999/rerank")
+	r := search.NewCrossEncoderRerankerFromEnv()
+	if r != nil {
+		t.Errorf("expected nil reranker when flag is OFF, got %T", r)
+	}
+}
+
+// Test 2: flag ON, URL empty -> NewCrossEncoderRerankerFromEnv returns nil.
+func TestCrossEncoderRerankerFromEnv_FlagOnURLEmpty(t *testing.T) {
+	t.Setenv("ENGRAM_CROSS_ENCODER_RERANK", "true")
+	t.Setenv("ENGRAM_CROSS_ENCODER_URL", "")
+	r := search.NewCrossEncoderRerankerFromEnv()
+	if r != nil {
+		t.Errorf("expected nil reranker when URL is empty, got %T", r)
+	}
+}
+
+// Test 3: stub server reranks - jointly-relevant chunk promoted above bi-encoder rank.
+//
+// Setup: 3 items. Bi-encoder scored them [0.90, 0.80, 0.70] (item-0 top).
+// The TEI stub says item-2 is jointly most relevant (score 0.95), item-0 second (0.60), item-1 last (0.40).
+// After reranking, the order should be [item-2, item-0, item-1].
+func TestCrossEncoderReranker_PromotesJointlyRelevantChunk(t *testing.T) {
+	srv := newTEIStub(t, map[int]float64{
+		0: 0.60,
+		1: 0.40,
+		2: 0.95,
+	})
+
+	r := search.NewCrossEncoderReranker(srv.URL + "/rerank")
+
+	items := []search.RerankItem{
+		{ID: "mem-0", Summary: "user prefers morning coffee", Score: 0.90},
+		{ID: "mem-1", Summary: "user owns a blue car", Score: 0.80},
+		{ID: "mem-2", Summary: "user drinks coffee every morning before work", Score: 0.70},
+	}
+
+	results, err := r.RerankResults(context.Background(), "what does the user drink in the morning?", items)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	// Sort by score desc to find ordering.
+	sorted := make([]search.RerankResult, len(results))
+	copy(sorted, results)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Score > sorted[j].Score })
+
+	if sorted[0].ID != "mem-2" {
+		t.Errorf("expected mem-2 ranked first (jointly relevant), got %s (score=%.3f)", sorted[0].ID, sorted[0].Score)
+	}
+	if sorted[1].ID != "mem-0" {
+		t.Errorf("expected mem-0 ranked second, got %s", sorted[1].ID)
+	}
+	if sorted[2].ID != "mem-1" {
+		t.Errorf("expected mem-1 ranked last, got %s", sorted[2].ID)
+	}
+}
+
+// Test 4: stub server HTTP error -> RerankResults returns non-nil error.
+func TestCrossEncoderReranker_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := search.NewCrossEncoderReranker(srv.URL + "/rerank")
+	items := []search.RerankItem{
+		{ID: "mem-0", Summary: "anything", Score: 0.5},
+	}
+	_, err := r.RerankResults(context.Background(), "query", items)
+	if err == nil {
+		t.Error("expected error from 500 response, got nil")
+	}
+}
+
+// Test 5: empty items slice -> returns nil, nil (no HTTP call made).
+func TestCrossEncoderReranker_EmptyItems(t *testing.T) {
+	// Use a server that fails if called -- proves no HTTP call is made.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("unexpected HTTP call with empty items")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := search.NewCrossEncoderReranker(srv.URL + "/rerank")
+	results, err := r.RerankResults(context.Background(), "query", nil)
+	if err != nil {
+		t.Errorf("unexpected error with empty items: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil results for empty items, got %v", results)
+	}
+}
+
+// Test 6: IsCrossEncoderRerankerEnabled reflects env var correctly.
+func TestIsCrossEncoderRerankerEnabled(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"1", true},
+		{"TRUE", true},
+		{"false", false},
+		{"0", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.val, func(t *testing.T) {
+			t.Setenv("ENGRAM_CROSS_ENCODER_RERANK", c.val)
+			got := search.IsCrossEncoderRerankerEnabled()
+			if got != c.want {
+				t.Errorf("IsCrossEncoderRerankerEnabled() = %v, want %v (env=%q)", got, c.want, c.val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Experiment**: LME Lever-2 — cross-encoder reranker via TEI endpoint

- Adds a flag-gated cross-encoder reranker stage calling a TEI rerank endpoint
- Default-off; no migration required
- Reviewed clean; experiment files disjoint from main
- `go build ./...` and `go test -race ./internal/search/... ./internal/mcp/...` green on rebased tip