### PR TITLE
feat(search): MemPalace 2-level hierarchical recall (LME exp #9, flag-gated)

### DIFF
--- a/docs/mempalace-backfill.md
+++ b/docs/mempalace-backfill.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Migration 026 adds a 2-level hierarchical recall path (MemPalace). The schema is in place
+Migration 028 adds a 2-level hierarchical recall path (MemPalace). The schema is in place
 after `go run ./cmd/engram-setup` or server startup, but **existing memories have
 `cluster_id = NULL` and gain no benefit until back-fill runs.**
 

--- a/docs/mempalace-backfill.md
+++ b/docs/mempalace-backfill.md
@@ -1,0 +1,133 @@
+# MemPalace Back-fill & Benchmark Guide (LME Experiment #9)
+
+## Overview
+
+Migration 026 adds a 2-level hierarchical recall path (MemPalace). The schema is in place
+after `go run ./cmd/engram-setup` or server startup, but **existing memories have
+`cluster_id = NULL` and gain no benefit until back-fill runs.**
+
+Flag: `ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true` (default: false, opt-in).
+
+---
+
+## Back-fill Step (run AFTER ingest, BEFORE benchmark)
+
+Back-fill assigns each memory to a cluster by:
+1. Pulling all embedded chunk vectors for the project.
+2. Running k-means (k=√N, max k=50) to produce cluster centroids.
+3. Inserting centroids into `memory_clusters`.
+4. Setting `memories.cluster_id` to the nearest centroid for each memory.
+
+**Do NOT run back-fill against prod DB.** This is a benchmark-only operation.
+
+```bash
+# Build the back-fill binary (once):
+go build -o bin/mempalace-backfill ./cmd/mempalace-backfill
+
+# Run back-fill for a specific LME project (replace lme-<run_id> with your run):
+DATABASE_URL="${DATABASE_URL}" \
+  bin/mempalace-backfill \
+    --project lme-<run_id> \
+    --clusters 20 \
+    --max-iter 100
+
+# Or back-fill all lme-* projects at once:
+DATABASE_URL="${DATABASE_URL}" \
+  bin/mempalace-backfill \
+    --pattern "lme-%" \
+    --clusters 20 \
+    --max-iter 100
+```
+
+> NOTE: `cmd/mempalace-backfill` does not exist yet — it is the next step after this
+> experiment's recall path lands. The back-fill binary should:
+> 1. Query `SELECT id, embedding FROM chunks WHERE project=$1 AND embedding IS NOT NULL`
+> 2. Run k-means on the embedding matrix (use `gonum.org/v1/gonum/mat` + Lloyd's algorithm)
+> 3. INSERT INTO memory_clusters (centroid per cluster)
+> 4. UPDATE memories SET cluster_id = nearest_centroid WHERE project=$1
+
+---
+
+## Benchmark Command (after back-fill)
+
+```bash
+# 1. Resolve routes
+./longmemeval route-discover --purpose generation > /tmp/lme-route.json
+export LME_LLM_URL="$(jq -r .llm_url /tmp/lme-route.json)"
+export LME_LLM_MODEL="$(jq -r .llm_model /tmp/lme-route.json)"
+
+# 2. Ingest (skip if already ingested with --no-cleanup from a prior run)
+./longmemeval ingest \
+  --data ~/path/to/longmemeval_m_cleaned.json \
+  --url http://localhost:8788 \
+  --workers 32 \
+  --out ~/benchmarks/lme-m-mp9 \
+  --cleanup-policy=never \
+  --scratch-ttl 168h
+
+# 3. Back-fill clusters (after ingest, before recall)
+DATABASE_URL="${DATABASE_URL}" bin/mempalace-backfill \
+  --pattern "lme-%" \
+  --clusters 20
+
+# 4. Run recall+generate with hierarchical flag ON
+ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true \
+  ./longmemeval run \
+    --data ~/path/to/longmemeval_m_cleaned.json \
+    --url http://localhost:8788 \
+    --llm-url "${LME_LLM_URL}" \
+    --llm-model "${LME_LLM_MODEL}" \
+    --workers 32 \
+    --out ~/benchmarks/lme-m-mp9 \
+    --recall-topk 100 \
+    --context-topk 8
+
+# 5. Score
+./longmemeval score-efficient \
+  --data ~/path/to/longmemeval_m_cleaned.json \
+  --scorer-url "${LME_SCORER_URL:-${LME_LLM_URL}}" \
+  --scorer-model "${LME_SCORER_MODEL:-${LME_LLM_MODEL}}" \
+  --workers 16 \
+  --out ~/benchmarks/lme-m-mp9
+
+# 6. Analyze — compare to golden baseline (run_id 7a87fd, 367/566 CORRECT)
+./longmemeval analyze --results ~/benchmarks/lme-m-mp9
+```
+
+---
+
+## Expected Improvement (from MemPalace paper, d3a98aa4)
+
+Target failure classes where cluster pre-filtering should help:
+- **multi-session (19.5%)** — off-topic sessions will be filtered by cluster boundary
+- **temporal-reasoning (18.8%)** — same-topic sessions grouped in cluster
+- **knowledge-update (46.2%)** — most recent cluster centroid closest to query
+
+Baseline: 367/566 CORRECT (run_id 7a87fd, main 4bf268c).
+Expected: ~490/566 if ~34% retrieval gain from MemPalace translates (upper bound).
+
+---
+
+## Ablation
+
+To compare hierarchical vs. flat on the same ingested data:
+
+```bash
+# Baseline (flat path):
+ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=false \
+  ./longmemeval run ... --out ~/benchmarks/lme-m-baseline
+
+# Hierarchical:
+ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true \
+  ./longmemeval run ... --out ~/benchmarks/lme-m-mp9
+```
+
+---
+
+## Tuning TopClusters
+
+The number of coarse clusters searched per recall is controlled by:
+- `RecallOpts.TopClusters` (programmatic, default 3)
+- The back-fill `--clusters` parameter controls total cluster count K
+
+Ablation values to try: TopClusters ∈ {1, 3, 5, 10}.

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -327,6 +327,32 @@ type Backend interface {
 	// CompleteExtractionJob marks an extraction job done (jobErr == nil) or failed.
 	CompleteExtractionJob(ctx context.Context, jobID string, err error) error
 
+	// ── MemPalace hierarchical clustering (LME experiment #9) ─────────────
+
+	// StoreMemoryCluster upserts a cluster centroid row for the project.
+	StoreMemoryCluster(ctx context.Context, c *MemoryCluster) error
+
+	// SetMemoryClusterID assigns cluster_id on a memory row. Pass "" to clear.
+	SetMemoryClusterID(ctx context.Context, memoryID, clusterID string) error
+
+	// FindNearestClusters returns the IDs of the top-K clusters whose centroids
+	// are closest to queryVec by cosine distance, scoped to project.
+	// Returns an empty slice (not an error) when no clusters exist for the project.
+	FindNearestClusters(ctx context.Context, project string, queryVec []float32, topK int) ([]string, error)
+
+	// VectorSearchWithClusters is like VectorSearchWithDateRange but restricts
+	// the candidate set to chunks whose parent memory has cluster_id IN clusterIDs.
+	// When clusterIDs is empty it falls back to the unconstrained search.
+	VectorSearchWithClusters(ctx context.Context, project string, queryVec []float32, limit int, clusterIDs []string, since, before *time.Time) ([]VectorHit, error)
+
+	// ── Diagnostics (used by tests and health endpoints) ─────────────────────
+
+	// TableExists returns true if the named table exists in the current schema.
+	TableExists(ctx context.Context, table string) (bool, error)
+
+	// ColumnExists returns true if the named column exists on the given table.
+	ColumnExists(ctx context.Context, table, column string) (bool, error)
+
 	// ── Transactions ────────────────────────────────────────────────────────
 
 	// Begin starts a new transaction.
@@ -385,3 +411,16 @@ type IntegrityStats struct {
 	Hashed  int
 	Corrupt int
 }
+
+// MemoryCluster is a topic-level centroid for hierarchical (MemPalace) recall.
+// Each cluster belongs to a project and has a representative centroid vector
+// computed from the mean of its member memory embeddings. Populated by the
+// MemPalace back-fill step (docs/mempalace-backfill.md).
+type MemoryCluster struct {
+	ID       string
+	Project  string
+	Centroid []float32
+	Label    string
+	Size     int
+}
+

--- a/internal/db/migrations/026_mempalace_clusters.sql
+++ b/internal/db/migrations/026_mempalace_clusters.sql
@@ -1,0 +1,55 @@
+-- Migration 026: MemPalace hierarchical clustering tables (LME experiment #9)
+--
+-- Adds a 2-level coarse→fine hierarchy for hierarchical recall filtering:
+--   Level 1 (coarse): memory_clusters — one centroid vector per topic cluster per project
+--   Level 2 (fine):   cluster_id column on memories — each memory belongs to one cluster
+--
+-- RECALL PATH (flag-gated, default OFF):
+--   1. Embed query → find top-C nearest cluster centroids (memory_clusters)
+--   2. Restrict VectorSearch to chunks whose parent memory.cluster_id IN (top-C clusters)
+--   3. Standard composite scoring on the narrowed candidate set
+--
+-- ABLATION: set ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=false (the default) to bypass
+-- the hierarchical path entirely and run the existing flat VectorSearch. No data is
+-- lost by disabling the flag — cluster_id is nullable and ignored by all existing queries.
+--
+-- BACK-FILL NOTE: existing memories have cluster_id = NULL. Hierarchical recall
+-- with NULL cluster_id falls back to the flat path automatically (NULL IN (...) = FALSE).
+-- Run the back-fill script (see docs/mempalace-backfill.md) AFTER enabling clustering
+-- and running longmemeval ingest to populate clusters.
+--
+-- DOWN: DROP TABLE IF EXISTS memory_clusters; ALTER TABLE memories DROP COLUMN IF EXISTS cluster_id;
+
+-- 1. Cluster centroid table.
+--    centroid is VECTOR(1024) to match the deployment contract (migration 018).
+CREATE TABLE IF NOT EXISTS memory_clusters (
+    id          TEXT         PRIMARY KEY,
+    project     TEXT         NOT NULL,
+    centroid    vector(1024) NOT NULL,
+    label       TEXT         NOT NULL DEFAULT '',
+    size        INTEGER      NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_clusters_project
+    ON memory_clusters(project);
+
+-- HNSW index on cluster centroids for fast nearest-centroid lookup.
+-- ef_construction=64, m=16 matches the chunks HNSW config (migration 018).
+CREATE INDEX IF NOT EXISTS idx_memory_clusters_centroid_hnsw
+    ON memory_clusters USING hnsw (centroid vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+-- 2. Add cluster_id to memories (nullable; NULL = unassigned / flat path fallback).
+ALTER TABLE memories ADD COLUMN IF NOT EXISTS cluster_id TEXT
+    REFERENCES memory_clusters(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memories_cluster_id
+    ON memories(cluster_id)
+    WHERE cluster_id IS NOT NULL;
+
+-- Composite index: project + cluster_id for the hierarchical VectorSearch filter.
+CREATE INDEX IF NOT EXISTS idx_memories_project_cluster
+    ON memories(project, cluster_id)
+    WHERE cluster_id IS NOT NULL;

--- a/internal/db/migrations/028_mempalace_clusters.sql
+++ b/internal/db/migrations/028_mempalace_clusters.sql
@@ -1,4 +1,4 @@
--- Migration 026: MemPalace hierarchical clustering tables (LME experiment #9)
+-- Migration 028: MemPalace hierarchical clustering tables (LME experiment #9)
 --
 -- Adds a 2-level coarse→fine hierarchy for hierarchical recall filtering:
 --   Level 1 (coarse): memory_clusters — one centroid vector per topic cluster per project

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -543,6 +543,7 @@ func rowToFTSResult(row pgx.CollectableRow) (FTSResult, error) {
 		episodeID                          *string
 		documentID                         *string
 		patternConfidence                  *float64
+		clusterID                          *string // (028_mempalace_clusters); scanned-but-ignored
 		rank                               float64
 	)
 	// Column order matches the live DB schema (search_vector was added between
@@ -552,7 +553,7 @@ func rowToFTSResult(row pgx.CollectableRow) (FTSResult, error) {
 	//   summary, content_hash, storage_mode, valid_from, valid_to, invalidation_reason,
 	//   dynamic_importance, retrieval_interval_hrs, next_review_at, times_retrieved,
 	//   times_useful, retrieval_precision, episode_id, document_id,
-	//   pattern_confidence (+rank appended by FTSSearch query).
+	//   pattern_confidence, cluster_id (028_mempalace) (+rank appended by FTSSearch query).
 	if err := row.Scan(
 		&id, &content, &memType, &proj, &tags,
 		&importance, &accessCount, &lastAccessed, &createdAt, &updatedAt,
@@ -561,7 +562,7 @@ func rowToFTSResult(row pgx.CollectableRow) (FTSResult, error) {
 		&validFrom, &validTo, &invalidationReason,
 		&dynamicImportance, &retrievalIntervalHrs, &nextReviewAt,
 		&timesRetrieved, &timesUseful, &retrievalPrecision, &episodeID, &documentID,
-		&patternConfidence, &rank,
+		&patternConfidence, &clusterID, &rank,
 	); err != nil {
 		return FTSResult{}, err
 	}
@@ -648,6 +649,7 @@ func rowToMemory(row pgx.CollectableRow) (*types.Memory, error) {
 		EpisodeID            *string  // nullable FK
 		DocumentID           *string  // nullable FK (010_documents)
 		PatternConfidence    *float64 // nullable (021_pattern_confidence)
+		ClusterID            *string  // nullable (028_mempalace_clusters); scanned-but-ignored filter column
 	}
 	var r raw
 	// Column order matches the live DB schema. search_vector was added between
@@ -662,6 +664,7 @@ func rowToMemory(row pgx.CollectableRow) (*types.Memory, error) {
 	//   episode_id                                           (008_episodes)
 	//   document_id                                          (010_documents)
 	//   pattern_confidence                                   (021_pattern_confidence)
+	//   cluster_id                                           (028_mempalace_clusters)
 	err := row.Scan(
 		&r.ID, &r.Content, &r.MemoryType, &r.Project, &r.Tags,
 		&r.Importance, &r.AccessCount, &r.LastAccessed, &r.CreatedAt, &r.UpdatedAt,
@@ -670,7 +673,7 @@ func rowToMemory(row pgx.CollectableRow) (*types.Memory, error) {
 		&r.ValidFrom, &r.ValidTo, &r.InvalidationReason,
 		&r.DynamicImportance, &r.RetrievalIntervalHrs, &r.NextReviewAt,
 		&r.TimesRetrieved, &r.TimesUseful, &r.RetrievalPrecision, &r.EpisodeID,
-		&r.DocumentID, &r.PatternConfidence,
+		&r.DocumentID, &r.PatternConfidence, &r.ClusterID,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/db/postgres_cluster.go
+++ b/internal/db/postgres_cluster.go
@@ -1,0 +1,185 @@
+package db
+
+// postgres_cluster.go — PostgreSQL implementation of MemPalace cluster methods.
+//
+// Implements the Backend interface additions from LME experiment #9:
+//   StoreMemoryCluster  — upsert a cluster centroid row
+//   SetMemoryClusterID  — assign cluster_id on a memory
+//   FindNearestClusters — top-K centroid lookup by cosine distance
+//   VectorSearchWithClusters — VectorSearchWithDateRange filtered to cluster set
+//   TableExists, ColumnExists — schema diagnostics used by tests and health probes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/types"
+	pgvector "github.com/pgvector/pgvector-go"
+)
+
+// StoreMemoryCluster upserts a cluster centroid row for the project.
+// On conflict on (id) the centroid, label, size, and updated_at are updated.
+func (b *PostgresBackend) StoreMemoryCluster(ctx context.Context, c *MemoryCluster) error {
+	if c.ID == "" {
+		c.ID = types.NewMemoryID()
+	}
+	_, err := b.pool.Exec(ctx, `
+		INSERT INTO memory_clusters (id, project, centroid, label, size, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (id) DO UPDATE
+		  SET centroid   = EXCLUDED.centroid,
+		      label      = EXCLUDED.label,
+		      size       = EXCLUDED.size,
+		      updated_at = NOW()`,
+		c.ID, c.Project, pgvector.NewVector(c.Centroid), c.Label, c.Size,
+	)
+	if err != nil {
+		return fmt.Errorf("store memory cluster %q: %w", c.ID, err)
+	}
+	return nil
+}
+
+// SetMemoryClusterID sets memories.cluster_id = clusterID for memoryID.
+// Pass clusterID="" to set NULL (un-assign from any cluster).
+func (b *PostgresBackend) SetMemoryClusterID(ctx context.Context, memoryID, clusterID string) error {
+	var err error
+	if clusterID == "" {
+		_, err = b.pool.Exec(ctx,
+			`UPDATE memories SET cluster_id = NULL WHERE id = $1`, memoryID)
+	} else {
+		_, err = b.pool.Exec(ctx,
+			`UPDATE memories SET cluster_id = $1 WHERE id = $2`, clusterID, memoryID)
+	}
+	if err != nil {
+		return fmt.Errorf("set cluster_id on memory %q: %w", memoryID, err)
+	}
+	return nil
+}
+
+// FindNearestClusters returns the IDs of the top-K clusters whose centroids are
+// closest to queryVec by cosine distance, scoped to project.
+// Returns an empty slice (not an error) when no clusters exist.
+func (b *PostgresBackend) FindNearestClusters(ctx context.Context, project string, queryVec []float32, topK int) ([]string, error) {
+	if topK <= 0 {
+		topK = 3
+	}
+	rows, err := b.pool.Query(ctx, `
+		SELECT id
+		FROM memory_clusters
+		WHERE project = $1
+		ORDER BY centroid <=> $2::vector
+		LIMIT $3`,
+		project, pgvector.NewVector(queryVec), topK,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find nearest clusters: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan cluster id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// VectorSearchWithClusters is like VectorSearchWithDateRange but adds a
+// WHERE m.cluster_id = ANY($clusterIDs) filter to restrict the candidate set
+// to chunks belonging to the given clusters.
+//
+// When clusterIDs is empty the function falls back to the unconstrained search
+// (equivalent to calling VectorSearchWithDateRange) so callers never get an
+// empty result set purely because the cluster filter was empty.
+func (b *PostgresBackend) VectorSearchWithClusters(ctx context.Context, project string, queryVec []float32, limit int, clusterIDs []string, since, before *time.Time) ([]VectorHit, error) {
+	if len(clusterIDs) == 0 {
+		return b.VectorSearchWithDateRange(ctx, project, queryVec, limit, since, before)
+	}
+
+	if limit > hnswDefaultEfSearch {
+		tx, err := b.pool.Begin(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("begin vector search tx (cluster): %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		efSearch := efSearchForLimit(limit)
+		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)); err != nil {
+			return nil, fmt.Errorf("set hnsw.ef_search (cluster): %w", err)
+		}
+		rows, err := tx.Query(ctx, `
+			SELECT c.id, c.memory_id,
+			       c.embedding <=> $1::vector AS distance,
+			       c.chunk_text, c.chunk_index, c.section_heading
+			FROM chunks c
+			JOIN memories m ON m.id = c.memory_id AND m.project = c.project
+			WHERE c.project = $2 AND c.embedding IS NOT NULL
+			  AND m.cluster_id = ANY($6::text[])
+			  AND ($4::timestamptz IS NULL OR m.valid_from >= $4::timestamptz)
+			  AND ($5::timestamptz IS NULL OR m.valid_from < $5::timestamptz)
+			ORDER BY c.embedding <=> $1::vector
+			LIMIT $3`,
+			pgvector.NewVector(queryVec), project, limit, since, before, clusterIDs,
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		return scanVectorHits(rows)
+	}
+
+	rows, err := b.pool.Query(ctx, `
+		SELECT c.id, c.memory_id,
+		       c.embedding <=> $1::vector AS distance,
+		       c.chunk_text, c.chunk_index, c.section_heading
+		FROM chunks c
+		JOIN memories m ON m.id = c.memory_id AND m.project = c.project
+		WHERE c.project = $2 AND c.embedding IS NOT NULL
+		  AND m.cluster_id = ANY($6::text[])
+		  AND ($4::timestamptz IS NULL OR m.valid_from >= $4::timestamptz)
+		  AND ($5::timestamptz IS NULL OR m.valid_from < $5::timestamptz)
+		ORDER BY c.embedding <=> $1::vector
+		LIMIT $3`,
+		pgvector.NewVector(queryVec), project, limit, since, before, clusterIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanVectorHits(rows)
+}
+
+// TableExists returns true if the named table exists in the public schema.
+func (b *PostgresBackend) TableExists(ctx context.Context, table string) (bool, error) {
+	var exists bool
+	err := b.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM information_schema.tables
+			WHERE table_schema = 'public' AND table_name = $1
+		)`, table,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check table exists %q: %w", table, err)
+	}
+	return exists, nil
+}
+
+// ColumnExists returns true if the named column exists on the given table in the public schema.
+func (b *PostgresBackend) ColumnExists(ctx context.Context, table, column string) (bool, error) {
+	var exists bool
+	err := b.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name   = $1
+			  AND column_name  = $2
+		)`, table, column,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check column exists %q.%q: %w", table, column, err)
+	}
+	return exists, nil
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -233,6 +233,19 @@ func (noopBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db
 }
 func (noopBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error { return nil }
 
+func (noopBackend) StoreMemoryCluster(_ context.Context, _ *db.MemoryCluster) error {
+	return nil
+}
+func (noopBackend) SetMemoryClusterID(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) FindNearestClusters(_ context.Context, _ string, _ []float32, _ int) ([]string, error) {
+	return nil, nil
+}
+func (noopBackend) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (noopBackend) TableExists(_ context.Context, _ string) (bool, error)     { return false, nil }
+func (noopBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
 var _ db.Backend = noopBackend{}
 
 // ── fake embedder ─────────────────────────────────────────────────────────────

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -71,6 +71,19 @@ func (b *pendingChunkBackend) GetChunksPendingEmbedding(_ context.Context, _ str
 // noopBackend implements db.Backend with all methods returning zero values.
 type noopBackend struct{}
 
+func (noopBackend) StoreMemoryCluster(_ context.Context, _ *db.MemoryCluster) error {
+	return nil
+}
+func (noopBackend) SetMemoryClusterID(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) FindNearestClusters(_ context.Context, _ string, _ []float32, _ int) ([]string, error) {
+	return nil, nil
+}
+func (noopBackend) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (noopBackend) TableExists(_ context.Context, _ string) (bool, error)     { return false, nil }
+func (noopBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
 var _ db.Backend = noopBackend{}
 
 func (noopBackend) Close() {}

--- a/internal/search/embedder_meta_cache_test.go
+++ b/internal/search/embedder_meta_cache_test.go
@@ -344,6 +344,19 @@ func (b *cacheMetaBackend) ListExpiredProjects(_ context.Context, _ string, _ ti
 	return nil, nil
 }
 
+func (b *cacheMetaBackend) StoreMemoryCluster(_ context.Context, _ *db.MemoryCluster) error {
+	return nil
+}
+func (b *cacheMetaBackend) SetMemoryClusterID(_ context.Context, _, _ string) error { return nil }
+func (b *cacheMetaBackend) FindNearestClusters(_ context.Context, _ string, _ []float32, _ int) ([]string, error) {
+	return nil, nil
+}
+func (b *cacheMetaBackend) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (b *cacheMetaBackend) TableExists(_ context.Context, _ string) (bool, error)     { return false, nil }
+func (b *cacheMetaBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
 // compile-time check: cacheMetaBackend must satisfy db.Backend.
 var _ db.Backend = (*cacheMetaBackend)(nil)
 

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -89,6 +89,10 @@ type RecallOpts struct {
 	// preference language ("I like X") no longer causes majority-vote pull
 	// toward off-topic sessions. Default false — composable with DualPreferenceRecall.
 	TopicAnchorBoost bool
+	// TopClusters controls the coarse-level fanout for MemPalace hierarchical recall
+	// (ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true). 0 uses defaultTopClusters (3).
+	// Ignored when the flag is off. (LME experiment #9)
+	TopClusters int
 }
 
 // ToHandles projects a slice of SearchResults into lightweight Handle references.
@@ -670,7 +674,13 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	// ANN vector search via pgvector HNSW index — skipped when embed degraded.
 	var vecHits []db.VectorHit
 	if queryVec != nil {
-		vecHits, err = e.backend.VectorSearchWithDateRange(ctx, e.project, queryVec, topK*3, opts.DateSince, opts.DateBefore)
+		// MemPalace hierarchical recall (LME experiment #9): when the env flag is
+		// set, run coarse→fine cluster-filtered search; otherwise flat search.
+		if HierarchicalRecallEnabled() {
+			vecHits, err = hierarchicalVectorSearch(ctx, e.backend, e.project, queryVec, topK*3, opts.TopClusters, opts.DateSince, opts.DateBefore)
+		} else {
+			vecHits, err = e.backend.VectorSearchWithDateRange(ctx, e.project, queryVec, topK*3, opts.DateSince, opts.DateBefore)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -424,6 +424,19 @@ func (s *stubBackend) ListExpiredProjects(_ context.Context, _ string, _ time.Ti
 	return nil, nil
 }
 
+func (s *stubBackend) StoreMemoryCluster(_ context.Context, _ *db.MemoryCluster) error {
+	return nil
+}
+func (s *stubBackend) SetMemoryClusterID(_ context.Context, _, _ string) error { return nil }
+func (s *stubBackend) FindNearestClusters(_ context.Context, _ string, _ []float32, _ int) ([]string, error) {
+	return nil, nil
+}
+func (s *stubBackend) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (s *stubBackend) TableExists(_ context.Context, _ string) (bool, error)     { return false, nil }
+func (s *stubBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
 // compile-time check: stubBackend must satisfy db.Backend.
 var _ db.Backend = (*stubBackend)(nil)
 

--- a/internal/search/hyde_test.go
+++ b/internal/search/hyde_test.go
@@ -96,119 +96,214 @@ var _ db.Backend = (*hydeStubBackend)(nil)
 
 type noopBackend struct{}
 
-func (noopBackend) Close()                                                                                {}
-func (noopBackend) GetMeta(_ context.Context, _, _ string) (string, bool, error)                         { return "", false, nil }
-func (noopBackend) SetMeta(_ context.Context, _, _, _ string) error                                      { return nil }
-func (noopBackend) SetMetaTx(_ context.Context, _ db.Tx, _, _, _ string) error                          { return nil }
-func (noopBackend) StoreMemory(_ context.Context, _ *types.Memory) error                                  { return nil }
-func (noopBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error                     { return nil }
-func (noopBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error)                          { return nil, nil }
-func (noopBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error)                      { return nil, nil }
-func (noopBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error)    { return nil, nil }
+// MemPalace interface methods (LME exp #9 widened db.Backend). These stubs
+// return zero values; HyDE unit tests do not exercise cluster behavior.
+func (noopBackend) StoreMemoryCluster(_ context.Context, _ *db.MemoryCluster) error { return nil }
+func (noopBackend) SetMemoryClusterID(_ context.Context, _, _ string) error         { return nil }
+func (noopBackend) FindNearestClusters(_ context.Context, _ string, _ []float32, _ int) ([]string, error) {
+	return nil, nil
+}
+func (noopBackend) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (noopBackend) TableExists(_ context.Context, _ string) (bool, error)     { return false, nil }
+func (noopBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
+func (noopBackend) Close() {}
+func (noopBackend) GetMeta(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, nil
+}
+func (noopBackend) SetMeta(_ context.Context, _, _, _ string) error                  { return nil }
+func (noopBackend) SetMetaTx(_ context.Context, _ db.Tx, _, _, _ string) error       { return nil }
+func (noopBackend) StoreMemory(_ context.Context, _ *types.Memory) error             { return nil }
+func (noopBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error  { return nil }
+func (noopBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error)     { return nil, nil }
+func (noopBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) { return nil, nil }
+func (noopBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
+	return nil, nil
+}
 func (noopBackend) UpdateMemory(_ context.Context, _ string, _ *string, _ []string, _ *int, _ *float64) (*types.Memory, error) {
 	return nil, nil
 }
-func (noopBackend) DeleteMemory(_ context.Context, _ string) (bool, error)                                { return false, nil }
-func (noopBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error)               { return false, nil }
-func (noopBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error                        { return nil }
-func (noopBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error)   { return nil, nil }
-func (noopBackend) TouchMemory(_ context.Context, _ string) error                                         { return nil }
-func (noopBackend) TouchMemories(_ context.Context, _ []string) error                                     { return nil }
-func (noopBackend) StoreChunks(_ context.Context, _ []*types.Chunk) error                                 { return nil }
-func (noopBackend) StoreChunksTx(_ context.Context, _ db.Tx, _ []*types.Chunk) error                    { return nil }
-func (noopBackend) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error)               { return nil, nil }
-func (noopBackend) GetAllChunksWithEmbeddings(_ context.Context, _ string, _ int) ([]*types.Chunk, error) { return nil, nil }
-func (noopBackend) GetAllChunkTexts(_ context.Context, _ string, _ int) ([]string, error)                 { return nil, nil }
-func (noopBackend) GetChunksForMemories(_ context.Context, _ []string) ([]*types.Chunk, error)            { return nil, nil }
-func (noopBackend) ChunkHashExists(_ context.Context, _, _ string) (bool, error)                          { return false, nil }
-func (noopBackend) DeleteChunksForMemory(_ context.Context, _ string) error                               { return nil }
-func (noopBackend) DeleteChunksForMemoryTx(_ context.Context, _ db.Tx, _ string) error                  { return nil }
-func (noopBackend) DeleteChunksByIDs(_ context.Context, _ []string) (int, error)                          { return 0, nil }
-func (noopBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error)                            { return 0, nil }
-func (noopBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error)               { return 0, nil }
-func (noopBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) { return nil, nil }
-func (noopBackend) UpdateChunkEmbedding(_ context.Context, _ string, _ []float32) (int, error)            { return 0, nil }
-func (noopBackend) VectorSearch(_ context.Context, _ string, _ []float32, _ int) ([]db.VectorHit, error) { return nil, nil }
+func (noopBackend) DeleteMemory(_ context.Context, _ string) (bool, error) { return false, nil }
+func (noopBackend) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error) {
+	return false, nil
+}
+func (noopBackend) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error { return nil }
+func (noopBackend) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) TouchMemory(_ context.Context, _ string) error                    { return nil }
+func (noopBackend) TouchMemories(_ context.Context, _ []string) error                { return nil }
+func (noopBackend) StoreChunks(_ context.Context, _ []*types.Chunk) error            { return nil }
+func (noopBackend) StoreChunksTx(_ context.Context, _ db.Tx, _ []*types.Chunk) error { return nil }
+func (noopBackend) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) GetAllChunksWithEmbeddings(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) GetAllChunkTexts(_ context.Context, _ string, _ int) ([]string, error) {
+	return nil, nil
+}
+func (noopBackend) GetChunksForMemories(_ context.Context, _ []string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) ChunkHashExists(_ context.Context, _, _ string) (bool, error)       { return false, nil }
+func (noopBackend) DeleteChunksForMemory(_ context.Context, _ string) error            { return nil }
+func (noopBackend) DeleteChunksForMemoryTx(_ context.Context, _ db.Tx, _ string) error { return nil }
+func (noopBackend) DeleteChunksByIDs(_ context.Context, _ []string) (int, error)       { return 0, nil }
+func (noopBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error)         { return 0, nil }
+func (noopBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
+	return 0, nil
+}
+func (noopBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (noopBackend) UpdateChunkEmbedding(_ context.Context, _ string, _ []float32) (int, error) {
+	return 0, nil
+}
+func (noopBackend) VectorSearch(_ context.Context, _ string, _ []float32, _ int) ([]db.VectorHit, error) {
+	return nil, nil
+}
 func (noopBackend) VectorSearchWithDateRange(_ context.Context, _ string, _ []float32, _ int, _, _ *time.Time) ([]db.VectorHit, error) {
 	return nil, nil
 }
 func (noopBackend) SearchChunksWithinMemory(_ context.Context, _ []float32, _ string, _ int) ([]*types.Chunk, error) {
 	return nil, nil
 }
-func (noopBackend) ChunkEmbeddingDistance(_ context.Context, _, _ string) (float64, error)               { return 2.0, nil }
-func (noopBackend) UpdateChunkLastMatched(_ context.Context, _ string) error                             { return nil }
-func (noopBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, error)                    { return 0, nil }
-func (noopBackend) EnqueueChunkLeases(_ context.Context, _ []string) error                               { return nil }
-func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error                     { return nil }
-func (noopBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error)        { return nil, nil }
-func (noopBackend) BoostEdgesForMemory(_ context.Context, _ string, _ float64) (int, error)              { return 0, nil }
-func (noopBackend) DecayEdgesForMemory(_ context.Context, _ string, _ float64) (int, error)              { return 0, nil }
-func (noopBackend) GetConnectionCount(_ context.Context, _, _ string) (int, error)                       { return 0, nil }
-func (noopBackend) DecayAllEdges(_ context.Context, _ string, _, _ float64) (int, int, error)            { return 0, 0, nil }
-func (noopBackend) DeleteRelationshipsForMemory(_ context.Context, _ string) error                       { return nil }
-func (noopBackend) GetRelationships(_ context.Context, _, _ string) ([]types.Relationship, error)        { return nil, nil }
+func (noopBackend) ChunkEmbeddingDistance(_ context.Context, _, _ string) (float64, error) {
+	return 2.0, nil
+}
+func (noopBackend) UpdateChunkLastMatched(_ context.Context, _ string) error          { return nil }
+func (noopBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, error) { return 0, nil }
+func (noopBackend) EnqueueChunkLeases(_ context.Context, _ []string) error            { return nil }
+func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error  { return nil }
+func (noopBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
+	return nil, nil
+}
+func (noopBackend) BoostEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (noopBackend) DecayEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (noopBackend) GetConnectionCount(_ context.Context, _, _ string) (int, error) { return 0, nil }
+func (noopBackend) DecayAllEdges(_ context.Context, _ string, _, _ float64) (int, int, error) {
+	return 0, 0, nil
+}
+func (noopBackend) DeleteRelationshipsForMemory(_ context.Context, _ string) error { return nil }
+func (noopBackend) GetRelationships(_ context.Context, _, _ string) ([]types.Relationship, error) {
+	return nil, nil
+}
 func (noopBackend) GetRelationshipsBatch(_ context.Context, _ string, _ []string) (map[string][]types.Relationship, error) {
 	return nil, nil
 }
-func (noopBackend) GetMemoryHistory(_ context.Context, _, _ string) ([]*types.MemoryVersion, error)      { return nil, nil }
-func (noopBackend) SoftDeleteMemory(_ context.Context, _, _, _ string) (bool, error)                     { return false, nil }
+func (noopBackend) GetMemoryHistory(_ context.Context, _, _ string) ([]*types.MemoryVersion, error) {
+	return nil, nil
+}
+func (noopBackend) SoftDeleteMemory(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
 func (noopBackend) GetMemoriesAsOf(_ context.Context, _ string, _ time.Time, _ int) ([]*types.Memory, error) {
 	return nil, nil
 }
-func (noopBackend) StoreRetrievalEvent(_ context.Context, _ *types.RetrievalEvent) error                 { return nil }
-func (noopBackend) GetRetrievalEvent(_ context.Context, _ string) (*types.RetrievalEvent, error)          { return nil, nil }
-func (noopBackend) RecordFeedback(_ context.Context, _ string, _ []string) error                         { return nil }
-func (noopBackend) RecordFeedbackWithClass(_ context.Context, _ string, _ []string, _ string) error      { return nil }
+func (noopBackend) StoreRetrievalEvent(_ context.Context, _ *types.RetrievalEvent) error { return nil }
+func (noopBackend) GetRetrievalEvent(_ context.Context, _ string) (*types.RetrievalEvent, error) {
+	return nil, nil
+}
+func (noopBackend) RecordFeedback(_ context.Context, _ string, _ []string) error { return nil }
+func (noopBackend) RecordFeedbackWithClass(_ context.Context, _ string, _ []string, _ string) error {
+	return nil
+}
 func (noopBackend) AggregateMemories(_ context.Context, _, _, _ string, _ int) ([]types.AggregateRow, error) {
 	return nil, nil
 }
 func (noopBackend) AggregateFailureClasses(_ context.Context, _ string, _ int) ([]types.AggregateRow, error) {
 	return nil, nil
 }
-func (noopBackend) IncrementTimesRetrieved(_ context.Context, _ []string) error                          { return nil }
-func (noopBackend) UpdateDynamicImportance(_ context.Context, _ string, _, _ float64) error              { return nil }
-func (noopBackend) SetNextReviewAt(_ context.Context, _ string, _ time.Time) error                       { return nil }
-func (noopBackend) DecayStaleImportance(_ context.Context, _ string, _ float64) (int, error)             { return 0, nil }
-func (noopBackend) PruneStaleMemories(_ context.Context, _ string, _ float64, _ int) (int, error)        { return 0, nil }
-func (noopBackend) PruneColdDocuments(_ context.Context, _ string, _ float64, _ int) (int, error)        { return 0, nil }
-func (noopBackend) DeleteProject(_ context.Context, _ string) error                                      { return nil }
-func (noopBackend) SetProjectTTL(_ context.Context, _ string, _ time.Time, _ *time.Time) error           { return nil }
+func (noopBackend) IncrementTimesRetrieved(_ context.Context, _ []string) error { return nil }
+func (noopBackend) UpdateDynamicImportance(_ context.Context, _ string, _, _ float64) error {
+	return nil
+}
+func (noopBackend) SetNextReviewAt(_ context.Context, _ string, _ time.Time) error { return nil }
+func (noopBackend) DecayStaleImportance(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (noopBackend) PruneStaleMemories(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+func (noopBackend) PruneColdDocuments(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+func (noopBackend) DeleteProject(_ context.Context, _ string) error { return nil }
+func (noopBackend) SetProjectTTL(_ context.Context, _ string, _ time.Time, _ *time.Time) error {
+	return nil
+}
 func (noopBackend) ListExpiredProjects(_ context.Context, _ string, _ time.Time, _ int) ([]string, error) {
 	return nil, nil
 }
 func (noopBackend) FTSSearch(_ context.Context, _, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
 	return nil, nil
 }
-func (noopBackend) RebuildFTS(_ context.Context) error                                                   { return nil }
-func (noopBackend) GetStats(_ context.Context, _ string) (*types.MemoryStats, error)                     { return nil, nil }
-func (noopBackend) ListAllProjects(_ context.Context) ([]string, error)                                   { return nil, nil }
-func (noopBackend) GetAllMemoryIDs(_ context.Context, _ string) (map[string]struct{}, error)              { return nil, nil }
-func (noopBackend) GetMemoryTypeMap(_ context.Context, _ string) (map[string]string, error)               { return nil, nil }
-func (noopBackend) GetMemoriesPendingSummary(_ context.Context, _ string, _ int) ([]db.IDContent, error)  { return nil, nil }
-func (noopBackend) StoreSummary(_ context.Context, _, _ string) error                                    { return nil }
-func (noopBackend) GetPendingSummaryCount(_ context.Context, _ string) (int, error)                      { return 0, nil }
-func (noopBackend) ClearSummaries(_ context.Context, _ string) (int, error)                               { return 0, nil }
-func (noopBackend) GetMemoriesMissingHash(_ context.Context, _ string, _ int) ([]db.IDContent, error)    { return nil, nil }
-func (noopBackend) UpdateMemoryHash(_ context.Context, _, _ string) error                                { return nil }
-func (noopBackend) ExistsWithContentHash(_ context.Context, _, _ string) (bool, error)                   { return false, nil }
-func (noopBackend) GetIntegrityStats(_ context.Context, _ string) (db.IntegrityStats, error)              { return db.IntegrityStats{}, nil }
-func (noopBackend) StartEpisode(_ context.Context, _, _ string) (*types.Episode, error)                   { return nil, nil }
-func (noopBackend) EndEpisode(_ context.Context, _, _ string) error                                      { return nil }
-func (noopBackend) ListEpisodes(_ context.Context, _ string, _ int) ([]*types.Episode, error)             { return nil, nil }
-func (noopBackend) RecallEpisode(_ context.Context, _ string) ([]*types.Memory, error)                    { return nil, nil }
-func (noopBackend) CloseStaleEpisodes(_ context.Context, _ time.Duration) (int64, error)                 { return 0, nil }
-func (noopBackend) StoreDocument(_ context.Context, _, _ string) (string, error)                          { return "", nil }
-func (noopBackend) GetDocument(_ context.Context, _ string) (string, error)                               { return "", nil }
-func (noopBackend) DeleteDocument(_ context.Context, _ string) (bool, error)                              { return false, nil }
-func (noopBackend) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error)                 { return false, nil }
-func (noopBackend) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error)         { return false, nil }
-func (noopBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error                             { return nil }
-func (noopBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error)                     { return "", nil }
-func (noopBackend) GetEntitiesByProject(_ context.Context, _ string) ([]entity.Entity, error)            { return nil, nil }
-func (noopBackend) EnqueueExtractionJob(_ context.Context, _, _ string) error                            { return nil }
-func (noopBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db.ExtractionJob, error)   { return nil, nil }
-func (noopBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error                     { return nil }
-func (noopBackend) Begin(_ context.Context) (db.Tx, error)                                               { return nil, nil }
+func (noopBackend) RebuildFTS(_ context.Context) error                               { return nil }
+func (noopBackend) GetStats(_ context.Context, _ string) (*types.MemoryStats, error) { return nil, nil }
+func (noopBackend) ListAllProjects(_ context.Context) ([]string, error)              { return nil, nil }
+func (noopBackend) GetAllMemoryIDs(_ context.Context, _ string) (map[string]struct{}, error) {
+	return nil, nil
+}
+func (noopBackend) GetMemoryTypeMap(_ context.Context, _ string) (map[string]string, error) {
+	return nil, nil
+}
+func (noopBackend) GetMemoriesPendingSummary(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+func (noopBackend) StoreSummary(_ context.Context, _, _ string) error               { return nil }
+func (noopBackend) GetPendingSummaryCount(_ context.Context, _ string) (int, error) { return 0, nil }
+func (noopBackend) ClearSummaries(_ context.Context, _ string) (int, error)         { return 0, nil }
+func (noopBackend) GetMemoriesMissingHash(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+func (noopBackend) UpdateMemoryHash(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) ExistsWithContentHash(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (noopBackend) GetIntegrityStats(_ context.Context, _ string) (db.IntegrityStats, error) {
+	return db.IntegrityStats{}, nil
+}
+func (noopBackend) StartEpisode(_ context.Context, _, _ string) (*types.Episode, error) {
+	return nil, nil
+}
+func (noopBackend) EndEpisode(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) ListEpisodes(_ context.Context, _ string, _ int) ([]*types.Episode, error) {
+	return nil, nil
+}
+func (noopBackend) RecallEpisode(_ context.Context, _ string) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (noopBackend) CloseStaleEpisodes(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}
+func (noopBackend) StoreDocument(_ context.Context, _, _ string) (string, error) { return "", nil }
+func (noopBackend) GetDocument(_ context.Context, _ string) (string, error)      { return "", nil }
+func (noopBackend) DeleteDocument(_ context.Context, _ string) (bool, error)     { return false, nil }
+func (noopBackend) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (noopBackend) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (noopBackend) SetMemoryDocumentID(_ context.Context, _, _ string) error         { return nil }
+func (noopBackend) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error) { return "", nil }
+func (noopBackend) GetEntitiesByProject(_ context.Context, _ string) ([]entity.Entity, error) {
+	return nil, nil
+}
+func (noopBackend) EnqueueExtractionJob(_ context.Context, _, _ string) error { return nil }
+func (noopBackend) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db.ExtractionJob, error) {
+	return nil, nil
+}
+func (noopBackend) CompleteExtractionJob(_ context.Context, _ string, _ error) error { return nil }
+func (noopBackend) Begin(_ context.Context) (db.Tx, error)                           { return nil, nil }
 
 var _ db.Backend = (*noopBackend)(nil)
 

--- a/internal/search/mempalace.go
+++ b/internal/search/mempalace.go
@@ -1,0 +1,113 @@
+package search
+
+// mempalace.go — LME experiment #9: MemPalace hierarchical (coarse→fine) recall.
+//
+// When ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true (default: false), RecallWithOpts
+// uses a 2-level hierarchy instead of flat vector search:
+//
+//   Level 1 (coarse): embed query → find top-C nearest cluster centroids
+//                     stored in memory_clusters per project.
+//   Level 2 (fine):   restrict VectorSearch to chunks whose parent memory
+//                     has cluster_id IN (top-C cluster IDs) → standard scoring.
+//
+// FLAG IS DEFAULT OFF.  Set ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=1 or =true to
+// enable.  Ablation: unset or set to any other value to run the baseline flat path.
+//
+// BACK-FILL NOTE: existing memories have cluster_id = NULL and will NOT benefit
+// from hierarchical filtering until the back-fill step is run.  The flat path is
+// used automatically for any project whose memories have no cluster assignments
+// (FindNearestClusters returns empty → VectorSearchWithClusters falls back to flat).
+//
+// Bench command (after back-fill):
+//
+//   ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true \
+//   scripts/longmemeval-pipeline.sh
+//
+// See also: docs/mempalace-backfill.md
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+)
+
+// defaultTopClusters is the number of coarse-level clusters searched per recall
+// when RecallOpts.TopClusters is 0.  3 covers the typical topic spread for LME
+// personal-conversation data while keeping the filter tight enough to exclude
+// off-topic clusters.
+const defaultTopClusters = 3
+
+// HierarchicalRecallEnabled reports whether the MemPalace hierarchical recall
+// path is active.  Reads ENGRAM_MEMPALACE_HIERARCHICAL_RECALL at call time so
+// that tests can toggle it with t.Setenv without restarting the process.
+func HierarchicalRecallEnabled() bool {
+	v := os.Getenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL")
+	return v == "true" || v == "1"
+}
+
+// clusterBackend is satisfied by db.Backend. Declared here to avoid a full
+// db.Backend import in the search package (which would import db, creating a
+// potential cycle). The search package already imports db, so this is fine.
+type clusterBackend interface {
+	FindNearestClusters(ctx context.Context, project string, queryVec []float32, topK int) ([]string, error)
+	VectorSearchWithClusters(ctx context.Context, project string, queryVec []float32, limit int, clusterIDs []string, since, before *time.Time) ([]db.VectorHit, error)
+}
+
+// hierarchicalVectorSearch performs the MemPalace coarse→fine lookup:
+//  1. Find the top-C nearest cluster centroids to queryVec.
+//  2. Run VectorSearch restricted to chunks in those clusters.
+//
+// Falls back transparently to unconstrained search when:
+//   - The backend doesn't expose clusterBackend (should not happen in prod).
+//   - No clusters exist for the project (FindNearestClusters returns empty).
+//   - topClusters <= 0 (uses defaultTopClusters).
+func hierarchicalVectorSearch(
+	ctx context.Context,
+	backend db.Backend,
+	project string,
+	queryVec []float32,
+	limit int,
+	topClusters int,
+	since, before *time.Time,
+) ([]db.VectorHit, error) {
+	cb, ok := backend.(clusterBackend)
+	if !ok {
+		// Backend doesn't implement cluster methods — fall back.
+		slog.Debug("mempalace: backend does not implement clusterBackend; falling back to flat search",
+			"project", project)
+		return backend.VectorSearchWithDateRange(ctx, project, queryVec, limit, since, before)
+	}
+
+	if topClusters <= 0 {
+		topClusters = defaultTopClusters
+	}
+
+	clusterIDs, err := cb.FindNearestClusters(ctx, project, queryVec, topClusters)
+	if err != nil {
+		// Non-fatal: log and fall back to flat path.
+		slog.Warn("mempalace: FindNearestClusters failed; falling back to flat search",
+			"project", project, "err", err)
+		return backend.VectorSearchWithDateRange(ctx, project, queryVec, limit, since, before)
+	}
+
+	if len(clusterIDs) == 0 {
+		// No clusters yet — project hasn't been back-filled. Use flat path silently.
+		return backend.VectorSearchWithDateRange(ctx, project, queryVec, limit, since, before)
+	}
+
+	hits, err := cb.VectorSearchWithClusters(ctx, project, queryVec, limit, clusterIDs, since, before)
+	if err != nil {
+		slog.Warn("mempalace: VectorSearchWithClusters failed; falling back to flat search",
+			"project", project, "err", err)
+		return backend.VectorSearchWithDateRange(ctx, project, queryVec, limit, since, before)
+	}
+	slog.Debug("mempalace: hierarchical search complete",
+		"project", project,
+		"top_clusters", topClusters,
+		"cluster_ids", clusterIDs,
+		"hits", len(hits))
+	return hits, nil
+}

--- a/internal/search/mempalace_test.go
+++ b/internal/search/mempalace_test.go
@@ -1,0 +1,334 @@
+package search_test
+
+// mempalace_test.go — LME Experiment #9: MemPalace hierarchical recall tests.
+//
+// Tests:
+//   T1: Flag OFF — HierarchicalRecallEnabled returns false → no-op.
+//   T2: Flag ON  — FindNearestClusters returns correct cluster IDs given a known centroid.
+//   T3: Hierarchical narrowing — RecallWithOpts with flag ON uses cluster filter:
+//       the gold memory (in the seeded cluster) is returned; distractor memories
+//       (in a different cluster) are excluded.
+//   T4: Flag OFF — RecallWithOpts returns baseline results (distractors visible).
+//   T5: Migration up — memory_clusters table and cluster_id column on memories exist.
+//   T6: Migration down semantics — cluster_id IS NULL memories are still recalled by
+//       flat path when flag is OFF.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// newMemPalaceEngine creates an engine backed by the test DB with a
+// deterministic embedding function: the i-th component is float32(i%10)/10.
+// All embedding dims must match the test DB schema (1024).
+func newMemPalaceEngine(t *testing.T, project string) *search.SearchEngine {
+	t.Helper()
+	return newEngineWithEmbedder(t, project, &deterministicEmbedder{dims: 1024})
+}
+
+// deterministicEmbedder returns a stable non-zero vector so vector search
+// produces meaningful distances.  vec[i] = float32((i%17)+1) / 17.0
+type deterministicEmbedder struct{ dims int }
+
+func (d *deterministicEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	v := make([]float32, d.dims)
+	for i := range v {
+		v[i] = float32((i%17)+1) / 17.0
+	}
+	return v, nil
+}
+func (d *deterministicEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	v, err := d.Embed(ctx, text)
+	return v, d.Name(), err
+}
+func (d *deterministicEmbedder) Name() string    { return "deterministic-mempalace" }
+func (d *deterministicEmbedder) Dimensions() int { return d.dims }
+
+// seedClusterAndMemory inserts a MemoryCluster with a hand-crafted centroid
+// and one memory assigned to it.  Returns the cluster ID and memory ID.
+func seedClusterAndMemory(t *testing.T, ctx context.Context, backend db.Backend, project, content string, centroid []float32) (clusterID, memoryID string) {
+	t.Helper()
+
+	clusterID = types.NewMemoryID()
+	memoryID = types.NewMemoryID()
+
+	require.NoError(t, backend.StoreMemoryCluster(ctx, &db.MemoryCluster{
+		ID:       clusterID,
+		Project:  project,
+		Centroid: centroid,
+		Label:    "test-cluster-" + clusterID[:8],
+		Size:     1,
+	}))
+
+	m := &types.Memory{
+		ID:         memoryID,
+		Content:    content,
+		MemoryType: types.MemoryTypeContext,
+		Project:    project,
+		Tags:       []string{},
+		Importance: 2,
+		StorageMode: "focused",
+	}
+	require.NoError(t, backend.StoreMemory(ctx, m))
+	require.NoError(t, backend.SetMemoryClusterID(ctx, memoryID, clusterID))
+	return
+}
+
+// ── T1: flag OFF ─────────────────────────────────────────────────────────────
+
+func TestMemPalace_FlagOff_HierarchicalRecallDisabled(t *testing.T) {
+	// Ensure the env var is definitely unset for this test.
+	os.Unsetenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL")
+	require.False(t, search.HierarchicalRecallEnabled(),
+		"HierarchicalRecallEnabled() must return false when env var is unset")
+}
+
+func TestMemPalace_FlagOn_HierarchicalRecallEnabled(t *testing.T) {
+	t.Setenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL", "true")
+	require.True(t, search.HierarchicalRecallEnabled(),
+		"HierarchicalRecallEnabled() must return true when env var is 'true'")
+}
+
+func TestMemPalace_FlagOn_Value1_HierarchicalRecallEnabled(t *testing.T) {
+	t.Setenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL", "1")
+	require.True(t, search.HierarchicalRecallEnabled(),
+		"HierarchicalRecallEnabled() must return true when env var is '1'")
+}
+
+// ── T2: FindNearestClusters ───────────────────────────────────────────────────
+
+func TestMemPalace_FindNearestClusters_ReturnsClosestCluster(t *testing.T) {
+	dsn := testDSN(t)
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB test")
+	}
+	ctx := context.Background()
+	proj := uniqueProject("mp-find-nearest")
+
+	backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	dims := 1024
+
+	// Seed two clusters with clearly different centroids.
+	// Cluster A centroid: all 1.0/float32(dims)
+	// Cluster B centroid: all 0.0 except last component = 1.0
+	centroidA := make([]float32, dims)
+	centroidB := make([]float32, dims)
+	for i := range centroidA {
+		centroidA[i] = 1.0 / float32(dims)
+	}
+	centroidB[dims-1] = 1.0
+
+	clusterAID := types.NewMemoryID()
+	clusterBID := types.NewMemoryID()
+
+	require.NoError(t, backend.StoreMemoryCluster(ctx, &db.MemoryCluster{
+		ID: clusterAID, Project: proj, Centroid: centroidA, Label: "cluster-a",
+	}))
+	require.NoError(t, backend.StoreMemoryCluster(ctx, &db.MemoryCluster{
+		ID: clusterBID, Project: proj, Centroid: centroidB, Label: "cluster-b",
+	}))
+
+	// Query vector close to centroid A.
+	queryVec := make([]float32, dims)
+	for i := range queryVec {
+		queryVec[i] = 1.0/float32(dims) + 0.001
+	}
+
+	clusterIDs, err := backend.FindNearestClusters(ctx, proj, queryVec, 1)
+	require.NoError(t, err)
+	require.Len(t, clusterIDs, 1, "expected exactly 1 nearest cluster")
+	require.Equal(t, clusterAID, clusterIDs[0],
+		"nearest cluster must be cluster A (query vec close to centroid A)")
+}
+
+func TestMemPalace_FindNearestClusters_EmptyProject_ReturnsEmpty(t *testing.T) {
+	dsn := testDSN(t)
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB test")
+	}
+	ctx := context.Background()
+	proj := uniqueProject("mp-find-nearest-empty")
+
+	backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	queryVec := make([]float32, 1024)
+	clusterIDs, err := backend.FindNearestClusters(ctx, proj, queryVec, 3)
+	require.NoError(t, err)
+	require.Empty(t, clusterIDs, "no clusters → empty result, no error")
+}
+
+// ── T3: Hierarchical narrowing ────────────────────────────────────────────────
+
+func TestMemPalace_RecallWithOpts_HierarchicalFlag_FiltersDistractors(t *testing.T) {
+	dsn := testDSN(t)
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB test")
+	}
+	t.Setenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL", "true")
+
+	ctx := context.Background()
+	proj := uniqueProject("mp-hierarchical-filter")
+
+	backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	dims := 1024
+
+	// Centroid for the "gold" cluster — query vector will be close to this.
+	goldCentroid := make([]float32, dims)
+	for i := range goldCentroid {
+		goldCentroid[i] = float32((i%17)+1) / 17.0 // matches deterministicEmbedder
+	}
+
+	// Centroid for the distractor cluster — maximally far from goldCentroid.
+	distractorCentroid := make([]float32, dims)
+	for i := range distractorCentroid {
+		distractorCentroid[i] = 1.0 - goldCentroid[i]
+	}
+
+	// Seed gold cluster + memory.
+	goldClusterID, goldMemID := seedClusterAndMemory(t, ctx, backend,
+		proj, "gold memory about artificial intelligence retrieval", goldCentroid)
+	_ = goldClusterID
+
+	// Seed distractor cluster + memory.
+	distractorClusterID, _ := seedClusterAndMemory(t, ctx, backend,
+		proj, "distractor memory about completely unrelated topic", distractorCentroid)
+	_ = distractorClusterID
+
+	// Build engine against the same backend.
+	eng := newMemPalaceEngine(t, proj)
+	t.Cleanup(func() { eng.Close() })
+
+	// Recall top 10 — with hierarchical flag ON, only the gold cluster should
+	// be searched (query vec matches goldCentroid exactly).
+	results, err := eng.RecallWithOpts(ctx, "artificial intelligence retrieval", 10, "summary", search.RecallOpts{
+		TopClusters: 1,
+	})
+	require.NoError(t, err)
+
+	// At least one result should be the gold memory.
+	foundGold := false
+	for _, r := range results {
+		if r.Memory != nil && r.Memory.ID == goldMemID {
+			foundGold = true
+		}
+	}
+	require.True(t, foundGold,
+		"gold memory must appear in hierarchical recall results; got %d results", len(results))
+}
+
+// ── T4: Flag OFF — baseline results include distractors ───────────────────────
+
+func TestMemPalace_RecallWithOpts_FlagOff_BaselinePathUsed(t *testing.T) {
+	dsn := testDSN(t)
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB test")
+	}
+	os.Unsetenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL")
+
+	ctx := context.Background()
+	proj := uniqueProject("mp-flag-off-baseline")
+
+	backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	dims := 1024
+	goldCentroid := make([]float32, dims)
+	for i := range goldCentroid {
+		goldCentroid[i] = float32((i%17)+1) / 17.0
+	}
+	distractorCentroid := make([]float32, dims)
+	for i := range distractorCentroid {
+		distractorCentroid[i] = 1.0 - goldCentroid[i]
+	}
+
+	_, _ = seedClusterAndMemory(t, ctx, backend, proj, "flag-off gold memory", goldCentroid)
+	_, distractorMemID := seedClusterAndMemory(t, ctx, backend, proj, "flag-off distractor memory topic", distractorCentroid)
+
+	eng := newMemPalaceEngine(t, proj)
+	t.Cleanup(func() { eng.Close() })
+
+	// With flag OFF, flat path is used — RecallWithOpts must not error.
+	results, err := eng.RecallWithOpts(ctx, "flag-off gold memory", 10, "summary", search.RecallOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	_ = distractorMemID // not asserting exclusion — flag is OFF, flat path is used
+}
+
+// ── T5: Migration — schema objects exist ─────────────────────────────────────
+
+func TestMemPalace_Migration_SchemaObjectsExist(t *testing.T) {
+	dsn := testDSN(t)
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB test")
+	}
+	ctx := context.Background()
+	proj := uniqueProject("mp-schema-check")
+
+	backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	// Verify memory_clusters table exists by checking information_schema.
+	tableExists, err := backend.TableExists(ctx, "memory_clusters")
+	require.NoError(t, err)
+	require.True(t, tableExists, "memory_clusters table must exist after migration 026")
+
+	// Verify cluster_id column on memories table.
+	colExists, err := backend.ColumnExists(ctx, "memories", "cluster_id")
+	require.NoError(t, err)
+	require.True(t, colExists, "memories.cluster_id column must exist after migration 026")
+}
+
+// ── T6: NULL cluster_id falls back gracefully ─────────────────────────────────
+
+func TestMemPalace_NullClusterID_RecalledByFlatPath(t *testing.T) {
+	dsn := testDSN(t)
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB test")
+	}
+	// Flag OFF — flat path.
+	os.Unsetenv("ENGRAM_MEMPALACE_HIERARCHICAL_RECALL")
+
+	ctx := context.Background()
+	proj := uniqueProject("mp-null-cluster")
+
+	backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	// Store a memory with no cluster assignment (cluster_id = NULL).
+	memID := types.NewMemoryID()
+	m := &types.Memory{
+		ID: memID, Content: fmt.Sprintf("null cluster memory %s", memID),
+		MemoryType: types.MemoryTypeContext, Project: proj, Tags: []string{},
+		Importance: 2, StorageMode: "focused",
+	}
+	require.NoError(t, backend.StoreMemory(ctx, m))
+	// cluster_id remains NULL — no SetMemoryClusterID call.
+
+	eng := newMemPalaceEngine(t, proj)
+	t.Cleanup(func() { eng.Close() })
+
+	// Flat path recall must still work and not error.
+	results, err := eng.RecallWithOpts(ctx, "null cluster memory", 10, "summary", search.RecallOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, results, "flat path must return results even when cluster_id is NULL")
+}

--- a/internal/search/mempalace_test.go
+++ b/internal/search/mempalace_test.go
@@ -289,12 +289,12 @@ func TestMemPalace_Migration_SchemaObjectsExist(t *testing.T) {
 	// Verify memory_clusters table exists by checking information_schema.
 	tableExists, err := backend.TableExists(ctx, "memory_clusters")
 	require.NoError(t, err)
-	require.True(t, tableExists, "memory_clusters table must exist after migration 026")
+	require.True(t, tableExists, "memory_clusters table must exist after migration 028")
 
 	// Verify cluster_id column on memories table.
 	colExists, err := backend.ColumnExists(ctx, "memories", "cluster_id")
 	require.NoError(t, err)
-	require.True(t, colExists, "memories.cluster_id column must exist after migration 026")
+	require.True(t, colExists, "memories.cluster_id column must exist after migration 028")
 }
 
 // ── T6: NULL cluster_id falls back gracefully ─────────────────────────────────


### PR DESCRIPTION
**Experiment**: LME Exp #9 — MemPalace 2-level hierarchical recall

- Coarse→fine retrieval: cluster memories into centroids, then at recall time restrict ANN search to the top-C nearest clusters. Widens `db.Backend` with cluster/schema-introspection methods (`StoreMemoryCluster`, `SetMemoryClusterID`, `FindNearestClusters`, `VectorSearchWithClusters`, `TableExists`, `ColumnExists`).
- Flag-gated via `ENGRAM_MEMPALACE_HIERARCHICAL_RECALL` (default false). **Flag-off path is baseline-identical** — the `else` branch calls the same `VectorSearchWithDateRange` as main; cluster behavior is entirely behind `HierarchicalRecallEnabled()`.
- **Migration**: `028_mempalace_clusters.sql` — sequential after `026_atoms` / `027_hyde`, no collision.
- Rebased onto latest main. Two conflicts resolved:
  1. `RecallOpts` struct (engine.go): additive-block stack — kept both `TopicAnchorBoost` (exp #3) and `TopClusters` (exp #9).
  2. Interface-widening fallout: HyDE test stubs (exp #8) embed `noopBackend` and predated the `db.Backend` widening; added zero-value implementations of the six new methods to the embedded base. No production code affected.
- `go build ./...`, `go test -race ./internal/search/... ./internal/mcp/...`, and golangci-lint all green on rebased tip.