### PR TITLE
feat(search): retrieval bundle — paraphrase-union (#2), exact-fact boost (#4), RRF fusion (#6)

### DIFF
--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -435,9 +435,15 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
 	since, before := temporalRecallWindow(item.Question, item.QuestionType, item.QuestionDate)
 	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
+		if cfg.ExactSignalBoost {
+			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, callSince, callBefore)
+		}
 		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost)
 	}
 	recallDefault := func(query string, topK int) ([]string, error) {
+		if cfg.ExactSignalBoost {
+			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, since, before)
+		}
 		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
 	}
 	retrievedIDs, temporalFallbackIDs, err := recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -263,7 +263,44 @@ func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK
 	return nil, lastErr
 }
 
+// RecallOpts holds optional parameters for the LongMemEval recall client.
+type RecallOpts struct {
+	// ExactFactBoost passes exact_fact_boost=true to the server-side memory_recall
+	// handler, enabling the entity-identifier scoring boost (LME #938 improvement #3).
+	ExactFactBoost bool
+}
+
+// RecallWithExactBoost calls recall with exact_fact_boost enabled.
+// Convenience wrapper for the longmemeval run command.
+func (c *Client) RecallWithExactBoost(ctx context.Context, project, query string, topK int, since, before *time.Time) ([]string, error) {
+	var lastErr error
+	for attempt := 0; attempt <= c.retries; attempt++ {
+		if attempt > 0 {
+			if err := c.Connect(ctx); err != nil {
+				return nil, fmt.Errorf("reconnect on retry %d: %w", attempt, err)
+			}
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		ids, err := c.recallWithBoostOpt(ctx, project, query, topK, since, before, true, false)
+		if err == nil {
+			return ids, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// recall is the internal retry-wrapped recall helper. topicAnchorBoost enables
+// H-TAB server-side scoring (LME exp #3, flag-gated).
 func (c *Client) recall(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]string, error) {
+	return c.recallWithBoostOpt(ctx, project, query, topK, since, before, false, topicAnchorBoost)
+}
+
+func (c *Client) recallWithBoostOpt(ctx context.Context, project, query string, topK int, since, before *time.Time, exactFactBoost, topicAnchorBoost bool) ([]string, error) {
 	args := map[string]any{
 		"query":   query,
 		"project": project,
@@ -276,6 +313,9 @@ func (c *Client) recall(ctx context.Context, project, query string, topK int, si
 		// full SearchResult graph. LongMemEval only needs ranked IDs, and
 		// this avoids oversized tool payloads on dense queries.
 		"mode": "handle",
+	}
+	if exactFactBoost {
+		args["exact_fact_boost"] = true
 	}
 	if since != nil {
 		args["since"] = since.UTC().Format(time.RFC3339)

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -358,6 +359,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		return nil, err
 	}
 	rerank := getBool(args, "rerank", false)
+	exactFactBoost := getBool(args, "exact_fact_boost", false)
 	var opts search.RecallOpts
 	opts.DateSince = since
 	opts.DateBefore = before
@@ -385,6 +387,21 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	// Inject current session episode for same-session score boosting (Phase 3).
 	if id, ok := episodeIDFromContext(ctx); ok {
 		opts.CurrentEpisodeID = id
+	}
+	// Exact-fact identifier boost (LME #938 improvement #3, default OFF).
+	opts.ExactFactBoost = exactFactBoost
+	// Paraphrase-union retrieval (LME experiment #2, default OFF).
+	// Enable server-wide via ENGRAM_PARAPHRASE_UNION=true env var,
+	// or per-call by passing paraphrase_union=true in the MCP args.
+	{
+		v := strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_PARAPHRASE_UNION")))
+		opts.ParaphraseUnion = v == "true" || v == "1" || getBool(args, "paraphrase_union", false)
+	}
+	// RRF fusion (LME experiment #6, issue #938 improvement #1, default OFF).
+	// Enable server-wide via ENGRAM_RRF_FUSION=true|1 env var, or per-call via rrf_fusion=true.
+	{
+		v := strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_RRF_FUSION")))
+		opts.Fusion = v == "true" || v == "1" || getBool(args, "rrf_fusion", false)
 	}
 
 	// Capture embedder degradation signal and reason from RecallWithOpts (#989).

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -93,6 +93,22 @@ type RecallOpts struct {
 	// (ENGRAM_MEMPALACE_HIERARCHICAL_RECALL=true). 0 uses defaultTopClusters (3).
 	// Ignored when the flag is off. (LME experiment #9)
 	TopClusters int
+	// ExactFactBoost enables the exact-fact / entity-identifier scoring boost
+	// (LME experiment #4, issue #938 improvement #3). When true, memories whose
+	// content contains a verbatim identifier from the query (named entity, URL,
+	// phone number) receive an additive score boost calibrated to surface them
+	// above high-cosine near-misses. Default false (ablation-safe).
+	ExactFactBoost bool
+	// Fusion enables Reciprocal Rank Fusion (RRF) candidate merging before
+	// composite scoring (LME experiment #6, issue #938 improvement #1). When
+	// true, the engine pre-computes rank positions from the vector and BM25 legs
+	// and passes them to CompositeScoreRRF instead of CompositeScoreWithWeights.
+	// Targets the gold_missing failure class (~168/271 incorrect where gold is
+	// absent from top-10 entirely). Default false (ablatable).
+	Fusion bool
+	// ParaphraseUnion enables multi-pass paraphrased query union retrieval
+	// (LME experiment #2, issue #938 improvement #4). Default false (ablatable).
+	ParaphraseUnion bool
 }
 
 // ToHandles projects a slice of SearchResults into lightweight Handle references.
@@ -157,6 +173,7 @@ type bestHit struct {
 	chunkIndex     int
 	sectionHeading *string // borrowed; see struct comment
 	chunkID        string
+	rrfScore       float64 // populated by applyFusion when RecallOpts.Fusion=true; 0 otherwise
 }
 
 // defaultEmbedRecallTimeoutMS is the bounded timeout for the embed call during
@@ -188,6 +205,9 @@ type SearchEngine struct {
 	embedGateway        embedGateway        // non-nil when ENGRAM_EMBED_GW_ENABLED=true
 	PreferenceExtractor PreferenceExtractor // nil = extraction disabled; default PatternPreferenceExtractor{}
 	hydeIndexer         *HydeIndexer        // nil when ENGRAM_HYDE_ENABLED=false or backend lacks hydeBackend
+	// Paraphraser generates query variants for the ParaphraseUnion recall path.
+	// Defaults to RuleBasedParaphraser{} when nil. Override via SetParaphraser.
+	Paraphraser QueryParaphraser
 	// embedRecallTimeout is the bounded embed deadline for recall. Read from
 	// ENGRAM_EMBED_RECALL_TIMEOUT_MS at engine construction; default 500ms.
 	embedRecallTimeout time.Duration
@@ -755,10 +775,105 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		memories[r.Memory.ID] = r.Memory
 	}
 
+	// ParaphraseUnion path (LME experiment #2): run additional vector+FTS passes
+	// for each paraphrase variant and union candidate sets before scoring.
+	// Targets missing_recall failures where gold is an incidental mention.
+	// When opts.ParaphraseUnion is false this block is entirely skipped.
+	if opts.ParaphraseUnion {
+		parer := e.Paraphraser
+		if parer == nil {
+			parer = RuleBasedParaphraser{}
+		}
+		paraphrases := parer.Paraphrase(query, 3)
+		for _, pq := range paraphrases {
+			// Vector pass for this variant (best-effort; errors are logged, not fatal).
+			var pEmbedCtx context.Context
+			var pEmbedCancel context.CancelFunc
+			if e.embedRecallTimeout == noEmbedTimeout {
+				pEmbedCtx, pEmbedCancel = ctx, func() {}
+			} else {
+				pEmbedCtx, pEmbedCancel = context.WithTimeout(ctx, e.embedRecallTimeout)
+			}
+			pVec, pErr := e.getEmbedder().Embed(pEmbedCtx, pq)
+			pEmbedCancel()
+			if pErr == nil && pVec != nil {
+				pVecHits, pVErr := e.backend.VectorSearchWithDateRange(ctx, e.project, pVec, topK*3, opts.DateSince, opts.DateBefore)
+				if pVErr == nil {
+					for _, h := range pVecHits {
+						cosine := 1.0 - h.Distance
+						if existing, ok := bestHits[h.MemoryID]; !ok || cosine > existing.cosine {
+							bestHits[h.MemoryID] = bestHit{
+								cosine:         cosine,
+								chunkText:      h.ChunkText,
+								chunkIndex:     h.ChunkIndex,
+								sectionHeading: h.SectionHeading,
+								chunkID:        h.ChunkID,
+							}
+						}
+						if !seen[h.MemoryID] {
+							seen[h.MemoryID] = true
+							uniqueIDs = append(uniqueIDs, h.MemoryID)
+						}
+					}
+				} else {
+					slog.Debug("paraphrase union: vector pass failed", "paraphrase", pq, "err", pVErr)
+				}
+			} else if pErr != nil {
+				slog.Debug("paraphrase union: embed failed", "paraphrase", pq, "err", pErr)
+			}
+			// FTS pass for this variant.
+			pFTSResults, pFErr := e.backend.FTSSearch(ctx, e.project, pq, topK*3, opts.DateSince, opts.DateBefore)
+			if pFErr == nil {
+				for _, r := range pFTSResults {
+					// Prefer higher BM25 score across passes.
+					if r.Score > ftsScores[r.Memory.ID] {
+						ftsScores[r.Memory.ID] = r.Score
+						if r.Score > maxBM25 {
+							maxBM25 = r.Score
+						}
+					}
+					if _, exists := memories[r.Memory.ID]; !exists {
+						memories[r.Memory.ID] = r.Memory
+					}
+				}
+			} else {
+				slog.Debug("paraphrase union: FTS pass failed", "paraphrase", pq, "err", pFErr)
+			}
+		}
+		// Batch-fetch any new vector-only candidates surfaced by paraphrase passes.
+		if len(uniqueIDs) > 0 {
+			newIDs := make([]string, 0, 8)
+			for _, id := range uniqueIDs {
+				if _, exists := memories[id]; !exists {
+					newIDs = append(newIDs, id)
+				}
+			}
+			if len(newIDs) > 0 {
+				newMems, fetchErr := e.backend.GetMemoriesByIDs(ctx, e.project, newIDs)
+				if fetchErr == nil {
+					for _, m := range newMems {
+						memories[m.ID] = m
+					}
+				} else {
+					slog.Debug("paraphrase union: batch fetch failed", "err", fetchErr)
+				}
+			}
+		}
+	}
+
 	// Detect query type once before the scoring loop.
 	prefQuery := isPreferenceQuery(query)
 	tempQuery := isTemporalQuery(query)
 	kuQuery := isKnowledgeUpdateQuery(query)
+	// Identifier query detection for exact-fact boost (LME #938 improvement #3).
+	// Only active when the caller enables the flag; detection is cheap (regex).
+	exactBoostEnabled := opts.ExactFactBoost && isIdentifierQuery(query)
+
+	// RRF setup (LME experiment #6, issue #938 improvement #1): pre-compute
+	// per-leg rank positions. applyFusion is a strict no-op when Fusion=false.
+	vecRanks := rankVectorHits(vecHits)
+	ftsRanks := rankFTSResults(ftsRes.results)
+	applyFusion(opts, memories, bestHits, vecRanks, ftsRanks)
 
 	// Resolve base weights: per-project cache when available, otherwise defaults.
 	// Type-specific profiles override the cache — recency dominance is correct
@@ -816,22 +931,27 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			bm25 = ftsScores[id] / maxBM25
 		}
 		hit := bestHits[id]
+		exactMatch := exactBoostEnabled && ExactIdentifierHit(m.Content, query)
 		input := ScoreInput{
-			Cosine:             hit.cosine,
-			BM25:               bm25,
-			HoursSince:         temporalAnchorHours(*m),
-			Importance:         m.Importance,
-			DynamicImportance:  m.DynamicImportance,
-			RetrievalPrecision: m.RetrievalPrecision,
-			EpisodeMatch:       opts.CurrentEpisodeID != "" && m.EpisodeID == opts.CurrentEpisodeID,
-			MemoryType:         m.MemoryType,
-			IsPreferenceQuery:  prefQuery,
+			Cosine:               hit.cosine,
+			BM25:                 bm25,
+			HoursSince:           temporalAnchorHours(*m),
+			Importance:           m.Importance,
+			DynamicImportance:    m.DynamicImportance,
+			RetrievalPrecision:   m.RetrievalPrecision,
+			EpisodeMatch:         opts.CurrentEpisodeID != "" && m.EpisodeID == opts.CurrentEpisodeID,
+			MemoryType:           m.MemoryType,
+			IsPreferenceQuery:    prefQuery,
 			// H-TAB: set when TopicAnchorBoost is on and the memory content
 			// contains at least one domain token from the recall query.
-			TopicAnchorMatch: len(topicAnchorTokens) > 0 && contentContainsTopicAnchor(m.Content, topicAnchorTokens),
+			TopicAnchorMatch:     len(topicAnchorTokens) > 0 && contentContainsTopicAnchor(m.Content, topicAnchorTokens),
+			ExactIdentifierMatch: exactMatch,
 		}
 		var score float64
-		if tempQuery {
+		if opts.Fusion {
+			// RRF path: use pre-computed rank fusion score in place of raw cosine/BM25.
+			score = CompositeScoreRRF(input, baseWeights, hit.rrfScore)
+		} else if tempQuery {
 			var validFrom time.Time
 			if m.ValidFrom != nil {
 				validFrom = *m.ValidFrom
@@ -881,6 +1001,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 				}
 				if m.RetrievalPrecision != nil {
 					bd["retrieval_precision"] = *m.RetrievalPrecision
+				}
+				if input.ExactIdentifierMatch {
+					bd["exact_identifier_boost"] = exactIdentifierBoost()
 				}
 				return bd
 			}(),

--- a/internal/search/exact_fact_boost.go
+++ b/internal/search/exact_fact_boost.go
@@ -1,0 +1,153 @@
+// exact_fact_boost.go — exact-fact / entity-identifier scoring boost.
+//
+// LME experiment #4, issue #938 improvement #3.
+//
+// Exported symbols:
+//   - IsIdentifierQuery(query string) bool
+//   - ExactIdentifierHit(content, query string) bool
+//
+// exactIdentifierBoost() is package-private; used only by score.go.
+package search
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// identifierBoostValue is the additive score boost applied when
+// ExactIdentifierMatch=true in ScoreInput. Calibrated so that a memory with
+// modest cosine (0.60) and BM25 (0.55) outscores a high-cosine near-miss
+// (cosine=0.82, BM25=0.50) under default weights:
+//
+//	right  = 0.40*0.60 + 0.30*0.55 + 0.15*recency + 0.15*precision + boost × ImportanceBoost
+//	wrong  = 0.40*0.82 + 0.30*0.50 + 0.15*recency + 0.15*precision
+//
+// At identical recency and precision, the gap to overcome is:
+//
+//	wrong − right ≈ 0.40*(0.82−0.60) + 0.30*(0.50−0.55) = 0.088 − 0.015 = 0.073
+//
+// Setting boost = 0.10 (multiplied by ImportanceBoost(2) = 1.0) → net +0.10,
+// which is sufficient to flip the ranking with a comfortable margin.
+const identifierBoostValue = 0.10
+
+func exactIdentifierBoost() float64 { return identifierBoostValue }
+
+// ── URL regex ────────────────────────────────────────────────────────────────
+
+var urlRe = regexp.MustCompile(`https?://\S+`)
+
+// ── Phone number regex ────────────────────────────────────────────────────────
+// Matches:
+//   +1-800-555-1234   (international prefix, dashes)
+//   (415) 555-0123    (parenthesised area code)
+//   650-555-9999      (plain dashes, 10-digit US)
+
+var phoneRe = regexp.MustCompile(
+	`(?:\+\d[\d\-]{7,}|` + // +1-800-… or +44…
+		`\(\d{3}\)\s?\d{3}[\-\s]\d{4}|` + // (415) 555-0123
+		`\d{3}[\-\s]\d{3}[\-\s]\d{4})`) // 650-555-9999
+
+// ── Named-entity: two consecutive title-cased tokens ──────────────────────────
+
+// isProperNounPair returns true when query contains at least two consecutive
+// tokens that both start with an uppercase letter. Single-word capitalisation
+// (start-of-sentence) is excluded by requiring a consecutive pair.
+func isProperNounPair(query string) bool {
+	tokens := strings.Fields(query)
+	prevTitle := false
+	for _, tok := range tokens {
+		runes := []rune(tok)
+		if len(runes) == 0 {
+			prevTitle = false
+			continue
+		}
+		// Strip leading punctuation for cleaner detection.
+		start := runes[0]
+		if !unicode.IsLetter(start) && !unicode.IsDigit(start) {
+			// Punctuation-stripped first char.
+			stripped := strings.TrimLeftFunc(tok, func(r rune) bool {
+				return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+			})
+			if stripped == "" {
+				prevTitle = false
+				continue
+			}
+			runes = []rune(stripped)
+			start = runes[0]
+		}
+		isTitle := unicode.IsUpper(start)
+		if isTitle && prevTitle {
+			return true
+		}
+		prevTitle = isTitle
+	}
+	return false
+}
+
+// IsIdentifierQuery returns true when query contains a high-precision entity
+// identifier: a URL, a phone number, or at least two consecutive title-cased
+// tokens (named entity). When true, the engine is allowed to apply the
+// exact-fact boost for memories whose content contains a verbatim match.
+func IsIdentifierQuery(query string) bool {
+	if urlRe.MatchString(query) {
+		return true
+	}
+	if phoneRe.MatchString(query) {
+		return true
+	}
+	return isProperNounPair(query)
+}
+
+// isIdentifierQuery is the unexported alias used within the search package.
+func isIdentifierQuery(query string) bool { return IsIdentifierQuery(query) }
+
+// ExactIdentifierHit returns true when content contains at least one token from
+// query that is also present in the identifier set (URLs, phone numbers, or
+// title-cased token pairs). The comparison is case-insensitive for title-cased
+// tokens and case-sensitive for URLs and phone numbers (to avoid false positives
+// on URLs containing random substrings of common words).
+func ExactIdentifierHit(content, query string) bool {
+	lowerContent := strings.ToLower(content)
+
+	// URL hit: verbatim substring match (case-sensitive at URL level).
+	for _, url := range urlRe.FindAllString(query, -1) {
+		if strings.Contains(content, url) {
+			return true
+		}
+	}
+
+	// Phone hit: verbatim.
+	for _, phone := range phoneRe.FindAllString(query, -1) {
+		if strings.Contains(content, phone) {
+			return true
+		}
+	}
+
+	// Named-entity hit: check whether any title-cased token from a consecutive
+	// pair appears in content (case-insensitive). We look for the *pair* as a
+	// phrase: both words adjacent in either order.
+	tokens := strings.Fields(query)
+	for i := 0; i+1 < len(tokens); i++ {
+		a := strings.TrimFunc(tokens[i], func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+		})
+		b := strings.TrimFunc(tokens[i+1], func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+		})
+		if len(a) == 0 || len(b) == 0 {
+			continue
+		}
+		aRunes := []rune(a)
+		bRunes := []rune(b)
+		if !unicode.IsUpper(aRunes[0]) || !unicode.IsUpper(bRunes[0]) {
+			continue
+		}
+		// Both title-cased: check if the pair phrase appears in content.
+		phrase := strings.ToLower(a + " " + b)
+		if strings.Contains(lowerContent, phrase) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/search/exact_fact_boost_test.go
+++ b/internal/search/exact_fact_boost_test.go
@@ -1,0 +1,203 @@
+package search_test
+
+// LME Experiment #4 — exact-fact / entity-identifier scoring boost.
+// Tests written BEFORE implementation (TDD). All tests must fail until
+// the implementation is wired in score.go, query_signal.go, and engine.go.
+//
+// Issue #938 improvement #3.
+
+import (
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+// ── Identifier detection (query_signal.go) ───────────────────────────────────
+
+// TestIsIdentifierQuery_DetectsURLs verifies that URLs in a query signal
+// high-precision identifier recall — not just semantic similarity.
+func TestIsIdentifierQuery_DetectsURLs(t *testing.T) {
+	require.True(t, search.IsIdentifierQuery("what is https://example.com"),
+		"URL in query must be detected as identifier query")
+	require.True(t, search.IsIdentifierQuery("visit http://foo.bar/path"),
+		"http URL must be detected as identifier query")
+}
+
+// TestIsIdentifierQuery_DetectsPhoneNumbers verifies that phone-number patterns
+// trigger identifier detection.
+func TestIsIdentifierQuery_DetectsPhoneNumbers(t *testing.T) {
+	require.True(t, search.IsIdentifierQuery("call +1-800-555-1234"),
+		"phone number with country code must be detected")
+	require.True(t, search.IsIdentifierQuery("phone (415) 555-0123"),
+		"parenthesized area code must be detected")
+	require.True(t, search.IsIdentifierQuery("reach me at 650-555-9999"),
+		"plain dash-format phone must be detected")
+}
+
+// TestIsIdentifierQuery_DetectsProperNouns verifies that a query containing
+// at least two consecutive Title-Cased words is treated as an identifier query.
+// Single capitalised words (start-of-sentence) are NOT flagged.
+func TestIsIdentifierQuery_DetectsProperNouns(t *testing.T) {
+	require.True(t, search.IsIdentifierQuery("who is John Smith"),
+		"two consecutive title-case tokens must be detected as named entity")
+	require.True(t, search.IsIdentifierQuery("where does Alice Johnson work"),
+		"named entity (first + last name) must trigger identifier mode")
+	require.False(t, search.IsIdentifierQuery("who is the president"),
+		"single-capitalised-word-only query must NOT trigger identifier mode")
+}
+
+// TestIsIdentifierQuery_FalseNegativeSafety verifies that generic prose queries
+// are not misclassified as identifier queries.
+func TestIsIdentifierQuery_FalseNegativeSafety(t *testing.T) {
+	require.False(t, search.IsIdentifierQuery("what did I do yesterday"),
+		"plain prose query must not be flagged as identifier query")
+	require.False(t, search.IsIdentifierQuery("tell me about my preferences"),
+		"preference query must not be flagged as identifier query")
+}
+
+// ── Content hit detection (query_signal.go) ──────────────────────────────────
+
+// TestExactIdentifierHit_ContentContainsQueryToken verifies that when a query
+// token appears verbatim (case-insensitive) in memory content, the function
+// returns true.
+func TestExactIdentifierHit_ContentContainsQueryToken(t *testing.T) {
+	require.True(t,
+		search.ExactIdentifierHit("John Smith called about the contract", "who is John Smith"),
+		"verbatim name in content must produce a hit")
+	require.True(t,
+		search.ExactIdentifierHit("visit https://example.com for details", "what is https://example.com"),
+		"verbatim URL in content must produce a hit")
+}
+
+// TestExactIdentifierHit_NegativeCase verifies no false-positive when the
+// content does not contain the query's identifier tokens.
+func TestExactIdentifierHit_NegativeCase(t *testing.T) {
+	require.False(t,
+		search.ExactIdentifierHit("Alice Johnson is unavailable", "where is John Smith"),
+		"different name in content must not produce a hit")
+}
+
+// ── Scoring integration: boost applied / not applied ─────────────────────────
+
+// TestCompositeScore_ExactIdentifierBoost_Applied verifies that a memory where
+// the ExactIdentifierMatch flag is set scores strictly higher than the same
+// memory without the flag, using default weights.
+func TestCompositeScore_ExactIdentifierBoost_Applied(t *testing.T) {
+	w := search.DefaultWeights()
+
+	base := search.ScoreInput{
+		Cosine:     0.55,
+		BM25:       0.40,
+		HoursSince: 24.0,
+		Importance: 2,
+	}
+	withBoost := base
+	withBoost.ExactIdentifierMatch = true
+
+	scoreBase := search.CompositeScoreWithWeights(base, w)
+	scoreBoosted := search.CompositeScoreWithWeights(withBoost, w)
+
+	require.Greater(t, scoreBoosted, scoreBase,
+		"ExactIdentifierMatch=true must increase the composite score")
+}
+
+// TestCompositeScore_ExactIdentifierBoost_AboveNearVectorMatch verifies the
+// primary LME #938 target: an exact-name match with only modest vector
+// similarity must outrank a near-vector match that does NOT contain the
+// identifier, simulating the case where vector similarity ranks the wrong
+// memory above the correct named-entity memory.
+func TestCompositeScore_ExactIdentifierBoost_AboveNearVectorMatch(t *testing.T) {
+	w := search.DefaultWeights()
+
+	// "Wrong" memory: semantically close (high cosine) but no identifier match.
+	wrongMem := search.ScoreInput{
+		Cosine:               0.82,
+		BM25:                 0.50,
+		HoursSince:           12.0,
+		Importance:           2,
+		ExactIdentifierMatch: false,
+	}
+
+	// "Right" memory: exact name match, but vector similarity only moderate.
+	rightMem := search.ScoreInput{
+		Cosine:               0.60,
+		BM25:                 0.55,
+		HoursSince:           12.0,
+		Importance:           2,
+		ExactIdentifierMatch: true,
+	}
+
+	scoreWrong := search.CompositeScoreWithWeights(wrongMem, w)
+	scoreRight := search.CompositeScoreWithWeights(rightMem, w)
+
+	require.Greater(t, scoreRight, scoreWrong,
+		"exact identifier match must outrank high-cosine non-match (LME #938 target)")
+}
+
+// TestCompositeScore_ExactIdentifierBoost_FlagOff_BaselineIdentical verifies
+// the ablation contract: when ExactIdentifierMatch is false, the score is
+// identical to the pre-flag baseline — no score change introduced by the new
+// field when it is not set.
+func TestCompositeScore_ExactIdentifierBoost_FlagOff_BaselineIdentical(t *testing.T) {
+	w := search.DefaultWeights()
+
+	in := search.ScoreInput{
+		Cosine:               0.70,
+		BM25:                 0.60,
+		HoursSince:           5.0,
+		Importance:           2,
+		ExactIdentifierMatch: false,
+	}
+
+	scoreViaWeights := search.CompositeScoreWithWeights(in, w)
+	scoreViaDefault := search.CompositeScore(in)
+
+	require.InDelta(t, scoreViaDefault, scoreViaWeights, 1e-9,
+		"when ExactIdentifierMatch is false, CompositeScoreWithWeights must be unchanged")
+}
+
+// TestCompositeScore_ExactIdentifierBoost_NonIdentifierOrdering_Unchanged
+// verifies that for generic memories (neither flagged as ExactIdentifierMatch),
+// relative ordering is undisturbed.
+func TestCompositeScore_ExactIdentifierBoost_NonIdentifierOrdering_Unchanged(t *testing.T) {
+	w := search.DefaultWeights()
+
+	memA := search.ScoreInput{Cosine: 0.9, BM25: 0.8, HoursSince: 0, Importance: 2}
+	memB := search.ScoreInput{Cosine: 0.4, BM25: 0.3, HoursSince: 0, Importance: 2}
+
+	scoreA := search.CompositeScoreWithWeights(memA, w)
+	scoreB := search.CompositeScoreWithWeights(memB, w)
+
+	require.Greater(t, scoreA, scoreB,
+		"non-identifier query ordering must not be disrupted by ExactIdentifierMatch path")
+}
+
+// TestCompositeScoreRRF_ExactIdentifierBoost_Applied verifies the boost also
+// applies to the RRF composite path.
+func TestCompositeScoreRRF_ExactIdentifierBoost_Applied(t *testing.T) {
+	w := search.DefaultWeights()
+	rrfBase := search.RRFScore(3, 4, 60)
+
+	base := search.ScoreInput{
+		HoursSince:           6.0,
+		Importance:           2,
+		ExactIdentifierMatch: false,
+	}
+	withBoost := base
+	withBoost.ExactIdentifierMatch = true
+
+	scoreBase := search.CompositeScoreRRF(base, w, rrfBase)
+	scoreBoosted := search.CompositeScoreRRF(withBoost, w, rrfBase)
+
+	require.Greater(t, scoreBoosted, scoreBase,
+		"ExactIdentifierMatch boost must also apply via the RRF scoring path")
+}
+
+// TestExactFactBoostDisabled_RecallOptsFlag verifies that ExactFactBoost
+// exists on RecallOpts and defaults to false (ablation: default OFF).
+func TestExactFactBoostDisabled_RecallOptsFlag(t *testing.T) {
+	var opts search.RecallOpts
+	require.False(t, opts.ExactFactBoost,
+		"ExactFactBoost must default to false (flag-gated, default OFF)")
+}

--- a/internal/search/fusion.go
+++ b/internal/search/fusion.go
@@ -1,0 +1,73 @@
+// fusion.go — Reciprocal Rank Fusion (RRF) candidate merging for RecallWithOpts.
+//
+// LME experiment #6 — issue #938 improvement #1.
+//
+// When RecallOpts.Fusion is true, the engine pre-computes 1-based rank
+// positions for each memory ID from the vector (ANN) and BM25/FTS retrieval
+// legs, then computes an RRF score for each candidate. The RRF score is stored
+// in bestHit.rrfScore and passed to CompositeScoreRRF in place of the raw
+// cosine and BM25 signals.
+//
+// Flag-gate: when Fusion=false (default), applyFusion is a strict no-op.
+package search
+
+import (
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+const rrfK = 60 // standard RRF constant (Cormack et al. 2009)
+
+// rankVectorHits assigns 1-based rank positions to memory IDs from a slice of
+// VectorHit values ordered by ascending cosine distance (pgvector order).
+// When a memory ID appears multiple times (multiple chunks), only the first
+// occurrence is ranked — it corresponds to the best (lowest-distance) chunk.
+func rankVectorHits(hits []db.VectorHit) map[string]int {
+	ranks := make(map[string]int, len(hits))
+	rank := 0
+	for _, h := range hits {
+		if _, seen := ranks[h.MemoryID]; !seen {
+			rank++
+			ranks[h.MemoryID] = rank
+		}
+	}
+	return ranks
+}
+
+// rankFTSResults assigns 1-based rank positions to memory IDs from a slice of
+// FTSResult values ordered by descending BM25 score (highest score = rank 1).
+// Results with nil Memory fields are skipped.
+func rankFTSResults(results []db.FTSResult) map[string]int {
+	ranks := make(map[string]int, len(results))
+	rank := 0
+	for _, r := range results {
+		if r.Memory == nil {
+			continue
+		}
+		rank++
+		if _, seen := ranks[r.Memory.ID]; !seen {
+			ranks[r.Memory.ID] = rank
+		}
+	}
+	return ranks
+}
+
+// applyFusion computes and stores RRF scores into the bestHit map for every
+// memory in memories. When opts.Fusion is false it is a strict no-op.
+//
+// After applyFusion, the scoring loop in RecallWithOpts detects opts.Fusion and
+// calls CompositeScoreRRF instead of CompositeScoreWithWeights, passing
+// hit.rrfScore in place of the raw cosine and BM25 signals.
+func applyFusion(opts RecallOpts, memories map[string]*types.Memory, bestHits map[string]bestHit, vecRanks, ftsRanks map[string]int) {
+	if !opts.Fusion {
+		return
+	}
+	for id := range memories {
+		vr := vecRanks[id] // 0 if absent
+		fr := ftsRanks[id] // 0 if absent
+		score := RRFScore(vr, fr, rrfK)
+		h := bestHits[id]
+		h.rrfScore = score
+		bestHits[id] = h
+	}
+}

--- a/internal/search/fusion_test.go
+++ b/internal/search/fusion_test.go
@@ -1,0 +1,273 @@
+// fusion_test.go — TDD tests for composite retrieval fusion (RRF flag-gate).
+//
+// Tests verify three invariants:
+//  1. Flag OFF → rrfScore stays 0 (no-op, baseline unchanged).
+//  2. Flag ON  → a gold candidate that only one retriever surfaces (absent from
+//     the other leg) still receives a non-zero RRF score (not suppressed).
+//  3. Ordering: both-legs candidate scores higher than single-leg candidate.
+//  4. Determinism: identical inputs → identical outputs.
+//
+// All tests are pure (no-DB); they exercise rankVectorHits, rankFTSResults,
+// and applyFusion via the package-internal test file.
+package search
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// rankVectorHits
+// ---------------------------------------------------------------------------
+
+func TestRankVectorHits_Empty(t *testing.T) {
+	ranks := rankVectorHits(nil)
+	if len(ranks) != 0 {
+		t.Fatalf("expected empty map for nil input, got len=%d", len(ranks))
+	}
+}
+
+func TestRankVectorHits_UniqueMemories(t *testing.T) {
+	hits := []db.VectorHit{
+		{MemoryID: "mem-a", Distance: 0.1}, // best → rank 1
+		{MemoryID: "mem-b", Distance: 0.5}, // second → rank 2
+		{MemoryID: "mem-c", Distance: 0.9}, // third → rank 3
+	}
+	ranks := rankVectorHits(hits)
+	if ranks["mem-a"] != 1 {
+		t.Errorf("mem-a rank = %d, want 1", ranks["mem-a"])
+	}
+	if ranks["mem-b"] != 2 {
+		t.Errorf("mem-b rank = %d, want 2", ranks["mem-b"])
+	}
+	if ranks["mem-c"] != 3 {
+		t.Errorf("mem-c rank = %d, want 3", ranks["mem-c"])
+	}
+}
+
+func TestRankVectorHits_BestChunkPerMemory(t *testing.T) {
+	// Same memory ID appears twice; rank should reflect first (best) occurrence.
+	hits := []db.VectorHit{
+		{MemoryID: "mem-x", Distance: 0.2, ChunkID: "chunk-1"}, // first → rank 1
+		{MemoryID: "mem-y", Distance: 0.4, ChunkID: "chunk-2"}, // rank 2
+		{MemoryID: "mem-x", Distance: 0.6, ChunkID: "chunk-3"}, // duplicate mem-x, ignored for rank
+	}
+	ranks := rankVectorHits(hits)
+	if ranks["mem-x"] != 1 {
+		t.Errorf("mem-x rank = %d, want 1 (best chunk)", ranks["mem-x"])
+	}
+	if ranks["mem-y"] != 2 {
+		t.Errorf("mem-y rank = %d, want 2", ranks["mem-y"])
+	}
+	if len(ranks) != 2 {
+		t.Errorf("expected 2 unique memory ranks, got %d", len(ranks))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// rankFTSResults
+// ---------------------------------------------------------------------------
+
+func TestRankFTSResults_Empty(t *testing.T) {
+	ranks := rankFTSResults(nil)
+	if len(ranks) != 0 {
+		t.Fatalf("expected empty map for nil input, got len=%d", len(ranks))
+	}
+}
+
+func TestRankFTSResults_Ordering(t *testing.T) {
+	results := []db.FTSResult{
+		{Memory: &types.Memory{ID: "fts-1"}, Score: 3.5}, // rank 1
+		{Memory: &types.Memory{ID: "fts-2"}, Score: 2.0}, // rank 2
+		{Memory: &types.Memory{ID: "fts-3"}, Score: 0.5}, // rank 3
+	}
+	ranks := rankFTSResults(results)
+	if ranks["fts-1"] != 1 {
+		t.Errorf("fts-1 rank = %d, want 1", ranks["fts-1"])
+	}
+	if ranks["fts-2"] != 2 {
+		t.Errorf("fts-2 rank = %d, want 2", ranks["fts-2"])
+	}
+	if ranks["fts-3"] != 3 {
+		t.Errorf("fts-3 rank = %d, want 3", ranks["fts-3"])
+	}
+}
+
+func TestRankFTSResults_NilMemorySkipped(t *testing.T) {
+	results := []db.FTSResult{
+		{Memory: nil, Score: 5.0},
+		{Memory: &types.Memory{ID: "fts-valid"}, Score: 1.0},
+	}
+	ranks := rankFTSResults(results)
+	if _, ok := ranks[""]; ok {
+		t.Error("nil Memory should not produce a rank entry")
+	}
+	if ranks["fts-valid"] != 1 {
+		t.Errorf("fts-valid rank = %d, want 1", ranks["fts-valid"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyFusion: flag OFF = strict no-op
+// ---------------------------------------------------------------------------
+
+func TestApplyFusion_FlagOff_NoChange(t *testing.T) {
+	// When Fusion is false, applyFusion must not modify rrfScore.
+	memories := map[string]*types.Memory{
+		"m1": {ID: "m1"},
+		"m2": {ID: "m2"},
+	}
+	bh := map[string]bestHit{
+		"m1": {cosine: 0.9},
+		"m2": {cosine: 0.7},
+	}
+	vecRanks := map[string]int{"m1": 1, "m2": 2}
+	ftsRanks := map[string]int{"m1": 2, "m2": 1}
+
+	opts := RecallOpts{Fusion: false}
+	applyFusion(opts, memories, bh, vecRanks, ftsRanks)
+
+	for id, h := range bh {
+		if h.rrfScore != 0 {
+			t.Errorf("flag OFF: %s rrfScore = %v, want 0 (no-op)", id, h.rrfScore)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyFusion: flag ON surfaces BM25-only candidate
+// ---------------------------------------------------------------------------
+
+func TestApplyFusion_FlagOn_SurfacesBM25OnlyCandidate(t *testing.T) {
+	// gold-mem: absent from vector (vecRank=0), present at ftsRank=3.
+	// With pure weighted-sum, cosine=0 → very low score.
+	// With RRF: gold-mem gets 1/(60+3)=0.0159 — non-zero.
+	memories := map[string]*types.Memory{
+		"gold-mem": {ID: "gold-mem"},
+		"vec-only": {ID: "vec-only"},
+	}
+	bh := map[string]bestHit{
+		"gold-mem": {cosine: 0.0},
+		"vec-only": {cosine: 0.95},
+	}
+	vecRanks := map[string]int{"vec-only": 1}
+	ftsRanks := map[string]int{"gold-mem": 3}
+
+	opts := RecallOpts{Fusion: true}
+	applyFusion(opts, memories, bh, vecRanks, ftsRanks)
+
+	goldHit, ok := bh["gold-mem"]
+	if !ok {
+		t.Fatal("gold-mem missing from bestHits after fusion")
+	}
+	if goldHit.rrfScore <= 0 {
+		t.Errorf("gold-mem rrfScore = %v, want > 0 (BM25-only candidate must not be zeroed)", goldHit.rrfScore)
+	}
+}
+
+func TestApplyFusion_FlagOn_BothLegsHigherThanSingle(t *testing.T) {
+	// champion: vecRank=1, ftsRank=1 → RRF = 1/61 + 1/61 ≈ 0.0328.
+	// single-leg: vecRank=2, ftsRank=0 → RRF = 1/62 ≈ 0.0161.
+	memories := map[string]*types.Memory{
+		"champion":   {ID: "champion"},
+		"single-leg": {ID: "single-leg"},
+	}
+	bh := map[string]bestHit{
+		"champion":   {cosine: 0.9},
+		"single-leg": {cosine: 0.7},
+	}
+	vecRanks := map[string]int{"champion": 1, "single-leg": 2}
+	ftsRanks := map[string]int{"champion": 1}
+
+	opts := RecallOpts{Fusion: true}
+	applyFusion(opts, memories, bh, vecRanks, ftsRanks)
+
+	champScore := bh["champion"].rrfScore
+	singleScore := bh["single-leg"].rrfScore
+	if champScore <= singleScore {
+		t.Errorf("champion rrfScore %v should exceed single-leg rrfScore %v", champScore, singleScore)
+	}
+}
+
+func TestApplyFusion_FlagOn_AbsentFromBothLegsGetsZero(t *testing.T) {
+	// A memory in the memories map but absent from both legs → rrfScore=0.
+	memories := map[string]*types.Memory{
+		"ghost": {ID: "ghost"},
+		"real":  {ID: "real"},
+	}
+	bh := map[string]bestHit{
+		"ghost": {cosine: 0.3},
+		"real":  {cosine: 0.8},
+	}
+	vecRanks := map[string]int{"real": 1}
+	ftsRanks := map[string]int{"real": 1}
+
+	opts := RecallOpts{Fusion: true}
+	applyFusion(opts, memories, bh, vecRanks, ftsRanks)
+
+	if bh["ghost"].rrfScore != 0 {
+		t.Errorf("ghost rrfScore = %v, want 0 (absent from both legs)", bh["ghost"].rrfScore)
+	}
+	if bh["real"].rrfScore <= 0 {
+		t.Errorf("real rrfScore = %v, want > 0 (present in both legs)", bh["real"].rrfScore)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+func TestApplyFusion_Deterministic(t *testing.T) {
+	// Run applyFusion twice with identical inputs; rrfScore must be stable.
+	setup := func() (map[string]*types.Memory, map[string]bestHit, map[string]int, map[string]int) {
+		return map[string]*types.Memory{
+				"m1": {ID: "m1"}, "m2": {ID: "m2"}, "m3": {ID: "m3"},
+			},
+			map[string]bestHit{
+				"m1": {cosine: 0.8}, "m2": {cosine: 0.6}, "m3": {cosine: 0.4},
+			},
+			map[string]int{"m1": 1, "m2": 2, "m3": 3},
+			map[string]int{"m2": 1, "m1": 2}
+	}
+
+	opts := RecallOpts{Fusion: true}
+
+	mems1, bh1, vr1, fr1 := setup()
+	applyFusion(opts, mems1, bh1, vr1, fr1)
+
+	mems2, bh2, vr2, fr2 := setup()
+	applyFusion(opts, mems2, bh2, vr2, fr2)
+
+	for id := range bh1 {
+		if bh1[id].rrfScore != bh2[id].rrfScore {
+			t.Errorf("non-deterministic: %s rrfScore run1=%v run2=%v", id, bh1[id].rrfScore, bh2[id].rrfScore)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecallOpts.Fusion default
+// ---------------------------------------------------------------------------
+
+func TestRecallOpts_FusionDefaultOff(t *testing.T) {
+	var opts RecallOpts
+	if opts.Fusion {
+		t.Error("RecallOpts zero value must have Fusion=false (default OFF)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func sortedKeys(m map[string]*types.Memory) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/search/fusion_test.go
+++ b/internal/search/fusion_test.go
@@ -12,7 +12,6 @@
 package search
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/db"
@@ -259,15 +258,3 @@ func TestRecallOpts_FusionDefaultOff(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
-
-func sortedKeys(m map[string]*types.Memory) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}

--- a/internal/search/paraphrase_union.go
+++ b/internal/search/paraphrase_union.go
@@ -1,0 +1,263 @@
+package search
+
+import (
+	"strings"
+)
+
+// QueryParaphraser generates alternative phrasings of a recall query.
+// Implementations are called server-side during RecallWithOpts when
+// RecallOpts.ParaphraseUnion is true.  The paraphrases are used to issue
+// additional recall passes whose candidate sets are merged (unioned) before
+// final ranking, targeting the missing_recall failure class: gold sessions
+// that contain the relevant fact only as an incidental off-topic mention,
+// making BM25 miss them on the primary query phrasing.
+//
+// Implementations must be goroutine-safe; the same instance may be shared
+// across concurrent recall calls.
+type QueryParaphraser interface {
+	// Paraphrase returns up to n alternative phrasings of query.
+	// Returning fewer than n is acceptable (e.g. when the query is already
+	// maximally atomic).  Returning zero paraphrases is safe — the caller
+	// skips the extra passes.  The original query must NOT be included in
+	// the returned slice (the engine always issues the primary pass first).
+	Paraphrase(query string, n int) []string
+}
+
+// RuleBasedParaphraser generates paraphrases deterministically using
+// linguistic transformation rules.  It requires no external LLM call,
+// adds negligible latency (<1 µs), and is safe to use under high concurrency.
+//
+// Rules applied (in order, up to n results):
+//  1. Strip wh-question prefix ("what is X" → "X", "who is X" → "X").
+//  2. Negate with "not" for near-antonym coverage ("X" → "X not").
+//  3. Expand known contractions ("what's" → "what is", "who's" → "who is", etc.).
+//  4. Drop leading auxiliary verbs ("did X" → "X", "does X" → "X").
+//  5. Paraphrase "tell me about X" → "X".
+//  6. Add "information about" wrapper ("X" → "information about X").
+//
+// These rules are designed to surface memories that mention the subject
+// incidentally (e.g. a session that mentions X's address while discussing
+// something else) by widening the lexical surface covered by the BM25 pass.
+type RuleBasedParaphraser struct{}
+
+// whPrefixes are wh-question openers that can be stripped to expose the
+// entity/topic the question is about.
+var whPrefixes = []string{
+	"what is ", "what are ", "what was ", "what were ",
+	"what's ", "what're ",
+	"who is ", "who are ", "who was ", "who were ",
+	"who's ",
+	"where is ", "where are ", "where was ", "where were ",
+	"where's ",
+	"when is ", "when was ",
+	"which is ", "which are ",
+	"how is ", "how was ",
+	"how's ",
+	"tell me about ",
+	"tell me what ",
+	"do you know ",
+	"do you remember ",
+	"can you tell me about ",
+	"what do you know about ",
+	"what do you remember about ",
+}
+
+// auxiliaryPrefixes are auxiliary-verb openers that can be stripped.
+var auxiliaryPrefixes = []string{
+	"did ", "does ", "do ", "has ", "have ", "had ",
+	"is ", "are ", "was ", "were ",
+	"can ", "could ", "would ", "should ",
+}
+
+// contractionExpansions maps common English contractions to their expansions.
+// Applied before stripping prefixes so "what's" becomes "what is" and then
+// the "what is " prefix rule fires.
+var contractionExpansions = map[string]string{
+	"what's":   "what is",
+	"who's":    "who is",
+	"where's":  "where is",
+	"how's":    "how is",
+	"when's":   "when is",
+	"that's":   "that is",
+	"there's":  "there is",
+	"it's":     "it is",
+	"he's":     "he is",
+	"she's":    "she is",
+	"they're":  "they are",
+	"we're":    "we are",
+	"you're":   "you are",
+	"i'm":      "i am",
+	"isn't":    "is not",
+	"aren't":   "are not",
+	"wasn't":   "was not",
+	"weren't":  "were not",
+	"don't":    "do not",
+	"doesn't":  "does not",
+	"didn't":   "did not",
+	"won't":    "will not",
+	"can't":    "cannot",
+	"couldn't": "could not",
+}
+
+// Paraphrase implements QueryParaphraser using the rule set described on
+// RuleBasedParaphraser.  It is deterministic and allocation-light.
+func (RuleBasedParaphraser) Paraphrase(query string, n int) []string {
+	if n <= 0 || strings.TrimSpace(query) == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, n+4)
+	original := strings.TrimSpace(strings.ToLower(query))
+	seen[original] = struct{}{}
+
+	add := func(s string) bool {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return false
+		}
+		s = strings.ToLower(s)
+		if _, dup := seen[s]; dup {
+			return false
+		}
+		seen[s] = struct{}{}
+		return true
+	}
+
+	var out []string
+
+	// Rule 3: expand contractions on the original query.
+	expanded := expandContractions(original)
+	if add(expanded) {
+		out = append(out, expanded)
+		if len(out) >= n {
+			return out
+		}
+	}
+
+	// Rule 1: strip wh-question prefix.
+	bare := stripWHPrefix(original)
+	if add(bare) {
+		out = append(out, bare)
+		if len(out) >= n {
+			return out
+		}
+	}
+
+	// Also try stripping prefix from the contraction-expanded form.
+	if expanded != original {
+		bareExpanded := stripWHPrefix(expanded)
+		if add(bareExpanded) {
+			out = append(out, bareExpanded)
+			if len(out) >= n {
+				return out
+			}
+		}
+	}
+
+	// Rule 4: strip leading auxiliary verb (applied to bare form).
+	stripped := stripAuxiliaryPrefix(bare)
+	if add(stripped) {
+		out = append(out, stripped)
+		if len(out) >= n {
+			return out
+		}
+	}
+
+	// Rule 6: "information about X" wrapper (applied to bare / stripped form).
+	subject := stripped
+	if subject == original {
+		subject = bare
+	}
+	infoAbout := "information about " + subject
+	if add(infoAbout) {
+		out = append(out, infoAbout)
+		if len(out) >= n {
+			return out
+		}
+	}
+
+	// Rule 2: append "not" for near-antonym coverage — only when bare is short
+	// enough that adding "not" doesn't create noise (max 60 chars).
+	if len(bare) <= 60 {
+		negated := bare + " not"
+		if add(negated) {
+			out = append(out, negated)
+			if len(out) >= n {
+				return out
+			}
+		}
+	}
+
+	return out
+}
+
+// expandContractions replaces all contraction tokens in s with their
+// long-form equivalents.  Token boundaries are whitespace.
+func expandContractions(s string) string {
+	words := strings.Fields(s)
+	changed := false
+	for i, w := range words {
+		if exp, ok := contractionExpansions[w]; ok {
+			words[i] = exp
+			changed = true
+		}
+	}
+	if !changed {
+		return s
+	}
+	return strings.Join(words, " ")
+}
+
+// stripWHPrefix removes the first matching wh-question or meta-query prefix
+// from s and returns the remainder.  Returns s unchanged if no prefix matches.
+func stripWHPrefix(s string) string {
+	for _, p := range whPrefixes {
+		if strings.HasPrefix(s, p) {
+			remainder := strings.TrimSpace(s[len(p):])
+			if remainder != "" {
+				return remainder
+			}
+		}
+	}
+	return s
+}
+
+// stripAuxiliaryPrefix removes the first matching auxiliary verb from s
+// and returns the remainder.  Returns s unchanged if no prefix matches.
+func stripAuxiliaryPrefix(s string) string {
+	for _, p := range auxiliaryPrefixes {
+		if strings.HasPrefix(s, p) {
+			remainder := strings.TrimSpace(s[len(p):])
+			if remainder != "" {
+				return remainder
+			}
+		}
+	}
+	return s
+}
+
+// unionCandidates merges two slices of candidate memory IDs, preserving
+// insertion order from setA and appending IDs from setB that are not already
+// in setA.  The result contains each ID at most once.
+//
+// This is used by RecallWithOpts (ParaphraseUnion path) to combine the primary
+// candidate set with candidates surfaced by paraphrase-variant passes before
+// the composite scoring step.
+func unionCandidates(setA, setB []string) []string {
+	if len(setB) == 0 {
+		return setA
+	}
+	seen := make(map[string]struct{}, len(setA)+len(setB))
+	for _, id := range setA {
+		seen[id] = struct{}{}
+	}
+	out := make([]string, len(setA), len(setA)+len(setB))
+	copy(out, setA)
+	for _, id := range setB {
+		if _, dup := seen[id]; !dup {
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/internal/search/paraphrase_union_test.go
+++ b/internal/search/paraphrase_union_test.go
@@ -9,7 +9,6 @@ package search
 
 import (
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -384,24 +383,3 @@ func TestStripAuxiliaryPrefix_Is(t *testing.T) {
 // Helpers (used only by tests in this file)
 // ---------------------------------------------------------------------------
 
-// stringsContains checks if slice contains s.
-func stringsContainsStr(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
-// sortedEqual returns true if a and b have the same elements (order-independent).
-func sortedEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	ac := append([]string{}, a...)
-	bc := append([]string{}, b...)
-	sort.Strings(ac)
-	sort.Strings(bc)
-	return reflect.DeepEqual(ac, bc)
-}

--- a/internal/search/paraphrase_union_test.go
+++ b/internal/search/paraphrase_union_test.go
@@ -1,0 +1,407 @@
+// paraphrase_union_test.go — unit tests for the ParaphraseUnion retrieval path.
+//
+// Coverage targets:
+//  - unionCandidates: dedup, order preservation, empty inputs.
+//  - RuleBasedParaphraser.Paraphrase: rule correctness, n limit, no-dup guarantee,
+//    empty/blank input, flag-off (ParaphraseUnion=false) identity guarantee.
+//  - expandContractions, stripWHPrefix, stripAuxiliaryPrefix: rule correctness.
+package search
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// unionCandidates
+// ---------------------------------------------------------------------------
+
+func TestUnionCandidates_EmptyBoth(t *testing.T) {
+	got := unionCandidates(nil, nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestUnionCandidates_EmptySetB(t *testing.T) {
+	a := []string{"id1", "id2"}
+	got := unionCandidates(a, nil)
+	if !reflect.DeepEqual(got, a) {
+		t.Errorf("expected %v, got %v", a, got)
+	}
+}
+
+func TestUnionCandidates_EmptySetA(t *testing.T) {
+	b := []string{"id3", "id4"}
+	got := unionCandidates(nil, b)
+	if len(got) != 2 || got[0] != "id3" || got[1] != "id4" {
+		t.Errorf("expected %v, got %v", b, got)
+	}
+}
+
+func TestUnionCandidates_DisjointSets(t *testing.T) {
+	a := []string{"a", "b"}
+	b := []string{"c", "d"}
+	got := unionCandidates(a, b)
+	want := []string{"a", "b", "c", "d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestUnionCandidates_DeduplicatesOverlap(t *testing.T) {
+	// setA and setB share "b"; "b" must appear only once in output.
+	a := []string{"a", "b", "c"}
+	b := []string{"b", "d", "e"}
+	got := unionCandidates(a, b)
+	want := []string{"a", "b", "c", "d", "e"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestUnionCandidates_PreservesSetAOrder(t *testing.T) {
+	// setA order must be preserved in the output prefix.
+	a := []string{"z", "y", "x"}
+	b := []string{"x", "w"}
+	got := unionCandidates(a, b)
+	if got[0] != "z" || got[1] != "y" || got[2] != "x" {
+		t.Errorf("setA order not preserved: %v", got)
+	}
+	if len(got) != 4 || got[3] != "w" {
+		t.Errorf("unexpected tail: %v", got)
+	}
+}
+
+func TestUnionCandidates_AllDuplicates(t *testing.T) {
+	a := []string{"a", "b"}
+	b := []string{"a", "b"}
+	got := unionCandidates(a, b)
+	if !reflect.DeepEqual(got, a) {
+		t.Errorf("expected %v (all dups), got %v", a, got)
+	}
+}
+
+func TestUnionCandidates_SingleElement(t *testing.T) {
+	got := unionCandidates([]string{"x"}, []string{"y"})
+	if len(got) != 2 || got[0] != "x" || got[1] != "y" {
+		t.Errorf("unexpected result: %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RuleBasedParaphraser.Paraphrase
+// ---------------------------------------------------------------------------
+
+func TestRuleBasedParaphraser_EmptyQuery(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("", 3)
+	if len(got) != 0 {
+		t.Errorf("expected nil for empty query, got %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_BlankQuery(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("   ", 3)
+	if len(got) != 0 {
+		t.Errorf("expected nil for blank query, got %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_ZeroN(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("what is the capital of France", 0)
+	if len(got) != 0 {
+		t.Errorf("expected nil for n=0, got %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_NegativeN(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("who is Alice", -1)
+	if len(got) != 0 {
+		t.Errorf("expected nil for n<0, got %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_LimitN(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	// Ask for only 1 paraphrase — must get at most 1.
+	got := p.Paraphrase("what is John's phone number", 1)
+	if len(got) > 1 {
+		t.Errorf("expected at most 1 paraphrase, got %d: %v", len(got), got)
+	}
+}
+
+func TestRuleBasedParaphraser_NoDuplicates(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("who is Alice Johnson", 5)
+	seen := make(map[string]int)
+	for i, s := range got {
+		seen[s]++
+		if seen[s] > 1 {
+			t.Errorf("duplicate paraphrase %q at index %d", s, i)
+		}
+	}
+}
+
+func TestRuleBasedParaphraser_OriginalNotIncluded(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	query := "where does alice live"
+	got := p.Paraphrase(query, 5)
+	for _, s := range got {
+		if s == query {
+			t.Errorf("original query %q should not appear in paraphrases", query)
+		}
+	}
+}
+
+func TestRuleBasedParaphraser_WHPrefixStripped(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	// "what is X" → bare form "X" must appear somewhere in the results.
+	got := p.Paraphrase("what is alice's address", 5)
+	found := false
+	for _, s := range got {
+		if s == "alice's address" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected bare form 'alice's address' in paraphrases; got: %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_ContractionExpanded(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	// "what's" → contraction expanded to "what is" before prefix stripping.
+	got := p.Paraphrase("what's alice's job", 5)
+	// At least one result should not start with "what's".
+	anyExpanded := false
+	for _, s := range got {
+		if !strings.HasPrefix(s, "what's") {
+			anyExpanded = true
+			break
+		}
+	}
+	if !anyExpanded {
+		t.Errorf("expected at least one contraction-expanded form in %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_TellMeAbout(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("tell me about bob's hobbies", 5)
+	found := false
+	for _, s := range got {
+		if s == "bob's hobbies" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected bare 'bob's hobbies' in %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_InformationAboutWrapper(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("alice johnson", 5)
+	found := false
+	for _, s := range got {
+		if s == "information about alice johnson" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'information about alice johnson' in %v", got)
+	}
+}
+
+func TestRuleBasedParaphraser_PlainQueryProducesVariants(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	// A plain noun phrase with no wh-prefix should still produce >= 1 variants.
+	got := p.Paraphrase("Bob Smith restaurant preference", 5)
+	if len(got) == 0 {
+		t.Error("expected at least one paraphrase for a plain noun phrase")
+	}
+}
+
+func TestRuleBasedParaphraser_AllParaphrasesAreLowercase(t *testing.T) {
+	p := RuleBasedParaphraser{}
+	got := p.Paraphrase("What Is Alice Johnson's Address", 5)
+	for _, s := range got {
+		if s != strings.ToLower(s) {
+			t.Errorf("paraphrase %q is not lowercase", s)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flag-off identity guarantee (zero-value test, no DB required)
+// ---------------------------------------------------------------------------
+
+// TestParaphraseUnionFlagOff verifies that RecallOpts.ParaphraseUnion defaults
+// to false (zero value), ensuring callers that don't set the flag get identical
+// baseline behavior with no extra recall passes.
+func TestParaphraseUnionFlagOff_IsZeroValue(t *testing.T) {
+	var opts RecallOpts
+	if opts.ParaphraseUnion {
+		t.Error("RecallOpts.ParaphraseUnion default must be false (flag-off = baseline)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// expandContractions
+// ---------------------------------------------------------------------------
+
+func TestExpandContractions_NoChange(t *testing.T) {
+	got := expandContractions("alice lives in paris")
+	want := "alice lives in paris"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandContractions_SingleContraction(t *testing.T) {
+	got := expandContractions("what's alice's address")
+	want := "what is alice's address"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandContractions_MultipleContractions(t *testing.T) {
+	got := expandContractions("it's not what i'm thinking")
+	want := "it is not what i am thinking"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandContractions_CantExpansion(t *testing.T) {
+	got := expandContractions("i can't stand opera")
+	want := "i cannot stand opera"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stripWHPrefix
+// ---------------------------------------------------------------------------
+
+func TestStripWHPrefix_WhatIs(t *testing.T) {
+	got := stripWHPrefix("what is alice's phone")
+	want := "alice's phone"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripWHPrefix_WhoIs(t *testing.T) {
+	got := stripWHPrefix("who is bob smith")
+	want := "bob smith"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripWHPrefix_WhereIs(t *testing.T) {
+	got := stripWHPrefix("where is the library")
+	want := "the library"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripWHPrefix_NoPrefix(t *testing.T) {
+	got := stripWHPrefix("alice johnson address")
+	want := "alice johnson address"
+	if got != want {
+		t.Errorf("got %q (no change expected), want %q", got, want)
+	}
+}
+
+func TestStripWHPrefix_PrefixOnlyNoChange(t *testing.T) {
+	// "where is " with trailing space but no subject → should return unchanged.
+	got := stripWHPrefix("where is ")
+	// trailing TrimSpace makes remainder empty → no strip
+	if got != "where is " {
+		t.Errorf("got %q, want 'where is ' (empty remainder, no strip)", got)
+	}
+}
+
+func TestStripWHPrefix_TellMeAbout(t *testing.T) {
+	got := stripWHPrefix("tell me about alice's pets")
+	want := "alice's pets"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stripAuxiliaryPrefix
+// ---------------------------------------------------------------------------
+
+func TestStripAuxiliaryPrefix_Did(t *testing.T) {
+	got := stripAuxiliaryPrefix("did alice change jobs")
+	want := "alice change jobs"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripAuxiliaryPrefix_Does(t *testing.T) {
+	got := stripAuxiliaryPrefix("does bob live in new york")
+	want := "bob live in new york"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripAuxiliaryPrefix_NoPrefix(t *testing.T) {
+	got := stripAuxiliaryPrefix("alice new york")
+	want := "alice new york"
+	if got != want {
+		t.Errorf("got %q (no change expected), want %q", got, want)
+	}
+}
+
+func TestStripAuxiliaryPrefix_Is(t *testing.T) {
+	got := stripAuxiliaryPrefix("is alice vegetarian")
+	want := "alice vegetarian"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (used only by tests in this file)
+// ---------------------------------------------------------------------------
+
+// stringsContains checks if slice contains s.
+func stringsContainsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedEqual returns true if a and b have the same elements (order-independent).
+func sortedEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string{}, a...)
+	bc := append([]string{}, b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	return reflect.DeepEqual(ac, bc)
+}

--- a/internal/search/score.go
+++ b/internal/search/score.go
@@ -245,10 +245,11 @@ type ScoreInput struct {
 	Importance         int      // [0,4]; 0=critical (never pruned), 4=trivial (auto-pruned)
 	DynamicImportance  *float64 // learned importance from spaced repetition; overrides Importance when non-nil
 	RetrievalPrecision *float64 // times_useful/times_retrieved; nil during cold start (<5 retrievals) → treated as 0.5
-	EpisodeMatch       bool     // true when memory.episode_id == current session episode
-	MemoryType         string   // memory_type field; used to apply type-specific boosts
-	IsPreferenceQuery  bool     // true when the recall query is preference-shaped (#364)
-	TopicAnchorMatch   bool     // true when the memory content contains topic-anchor tokens from the query (H-TAB, LME exp #3)
+	EpisodeMatch         bool     // true when memory.episode_id == current session episode
+	MemoryType           string   // memory_type field; used to apply type-specific boosts
+	IsPreferenceQuery    bool     // true when the recall query is preference-shaped (#364)
+	TopicAnchorMatch     bool     // true when the memory content contains topic-anchor tokens from the query (H-TAB, LME exp #3)
+	ExactIdentifierMatch bool     // true when memory content contains a verbatim entity identifier from the query (LME #938 improvement #3)
 }
 
 // RecencyDecay returns exp(-rate * hours), optionally clamped by a floor.
@@ -339,6 +340,11 @@ func CompositeScoreRRF(in ScoreInput, w Weights, rrfBase float64) float64 {
 	// existing preference boost so it doesn't affect non-preference paths.
 	if in.IsPreferenceQuery && in.TopicAnchorMatch && in.MemoryType == "preference" {
 		raw *= 1.25
+	}
+	// Exact-fact identifier boost (LME #938 improvement #3, flag-gated via
+	// RecallOpts.ExactFactBoost; set into ScoreInput by the engine).
+	if in.ExactIdentifierMatch {
+		raw += exactIdentifierBoost()
 	}
 	return raw * boost
 }
@@ -462,6 +468,9 @@ func CompositeScoreWithRankNorm(in ScoreInput, w Weights, validFrom time.Time, c
 	if in.IsPreferenceQuery && in.TopicAnchorMatch && in.MemoryType == "preference" {
 		raw *= 1.25
 	}
+	if in.ExactIdentifierMatch {
+		raw += exactIdentifierBoost()
+	}
 	return raw * boost
 }
 
@@ -499,6 +508,11 @@ func CompositeScoreWithWeights(in ScoreInput, w Weights) float64 {
 	// no longer crowd out the on-topic gold session. Default OFF (flag-gated).
 	if in.IsPreferenceQuery && in.TopicAnchorMatch && in.MemoryType == "preference" {
 		raw *= 1.25
+	}
+	// Exact-fact identifier boost (LME #938 improvement #3, flag-gated via
+	// RecallOpts.ExactFactBoost; set into ScoreInput by the engine).
+	if in.ExactIdentifierMatch {
+		raw += exactIdentifierBoost()
 	}
 	return raw * boost
 }


### PR DESCRIPTION
## Summary

Three flag-gated retrieval improvements targeting the gold_missing failure class, rebased onto wave-1 main (8403bde). Each defaults OFF (ablation-safe):

- **Exp #2 ParaphraseUnion**: multi-pass paraphrased query union via `ENGRAM_PARAPHRASE_UNION` env var or `paraphrase_union=true` MCP arg
- **Exp #4 ExactFactBoost**: entity-identifier score boost for verbatim matches via `exact_fact_boost=true` MCP arg
- **Exp #6 RRF Fusion**: Reciprocal Rank Fusion pre-scoring via `ENGRAM_RRF_FUSION` env var or `rrf_fusion=true` MCP arg

Targets the gold_missing failure class (~168/271 incorrect where gold is absent from top-10 entirely).

## Rebase notes

- Rebased `feat/lme-retrieval-bundle` (da05ee6, base 3133639) onto origin/main (8403bde) which includes all wave-1 merges (LME experiments #3/#7/#8/#9 + #5 validity-windows)
- Conflict resolution used additive-block pattern: kept ALL wave-1 fields in RecallOpts (TopicAnchorBoost, TopClusters) and ALL wave-1 blocks in handleMemoryRecall (H-TAB, answerability reranker, cross-encoder reranker)
- Atom-mode code preserved: FetchAtoms in engram.go + atomContextBlock/AtomMode block in cmd/longmemeval/run.go
- No DB migrations → no scanner drift check needed

## Flag-OFF baseline confirmation

All three experiments use boolean struct fields defaulting to `false` (Go zero value):
- ParaphraseUnion: entire union block gated on `if opts.ParaphraseUnion { ... }` — skipped when false
- ExactFactBoost: `exactBoostEnabled := opts.ExactFactBoost && isIdentifierQuery(query)` — false by default
- Fusion: `applyFusion` returns immediately when `!opts.Fusion`; scoring loop uses original CompositeScoreWithWeights path

## Test results

- `go build -buildvcs=false ./...` — PASS
- `go test -race -count=1 ./internal/search/... ./internal/mcp/...` — PASS (search: 2.05s, mcp: 15.1s)
- No DB migrations → DB integration suite skipped locally, CI is authoritative

## Labels

ai-generated

Co-authored-by: Peter Simmons <petersimmons1972@gmail.com>