### PR TITLE
feat(recall): H-NEW-2 centroid-MMR preference diversity pass (flag-gated)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -489,6 +489,7 @@ func run() error {
 			return "closed"
 		},
 		DegradedErrorMode:      envOr("ENGRAM_DEGRADED_ERROR_MODE", ""),
+		PreferenceMMR:          envOr("ENGRAM_PREFERENCE_MMR", "") == "1" || envOr("ENGRAM_PREFERENCE_MMR", "") == "true",
 		SessionDB:              retentionBackend, // retentionBackend satisfies db.SessionRegistry
 		IngestQueue:            ingestQ,
 		RateLimitRPS:           *rateLimitRPS,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -141,6 +141,13 @@ type Config struct {
 	// Set via --session-ndcg-agg flag or ENGRAM_SESSION_NDCG_AGG=true env var.
 	// Default false (ablation-safe; identical to baseline when false). (LEVER-8)
 	SessionNDCGAgg bool
+
+	// PreferenceMMR enables the H-NEW-2 centroid-MMR diversity pass for
+	// preference-shaped recall queries. When true, RecallWithOpts applies an
+	// MMR re-scoring post-pass that surfaces domain-specific preference sessions
+	// buried under the user's dominant topic. Default false.
+	// Set via ENGRAM_PREFERENCE_MMR=1. (#H-NEW-2)
+	PreferenceMMR bool
 }
 
 // rateLimitRPS returns the configured RPS, or the default of 50 when unset.

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -407,6 +407,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	// LEVER-8: propagate server-level session-DCG aggregation flag.
 	opts.SessionNDCGAgg = cfg.SessionNDCGAgg
 
+	// H-NEW-2: propagate server-side PreferenceMMR flag into RecallOpts.
+	opts.PreferenceMMR = cfg.PreferenceMMR
+
 	// Capture embedder degradation signal and reason from RecallWithOpts (#989).
 	var embedDegraded bool
 	var embedDegradeReason string

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -122,6 +122,16 @@ type RecallOpts struct {
 	// ablatable: when false the code path is entirely bypassed and results are
 	// identical to the baseline. Default false. (LEVER-8)
 	SessionNDCGAgg bool
+
+	// PreferenceMMR enables the H-NEW-2 centroid-MMR diversity pass for preference
+	// queries. When true and the query is preference-shaped, the engine fetches
+	// best-chunk embeddings for top candidates, computes a centroid of the top-10
+	// results (the "dominant topic cluster"), and re-scores all candidates using
+	// MMR: score = λ·relevance - (1-λ)·sim(doc, centroid). This surfaces
+	// domain-specific preference sessions buried under the dominant topic.
+	// Default OFF (false). Ablatable: flag-off → baseline identical.
+	// Composable with DualPreferenceRecall (H15). Server-side only. (#H-NEW-2)
+	PreferenceMMR bool
 }
 
 // ToHandles projects a slice of SearchResults into lightweight Handle references.
@@ -1079,6 +1089,12 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	// Strategy: split sorted results into preference-typed and general pools;
 	// take up to min(topK/2, 10) from the preference pool first, fill remaining
 	// slots from the general pool, deduplicate by ID, reassemble.
+	//
+	// topicPool captures the relevance-ranked general (non-preference) pool before
+	// the preference-front-load merge. Used by applyPreferenceMMR (H-NEW-2) as the
+	// dominant-topic centroid source so the centroid reflects the actual topic
+	// cluster rather than the preference-front-loaded order.
+	var topicPool []types.SearchResult
 	if prefQuery {
 		prefSlots := topK / 2
 		if prefSlots > 10 {
@@ -1095,6 +1111,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 				generalResults = append(generalResults, r)
 			}
 		}
+		// Capture the general pool (relevance-ranked, no preference front-load) for
+		// use as the dominant-topic centroid source in the MMR pass (Bug 2 fix).
+		topicPool = generalResults
 		if len(prefResults) > 0 {
 			// Take up to prefSlots from preference pool.
 			taken := prefSlots
@@ -1145,6 +1164,22 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			}
 			results = merged
 		}
+	}
+
+	// H-NEW-2: Centroid-MMR diversity pass for preference queries.
+	// When PreferenceMMR is enabled and the query is preference-shaped, re-score
+	// all candidates by penalising similarity to the dominant-topic centroid.
+	// This surfaces domain-specific preference sessions buried under the dominant
+	// topic (e.g. books/reading flooding a generic preference query).
+	//
+	// The pass is entirely post-processing — no schema changes, no re-ingest.
+	// It runs AFTER the preference-first pool split (above) so both paths benefit.
+	// Flag-off (PreferenceMMR=false): this block is skipped → baseline identical.
+	//
+	// topicPool is passed so the centroid reflects the dominant topic (general pool)
+	// rather than the preference-front-loaded merged order (Bug 2 fix).
+	if opts.PreferenceMMR && prefQuery && len(results) > 1 {
+		results = e.applyPreferenceMMR(ctx, results, topicPool)
 	}
 
 	// Optional re-ranking: cap at topK candidates so the reranker only sees the
@@ -2100,6 +2135,178 @@ func (e *SearchEngine) Aggregate(ctx context.Context, by, filter string, limit i
 	default:
 		return nil, fmt.Errorf("aggregate: unsupported by %q (must be tag, type, or failure_class)", by)
 	}
