### PR TITLE
feat(lme5): temporal validity window filter for knowledge-update recall

### DIFF
--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -841,16 +841,35 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			score = CompositeScoreWithWeights(input, baseWeights)
 		}
 
+		// LME Experiment #5: apply validity window boost when ENGRAM_VALIDITY_WINDOW_FILTER=true.
+		// Multiplies the composite score by a valid_from recency factor so that
+		// more-recently-dated memories rank above older ones for the same query.
+		// Flag OFF (default) → vwBoost = 1.0, score unchanged (baseline-safe).
+		//
+		// Guard: do NOT apply on temporal queries (tempQuery=true). CompositeScoreWithRankNorm
+		// already incorporates valid_from via RankNormalizedRecency; applying vwBoost there
+		// would double-count the recency signal. The experiment target is knowledge-update
+		// queries (kuQuery), which use CompositeScoreWithWeights and have no rank-norm path.
+		vwBoost := ValidFromBoost(m.ValidFrom)
+		if !tempQuery {
+			score *= vwBoost
+		} else {
+			// Record 1.0 in the breakdown so observability accurately reflects that
+			// no extra boost was applied on this path.
+			vwBoost = 1.0
+		}
+
 		result := types.SearchResult{
 			Memory:     m,
 			Score:      score,
 			ChunkScore: hit.cosine,
 			ScoreBreakdown: func() map[string]float64 {
 				bd := map[string]float64{
-					"cosine":        hit.cosine,
-					"bm25":          bm25,
-					"recency":       RecencyDecay(input.HoursSince),
-					"episode_boost": 1.0,
+					"cosine":           hit.cosine,
+					"bm25":             bm25,
+					"recency":          RecencyDecay(input.HoursSince),
+					"episode_boost":    1.0,
+					"valid_from_boost": vwBoost,
 				}
 				if input.EpisodeMatch {
 					bd["episode_boost"] = 1.15

--- a/internal/search/validity_window.go
+++ b/internal/search/validity_window.go
@@ -1,0 +1,155 @@
+package search
+
+// LME Experiment #5 — Temporal Validity Window Filter.
+//
+// ENGRAM_VALIDITY_WINDOW_FILTER (default: false/off)
+//
+// When enabled, RecallWithOpts applies a ValidFromBoost multiplier to each
+// memory's composite score based on the recency of its valid_from timestamp.
+// Memories with more-recent valid_from values score higher; memories without
+// a valid_from (nil) receive a neutral multiplier of 1.0 so they are not
+// penalized.
+//
+// This targets the knowledge-update failure class in LME-M: when the current
+// fact and an outdated fact are both in the candidate set, the current-value
+// (most-recent valid_from) wins.
+//
+// Design decision (advisory-gate, 2026-06-02, Option C):
+//   - DB layer already enforces valid_to IS NULL (active-only) everywhere.
+//   - The remaining gap is valid_from recency signal at scoring time.
+//   - Flag gate required to preserve golden baseline (run_id 7a87fd) for
+//     clean ablation: flag OFF = baseline, flag ON = experiment.
+//
+// Re-ingest caveat (Engram 019e100c): existing benchmark data must be
+// re-ingested with date: tags for ValidFrom to be populated. This flag has
+// no effect on memories without valid_from set at ingest time (they receive
+// boost = 1.0 regardless of flag state).
+//
+// Bench+re-ingest command (do NOT run now — document only):
+//
+//   # 1. Re-ingest LME-M dataset with date: tags.
+//   longmemeval ingest \
+//     --data ~/path/to/longmemeval_m_cleaned.json \
+//     --url http://localhost:8788 \
+//     --workers 32 \
+//     --out ~/benchmarks/lme-exp5 \
+//     --cleanup-policy=never \
+//     --scratch-ttl 168h
+//
+//   # 2. Run recall+generate with validity window flag ON.
+//   ENGRAM_VALIDITY_WINDOW_FILTER=true \
+//   longmemeval run \
+//     --data ~/path/to/longmemeval_m_cleaned.json \
+//     --url http://localhost:8788 \
+//     --llm-url "${LME_LLM_URL}" \
+//     --llm-model "${LME_LLM_MODEL}" \
+//     --workers 32 \
+//     --out ~/benchmarks/lme-exp5 \
+//     --recall-topk 100 \
+//     --context-topk 8
+//
+//   # 3. Score.
+//   longmemeval score-efficient \
+//     --data ~/path/to/longmemeval_m_cleaned.json \
+//     --scorer-url "${LME_SCORER_URL:-${LME_LLM_URL}}" \
+//     --scorer-model "${LME_SCORER_MODEL:-${LME_LLM_MODEL}}" \
+//     --workers 16 \
+//     --out ~/benchmarks/lme-exp5
+//
+//   # 4. Analyze — compare knowledge-update accuracy vs golden baseline (run_id 7a87fd).
+//   longmemeval analyze --results ~/benchmarks/lme-exp5
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// validityWindowEnabled is the cached state of ENGRAM_VALIDITY_WINDOW_FILTER.
+// Initialized once via validityWindowOnce; reset in tests via ResetValidityWindowForTesting.
+var (
+	validityWindowOnce    sync.Once
+	validityWindowEnabled bool
+)
+
+// loadValidityWindowFlag reads ENGRAM_VALIDITY_WINDOW_FILTER from the environment.
+// Any non-empty value other than "false", "0", or "no" is treated as enabled.
+func loadValidityWindowFlag() {
+	val := os.Getenv("ENGRAM_VALIDITY_WINDOW_FILTER")
+	switch val {
+	case "", "false", "0", "no":
+		validityWindowEnabled = false
+	default:
+		validityWindowEnabled = true
+	}
+}
+
+// isValidityWindowEnabled returns true when ENGRAM_VALIDITY_WINDOW_FILTER is
+// set to a truthy value ("true", "1", "yes", or any non-empty non-false value).
+// The result is cached after the first call.
+func isValidityWindowEnabled() bool {
+	validityWindowOnce.Do(loadValidityWindowFlag)
+	return validityWindowEnabled
+}
+
+// ResetValidityWindowForTesting resets the validity window sync.Once so tests
+// can inject different ENGRAM_VALIDITY_WINDOW_FILTER values between sub-tests.
+// Must only be called from test code.
+func ResetValidityWindowForTesting() {
+	validityWindowOnce = sync.Once{}
+}
+
+// validityWindowYearScale is the characteristic time scale for the ValidFromBoost
+// decay formula, expressed in years. A memory valid_from exactly this many years
+// ago receives boost = 0.5; a memory from now receives boost approaching 1.0.
+//
+// 2.0 years chosen to span the LME-M benchmark range (sessions from 2022–2024
+// evaluated in 2026): a 2024 fact (~2 yr ago) gets boost ≈ 0.5, while a 2020
+// fact (~6 yr ago) gets boost ≈ 0.25 — meaningful separation without clamping.
+//
+// The boost is a Lorentzian (inverse-square) decay for long time scales rather
+// than exponential, which would collapse all multi-year memories to the same floor.
+const validityWindowYearScale = 2.0
+
+// ValidFromBoost computes a multiplicative score boost based on the memory's
+// valid_from recency. It is applied in RecallWithOpts when
+// ENGRAM_VALIDITY_WINDOW_FILTER=true.
+//
+// Behavior:
+//   - nil valid_from → 1.0 (neutral; no penalty for undated memories)
+//   - flag OFF       → 1.0 (neutral; baseline-safe)
+//   - flag ON        → monotonically decreasing from 1.0 (present-day)
+//     as valid_from recedes into the past
+//
+// Formula: inverse-linear decay with characteristic scale T (years):
+//
+//	boost(t) = T / (T + yearsAgo)
+//
+// At yearsAgo=0:  boost = T/T = 1.0 (present-day → no penalty)
+// At yearsAgo=T:  boost = T/(2T) = 0.5 (at scale T years: half boost)
+// At yearsAgo=2T: boost = T/(3T) ≈ 0.333
+// At yearsAgo=6T: boost = T/(7T) ≈ 0.143
+//
+// This gives continuous, monotonically decreasing values across multi-year spans.
+// No floor clamp needed: the minimum is positive and bounded away from zero.
+//
+// Example (T=2 years, evaluated 2026):
+//   - valid_from=2026: boost=1.0 (present)
+//   - valid_from=2024: boost≈0.5 (2yr ago)
+//   - valid_from=2022: boost≈0.25 (4yr ago)
+//   - valid_from=2020: boost≈0.167 (6yr ago)
+func ValidFromBoost(validFrom *time.Time) float64 {
+	if !isValidityWindowEnabled() {
+		return 1.0
+	}
+	if validFrom == nil || validFrom.IsZero() {
+		return 1.0
+	}
+	yearsAgo := time.Since(*validFrom).Hours() / (365.25 * 24.0)
+	if yearsAgo < 0 {
+		// Future-dated memory (e.g., planned event): treat as present-day.
+		yearsAgo = 0
+	}
+	// boost = T / (T + yearsAgo), where T = validityWindowYearScale.
+	return validityWindowYearScale / (validityWindowYearScale + yearsAgo)
+}

--- a/internal/search/validity_window_test.go
+++ b/internal/search/validity_window_test.go
@@ -1,0 +1,172 @@
+package search_test
+
+// LME Experiment #5 — temporal validity windows (server-side recall).
+//
+// Tests in this file are the TDD anchor for ENGRAM_VALIDITY_WINDOW_FILTER.
+// They must FAIL before implementation and PASS after.
+//
+// Failure class targeted: knowledge-update (LME-M baseline 46.2% on run c3d9f1;
+// updated baseline 4bf268c to be measured after re-ingest with this flag ON).
+//
+// Re-ingest caveat (Engram 019e100c): existing benchmark data must be re-ingested
+// with date: tags for ValidFrom to be set. Tests here use in-memory mocks and
+// do not require prod data.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidFromBoost_FlagOff verifies that ValidFromBoost returns 1.0 (neutral)
+// when ENGRAM_VALIDITY_WINDOW_FILTER is unset (default OFF), so the baseline
+// composite score is unchanged. This is the ablation guard.
+func TestValidFromBoost_FlagOff(t *testing.T) {
+	t.Setenv("ENGRAM_VALIDITY_WINDOW_FILTER", "")
+	search.ResetValidityWindowForTesting()
+
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// With flag OFF, both old and recent dates must return boost = 1.0 (no-op).
+	assert.InDelta(t, 1.0, search.ValidFromBoost(&old), 0.001,
+		"flag OFF: old valid_from must return neutral boost 1.0")
+	assert.InDelta(t, 1.0, search.ValidFromBoost(&recent), 0.001,
+		"flag OFF: recent valid_from must return neutral boost 1.0")
+	assert.InDelta(t, 1.0, search.ValidFromBoost(nil), 0.001,
+		"flag OFF: nil valid_from must return neutral boost 1.0")
+}
+
+// TestValidFromBoost_FlagOn_RecentBeatsOld verifies that when
+// ENGRAM_VALIDITY_WINDOW_FILTER=true, a memory with a more recent valid_from
+// receives a higher boost than one with an older valid_from.
+//
+// This is the core invariant: "current-value-wins".
+func TestValidFromBoost_FlagOn_RecentBeatsOld(t *testing.T) {
+	t.Setenv("ENGRAM_VALIDITY_WINDOW_FILTER", "true")
+	search.ResetValidityWindowForTesting()
+
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	boostOld := search.ValidFromBoost(&old)
+	boostRecent := search.ValidFromBoost(&recent)
+
+	require.Greater(t, boostRecent, boostOld,
+		"flag ON: more recent valid_from must yield a higher boost than older valid_from")
+}
+
+// TestValidFromBoost_FlagOn_NilIsNeutral verifies that memories without a
+// valid_from (most pre-existing memories that lack date: tags) receive a
+// neutral boost (1.0) rather than a penalty. This prevents the flag from
+// degrading recall for undated memories.
+func TestValidFromBoost_FlagOn_NilIsNeutral(t *testing.T) {
+	t.Setenv("ENGRAM_VALIDITY_WINDOW_FILTER", "true")
+	search.ResetValidityWindowForTesting()
+
+	boost := search.ValidFromBoost(nil)
+	assert.InDelta(t, 1.0, boost, 0.001,
+		"flag ON: nil valid_from must return neutral boost 1.0 (no penalty for undated memories)")
+}
+
+// TestValidFromBoost_FlagOn_PresentDayIsMax verifies that a memory timestamped
+// very close to now (within minutes) receives a boost >= 1.0, confirming that
+// recency is rewarded, not penalized.
+func TestValidFromBoost_FlagOn_PresentDayIsMax(t *testing.T) {
+	t.Setenv("ENGRAM_VALIDITY_WINDOW_FILTER", "true")
+	search.ResetValidityWindowForTesting()
+
+	now := time.Now().UTC().Add(-time.Minute) // 1 minute ago
+	boost := search.ValidFromBoost(&now)
+	// boost = T/(T+yearsAgo) at 1 minute ago ≈ T/(T+tiny) ≈ 0.9999990 — just below 1.0.
+	// Assert > 0.999 rather than >= 1.0: the formula is strictly < 1.0 for any past time,
+	// but a 1-minute-old memory is effectively not penalized (0.001% reduction).
+	assert.Greater(t, boost, 0.999,
+		"flag ON: very recent valid_from must not be meaningfully penalised (boost > 0.999)")
+}
+
+// TestValidityWindowFilter_SupersededFactDeranked verifies end-to-end via the
+// search engine that when ENGRAM_VALIDITY_WINDOW_FILTER=true, a memory with a
+// more recent valid_from outscores a memory with the same semantic content but
+// an older valid_from. This simulates the knowledge-update failure class where
+// the outdated fact and the current fact are both in the candidate set.
+//
+// NOTE: This test requires a running Postgres instance (uses newTestEngine).
+// It is an integration test gated by the DSN environment variable.
+func TestValidityWindowFilter_SupersededFactDeranked(t *testing.T) {
+	t.Setenv("ENGRAM_VALIDITY_WINDOW_FILTER", "true")
+	search.ResetValidityWindowForTesting()
+
+	engine := newTestEngine(t, uniqueProject("test-validity-window"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	// Outdated fact: John lives in New York (2020).
+	outdated := time.Date(2020, 3, 10, 0, 0, 0, 0, time.UTC)
+	mOld := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "John currently lives in New York",
+		MemoryType:  types.MemoryTypeContext,
+		Importance:  2,
+		StorageMode: "focused",
+		ValidFrom:   &outdated,
+	}
+	// Current fact: John lives in San Francisco (2024).
+	current := time.Date(2024, 9, 1, 0, 0, 0, 0, time.UTC)
+	mNew := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "John currently lives in San Francisco",
+		MemoryType:  types.MemoryTypeContext,
+		Importance:  2,
+		StorageMode: "focused",
+		ValidFrom:   &current,
+	}
+	require.NoError(t, engine.Store(ctx, mOld))
+	require.NoError(t, engine.Store(ctx, mNew))
+
+	results, err := engine.Recall(ctx, "Where does John currently live?", 10, "full")
+	require.NoError(t, err)
+	require.NotEmpty(t, results, "recall must return at least one result")
+
+	// Find both results by ID.
+	var scoreOld, scoreNew float64
+	var foundOld, foundNew bool
+	for _, r := range results {
+		switch r.Memory.ID {
+		case mOld.ID:
+			scoreOld = r.Score
+			foundOld = true
+		case mNew.ID:
+			scoreNew = r.Score
+			foundNew = true
+		}
+	}
+
+	require.True(t, foundOld, "outdated memory must be in recall results")
+	require.True(t, foundNew, "current memory must be in recall results")
+	assert.Greater(t, scoreNew, scoreOld,
+		"current fact (valid_from=2024) must outscore outdated fact (valid_from=2020) when validity window filter is ON")
+}
+
+// TestValidityWindowFilter_FlagOff_BaselineUnchanged verifies that with the
+// flag OFF (default), ValidFromBoost returns identical values for different
+// valid_from dates. This is the ablation guard ensuring the baseline is
+// reproducible without any validity-window scoring change.
+func TestValidityWindowFilter_FlagOff_BaselineUnchanged(t *testing.T) {
+	t.Setenv("ENGRAM_VALIDITY_WINDOW_FILTER", "")
+	search.ResetValidityWindowForTesting()
+
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// Both get boost 1.0 with flag OFF — no ordering change.
+	boostOld := search.ValidFromBoost(&old)
+	boostRecent := search.ValidFromBoost(&recent)
+	assert.Equal(t, boostOld, boostRecent,
+		"flag OFF: valid_from must not affect score ordering (baseline ablation guard)")
+}


### PR DESCRIPTION
## Summary

- Adds LME experiment #5: validity-window scoring boost (`ENGRAM_VALIDITY_WINDOW_FILTER`, default OFF).
- When the flag is ON, `ValidFromBoost` applies an inverse-linear decay multiplier based on `valid_from` recency. Flag OFF → `vwBoost = 1.0` → score unchanged (baseline-identical).
- Double-apply guard: boost is skipped on `tempQuery` path (which already has `RankNormalizedRecency`); only applies to `kuQuery`/non-temporal path via `CompositeScoreWithWeights`.
- Adds `valid_from_boost` key to `ScoreBreakdown` for observability (non-behavioral).
- No DB migrations, no new columns, no scanner drift risk.

## Wave-2 merge notes

- Rebased `3133639..1a2e8e5` onto `origin/main` (40e9c89, wave-1 healthy).
- Rebase was clean (no conflicts): wave-1 features (TopicAnchorBoost, TopClusters, HyDE, MemPalace hierarchical recall, H-TAB) are fully preserved.
- `go build -buildvcs=false ./...` ✅
- `go test -race ./internal/search/... ./internal/mcp/...` ✅
- No DB code touched → no local DB integration needed; CI is authoritative.

## Flag-OFF baseline check

`ValidFromBoost` returns `1.0` unconditionally when `ENGRAM_VALIDITY_WINDOW_FILTER` is unset or `"false"`. `score *= 1.0` is a no-op. Behavior is baseline-identical with flag off.

## Merge intent: squash-merge, --delete-branch=false