### PR TITLE
fix(lme): Streamable HTTP transport + Sonnet-auth hook (#1019)

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -32,6 +32,7 @@ type Config struct {
 	OutDir         string
 	LLMBaseURL     string // OpenAI-compatible base URL; bypasses claude CLI when set
 	LLMModel       string // model name for LLMBaseURL endpoint
+	LLMApiKey      string // API key for LLMBaseURL endpoint (env: LLM_API_KEY)
 	EnableThinking bool   // enable chain-of-thought for models that support it (Qwen3)
 	LLMMaxTokens   int    // output token budget; 0 → default (2048 thinking-off, 8192 thinking-on)
 	ScoreOutput    string // score stdout mode: text, json, or quiet
@@ -141,6 +142,7 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  --api-key <key>         Engram API key                                    (env: ENGRAM_API_KEY)")
 	_, _ = fmt.Fprintln(w, "  --llm-url <url>         OpenAI-compatible LLM base URL                    (env: LME_LLM_URL)")
 	_, _ = fmt.Fprintln(w, "  --llm-model <name>      Model name for --llm-url                          (env: LME_LLM_MODEL)")
+	_, _ = fmt.Fprintln(w, "  --llm-api-key <key>     API key for --llm-url (leave empty for local)     (env: LLM_API_KEY)")
 	_, _ = fmt.Fprintln(w, "  --workers <n>           Parallel worker count (default 4)")
 	_, _ = fmt.Fprintln(w, "  --out <dir>             Output directory for checkpoints (default .)")
 	_, _ = fmt.Fprintln(w, "  --run-id <hex>          Run identifier (auto-generated if empty)")
@@ -202,6 +204,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.OutDir, "out", ".", "Output directory for checkpoint and result files")
 	fs.StringVar(&cfg.LLMBaseURL, "llm-url", envOr("LME_LLM_URL", ""), "OpenAI-compatible base URL (e.g. http://oblivion:8000/v1); bypasses claude CLI when set")
 	fs.StringVar(&cfg.LLMModel, "llm-model", envOr("LME_LLM_MODEL", ""), "Model name for --llm-url endpoint")
+	fs.StringVar(&cfg.LLMApiKey, "llm-api-key", envOr("LLM_API_KEY", ""), "API key for --llm-url endpoint (env: LLM_API_KEY); leave empty for unauthenticated local endpoints")
 	fs.BoolVar(&cfg.EnableThinking, "enable-thinking", false, "Enable chain-of-thought reasoning (Qwen3 and compatible models; do NOT use with Nemotron v3)")
 	fs.IntVar(&cfg.LLMMaxTokens, "max-tokens", 0, "Output token budget for OAI endpoint; 0 = auto (2048 without thinking, 8192 with thinking)")
 	fs.StringVar(&cfg.ScoreOutput, "score-output", envOr("LME_SCORE_OUTPUT", "text"), "score summary stdout mode: text, json, or quiet")

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -656,7 +656,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		if maxTok == 0 && cfg.EnableThinking {
 			maxTok = 8192 // thinking mode default: room for reasoning chain + answer
 		}
-		opts := longmemeval.OAIOptions{EnableThinking: cfg.EnableThinking, MaxTokens: maxTok}
+		opts := longmemeval.OAIOptions{EnableThinking: cfg.EnableThinking, MaxTokens: maxTok, APIKey: cfg.LLMApiKey}
 		hypothesis, err = longmemeval.GenerateOAIWithOpts(ctx, prompt, cfg.LLMBaseURL, cfg.LLMModel, cfg.Retries, opts)
 	} else {
 		hypothesis, err = longmemeval.GenerateForModel(ctx, prompt, cfg.GenerationModel, cfg.Retries)

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -160,6 +160,11 @@ type OAIOptions struct {
 	// MaxTokens caps the output token budget. Default 2048 is fine for
 	// enable_thinking=false; use ≥8192 when thinking is enabled.
 	MaxTokens int
+	// APIKey is the Bearer token for the generation endpoint. When non-empty,
+	// the Authorization header is set on the OAI request. When empty the
+	// request is sent without auth (local/oblivion endpoints). Populated from
+	// --llm-api-key flag or LLM_API_KEY env var.
+	APIKey string
 }
 
 // GenerateOAI calls an OpenAI-compatible chat completions endpoint instead of
@@ -221,6 +226,9 @@ func callOAI(ctx context.Context, prompt, baseURL, model string, opts OAIOptions
 		return "", fmt.Errorf("create OAI request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if opts.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+	}
 	if debugOAIRequests {
 		log.Printf("DEBUG callOAI: url=%s request_body_bytes=%d", url, len(reqBody))
 	}

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -16,7 +16,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/atom"
 )
 
-// Client wraps the MCP SSE client with retry logic for eval use.
+// Client wraps the MCP Streamable HTTP client with retry logic for eval use.
 type Client struct {
 	mcp       *client.Client
 	retries   int
@@ -33,18 +33,15 @@ func toolErrorMsg(result *mcp.CallToolResult, toolName string) error {
 	return fmt.Errorf("%s tool error", toolName)
 }
 
-// Connect creates an authenticated MCP SSE client connected to serverURL.
+// Connect creates an authenticated Streamable HTTP MCP client connected to serverURL.
 func Connect(ctx context.Context, serverURL, apiKey string) (*Client, error) {
-	sseURL := strings.TrimRight(serverURL, "/") + "/sse"
+	mcpURL := strings.TrimRight(serverURL, "/") + "/mcp"
 	headers := map[string]string{}
 	if apiKey != "" {
 		headers["Authorization"] = "Bearer " + apiKey
 	}
-	c, err := client.NewSSEMCPClient(sseURL, transport.WithHeaders(headers))
+	c, err := client.NewStreamableHttpClient(mcpURL, transport.WithHTTPHeaders(headers))
 	if err != nil {
-		return nil, err
-	}
-	if err := c.Start(ctx); err != nil {
 		return nil, err
 	}
 	_, err = c.Initialize(ctx, mcp.InitializeRequest{
@@ -59,21 +56,17 @@ func Connect(ctx context.Context, serverURL, apiKey string) (*Client, error) {
 	return &Client{mcp: c, retries: 1, serverURL: serverURL, apiKey: apiKey}, nil
 }
 
-// Connect re-establishes the MCP SSE connection using the stored server URL and
-// API key. Called by Recall before each retry attempt because a dead SSE
-// connection fails identically to a live one — reconnect is required to recover
-// from the mcp-go SSE drop race (issue #861).
+// Connect re-establishes the Streamable HTTP MCP connection using the stored server URL and
+// API key. Called by Recall before each retry attempt because a failed connection
+// may need to be re-initialized — reconnect is required to recover from transient errors.
 func (c *Client) Connect(ctx context.Context) error {
-	sseURL := strings.TrimRight(c.serverURL, "/") + "/sse"
+	mcpURL := strings.TrimRight(c.serverURL, "/") + "/mcp"
 	headers := map[string]string{}
 	if c.apiKey != "" {
 		headers["Authorization"] = "Bearer " + c.apiKey
 	}
-	newMCP, err := client.NewSSEMCPClient(sseURL, transport.WithHeaders(headers))
+	newMCP, err := client.NewStreamableHttpClient(mcpURL, transport.WithHTTPHeaders(headers))
 	if err != nil {
-		return err
-	}
-	if err := newMCP.Start(ctx); err != nil {
 		return err
 	}
 	_, err = newMCP.Initialize(ctx, mcp.InitializeRequest{


### PR DESCRIPTION
Closes #1019. Client-side fix: longmemeval MCP client uses Streamable HTTP (/mcp) instead of SSE (/sse), eliminating session misrouting across the 3 engram replicas (intermittent empty recalls). Also adds a dormant --llm-api-key hook for Anthropic-auth generation (no effect when unused).

Validated today: built into the benchmark binary; the 500-question Wave-0 re-run is using it. Founder waived the 3-round review for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)