### PR TITLE
feat(search): H-NEW-1 server-side two-pass temporal recall (flag-gated)

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -62,6 +62,9 @@ type Config struct {
 	// H16: question_date injection
 	InjectQuestionDate bool // prepend "Today's date is: {question_date}" to temporal-reasoning prompts (default off)
 
+	// H-NEW-1: server-side two-pass date-windowed temporal recall
+	TemporalWindowRecall bool // enable server-side two-pass date-windowed recall for temporal-reasoning questions (default off)
+
 	// Exp-14: H-M5 chrono-sort forcing + H-M1 entity enumeration pass
 	TemporalPromptAug bool // inject H-M5 ordering instruction and H-M1 entity enumeration step into temporal-reasoning prompts (default off)
 
@@ -212,6 +215,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.RepairPreset, "repair-preset", "", "named LongMemEval repair preset to enable known repair switches: recall-repair")
 	// H16: prepend question_date as first line of temporal-reasoning prompts
 	fs.BoolVar(&cfg.InjectQuestionDate, "inject-question-date", false, "prepend 'Today's date is: {question_date}' as the first line of temporal-reasoning prompts to anchor relative-time references before the model reads memory context (default off)")
+	// H-NEW-1: server-side two-pass date-windowed temporal recall
+	fs.BoolVar(&cfg.TemporalWindowRecall, "temporal-window-recall", false, "H-NEW-1: enable server-side two-pass date-windowed recall — the server parses the question's temporal anchor against question_date and unions a valid_from-filtered pass with the unfiltered pass to temporally scope the candidate set for temporal-reasoning questions (default off)")
 	// Exp-14: H-M5 chrono-sort forcing + H-M1 entity enumeration pass
 	fs.BoolVar(&cfg.TemporalPromptAug, "temporal-prompt-aug", false, "inject ordering and entity-enumeration instructions into temporal-reasoning prompts: asks the model to list events chronologically and enumerate all matching events before committing to an answer (default off)")
 	// H15: paraphrased multi-pass BM25 union

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -434,6 +434,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// When --disable-query-rewrite is set, use the raw question unchanged.
 	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
 	since, before := temporalRecallWindow(item.Question, item.QuestionType, item.QuestionDate)
+
 	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
 		if cfg.ExactSignalBoost {
 			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, callSince, callBefore)
@@ -446,16 +447,41 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		}
 		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
 	}
