### PR TITLE
fix: report MCP degraded reason accurately

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1159,6 +1159,28 @@ func withWarnLog(name string, h toolHandler) toolHandler {
 // quickly — the heavy lifting happens in background goroutines, not the handler.
 const defaultToolTimeout = 60 * time.Second
 
+func degradedToolMessage(toolName, reason string) string {
+	base := toolName + " ran in degraded mode"
+	suffix := "results use BM25 text search only. Memory tools remain accessible."
+	switch reason {
+	case "tool_timeout":
+		return base + " (tool deadline exceeded) — " + suffix +
+			" Recovery is automatic when recall latency improves."
+	case "embed_unavailable", "embed_timeout":
+		return base + " (embedding backend unavailable) — " + suffix +
+			" Recovery is automatic when embedding service health returns."
+	case "embed_error":
+		return base + " (embedding backend error) — " + suffix +
+			" Recovery is automatic when embedding service health returns."
+	case "circuit_open":
+		return base + " (embed circuit breaker open) — " + suffix +
+			" Recovery is automatic when the embed circuit closes."
+	default:
+		return base + " (" + reason + ") — " + suffix +
+			" Recovery is automatic when the degraded dependency recovers."
+	}
+}
+
 // registerToolWithTimeout adds a tool to the MCP server with a per-call deadline
 // and Prometheus instrumentation. timeout=0 uses defaultToolTimeout. readOnly
 // sets the MCP ReadOnlyHint annotation: clients (notably Claude Code's plan
@@ -1203,9 +1225,7 @@ func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeo
 					"_engram_degraded_reason": "tool_timeout",
 					"_engram_tool":            toolName,
 					"status":                  "degraded",
-					"message": toolName + " ran in degraded mode (tool deadline exceeded) — " +
-						"results use BM25 text search only. Memory tools remain accessible. " +
-						"Recovery is automatic when GPU pressure eases.",
+					"message":                 degradedToolMessage(toolName, "tool_timeout"),
 				})
 				return mcpgo.NewToolResultText(string(degradedJSON)), nil
 			}

--- a/internal/mcp/timeout_degraded_test.go
+++ b/internal/mcp/timeout_degraded_test.go
@@ -53,9 +53,7 @@ func simulateFixedTimeoutPath(_ context.Context, _ *EnginePool, _ Config) (*mcpg
 		"_engram_degraded_reason": "tool_timeout",
 		"_engram_tool":            toolName,
 		"status":                  "degraded",
-		"message": toolName + " ran in degraded mode (tool deadline exceeded) — " +
-			"results use BM25 text search only. Memory tools remain accessible. " +
-			"Recovery is automatic when GPU pressure eases.",
+		"message":                 degradedToolMessage(toolName, "tool_timeout"),
 	})
 	return mcpgo.NewToolResultText(string(degradedJSON)), nil
 }
@@ -153,4 +151,25 @@ func TestToolTimeout_DegradedReason_IsEmbedTimeout(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &body))
 	require.Equal(t, "tool_timeout", body["_engram_degraded_reason"],
 		"_engram_degraded_reason must be 'tool_timeout'")
+}
+
+func TestDegradedToolMessage_UsesReasonSpecificText(t *testing.T) {
+	t.Run("tool_timeout", func(t *testing.T) {
+		msg := degradedToolMessage("memory_recall", "tool_timeout")
+		require.Contains(t, msg, "tool deadline exceeded")
+		require.Contains(t, msg, "recall latency improves")
+		require.NotContains(t, strings.ToLower(msg), "gpu")
+	})
+
+	t.Run("embed_error", func(t *testing.T) {
+		msg := degradedToolMessage("memory_recall", "embed_error")
+		require.Contains(t, msg, "embedding backend error")
+		require.Contains(t, msg, "embedding service health returns")
+	})
+
+	t.Run("circuit_open", func(t *testing.T) {
+		msg := degradedToolMessage("memory_recall", "circuit_open")
+		require.Contains(t, msg, "embed circuit breaker open")
+		require.Contains(t, msg, "embed circuit closes")
+	})
 }


### PR DESCRIPTION
Closes #1021

## Summary
- replace the hardcoded GPU-pressure degraded message with reason-specific operator text
- keep the BM25 fallback explanation while making tool timeout, embed backend, and circuit-open recovery messages accurate
- extend MCP timeout tests to assert reason-specific wording and ensure tool timeouts never mention GPU

## Testing
- not run (not requested)
