### PR TITLE
test(lme): use Streamable HTTP test server to match transport fix

### DIFF
--- a/cmd/longmemeval/pipeline_test.go
+++ b/cmd/longmemeval/pipeline_test.go
@@ -26,7 +26,7 @@ func newTestEngram(t *testing.T, handlers map[string]func(mcp.CallToolRequest) (
 			return handler(req)
 		})
 	}
-	ts := server.NewTestServer(mcpServer)
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
 	t.Cleanup(ts.Close)
 	return ts.URL
 }

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -29,7 +29,7 @@ func newTestMCPServer(t *testing.T, handlers map[string]func(req mcp.CallToolReq
 		})
 	}
 
-	ts := server.NewTestServer(mcpServer)
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
 	t.Cleanup(ts.Close)
 	return ts.URL
 }

--- a/internal/longmemeval/recall_retry_test.go
+++ b/internal/longmemeval/recall_retry_test.go
@@ -40,7 +40,7 @@ func newTestMCPServerWithInitCount(t *testing.T, initCalls *atomic.Int32, handle
 		})
 	}
 
-	ts := server.NewTestServer(mcpServer)
+	ts := server.NewTestStreamableHTTPServer(mcpServer)
 	t.Cleanup(ts.Close)
 	return ts.URL
 }


### PR DESCRIPTION
Closes #1032.

PR #1028 switched the longmemeval MCP client to Streamable HTTP (`/mcp`) but the test mocks stayed on mcp-go's SSE `NewTestServer`, so client/pipeline/recall/score tests failed with '4xx for initialize POST, likely a legacy SSE server' — main CI red at 34b0568. Swaps the 3 harnesses to `server.NewTestStreamableHTTPServer` (serves `/mcp`).

**Verification:** `go test ./internal/longmemeval/ ./cmd/longmemeval/ -count=1` → both ok (71s + 5s). Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)