-	retrievedIDs, temporalFallbackIDs, err := recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)
-	if err != nil {
-		return longmemeval.RunEntry{
-			QuestionID: item.QuestionID,
-			Status:     "error",
-			Error:      fmt.Sprintf("recall: %v", err),
+
+	// H-NEW-1: when --temporal-window-recall is set, hand temporal anchoring to the
+	// server for temporal-reasoning questions. The server runs a two-pass
+	// date-windowed recall (unfiltered + valid_from-filtered, unioned) using the raw
+	// question and question_date, and falls back to baseline single-pass recall
+	// server-side for non-windowable questions ("how many X ago"). This path is
+	// exclusive of the client-side temporal fallback and the recall-augmentation
+	// passes below (fusion/paraphrase/aggregation) so the lever is measured cleanly.
+	var (
+		retrievedIDs        []string
+		temporalFallbackIDs []string
+		err                 error
+	)
+	serverTemporalWindow := cfg.TemporalWindowRecall && item.QuestionType == "temporal-reasoning"
+	if serverTemporalWindow {
+		retrievedIDs, err = mcpClient.RecallWithTemporalWindow(ctx, ingest.Project, recallQuery, cfg.RecallTopK, item.Question, item.QuestionDate)
+		if err != nil {
+			return longmemeval.RunEntry{
+				QuestionID: item.QuestionID,
+				Status:     "error",
+				Error:      fmt.Sprintf("temporal-window recall: %v", err),
+			}
+		}
+	} else {
+		retrievedIDs, temporalFallbackIDs, err = recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)
+		if err != nil {
+			return longmemeval.RunEntry{
+				QuestionID: item.QuestionID,
+				Status:     "error",
+				Error:      fmt.Sprintf("recall: %v", err),
+			}
 		}
 	}
 	secondaryContextIDs := temporalFallbackIDs
-	if cfg.RetrievalFusion {
+	if cfg.RetrievalFusion && !serverTemporalWindow {
 		// Fix #938: fusion candidates flow through retrievedIDs (primary) only —
 		// NOT secondaryContextIDs — to avoid the reserve≤3 secondary-slot cap in
 		// selectContextIDs. UnionMemoryIDs deduplicates and preserves primary order,
@@ -475,7 +501,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 
 	// H8 (lme-h8h12h15): exhaustive aggregation recall — run a topK=500 sweep on
 	// the object noun-phrase for count-shaped questions and union with primary.
-	if cfg.ExhaustiveAggregation && longmemeval.IsAggregationQuestion(item.Question) {
+	if cfg.ExhaustiveAggregation && !serverTemporalWindow && longmemeval.IsAggregationQuestion(item.Question) {
 		const aggregationSweepTopK = 500
 		sweepQuery := longmemeval.ExtractAggregationAnchor(item.Question)
 		sweepIDs, sweepErr := recallDefault(sweepQuery, aggregationSweepTopK)
@@ -510,7 +536,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// union all retrieved IDs (deduped, primary-pass order preserved first).
 	// On paraphrase or recall errors we log a warning and continue with the IDs
 	// collected so far — a partial union is strictly better than no union.
-	if cfg.QueryParaphrasePasses > 0 {
+	if cfg.QueryParaphrasePasses > 0 && !serverTemporalWindow {
 		paraphrases, pErr := longmemeval.GenerateParaphrases(ctx, recallQuery, cfg.QueryParaphrasePasses, cfg.Retries)
 		if pErr != nil {
 			log.Printf("WARN run [%s] paraphrase: %v — falling back to single-pass recall", item.QuestionID, pErr)

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -693,6 +693,32 @@ func TestTemporalRecallWindow_HowManyAgoDoesNotFilter(t *testing.T) {
 	}
 }
 
+// TestTemporalRecallWindow_Yesterday verifies that "yesterday" questions produce a
+// one-day window anchored to the day before the question_date. This aligns the
+// client-side temporalRecallWindow with the server-side ParseTemporalWindow.
+func TestTemporalRecallWindow_Yesterday(t *testing.T) {
+	// question_date 2023/06/09 → "yesterday" → target 2023/06/08, window [2023/06/08, 2023/06/09)
+	since, before := temporalRecallWindow(
+		"What happened yesterday with my dentist appointment?",
+		"temporal-reasoning",
+		"2023/06/09 (Fri)",
+	)
+	if since == nil || before == nil {
+		t.Fatal("temporalRecallWindow returned nil bounds for 'yesterday' question")
+	}
+	wantSince := time.Date(2023, 6, 8, 0, 0, 0, 0, time.UTC)
+	wantBefore := time.Date(2023, 6, 9, 0, 0, 0, 0, time.UTC)
+	if !since.Equal(wantSince) {
+		t.Errorf("since = %s, want %s", since.Format("2006-01-02"), wantSince.Format("2006-01-02"))
+	}
+	if !before.Equal(wantBefore) {
+		t.Errorf("before = %s, want %s", before.Format("2006-01-02"), wantBefore.Format("2006-01-02"))
+	}
+	if !since.Before(*before) {
+		t.Errorf("since must be before before: since=%s before=%s", since.Format(time.RFC3339), before.Format(time.RFC3339))
+	}
+}
+
 func TestTargetDateFromQuestion_RelativeAgo(t *testing.T) {
 	got, ok := targetDateFromQuestion(
 		"What did I buy 3 weeks ago?",

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -235,12 +235,47 @@ func (c *Client) Recall(ctx context.Context, project, query string, topK int) ([
 }
 
 func (c *Client) RecallWithDateRange(ctx context.Context, project, query string, topK int, since, before *time.Time) ([]string, error) {
-	return c.RecallWithOpts(ctx, project, query, topK, since, before, false)
+	return c.recallWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+	})
+}
+
+// RecallWithTemporalWindow enables the server-side H-NEW-1 two-pass date-windowed
+// recall: the server parses temporal anchors from questionText against questionDate
+// and unions a date-filtered pass with the unfiltered pass. questionText/questionDate
+// are advisory — the server falls back to baseline single-pass recall when no window
+// resolves (e.g. "how many X ago").
+func (c *Client) RecallWithTemporalWindow(ctx context.Context, project, query string, topK int, questionText, questionDate string) ([]string, error) {
+	return c.recallWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK,
+		temporalWindow: true, questionText: questionText, questionDate: questionDate,
+	})
 }
 
 // RecallWithOpts calls memory_recall with additional server-side options.
 // topicAnchorBoost=true sets topic_anchor_boost on the server (H-TAB, LME exp #3).
 func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]string, error) {
+	return c.recallWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		topicAnchorBoost: topicAnchorBoost,
+	})
+}
+
+// recallParams carries the optional knobs for a single memory_recall call.
+type recallParams struct {
+	project          string
+	query            string
+	topK             int
+	since            *time.Time
+	before           *time.Time
+	temporalWindow   bool
+	questionText     string
+	questionDate     string
+	exactFactBoost   bool
+	topicAnchorBoost bool
+}
+
+func (c *Client) recallWithParams(ctx context.Context, p recallParams) ([]string, error) {
 	var lastErr error
 	for attempt := 0; attempt <= c.retries; attempt++ {
 		if attempt > 0 {
@@ -254,7 +289,7 @@ func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK
 				return nil, ctx.Err()
 			}
 		}
-		ids, err := c.recall(ctx, project, query, topK, since, before, topicAnchorBoost)
+		ids, err := c.recall(ctx, p)
 		if err == nil {
 			return ids, nil
 		}
@@ -273,38 +308,17 @@ type RecallOpts struct {
 // RecallWithExactBoost calls recall with exact_fact_boost enabled.
 // Convenience wrapper for the longmemeval run command.
 func (c *Client) RecallWithExactBoost(ctx context.Context, project, query string, topK int, since, before *time.Time) ([]string, error) {
-	var lastErr error
-	for attempt := 0; attempt <= c.retries; attempt++ {
-		if attempt > 0 {
-			if err := c.Connect(ctx); err != nil {
-				return nil, fmt.Errorf("reconnect on retry %d: %w", attempt, err)
-			}
-			select {
-			case <-time.After(5 * time.Second):
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-		}
-		ids, err := c.recallWithBoostOpt(ctx, project, query, topK, since, before, true, false)
-		if err == nil {
-			return ids, nil
-		}
-		lastErr = err
-	}
-	return nil, lastErr
+	return c.recallWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		exactFactBoost: true,
+	})
 }
 
-// recall is the internal retry-wrapped recall helper. topicAnchorBoost enables
-// H-TAB server-side scoring (LME exp #3, flag-gated).
-func (c *Client) recall(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]string, error) {
-	return c.recallWithBoostOpt(ctx, project, query, topK, since, before, false, topicAnchorBoost)
-}
-
-func (c *Client) recallWithBoostOpt(ctx context.Context, project, query string, topK int, since, before *time.Time, exactFactBoost, topicAnchorBoost bool) ([]string, error) {
+func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 	args := map[string]any{
-		"query":   query,
-		"project": project,
-		"top_k":   topK,
+		"query":   p.query,
+		"project": p.project,
+		"top_k":   p.topK,
 		"detail":  "summary",
 		// Benchmark retrieval must not mutate retrieval telemetry while
 		// measuring recall quality.
@@ -314,17 +328,22 @@ func (c *Client) recallWithBoostOpt(ctx context.Context, project, query string, 
 		// this avoids oversized tool payloads on dense queries.
 		"mode": "handle",
 	}
-	if exactFactBoost {
+	if p.exactFactBoost {
 		args["exact_fact_boost"] = true
 	}
-	if since != nil {
-		args["since"] = since.UTC().Format(time.RFC3339)
+	if p.since != nil {
+		args["since"] = p.since.UTC().Format(time.RFC3339)
 	}
-	if before != nil {
-		args["before"] = before.UTC().Format(time.RFC3339)
+	if p.before != nil {
+		args["before"] = p.before.UTC().Format(time.RFC3339)
+	}
+	if p.temporalWindow {
+		args["temporal_window_recall"] = true
+		args["question_text"] = p.questionText
+		args["question_date"] = p.questionDate
 	}
 	// H-TAB (LME exp #3): pass topic-anchor boost flag to server.
-	if topicAnchorBoost {
+	if p.topicAnchorBoost {
 		args["topic_anchor_boost"] = true
 	}
 	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -276,6 +276,13 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if err != nil {
 		return nil, err
 	}
+	// H-NEW-1: server-side two-pass date-windowed temporal recall (flag-gated,
+	// default off). When enabled, the engine parses temporal anchors from
+	// question_text (falling back to query) against question_date and runs a
+	// second, date-filtered pass unioned with the first.
+	temporalWindowRecall := getBool(args, "temporal_window_recall", false)
+	questionText := getString(args, "question_text", "")
+	questionDate := getString(args, "question_date", "")
 
 	// Federated path: "projects" overrides the single-project recall.
 	projectNames, err := toStringSlice(args["projects"])
@@ -365,6 +372,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	opts.DateBefore = before
 	// H-TAB (LME exp #3): topic-anchor boost for preference queries.
 	opts.TopicAnchorBoost = getBool(args, "topic_anchor_boost", false)
+	opts.TemporalWindowRecall = temporalWindowRecall
+	opts.QuestionText = questionText
+	opts.QuestionDate = questionDate
 	// Claude reranker is opt-in via rerank=true.
 	claudeRerankEnabled := cfg.ClaudeRerankEnabled
 	if cfg.RuntimeConfig != nil {
@@ -426,7 +436,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		if recordEvent {
 			eventID = recordRecallEvent(ctx, h, project, query, results, "rerank path")
 		}
-	} else if opts.CurrentEpisodeID != "" || opts.DateSince != nil || opts.DateBefore != nil {
+	} else if opts.CurrentEpisodeID != "" || opts.DateSince != nil || opts.DateBefore != nil || opts.TemporalWindowRecall {
 		results, err = h.Engine.RecallWithOpts(ctx, query, topK, detail, opts)
 		if err != nil {
 			return nil, err

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -132,6 +132,20 @@ type RecallOpts struct {
 	// Default OFF (false). Ablatable: flag-off → baseline identical.
 	// Composable with DualPreferenceRecall (H15). Server-side only. (#H-NEW-2)
 	PreferenceMMR bool
+	// TemporalWindowRecall enables H-NEW-1 server-side two-pass date-windowed
+	// recall. When true and QuestionText resolves to a temporal window via
+	// ParseTemporalWindow(QuestionText, QuestionDate), Recall runs a second,
+	// date-filtered pass and unions it with the unfiltered pass so the caller
+	// receives a temporally-scoped candidate set. Default false = baseline.
+	TemporalWindowRecall bool
+	// QuestionText is the raw natural-language question used only for temporal
+	// anchor parsing when TemporalWindowRecall is true. When empty the recall
+	// query itself is used. Has no effect unless TemporalWindowRecall is true.
+	QuestionText string
+	// QuestionDate is the asked-on reference date (LongMemEval question_date
+	// format, e.g. "2023/06/09 (Fri)") used to resolve relative anchors such as
+	// "3 days ago". Has no effect unless TemporalWindowRecall is true.
+	QuestionDate string
 }
 
 // ToHandles projects a slice of SearchResults into lightweight Handle references.
@@ -651,6 +665,24 @@ func (e *SearchEngine) Recall(ctx context.Context, query string, topK int, detai
 func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK int, detail string, opts RecallOpts) ([]types.SearchResult, error) {
 	if topK <= 0 {
 		topK = 10
+	}
+
+	// H-NEW-1: server-side two-pass date-windowed temporal recall. Delegated here
+	// (before any work) so the existing single-pass scoring path below stays
+	// untouched and fully ablatable. The branch is taken only when the caller opts
+	// in AND a temporal window resolves; otherwise recall is byte-for-byte baseline.
+	if opts.TemporalWindowRecall {
+		anchorText := opts.QuestionText
+		if anchorText == "" {
+			anchorText = query
+		}
+		if since, before := ParseTemporalWindow(anchorText, opts.QuestionDate); since != nil || before != nil {
+			return e.recallTwoPassTemporal(ctx, query, topK, detail, opts, since, before)
+		}
+		// No window resolved (e.g. "how many X ago", non-temporal): fall through
+		// to the unfiltered single-pass path below. TemporalWindowRecall=true is
+		// harmless at this point — the flag is not re-checked on this path and
+		// RecallWithOpts is not called recursively here.
 	}
 
 	// Guard: ensure the current embedder matches the stored metadata before
@@ -1291,6 +1323,137 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	}
 
 	return results, nil
+}
+
+// recallTwoPassTemporal implements H-NEW-1: a date-windowed two-pass recall.
+//
+// Pass 1 is the standard unfiltered recall (topical scope). Pass 2 re-runs recall
+// constrained to [since, before) via the indexed valid_from filter (temporal scope).
+// The two result sets are unioned with pass-1 order preserved first, deduplicated by
+// memory ID, and truncated to topK. This gives the model a candidate set that is both
+// topically relevant AND temporally scoped, so it can resolve which retrieved session
+// belongs to the asked-about time window — the failure mode behind temporal PARTIALs.
+//
+// Both passes clear TemporalWindowRecall to prevent re-entry, and pass 1 clears any
+// DateSince/DateBefore so it stays a true unfiltered baseline pass.
+//
+// Re-ranking: both internal passes suppress opts.Reranker so the reranker runs
+// exactly once — on the merged, deduplicated, topK-truncated result set. Running
+// it per-pass would produce two independently-ranked lists merged in incoherent
+// order and double the latency/cost.
+func (e *SearchEngine) recallTwoPassTemporal(ctx context.Context, query string, topK int, detail string, opts RecallOpts, since, before *time.Time) ([]types.SearchResult, error) {
+	pass1Opts := opts
+	pass1Opts.TemporalWindowRecall = false
+	pass1Opts.QuestionText = ""
+	pass1Opts.QuestionDate = ""
+	pass1Opts.DateSince = nil
+	pass1Opts.DateBefore = nil
+	// Suppress reranker inside both passes; apply it once to the merged result below.
+	pass1Opts.Reranker = nil
+	pass1, err := e.RecallWithOpts(ctx, query, topK, detail, pass1Opts)
+	if err != nil {
+		return nil, err
+	}
+
+	pass2Opts := pass1Opts
+	pass2Opts.DateSince = since
+	pass2Opts.DateBefore = before
+	// EmbedDegraded pointers were populated by pass 1; do not let pass 2 overwrite
+	// the caller-visible signal (a degraded pass 1 is the meaningful event).
+	pass2Opts.EmbedDegraded = nil
+	pass2Opts.EmbedDegradedReason = nil
+	// pass2Opts.Reranker is already nil (inherited from pass1Opts above).
+	pass2, err := e.RecallWithOpts(ctx, query, topK, detail, pass2Opts)
+	if err != nil {
+		// Pass 2 is additive. If the date-filtered pass fails, return pass 1 rather
+		// than failing the whole recall — a topically-scoped set still beats nothing.
+		// Apply reranker to pass 1 alone before returning so the caller still gets
+		// reranked output when pass 2 is unavailable.
+		slog.Warn("temporal-window recall: pass 2 failed, returning pass 1 only",
+			"project", e.project, "err", err)
+		return e.maybeRerank(ctx, query, topK, pass1, opts.Reranker), nil
+	}
+
+	merged := mergeSearchResults(pass1, pass2, topK)
+	// Apply reranker once to the coherent merged set.
+	return e.maybeRerank(ctx, query, topK, merged, opts.Reranker), nil
+}
+
+// maybeRerank applies reranker to results if reranker is non-nil, otherwise returns
+// results unchanged. It mirrors the reranking block in RecallWithOpts so the
+// temporal two-pass path and the single-pass path produce identically-sorted output.
+func (e *SearchEngine) maybeRerank(ctx context.Context, query string, topK int, results []types.SearchResult, reranker ResultReranker) []types.SearchResult {
+	if reranker == nil || len(results) == 0 {
+		return results
+	}
+	rerankCandidates := results
+	if len(rerankCandidates) > topK {
+		rerankCandidates = rerankCandidates[:topK]
+	}
+	items := make([]RerankItem, len(rerankCandidates))
+	for i, r := range rerankCandidates {
+		summary := ""
+		if r.Memory.Summary != nil {
+			summary = *r.Memory.Summary
+		} else {
+			summary = r.Memory.Content
+			if len(summary) > 500 {
+				summary = summary[:500]
+			}
+		}
+		items[i] = RerankItem{
+			ID:      r.Memory.ID,
+			Summary: summary,
+			Score:   r.Score,
+		}
+	}
+	reranked, err := reranker.RerankResults(ctx, query, items)
+	if err == nil && len(reranked) > 0 {
+		scoreMap := make(map[string]float64, len(reranked))
+		for _, rr := range reranked {
+			scoreMap[rr.ID] = rr.Score
+		}
+		for i := range results {
+			if newScore, ok := scoreMap[results[i].Memory.ID]; ok {
+				results[i].Score = newScore
+			}
+		}
+		sortResults(results)
+	}
+	return results
+}
+
+// mergeSearchResults unions two result slices, preserving the order of a first and
+// appending only the IDs from b that a did not already contain, then truncates to
+// limit. Results with a nil Memory are dropped. Pass-1 order is preserved because the
+// unfiltered pass carries the composite-scored ranking the caller expects on top.
+func mergeSearchResults(a, b []types.SearchResult, limit int) []types.SearchResult {
+	merged := make([]types.SearchResult, 0, len(a)+len(b))
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, r := range a {
+		if r.Memory == nil {
+			continue
+		}
+		if _, dup := seen[r.Memory.ID]; dup {
+			continue
+		}
+		seen[r.Memory.ID] = struct{}{}
+		merged = append(merged, r)
+	}
+	for _, r := range b {
+		if r.Memory == nil {
+			continue
+		}
+		if _, dup := seen[r.Memory.ID]; dup {
+			continue
+		}
+		seen[r.Memory.ID] = struct{}{}
+		merged = append(merged, r)
+	}
+	if limit > 0 && len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged
 }
 
 // RecallWithinMemory returns up to topK chunks from a single memory's document

--- a/internal/search/engine_pure_test.go
+++ b/internal/search/engine_pure_test.go
@@ -4,7 +4,9 @@
 package search
 
 import (
+	"context"
 	"math"
+	"sync/atomic"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/types"
@@ -250,4 +252,108 @@ func TestToConnectedMemories_MixedDirections(t *testing.T) {
 	if dirs["in-source"] != "incoming" {
 		t.Errorf("in-source direction = %q, want 'incoming'", dirs["in-source"])
 	}
+}
+
+
+// ---------------------------------------------------------------------------
+// maybeRerank
+// ---------------------------------------------------------------------------
+
+// countingReranker is a stub ResultReranker that records how many times
+// RerankResults has been invoked. It returns the input items unchanged (same IDs,
+// same scores) so callers can observe call count without altering result ordering.
+type countingReranker struct {
+	calls atomic.Int64
+}
+
+func (r *countingReranker) RerankResults(_ context.Context, _ string, items []RerankItem) ([]RerankResult, error) {
+	r.calls.Add(1)
+	out := make([]RerankResult, len(items))
+	for i, it := range items {
+		out[i] = RerankResult{ID: it.ID, Score: it.Score}
+	}
+	return out, nil
+}
+
+// TestMaybeRerank_NilRerankerIsNoop verifies that maybeRerank returns the
+// input slice unchanged when the reranker is nil.
+func TestMaybeRerank_NilRerankerIsNoop(t *testing.T) {
+	e := &SearchEngine{}
+	results := []types.SearchResult{
+		{Memory: &types.Memory{ID: "a"}, Score: 0.9},
+		{Memory: &types.Memory{ID: "b"}, Score: 0.5},
+	}
+	out := e.maybeRerank(context.Background(), "query", 10, results, nil)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(out))
+	}
+	if out[0].Memory.ID != "a" || out[1].Memory.ID != "b" {
+		t.Errorf("nil reranker must not reorder results; got %v %v", out[0].Memory.ID, out[1].Memory.ID)
+	}
+}
+
+// TestMaybeRerank_EmptyResultsIsNoop verifies that maybeRerank returns nil/empty
+// without calling the reranker when results is empty.
+func TestMaybeRerank_EmptyResultsIsNoop(t *testing.T) {
+	e := &SearchEngine{}
+	cr := &countingReranker{}
+	out := e.maybeRerank(context.Background(), "query", 10, nil, cr)
+	if out != nil {
+		t.Errorf("expected nil out for nil input, got %v", out)
+	}
+	if cr.calls.Load() != 0 {
+		t.Errorf("reranker called %d times on empty input, want 0", cr.calls.Load())
+	}
+}
+
+// TestMaybeRerank_InvokesRerankerExactlyOnce verifies that maybeRerank calls
+// the reranker exactly once and applies the returned scores.
+func TestMaybeRerank_InvokesRerankerExactlyOnce(t *testing.T) {
+	e := &SearchEngine{}
+	cr := &countingReranker{}
+	results := []types.SearchResult{
+		{Memory: &types.Memory{ID: "x"}, Score: 0.3},
+		{Memory: &types.Memory{ID: "y"}, Score: 0.7},
+	}
+	out := e.maybeRerank(context.Background(), "query", 10, results, cr)
+	if cr.calls.Load() != 1 {
+		t.Errorf("reranker called %d times, want exactly 1", cr.calls.Load())
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(out))
+	}
+}
+
+// TestMaybeRerank_TopKCapLimitsRerankCandidates verifies that when len(results)
+// exceeds topK the reranker only receives topK candidates (not the full slice).
+func TestMaybeRerank_TopKCapLimitsRerankCandidates(t *testing.T) {
+	e := &SearchEngine{}
+	var capturedItemCount int
+	spy := &spyReranker{onCall: func(items []RerankItem) {
+		capturedItemCount = len(items)
+	}}
+	results := make([]types.SearchResult, 5)
+	for i := range results {
+		results[i] = types.SearchResult{Memory: &types.Memory{ID: string(rune('a' + i))}, Score: float64(i) * 0.1}
+	}
+	e.maybeRerank(context.Background(), "q", 3, results, spy)
+	if capturedItemCount != 3 {
+		t.Errorf("reranker received %d items, want 3 (topK cap)", capturedItemCount)
+	}
+}
+
+// spyReranker invokes an onCall hook on each RerankResults call.
+type spyReranker struct {
+	onCall func(items []RerankItem)
+}
+
+func (s *spyReranker) RerankResults(_ context.Context, _ string, items []RerankItem) ([]RerankResult, error) {
+	if s.onCall != nil {
+		s.onCall(items)
+	}
+	out := make([]RerankResult, len(items))
+	for i, it := range items {
+		out[i] = RerankResult{ID: it.ID, Score: it.Score}
+	}
+	return out, nil
 }

--- a/internal/search/temporal_window.go
+++ b/internal/search/temporal_window.go
@@ -1,0 +1,114 @@
+package search
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// H-NEW-1: server-side date-windowed two-pass temporal recall.
+//
+// ParseTemporalWindow resolves a [since, before) date window from a natural-language
+// question and its reference (asked-on) date. It is a deterministic, dependency-free
+// port of the client-side temporalRecallWindow logic in cmd/longmemeval/run.go, moved
+// server-side so retrieval — not generation — can be temporally scoped (the H16 date
+// injection at generation time was falsified; disambiguation must happen at retrieval).
+//
+// The window is intentionally padded around the resolved target date because session
+// valid_from timestamps rarely land exactly on the arithmetic anchor. Returns (nil, nil)
+// when no anchor can be resolved, including the "how many X ago" case (where the answer
+// IS the date being computed, so windowing would discard the gold session).
+
+// twRelativeAgoRe matches "<N> <unit> ago" with numeric or spelled-out N.
+var twRelativeAgoRe = regexp.MustCompile(`(?i)\b(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(day|days|week|weeks|month|months|year|years)\s+ago\b`)
+
+// twAgoWords maps spelled-out small numbers to their integer value.
+var twAgoWords = map[string]int{
+	"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+	"seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+}
+
+// parseTWAgoAmount parses a numeric or spelled-out positive integer.
+func parseTWAgoAmount(raw string) (int, bool) {
+	if n, err := strconv.Atoi(raw); err == nil {
+		return n, n > 0
+	}
+	n := twAgoWords[strings.ToLower(raw)]
+	return n, n > 0
+}
+
+// twDateOnly truncates a timestamp to midnight UTC.
+func twDateOnly(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// parseQuestionDate parses the LongMemEval question_date field, tolerating the
+// trailing "(Weekday)" annotation and both "/" and "-" separators.
+func parseQuestionDate(questionDate string) (time.Time, bool) {
+	fields := strings.Fields(questionDate)
+	if len(fields) == 0 {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{"2006/01/02", "2006-01-02"} {
+		if t, err := time.ParseInLocation(layout, fields[0], time.UTC); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// ParseTemporalWindow returns a [since, before) date window derived from the
+// question's relative-time anchor and the asked-on questionDate. Both bounds are
+// nil when no anchor resolves (non-temporal questions, "how many X ago" questions,
+// or an unparseable/empty questionDate). The returned bounds always satisfy
+// since.Before(before).
+func ParseTemporalWindow(question, questionDate string) (*time.Time, *time.Time) {
+	anchor, ok := parseQuestionDate(questionDate)
+	if !ok {
+		return nil, nil
+	}
+	lower := strings.ToLower(strings.TrimSpace(question))
+
+	// "How many ... ago" computes the date as its answer; windowing by that date
+	// would discard the very session that holds the answer. Leave unscoped.
+	if strings.HasPrefix(lower, "how many") {
+		return nil, nil
+	}
+
+	if strings.Contains(lower, "yesterday") {
+		target := twDateOnly(anchor).AddDate(0, 0, -1)
+		before := target.AddDate(0, 0, 1)
+		return &target, &before
+	}
+
+	match := twRelativeAgoRe.FindStringSubmatch(lower)
+	if len(match) != 3 {
+		return nil, nil
+	}
+	n, ok := parseTWAgoAmount(match[1])
+	if !ok {
+		return nil, nil
+	}
+	target := twDateOnly(anchor)
+	padDays := 0
+	switch match[2] {
+	case "day", "days":
+		target = target.AddDate(0, 0, -n)
+		padDays = 1
+	case "week", "weeks":
+		target = target.AddDate(0, 0, -7*n)
+		padDays = 3
+	case "month", "months":
+		target = target.AddDate(0, -n, 0)
+		padDays = 7
+	case "year", "years":
+		target = target.AddDate(-n, 0, 0)
+		padDays = 30
+	default:
+		return nil, nil
+	}
+	since := target.AddDate(0, 0, -padDays)
+	before := target.AddDate(0, 0, padDays+1)
+	return &since, &before
+}

--- a/internal/search/temporal_window_recall_test.go
+++ b/internal/search/temporal_window_recall_test.go
@@ -1,0 +1,164 @@
+// temporal_window_recall_test.go — integration tests for H-NEW-1 two-pass
+// date-windowed recall. These require a Postgres backend and skip gracefully
+// when TEST_DATABASE_URL is unset (see testutil.DSN).
+package search_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// storeWindowFixtures stores an in-window and an out-of-window memory whose
+// content is otherwise identical, so retrieval ordering is driven by the date
+// window rather than semantics. Returns the two IDs.
+func storeWindowFixtures(t *testing.T, engine *search.SearchEngine) (inWindowID, outOfWindowID string) {
+	t.Helper()
+	ctx := context.Background()
+	// question_date 2023/06/09, "3 days ago" -> target 2023/06/06, window
+	// [06-05, 06-08). In-window session on 06-06; distractor on 05-09 (out).
+	inWindowDate := time.Date(2023, 6, 6, 0, 0, 0, 0, time.UTC)
+	outOfWindowDate := time.Date(2023, 5, 9, 0, 0, 0, 0, time.UTC)
+	inWindow := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "dentist appointment scheduling notes",
+		MemoryType:  types.MemoryTypeContext,
+		StorageMode: "focused",
+		ValidFrom:   &inWindowDate,
+	}
+	outOfWindow := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "dentist appointment scheduling notes",
+		MemoryType:  types.MemoryTypeContext,
+		StorageMode: "focused",
+		ValidFrom:   &outOfWindowDate,
+	}
+	require.NoError(t, engine.Store(ctx, inWindow))
+	require.NoError(t, engine.Store(ctx, outOfWindow))
+	return inWindow.ID, outOfWindow.ID
+}
+
+// TestTemporalWindowRecall_SurfacesInWindowSession verifies that with the flag on,
+// the in-window gold session is retrieved (the second, date-filtered pass adds it
+// to the candidate set even though the distractor is semantically identical).
+func TestTemporalWindowRecall_SurfacesInWindowSession(t *testing.T) {
+	engine := newTestEngine(t, uniqueProject("test-twr-surfaces"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	inWindowID, _ := storeWindowFixtures(t, engine)
+
+	results, err := engine.RecallWithOpts(ctx, "dentist appointment", 10, "summary", search.RecallOpts{
+		TemporalWindowRecall: true,
+		QuestionText:         "What did I schedule 3 days ago?",
+		QuestionDate:         "2023/06/09 (Fri)",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	var sawInWindow bool
+	for _, r := range results {
+		if r.Memory != nil && r.Memory.ID == inWindowID {
+			sawInWindow = true
+		}
+	}
+	require.True(t, sawInWindow, "in-window session must appear in temporal-window recall results")
+}
+
+// TestTemporalWindowRecall_FlagOffIsBaseline verifies that with the flag off,
+// recall is byte-for-byte identical to a plain RecallWithOpts call — the lever is
+// fully ablatable and adds no behaviour when disabled.
+func TestTemporalWindowRecall_FlagOffIsBaseline(t *testing.T) {
+	engine := newTestEngine(t, uniqueProject("test-twr-baseline"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	storeWindowFixtures(t, engine)
+
+	baseline, err := engine.RecallWithOpts(ctx, "dentist appointment", 10, "summary", search.RecallOpts{})
+	require.NoError(t, err)
+
+	flagOff, err := engine.RecallWithOpts(ctx, "dentist appointment", 10, "summary", search.RecallOpts{
+		TemporalWindowRecall: false,
+		QuestionText:         "What did I schedule 3 days ago?",
+		QuestionDate:         "2023/06/09 (Fri)",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, len(baseline), len(flagOff), "flag-off result count must match baseline")
+	for i := range baseline {
+		require.Equal(t, baseline[i].Memory.ID, flagOff[i].Memory.ID,
+			"flag-off ordering must match baseline at index %d", i)
+	}
+}
+
+// TestTemporalWindowRecall_HowManyFallsBackToBaseline verifies that a "how many
+// X ago" question (where ParseTemporalWindow returns nil) does not invoke the
+// second pass and produces baseline results, even with the flag on.
+func TestTemporalWindowRecall_HowManyFallsBackToBaseline(t *testing.T) {
+	engine := newTestEngine(t, uniqueProject("test-twr-howmany"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	storeWindowFixtures(t, engine)
+
+	baseline, err := engine.RecallWithOpts(ctx, "dentist appointment", 10, "summary", search.RecallOpts{})
+	require.NoError(t, err)
+
+	howMany, err := engine.RecallWithOpts(ctx, "dentist appointment", 10, "summary", search.RecallOpts{
+		TemporalWindowRecall: true,
+		QuestionText:         "How many weeks ago did I visit the dentist?",
+		QuestionDate:         "2023/06/09 (Fri)",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, len(baseline), len(howMany), "'how many' must fall back to baseline result count")
+	for i := range baseline {
+		require.Equal(t, baseline[i].Memory.ID, howMany[i].Memory.ID,
+			"'how many' ordering must match baseline at index %d", i)
+	}
+}
+
+// twrCountingReranker is a stub search.ResultReranker that counts RerankResults
+// invocations. Used to verify the temporal two-pass path invokes reranking once.
+type twrCountingReranker struct {
+	calls atomic.Int64
+}
+
+func (r *twrCountingReranker) RerankResults(_ context.Context, _ string, items []search.RerankItem) ([]search.RerankResult, error) {
+	r.calls.Add(1)
+	out := make([]search.RerankResult, len(items))
+	for i, it := range items {
+		out[i] = search.RerankResult{ID: it.ID, Score: it.Score}
+	}
+	return out, nil
+}
+
+// TestTemporalWindowRecall_RerankerRunsOnce proves that when a reranker is wired
+// and TemporalWindowRecall is true, the reranker is invoked exactly once — on the
+// merged result set — not once per internal pass.
+func TestTemporalWindowRecall_RerankerRunsOnce(t *testing.T) {
+	engine := newTestEngine(t, uniqueProject("test-twr-rerank"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	storeWindowFixtures(t, engine)
+
+	reranker := &twrCountingReranker{}
+	_, err := engine.RecallWithOpts(ctx, "dentist appointment", 10, "summary", search.RecallOpts{
+		TemporalWindowRecall: true,
+		QuestionText:         "What did I schedule 3 days ago?",
+		QuestionDate:         "2023/06/09 (Fri)",
+		Reranker:             reranker,
+	})
+	require.NoError(t, err)
+
+	calls := reranker.calls.Load()
+	require.Equal(t, int64(1), calls,
+		"reranker must be invoked exactly once on the merged result (not once per pass); got %d calls", calls)
+}

--- a/internal/search/temporal_window_test.go
+++ b/internal/search/temporal_window_test.go
@@ -1,0 +1,108 @@
+// temporal_window_test.go — pure (no-DB) unit tests for the server-side
+// temporal anchor parser used by H-NEW-1 two-pass date-windowed recall.
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+func twDate(t *testing.T, y int, m time.Month, d int) time.Time {
+	t.Helper()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+func TestParseTemporalWindow_RelativeDaysAgo(t *testing.T) {
+	// question_date 2023-06-09; "3 days ago" -> 2023-06-06, padded +/-1 day.
+	since, before := ParseTemporalWindow("What did I do 3 days ago?", "2023/06/09 (Fri)")
+	if since == nil || before == nil {
+		t.Fatalf("expected non-nil window, got since=%v before=%v", since, before)
+	}
+	target := twDate(t, 2023, 6, 6)
+	wantSince := target.AddDate(0, 0, -1)
+	wantBefore := target.AddDate(0, 0, 2) // padDays+1
+	if !since.Equal(wantSince) {
+		t.Errorf("since = %v, want %v", since, wantSince)
+	}
+	if !before.Equal(wantBefore) {
+		t.Errorf("before = %v, want %v", before, wantBefore)
+	}
+}
+
+func TestParseTemporalWindow_WeeksAgoWiderPad(t *testing.T) {
+	since, before := ParseTemporalWindow("Where did I go two weeks ago?", "2023-06-09")
+	if since == nil || before == nil {
+		t.Fatalf("expected non-nil window, got since=%v before=%v", since, before)
+	}
+	target := twDate(t, 2023, 6, 9).AddDate(0, 0, -14)
+	wantSince := target.AddDate(0, 0, -3) // week pad
+	wantBefore := target.AddDate(0, 0, 4)
+	if !since.Equal(wantSince) {
+		t.Errorf("since = %v, want %v", since, wantSince)
+	}
+	if !before.Equal(wantBefore) {
+		t.Errorf("before = %v, want %v", before, wantBefore)
+	}
+}
+
+func TestParseTemporalWindow_Yesterday(t *testing.T) {
+	since, before := ParseTemporalWindow("What appointment did I have yesterday?", "2023/06/09")
+	if since == nil || before == nil {
+		t.Fatalf("expected non-nil window, got since=%v before=%v", since, before)
+	}
+	target := twDate(t, 2023, 6, 8)
+	if !since.Equal(target) {
+		t.Errorf("since = %v, want %v", since, target)
+	}
+	if !before.Equal(target.AddDate(0, 0, 1)) {
+		t.Errorf("before = %v, want %v", before, target.AddDate(0, 0, 1))
+	}
+}
+
+func TestParseTemporalWindow_HowManyReturnsNil(t *testing.T) {
+	// "How many ... ago" questions must NOT be windowed: the answer date is the
+	// thing being computed, so filtering by it would discard the gold session.
+	since, before := ParseTemporalWindow("How many weeks ago did I visit the dentist?", "2023/06/09")
+	if since != nil || before != nil {
+		t.Fatalf("expected nil window for 'how many ago', got since=%v before=%v", since, before)
+	}
+}
+
+func TestParseTemporalWindow_NoAnchorReturnsNil(t *testing.T) {
+	since, before := ParseTemporalWindow("What is my favourite colour?", "2023/06/09")
+	if since != nil || before != nil {
+		t.Fatalf("expected nil window for non-temporal question, got since=%v before=%v", since, before)
+	}
+}
+
+func TestParseTemporalWindow_UnparseableDateReturnsNil(t *testing.T) {
+	since, before := ParseTemporalWindow("What did I do 3 days ago?", "not-a-date")
+	if since != nil || before != nil {
+		t.Fatalf("expected nil window for unparseable question_date, got since=%v before=%v", since, before)
+	}
+}
+
+func TestParseTemporalWindow_EmptyQuestionDateReturnsNil(t *testing.T) {
+	since, before := ParseTemporalWindow("What did I do 3 days ago?", "")
+	if since != nil || before != nil {
+		t.Fatalf("expected nil window for empty question_date, got since=%v before=%v", since, before)
+	}
+}
+
+func TestParseTemporalWindow_WindowOrderingValid(t *testing.T) {
+	// since must always be strictly before `before`.
+	for _, q := range []string{
+		"What did I do 1 day ago?",
+		"Where was I 5 months ago?",
+		"What happened 2 years ago?",
+		"yesterday's plan?",
+	} {
+		since, before := ParseTemporalWindow(q, "2023/06/09")
+		if since == nil || before == nil {
+			t.Fatalf("q=%q: expected non-nil window", q)
+		}
+		if !since.Before(*before) {
+			t.Errorf("q=%q: since %v not before %v", q, since, before)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

H-NEW-1 LME experiment: server-side date-windowed two-pass temporal recall, flag-gated and default OFF.

When `temporal_window_recall=true` is passed to `memory_recall`, the engine parses temporal anchors from `question_text`/`question_date` (relative anchors like "3 days ago") and runs a second, date-filtered recall pass. Results are unioned with the unfiltered pass and deduplicated, giving the model a candidate set that is both topically relevant AND temporally scoped.

**Flag invariant:** `TemporalWindowRecall` defaults `false`. Entry point: `if opts.TemporalWindowRecall { ... ParseTemporalWindow ... return e.recallTwoPassTemporal(...) }` — falls straight through to baseline single-pass if false. ✓

**Fix present (reviewed, APPROVE):** `pass1Opts.Reranker = nil` — pass2 inherits nil via struct copy; `maybeRerank` applied exactly ONCE on the merged result set.

**Regression test:** `TestTemporalWindowRecall_RerankerRunsOnce` (DB-integration test in `internal/search/temporal_window_recall_test.go`) — skips locally without `TEST_DATABASE_URL`. CI is authoritative for this guard. All pure-Go tests pass locally.

**Review notes (non-blocking, from review):**
1. The `engine.go` window guard uses `||` where `&&` would be marginally more defensive — noted, non-blocking.
2. `TestTemporalRecallWindow_Yesterday` in `cmd/longmemeval/run_test.go` tests the client-side parser, not the server-side fixed path. The actual regression guard is `TestTemporalWindowRecall_RerankerRunsOnce` (CI-only).

**Conflict resolution notes (rebase onto main post-Lever-8):**
- `RecallOpts` in engine.go: additive-block — kept `SessionNDCGAgg` (LEVER-8) + added `TemporalWindowRecall`/`QuestionText`/`QuestionDate` (H-NEW-1)
- `internal/longmemeval/engram.go`: structural conflict — H-NEW-1 refactored to `recallParams` struct; merged by extending `recallParams` with `exactFactBoost`/`topicAnchorBoost` fields from wave-1/2, preserving `RecallWithOpts`, `RecallWithExactBoost`, and `RecallWithDateRange` as wrappers around `recallWithParams`; dropped `recallWithBoostOpt` (absorbed into `recall(ctx, p recallParams)`)

## Wave context

Wave-3, Branch 3 of 3. Squash-merge intent. Branch preserved (`--delete-branch=false`).
RecallOpts after this merge: Reranker, Mode, CurrentEpisodeID, EmbedDegraded, EmbedDegradedReason, DateSince, DateBefore, TopicAnchorBoost, TopClusters, ExactFactBoost, Fusion, ParaphraseUnion (wave 1/2) + SessionNDCGAgg (Lever-8, #1016) + PreferenceMMR (H-NEW-2, #1017) + TemporalWindowRecall/QuestionText/QuestionDate (H-NEW-1, this PR) = all 10 experiments.

## Test plan

- [x] `go build -buildvcs=false ./...` passes
- [x] `go test -race ./internal/search/... ./internal/mcp/... ./internal/longmemeval/...` passes
- [x] `TestParseTemporalWindow_*` all pass
- [x] `TestTemporalRecallWindow_Yesterday` passes (client-side parser test)
- [ ] `TestTemporalWindowRecall_RerankerRunsOnce` — requires CI with TEST_DATABASE_URL
- [ ] CI green (authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)