+}
+
+// applyPreferenceMMR executes the H-NEW-2 centroid-MMR diversity pass on the
+// given result slice. It fetches best-chunk embeddings for candidate memories,
+// computes the dominant-topic centroid, re-scores all candidates via mmrReScore,
+// and returns the re-sorted slice with MMR scores written back into r.Score.
+//
+// topicPool is the relevance-ranked general (non-preference) pool captured before
+// the preference-first split. The centroid is computed from topicPool rather than
+// from the preference-front-loaded results slice, so the centroid represents the
+// dominant topic the query actually hits — not the preference memories that were
+// artificially promoted. If topicPool is empty, results is used as a fallback.
+// (Bug 2 fix: centroid must reflect dominant topic, not preference front-load.)
+//
+// r.Score is overwritten with the MMR score for each result. This ensures that
+// any downstream sortResults call (e.g. from the reranker block) preserves the
+// MMR ordering rather than reverting to the original composite score order.
+// (Bug 1 fix: MMR ordering must survive when a reranker is active.)
+//
+// On any DB error the original (unmodified) results are returned so the recall
+// path never fails due to the MMR pass. Best-effort: partial embedding coverage
+// is handled gracefully (candidates without embeddings receive a zero penalty).
+func (e *SearchEngine) applyPreferenceMMR(ctx context.Context, results []types.SearchResult, topicPool []types.SearchResult) []types.SearchResult {
+	if len(results) == 0 {
+		return results
+	}
+
+	// Collect all memory IDs we need embeddings for: the full result set plus the
+	// topic pool (for centroid computation). De-duplicate to minimise DB round-trips.
+	allIDs := make([]string, 0, len(results)+len(topicPool))
+	seen := make(map[string]struct{}, len(results)+len(topicPool))
+	for _, r := range results {
+		if r.Memory != nil {
+			if _, dup := seen[r.Memory.ID]; !dup {
+				allIDs = append(allIDs, r.Memory.ID)
+				seen[r.Memory.ID] = struct{}{}
+			}
+		}
+	}
+	for _, r := range topicPool {
+		if r.Memory != nil {
+			if _, dup := seen[r.Memory.ID]; !dup {
+				allIDs = append(allIDs, r.Memory.ID)
+				seen[r.Memory.ID] = struct{}{}
+			}
+		}
+	}
+	if len(allIDs) == 0 {
+		return results
+	}
+
+	// Batch-fetch best-chunk embeddings for all candidate memories.
+	chunks, err := e.backend.GetChunksForMemories(ctx, allIDs)
+	if err != nil {
+		slog.Warn("preference-mmr: GetChunksForMemories failed, skipping MMR pass",
+			"project", e.project, "err", err)
+		return results
+	}
+
+	// Build a map from memory_id → best-chunk embedding (highest-index chunk
+	// as a simple proxy for the most representative chunk). GetChunksForMemories
+	// returns chunks ordered by chunk_index so the last entry per memory_id is
+	// the last chunk; use the first (index 0) instead — it's most general.
+	embByMemID := make(map[string][]float32, len(allIDs))
+	for _, ch := range chunks {
+		if len(ch.Embedding) > 0 {
+			if _, exists := embByMemID[ch.MemoryID]; !exists {
+				embByMemID[ch.MemoryID] = ch.Embedding
+			}
+		}
+	}
+
+	// Build mmrCandidate slice preserving original score as relevance.
+	candidates := make([]mmrCandidate, 0, len(results))
+	for _, r := range results {
+		if r.Memory == nil {
+			continue
+		}
+		candidates = append(candidates, mmrCandidate{
+			memoryID:  r.Memory.ID,
+			relevance: r.Score,
+			embedding: embByMemID[r.Memory.ID], // nil when no embedding available
+		})
+	}
+
+	// Bug 2 fix: compute centroid from topicPool (general/non-preference pool,
+	// relevance-ranked before the preference-first split). This represents the
+	// dominant topic cluster the query is about — not the preference memories
+	// that were front-loaded. If topicPool is empty (no general results, or the
+	// preference split did not fire), fall back to the full candidate pool.
+	centroidSource := topicPool
+	if len(centroidSource) == 0 {
+		// Fallback: use results directly (preference split did not produce a general pool).
+		centroidSource = results
+	}
+	poolSize := mmrCentroidPoolSize
+	if poolSize > len(centroidSource) {
+		poolSize = len(centroidSource)
+	}
+	centroidVecs := make([][]float32, 0, poolSize)
+	for i := 0; i < poolSize; i++ {
+		r := centroidSource[i]
+		if r.Memory == nil {
+			continue
+		}
+		if emb := embByMemID[r.Memory.ID]; emb != nil {
+			centroidVecs = append(centroidVecs, emb)
+		}
+	}
+	centroid := computeCentroid(centroidVecs)
+	if centroid == nil {
+		// No embeddings available in topic pool — skip MMR (no centroid to penalise against).
+		slog.Debug("preference-mmr: no embeddings in topic pool, skipping MMR pass",
+			"project", e.project)
+		return results
+	}
+
+	// Re-score all candidates with MMR formula.
+	reScored := mmrReScore(candidates, centroid, mmrLambdaDefault)
+
+	// Build a score map from the MMR re-scoring so we can update r.Score.
+	// Bug 1 fix: write the MMR score back into r.Score so that any subsequent
+	// sortResults call (e.g. in the reranker block) preserves the MMR ordering
+	// rather than reverting to the original composite score.
+	mmrScoreByID := make(map[string]float64, len(reScored))
+	for i, c := range reScored {
+		// Use rank-derived score: highest-ranked gets the largest value.
+		// We use the mmrCandidate relevance field (which holds the per-candidate MMR
+		// score) but that is not directly accessible after mmrReScore returns the
+		// candidates in order without exposing the computed score. Instead, encode
+		// rank position as a descending float so sortResults keeps the MMR order:
+		// rank 0 → N, rank 1 → N-1, …, rank N-1 → 1. Integer offsets are sufficient
+		// since sortResults only requires a consistent total order.
+		mmrScoreByID[c.memoryID] = float64(len(reScored) - i)
+	}
+
+	// Re-map back to SearchResults in the MMR-determined order, updating Score.
+	resultByID := make(map[string]types.SearchResult, len(results))
+	for _, r := range results {
+		if r.Memory != nil {
+			resultByID[r.Memory.ID] = r
+		}
+	}
+	out := make([]types.SearchResult, 0, len(reScored))
+	for _, c := range reScored {
+		if r, ok := resultByID[c.memoryID]; ok {
+			r.Score = mmrScoreByID[c.memoryID] // write MMR rank score (Bug 1 fix)
+			out = append(out, r)
+		}
+	}
+	// Preserve any results that had no memory ID (shouldn't happen but be safe).
+	if len(out) < len(results) {
+		seenOut := make(map[string]struct{}, len(out))
+		for _, r := range out {
+			if r.Memory != nil {
+				seenOut[r.Memory.ID] = struct{}{}
+			}
+		}
+		for _, r := range results {
+			id := ""
+			if r.Memory != nil {
+				id = r.Memory.ID
+			}
+			if _, found := seenOut[id]; !found {
+				out = append(out, r)
+				if id != "" {
+					seenOut[id] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
 }
 
 // SummarizeNow: handled directly by the MCP tool via summarize package (see tools.go).

--- a/internal/search/preference_mmr.go
+++ b/internal/search/preference_mmr.go
@@ -1,0 +1,132 @@
+// preference_mmr.go — Centroid-MMR diversity pass for H-NEW-2.
+//
+// Experiment: When PreferenceMMR is enabled in RecallOpts, a post-processing
+// pass re-scores preference-query results using Maximal Marginal Relevance
+// against the dominant-topic centroid. This surfaces domain-specific preference
+// sessions that pure cosine similarity buries under the user's dominant topic
+// (e.g. books/reading matching a generic preference query).
+//
+// Algorithm (Approach A from advisory-gate decision):
+//   1. Sort primary results by composite score.
+//   2. Compute centroid of top-N (default 10) result embeddings.
+//   3. Re-score ALL candidates: mmr_score = λ·relevance - (1-λ)·sim(doc,centroid)
+//   4. Re-sort by mmr_score, return topK.
+//
+// λ default: 0.7 (70% relevance, 30% anti-centroid diversity penalty).
+// Ablatable: flag-off (PreferenceMMR=false) → baseline unchanged.
+// Deterministic: centroid + linear formula produces identical output for
+// identical inputs.
+package search
+
+import (
+	"math"
+	"sort"
+)
+
+const (
+	// mmrLambdaDefault is the relevance weight in the MMR formula.
+	// Advisory recommendation: 0.7 (conservative start; lower if 0 improvement).
+	mmrLambdaDefault = 0.7
+
+	// mmrCentroidPoolSize is the number of top results used to compute the
+	// dominant-cluster centroid. Using top-10 captures the dominant topic cluster
+	// without diluting the centroid with lower-ranked, less-representative results.
+	mmrCentroidPoolSize = 10
+)
+
+// mmrCandidate bundles the fields needed for MMR re-scoring.
+type mmrCandidate struct {
+	memoryID  string
+	relevance float64  // composite score from primary recall
+	embedding []float32 // best-chunk embedding for this memory; nil = no embedding
+}
+
+// computeCentroid returns the element-wise mean of vecs. Vectors shorter than
+// the first vector's length are skipped (dimension mismatch guard). Returns nil
+// when vecs is empty.
+func computeCentroid(vecs [][]float32) []float32 {
+	if len(vecs) == 0 {
+		return nil
+	}
+	// Determine dimensionality from the first vector.
+	dims := len(vecs[0])
+	if dims == 0 {
+		return nil
+	}
+
+	sum := make([]float64, dims)
+	count := 0
+	for _, v := range vecs {
+		if len(v) < dims {
+			continue // skip dim-mismatched vectors
+		}
+		for i := 0; i < dims; i++ {
+			sum[i] += float64(v[i])
+		}
+		count++
+	}
+	if count == 0 {
+		return nil
+	}
+	out := make([]float32, dims)
+	for i, s := range sum {
+		out[i] = float32(s / float64(count))
+	}
+	return out
+}
+
+// cosineSimilarityF32 computes the cosine similarity between two float32 vectors.
+// Returns 0.0 for zero-length vectors or dimension mismatches.
+func cosineSimilarityF32(a, b []float32) float32 {
+	if len(a) == 0 || len(b) == 0 || len(a) != len(b) {
+		return 0.0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0.0
+	}
+	return float32(dot / denom)
+}
+
+// mmrReScore re-scores candidates using the centroid-MMR formula:
+//
+//	score = lambda * relevance - (1-lambda) * cosineSim(embedding, centroid)
+//
+// A high score means the candidate is relevant AND far from the dominant cluster.
+// Returns the candidates sorted descending by MMR score.
+//
+// Nil centroid or lambda==1.0 degrades to pure relevance ordering (no-op baseline).
+// Input slice is not modified; a new sorted slice is returned.
+func mmrReScore(candidates []mmrCandidate, centroid []float32, lambda float64) []mmrCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	type scored struct {
+		c     mmrCandidate
+		score float64
+	}
+	out := make([]scored, len(candidates))
+	for i, c := range candidates {
+		var antiCentroid float64
+		if centroid != nil && lambda < 1.0 {
+			sim := cosineSimilarityF32(c.embedding, centroid)
+			antiCentroid = float64(sim)
+		}
+		mmr := lambda*c.relevance - (1-lambda)*antiCentroid
+		out[i] = scored{c: c, score: mmr}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].score > out[j].score
+	})
+	result := make([]mmrCandidate, len(out))
+	for i, s := range out {
+		result[i] = s.c
+	}
+	return result
+}

--- a/internal/search/preference_mmr_test.go
+++ b/internal/search/preference_mmr_test.go
@@ -1,0 +1,499 @@
+// preference_mmr_test.go — pure unit tests for H-NEW-2 centroid-MMR helpers.
+// All tests run without a DB. The key property under test:
+//   - computeCentroid correctly averages float32 vectors
+//   - cosineSimilarityF32 returns 1.0 for identical vectors, 0.0 for orthogonal
+//   - mmrReScore promotes a domain-specific result that pure relevance buried
+//   - mmrReScore with flag off (lambda=0 shortcircuit) produces unchanged order
+//   - determinism: same inputs → same output every call
+//
+// Integration tests for applyPreferenceMMR (engine method):
+//   - Bug 1: MMR ordering survives when a downstream sortResults pass is active
+//     (r.Score is written with MMR-derived rank so sort preserves MMR order)
+//   - Bug 2: centroid reflects the dominant-topic (general) pool, not the
+//     preference-front-loaded results slice
+package search
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// mmrChunkBackend overrides GetChunksForMemories on cacheMetaBackend so tests
+// can inject specific per-memory embeddings without a real database.
+// All other Backend methods delegate to cacheMetaBackend's no-op
+// implementations.
+// ---------------------------------------------------------------------------
+
+type mmrChunkBackend struct {
+	cacheMetaBackend
+	// chunksByMemID maps memory_id → embedding vector to return.
+	chunksByMemID map[string][]float32
+}
+
+func newMMRChunkBackend(embeddings map[string][]float32) *mmrChunkBackend {
+	return &mmrChunkBackend{
+		cacheMetaBackend: cacheMetaBackend{meta: make(map[string]string)},
+		chunksByMemID:    embeddings,
+	}
+}
+
+func (b *mmrChunkBackend) GetChunksForMemories(_ context.Context, memIDs []string) ([]*types.Chunk, error) {
+	var out []*types.Chunk
+	for _, id := range memIDs {
+		if emb, ok := b.chunksByMemID[id]; ok {
+			out = append(out, &types.Chunk{
+				MemoryID:   id,
+				ChunkIndex: 0,
+				Embedding:  emb,
+			})
+		}
+	}
+	return out, nil
+}
+
+// makeSearchResult is a test helper that builds a SearchResult with a fixed
+// Score and optional memory_type.
+func makeSearchResult(id string, score float64, memType string) types.SearchResult {
+	return types.SearchResult{
+		Memory: &types.Memory{ID: id, MemoryType: memType},
+		Score:  score,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: MMR ordering survives a downstream sortResults pass
+//
+// Setup: three preference results where raw-score order is dominant-a >
+// dominant-b > domain-x, but MMR (using topic centroid [1,0]) promotes domain-x
+// above dominant-b because domain-x is orthogonal to the dominant cluster.
+//
+// A (stub) reranker would call sortResults on the output of applyPreferenceMMR.
+// The bug was: applyPreferenceMMR reordered results but left r.Score at the
+// original composite score, so sortResults reverted to score order, silently
+// discarding the MMR ordering.
+//
+// The fix writes the MMR-derived rank into r.Score, so sortResults preserves it.
+//
+// We prove: after applyPreferenceMMR,
+//   (a) domain-x ranks above dominant-b in the returned slice, AND
+//   (b) domain-x.Score > dominant-b.Score (so a subsequent sortResults call
+//       keeps domain-x above dominant-b — the reranker path is safe).
+//
+// Embeddings and topicPool are chosen so the centroid from topicPool is clearly
+// [1,0], making domain-x's [0,1] get minimal penalty and dominant-b's [0.95,0.05]
+// get near-maximum penalty.
+// ---------------------------------------------------------------------------
+
+func TestApplyPreferenceMMR_OrderingsSurviveSortResults_Bug1(t *testing.T) {
+	embeddings := map[string][]float32{
+		"dominant-a": {1.0, 0.0},
+		"dominant-b": {0.95, 0.05},
+		"domain-x":   {0.0, 1.0},
+		// topicPool source memories:
+		"general-1": {1.0, 0.0},
+		"general-2": {0.98, 0.02},
+	}
+	backend := newMMRChunkBackend(embeddings)
+	emb := &cacheTestEmbedder{name: "test", dims: 2}
+	eng := newCacheTestEngine(t, &backend.cacheMetaBackend, emb)
+	// Wire the overridden GetChunksForMemories by replacing the backend field
+	// directly — SearchEngine.backend is package-private so we set it here.
+	eng.backend = backend
+
+	results := []types.SearchResult{
+		makeSearchResult("dominant-a", 0.90, "preference"),
+		makeSearchResult("dominant-b", 0.85, "preference"),
+		makeSearchResult("domain-x", 0.60, "preference"),
+	}
+
+	// topicPool: general memories with embeddings tightly clustered around [1,0].
+	// This makes the centroid ≈ [1,0], giving domain-x (embedding [0,1]) near-zero
+	// cosine similarity to the centroid and thus near-zero penalty.
+	// dominant-b (embedding [0.95,0.05]) has cosine_sim ≈ 0.999 to [1,0] centroid
+	// → high penalty. With lambda=0.7:
+	//   dominant-a mmr ≈ 0.7*0.9 - 0.3*1.0   = 0.63 - 0.30 = 0.33
+	//   dominant-b mmr ≈ 0.7*0.85 - 0.3*0.999 = 0.595 - 0.300 = 0.295
+	//   domain-x   mmr ≈ 0.7*0.6 - 0.3*0.0   = 0.42 - 0.00 = 0.42
+	// → MMR order: domain-x > dominant-a > dominant-b
+	topicPool := []types.SearchResult{
+		makeSearchResult("general-1", 0.95, "context"),
+		makeSearchResult("general-2", 0.90, "context"),
+	}
+
+	ctx := context.Background()
+	out := eng.applyPreferenceMMR(ctx, results, topicPool)
+
+	if len(out) != 3 {
+		t.Fatalf("applyPreferenceMMR returned %d results, want 3", len(out))
+	}
+
+	// Find ranks in output.
+	rankOf := func(id string) int {
+		for i, r := range out {
+			if r.Memory != nil && r.Memory.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	domainXRank := rankOf("domain-x")
+	dominantBRank := rankOf("dominant-b")
+	if domainXRank == -1 || dominantBRank == -1 {
+		t.Fatalf("expected both domain-x and dominant-b in output; got %v", out)
+	}
+	if domainXRank >= dominantBRank {
+		t.Errorf("Bug 1 (ordering): domain-x rank=%d, dominant-b rank=%d — MMR did not promote domain-x before dominant-b",
+			domainXRank, dominantBRank)
+	}
+
+	// Key assertion for Bug 1: r.Score must encode MMR rank order so that a
+	// subsequent sortResults call (from the reranker block) preserves MMR order.
+	// domain-x ranked above dominant-b under MMR → domain-x.Score must be larger.
+	scoreOf := func(id string) float64 {
+		for _, r := range out {
+			if r.Memory != nil && r.Memory.ID == id {
+				return r.Score
+			}
+		}
+		t.Fatalf("id %q not found", id)
+		return 0
+	}
+	domainXScore := scoreOf("domain-x")
+	dominantBScore := scoreOf("dominant-b")
+	if domainXScore <= dominantBScore {
+		t.Errorf("Bug 1 (score): domain-x.Score=%.4f is not > dominant-b.Score=%.4f — sortResults would revert MMR ordering",
+			domainXScore, dominantBScore)
+	}
+
+	// Confirm: sortResults on the MMR output must still place domain-x before dominant-b.
+	sortResults(out)
+	domainXRankAfterSort := rankOf("domain-x")
+	dominantBRankAfterSort := rankOf("dominant-b")
+	if domainXRankAfterSort >= dominantBRankAfterSort {
+		t.Errorf("Bug 1 (sort-stable): after sortResults domain-x rank=%d, dominant-b rank=%d — MMR ordering was lost",
+			domainXRankAfterSort, dominantBRankAfterSort)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2: centroid reflects dominant topic (general/topicPool), not the
+// preference-front-loaded results.
+//
+// Setup: results has preference memories front-loaded, all with embeddings
+// pointing in direction [0,1] (the "preference cluster"). topicPool has
+// general memories with embeddings pointing in direction [1,0] (the "topic
+// cluster"). When the bug was present, the centroid was computed from results
+// (preference-front-loaded) → centroid ≈ [0,1] → MMR penalised the [0,1]
+// preference memories rather than the [1,0] topic cluster, inverting intent.
+// With the fix, centroid is computed from topicPool → centroid ≈ [1,0] →
+// preference memories (orthogonal to centroid) are promoted.
+//
+// We verify: the memory with embedding [0,1] (preference-shaped, far from topic
+// centroid [1,0]) gets a higher MMR score (lower rank position) than the memory
+// with embedding [1,0] (aligned with topic centroid, thus penalised).
+// ---------------------------------------------------------------------------
+
+func TestApplyPreferenceMMR_CentroidFromTopicPool_Bug2(t *testing.T) {
+	// Two preference memories (in results, front-loaded):
+	//   "pref-ortho": embedding [0,1] — orthogonal to topic centroid [1,0]
+	//     → should be PROMOTED by MMR (low centroid similarity → low penalty)
+	//   "pref-aligned": embedding [0.95,0.1] — aligned with topic centroid [1,0]
+	//     → should be DEMOTED by MMR (high centroid similarity → high penalty)
+	// Both start with equal relevance scores so any reordering is purely MMR-driven.
+	//
+	// Two general memories (in topicPool only — they define the dominant topic):
+	//   "general-a": embedding [1,0]
+	//   "general-b": embedding [0.9,0.1]
+	embeddings := map[string][]float32{
+		"pref-ortho":   {0.0, 1.0},
+		"pref-aligned": {0.95, 0.1},
+		"general-a":    {1.0, 0.0},
+		"general-b":    {0.9, 0.1},
+	}
+	backend := newMMRChunkBackend(embeddings)
+	emb := &cacheTestEmbedder{name: "test", dims: 2}
+	eng := newCacheTestEngine(t, &backend.cacheMetaBackend, emb)
+	eng.backend = backend
+
+	// results: preference memories front-loaded (as after preference-first split).
+	// Equal scores so ordering is purely MMR-driven.
+	results := []types.SearchResult{
+		makeSearchResult("pref-ortho", 0.80, "preference"),
+		makeSearchResult("pref-aligned", 0.80, "preference"),
+	}
+
+	// topicPool: general memories only, relevance-ranked — represents dominant topic.
+	topicPool := []types.SearchResult{
+		makeSearchResult("general-a", 0.75, "context"),
+		makeSearchResult("general-b", 0.70, "context"),
+	}
+
+	ctx := context.Background()
+	out := eng.applyPreferenceMMR(ctx, results, topicPool)
+
+	if len(out) != 2 {
+		t.Fatalf("applyPreferenceMMR returned %d results, want 2", len(out))
+	}
+
+	// With the fix (centroid from topicPool ≈ [1,0]):
+	//   pref-ortho [0,1] has cosine_sim ≈ 0 to centroid → low penalty → higher MMR
+	//   pref-aligned [0.95,0.1] has cosine_sim ≈ 0.95 to centroid → high penalty → lower MMR
+	// So pref-ortho should rank first (rank 0), pref-aligned second (rank 1).
+	//
+	// If the bug were present (centroid from preference-front-loaded results):
+	//   centroid ≈ ([0,1] + [0.95,0.1]) / 2 ≈ [0.475, 0.55]
+	//   Both memories have similar cosine_sim to this centroid → ordering is arbitrary
+	//   and does NOT reliably promote pref-ortho. In the worst case pref-aligned wins.
+
+	if out[0].Memory == nil {
+		t.Fatal("out[0].Memory is nil")
+	}
+	if out[0].Memory.ID != "pref-ortho" {
+		t.Errorf("Bug 2: expected pref-ortho at rank 0 (promoted via topic centroid), got %q",
+			out[0].Memory.ID)
+	}
+	if out[1].Memory.ID != "pref-aligned" {
+		t.Errorf("Bug 2: expected pref-aligned at rank 1 (penalised by topic centroid), got %q",
+			out[1].Memory.ID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// computeCentroid
+// ---------------------------------------------------------------------------
+
+func TestComputeCentroid_Empty(t *testing.T) {
+	c := computeCentroid(nil)
+	if c != nil {
+		t.Errorf("computeCentroid(nil) = %v, want nil", c)
+	}
+	c2 := computeCentroid([][]float32{})
+	if c2 != nil {
+		t.Errorf("computeCentroid([]) = %v, want nil", c2)
+	}
+}
+
+func TestComputeCentroid_SingleVector(t *testing.T) {
+	v := []float32{1.0, 0.0, 0.0}
+	c := computeCentroid([][]float32{v})
+	if len(c) != 3 {
+		t.Fatalf("centroid len = %d, want 3", len(c))
+	}
+	if math.Abs(float64(c[0])-1.0) > 1e-6 || math.Abs(float64(c[1])) > 1e-6 || math.Abs(float64(c[2])) > 1e-6 {
+		t.Errorf("centroid of single [1,0,0] = %v, want [1,0,0]", c)
+	}
+}
+
+func TestComputeCentroid_TwoVectors(t *testing.T) {
+	v1 := []float32{1.0, 0.0}
+	v2 := []float32{0.0, 1.0}
+	c := computeCentroid([][]float32{v1, v2})
+	if len(c) != 2 {
+		t.Fatalf("centroid len = %d, want 2", len(c))
+	}
+	if math.Abs(float64(c[0])-0.5) > 1e-6 || math.Abs(float64(c[1])-0.5) > 1e-6 {
+		t.Errorf("centroid([1,0],[0,1]) = %v, want [0.5,0.5]", c)
+	}
+}
+
+func TestComputeCentroid_DimMismatch_SkipsShort(t *testing.T) {
+	// Vectors with different dims: shorter ones are skipped (truncated).
+	v1 := []float32{2.0, 4.0}
+	v2 := []float32{0.0} // too short — only 1 dim
+	c := computeCentroid([][]float32{v1, v2})
+	// Only v1 contributes because v2 has dim < len(v1).
+	if len(c) != 2 {
+		t.Fatalf("centroid len = %d, want 2", len(c))
+	}
+	if math.Abs(float64(c[0])-2.0) > 1e-6 || math.Abs(float64(c[1])-4.0) > 1e-6 {
+		t.Errorf("centroid with dim-mismatch = %v, want [2,4]", c)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cosineSimilarityF32
+// ---------------------------------------------------------------------------
+
+func TestCosineSimilarityF32_Identical(t *testing.T) {
+	v := []float32{1.0, 2.0, 3.0}
+	sim := cosineSimilarityF32(v, v)
+	if math.Abs(float64(sim)-1.0) > 1e-5 {
+		t.Errorf("cosineSimilarityF32(v,v) = %v, want 1.0", sim)
+	}
+}
+
+func TestCosineSimilarityF32_Orthogonal(t *testing.T) {
+	a := []float32{1.0, 0.0, 0.0}
+	b := []float32{0.0, 1.0, 0.0}
+	sim := cosineSimilarityF32(a, b)
+	if math.Abs(float64(sim)) > 1e-5 {
+		t.Errorf("cosineSimilarityF32([1,0,0],[0,1,0]) = %v, want 0.0", sim)
+	}
+}
+
+func TestCosineSimilarityF32_Opposite(t *testing.T) {
+	a := []float32{1.0, 0.0}
+	b := []float32{-1.0, 0.0}
+	sim := cosineSimilarityF32(a, b)
+	if math.Abs(float64(sim)+1.0) > 1e-5 {
+		t.Errorf("cosineSimilarityF32([1,0],[-1,0]) = %v, want -1.0", sim)
+	}
+}
+
+func TestCosineSimilarityF32_ZeroVector(t *testing.T) {
+	a := []float32{0.0, 0.0}
+	b := []float32{1.0, 0.0}
+	sim := cosineSimilarityF32(a, b)
+	if math.IsNaN(float64(sim)) || math.IsInf(float64(sim), 0) {
+		t.Errorf("cosineSimilarityF32(zero, v) = %v, want finite (0)", sim)
+	}
+	if sim != 0.0 {
+		t.Errorf("cosineSimilarityF32(zero, v) = %v, want 0", sim)
+	}
+}
+
+func TestCosineSimilarityF32_DimMismatch_ReturnsZero(t *testing.T) {
+	a := []float32{1.0, 2.0}
+	b := []float32{1.0}
+	sim := cosineSimilarityF32(a, b)
+	if sim != 0.0 {
+		t.Errorf("cosineSimilarityF32 dim mismatch = %v, want 0.0", sim)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mmrReScore: the key property
+//
+// Setup: three candidates
+//   - "dominant-A": high relevance (cosine=0.9), closely aligned with centroid
+//   - "dominant-B": high relevance (cosine=0.85), closely aligned with centroid
+//   - "domain-specific": lower relevance (cosine=0.6), far from centroid
+//
+// Without MMR: order is dominant-A, dominant-B, domain-specific.
+// With MMR (lambda=0.7): domain-specific gets promoted because it avoids centroid.
+// ---------------------------------------------------------------------------
+
+func TestMMRReScore_DomainSpecificPromoted(t *testing.T) {
+	// Centroid points in direction [1,0] (dominant cluster = books/reading).
+	centroid := []float32{1.0, 0.0}
+
+	// dominant-A: aligned with centroid, high relevance
+	dominantA := mmrCandidate{
+		memoryID:  "dominant-a",
+		relevance: 0.90,
+		embedding: []float32{0.95, 0.05}, // nearly parallel to centroid
+	}
+	// dominant-B: aligned with centroid, slightly lower relevance
+	dominantB := mmrCandidate{
+		memoryID:  "dominant-b",
+		relevance: 0.85,
+		embedding: []float32{0.92, 0.10},
+	}
+	// domain-specific: lower relevance but orthogonal to centroid
+	domainSpecific := mmrCandidate{
+		memoryID:  "domain-specific",
+		relevance: 0.60,
+		embedding: []float32{0.05, 0.95}, // near-orthogonal to centroid
+	}
+
+	candidates := []mmrCandidate{dominantA, dominantB, domainSpecific}
+	const lambda = 0.7
+
+	reScored := mmrReScore(candidates, centroid, lambda)
+
+	// Find domain-specific rank in reScored output.
+	domainRank := -1
+	for i, c := range reScored {
+		if c.memoryID == "domain-specific" {
+			domainRank = i
+			break
+		}
+	}
+	if domainRank == -1 {
+		t.Fatal("domain-specific not found in reScored output")
+	}
+	// With MMR, domain-specific should outrank at least dominant-B.
+	// dominant-A has relevance 0.9 vs domain-specific 0.6 — check relative to B.
+	dominantBRank := -1
+	for i, c := range reScored {
+		if c.memoryID == "dominant-b" {
+			dominantBRank = i
+			break
+		}
+	}
+	if domainRank >= dominantBRank {
+		t.Errorf("domain-specific rank=%d is not better than dominant-b rank=%d; MMR did not promote it",
+			domainRank, dominantBRank)
+	}
+}
+
+// TestMMRReScore_FlagOff verifies that lambda=1.0 (no diversity penalty) preserves
+// relevance-only order — used to confirm the flag-off baseline is identical.
+func TestMMRReScore_FlagOff_NoChange(t *testing.T) {
+	centroid := []float32{1.0, 0.0}
+
+	candidates := []mmrCandidate{
+		{memoryID: "a", relevance: 0.9, embedding: []float32{1.0, 0.0}},
+		{memoryID: "b", relevance: 0.7, embedding: []float32{0.5, 0.5}},
+		{memoryID: "c", relevance: 0.5, embedding: []float32{0.0, 1.0}},
+	}
+
+	// lambda=1.0 means pure relevance: MMR score = relevance, no penalty.
+	reScored := mmrReScore(candidates, centroid, 1.0)
+
+	// Order should be a > b > c (descending relevance).
+	wantOrder := []string{"a", "b", "c"}
+	for i, want := range wantOrder {
+		if reScored[i].memoryID != want {
+			t.Errorf("position %d: got %q, want %q (lambda=1.0 should preserve relevance order)",
+				i, reScored[i].memoryID, want)
+		}
+	}
+}
+
+// TestMMRReScore_Deterministic verifies identical inputs produce identical outputs.
+func TestMMRReScore_Deterministic(t *testing.T) {
+	centroid := []float32{1.0, 0.0}
+	candidates := []mmrCandidate{
+		{memoryID: "x", relevance: 0.9, embedding: []float32{0.9, 0.1}},
+		{memoryID: "y", relevance: 0.8, embedding: []float32{0.1, 0.9}},
+		{memoryID: "z", relevance: 0.7, embedding: []float32{0.5, 0.5}},
+	}
+
+	result1 := mmrReScore(candidates, centroid, 0.7)
+	result2 := mmrReScore(candidates, centroid, 0.7)
+
+	for i := range result1 {
+		if result1[i].memoryID != result2[i].memoryID {
+			t.Errorf("position %d: run1=%q run2=%q — not deterministic",
+				i, result1[i].memoryID, result2[i].memoryID)
+		}
+	}
+}
+
+// TestMMRReScore_EmptyCandidates verifies no panic on empty input.
+func TestMMRReScore_EmptyCandidates(t *testing.T) {
+	centroid := []float32{1.0, 0.0}
+	result := mmrReScore(nil, centroid, 0.7)
+	if result != nil {
+		t.Errorf("mmrReScore(nil,...) = %v, want nil", result)
+	}
+}
+
+// TestMMRReScore_NilCentroid verifies graceful handling when centroid is nil
+// (falls back to relevance-only ordering).
+func TestMMRReScore_NilCentroid(t *testing.T) {
+	candidates := []mmrCandidate{
+		{memoryID: "a", relevance: 0.9, embedding: []float32{1.0, 0.0}},
+		{memoryID: "b", relevance: 0.6, embedding: []float32{0.0, 1.0}},
+	}
+	result := mmrReScore(candidates, nil, 0.7)
+	// With nil centroid: anti-centroid penalty is 0 for all; pure relevance order.
+	if len(result) != 2 || result[0].memoryID != "a" {
+		t.Errorf("mmrReScore with nil centroid = %v, want a>b (relevance order)", result)
+	}
+}


### PR DESCRIPTION
## Summary

H-NEW-2 LME experiment: centroid-MMR diversity pass for preference-shaped recall, flag-gated and default OFF.

When `ENGRAM_PREFERENCE_MMR=1`, the engine fetches best-chunk embeddings for top candidates, computes a centroid of the dominant topic cluster (from the general/non-preference pool), and re-scores all candidates using MMR: `score = λ·relevance - (1-λ)·sim(doc, centroid)`. This surfaces domain-specific preference sessions buried under the user's dominant topic.

**Flag invariant:** `PreferenceMMR` defaults `false`. Entry point: `if opts.PreferenceMMR && prefQuery && len(results) > 1`. Flag-OFF is byte-for-byte baseline identical. ✓

**Fixes present (reviewed, APPROVE):**
- Bug 1 fix: `applyPreferenceMMR` writes rank-derived value into `r.Score` so the descending `sortResults` preserves MMR order
- Bug 2 fix: centroid computed from `topicPool` (non-preference general pool) with empty-pool fallback, so the centroid reflects the dominant topic rather than preference-front-loaded results

**Conflict resolution notes (rebase onto main post-Lever-8):**
- `RecallOpts` in engine.go: additive-block — kept `SessionNDCGAgg` (LEVER-8) + added `PreferenceMMR` (H-NEW-2)
- `Config` in tools.go: additive-block — kept `SessionNDCGAgg` + added `PreferenceMMR`
- `tools_recall.go`: additive-block — kept `opts.SessionNDCGAgg = cfg.SessionNDCGAgg` + added `opts.PreferenceMMR = cfg.PreferenceMMR`

## Wave context

Wave-3, Branch 2 of 3. Squash-merge intent. Branch preserved (`--delete-branch=false`).
All 10 RecallOpts fields preserved: TopicAnchorBoost, TopClusters, ExactFactBoost, Fusion, ParaphraseUnion (wave 1/2) + SessionNDCGAgg (Lever-8, #1016) + PreferenceMMR (this PR).

## Test plan

- [x] `go build -buildvcs=false ./...` passes
- [x] `go test -race ./internal/search/... ./internal/mcp/...` passes
- [ ] CI green (authoritative — DB-integration suite requires TEST_DATABASE_URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)