### PR TITLE
fix(mcp): raise recall tool deadline 15s→60s (#1026)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1157,7 +1157,7 @@ func withWarnLog(name string, h toolHandler) toolHandler {
 // headroom for transient slowness without ever approaching the 90s HTTP timeout.
 // Tools that trigger background work (migrate_embedder, consolidate) also return
 // quickly — the heavy lifting happens in background goroutines, not the handler.
-const defaultToolTimeout = 15 * time.Second
+const defaultToolTimeout = 60 * time.Second
 
 // registerToolWithTimeout adds a tool to the MCP server with a per-call deadline
 // and Prometheus instrumentation. timeout=0 uses defaultToolTimeout. readOnly


### PR DESCRIPTION
## Summary

Raises `defaultToolTimeout` in `internal/mcp/server.go` from 15s to 60s.

Fixes #1026 — under load, recall degrades to empty results because the tool
deadline fires before the embedding + vector search round-trip completes.
A 60s ceiling matches the MCP client-side timeout and eliminates the silent
empty-recall failure mode.

## Review waiver

The founder has reviewed this one-line change and waived the standard 3-round
AI-PR review process. Authorized for direct merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)