### PR TITLE
fix: tighten recall handle-mode and federation contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ Both setups share the same PostgreSQL backend, API contract, and tool set. Swap 
 # stack; if you don't have one, the empty networks created by this command
 # are harmless. (Fixes #660.)
 make init && make up && make setup
-# Done. Memory server at localhost:8788 (default: hybrid; routes to external olla via LITELLM_URL).
+# Hybrid path: memory server at localhost:8788 (routes to your external backend via LITELLM_URL).
 ```
 
-For local-only, use: `docker compose -f docker-compose.local.yml up -d`
+For a first run without external dependencies, prefer local-only:
+
+```bash
+make init
+docker compose -f docker-compose.local.yml up -d
+make setup
+```
 
 ---
 
@@ -72,7 +78,7 @@ For local-only, use: `docker compose -f docker-compose.local.yml up -d`
 ```bash
 git clone https://github.com/petersimmons1972/engram-go.git && cd engram-go
 make init     # generates POSTGRES_PASSWORD, ENGRAM_API_KEY, creates volumes
-make up       # starts postgres + engram-go (the embed/LLM backend at LITELLM_URL is external — start it separately)
+make up       # starts the hybrid profile: postgres + engram-go, using the external backend at LITELLM_URL
 make setup    # writes bearer token to ~/.claude/mcp_servers.json
 ```
 
@@ -136,7 +142,7 @@ Without this, `/setup-token` only accepts loopback (127.0.0.1 / ::1). See [Opera
 
 ## Read-Only Tool Permissions (Claude Code)
 
-Engram's read-side tools (`memory_recall`, `memory_fetch`, `memory_query`, `memory_list`, `memory_status`, `memory_history`, `memory_timeline`, `memory_projects`, audit/episode listings, constraint checks, `memory_diagnose`) carry the MCP `ReadOnlyHint: true` annotation. Claude Code's plan mode treats them as safe to invoke without a permission prompt.
+Engram's strictly read-only tools (`memory_fetch`, `memory_list`, `memory_status`, `memory_history`, `memory_timeline`, `memory_projects`, audit/episode listings, constraint checks, `memory_diagnose`) carry the MCP `ReadOnlyHint: true` annotation. `memory_recall` and `memory_query` are excluded because callers can opt into `record_event=true`, which stores retrieval telemetry. Claude Code's plan mode uses that annotation for permission gating.
 
 Mutating tools (`memory_store`, `memory_correct`, `memory_forget`, `memory_consolidate`, `memory_delete_project`, etc.) intentionally prompt for permission on first use. To allow all engram tools without further prompts, add to `~/.claude/settings.json`:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,17 +62,17 @@ POST /quick-recall (or MCP tool memory_recall)
   ↓
 handleQuickRecall (server.go) — validate input, extract fields
   ↓
-handleMemoryRecall (tools_recall.go) — parse project/tags/limit
+handleMemoryRecall (tools_recall.go) — parse project/projects, top_k|limit, mode, and telemetry flags
   ↓
-engine.Recall (search.go) — semantic + BM25 hybrid ranking
+engine.RecallWithOpts / RecallAcrossEnginesWithEventsAndOpts — semantic + BM25 hybrid ranking
   ↓
 embed.NewClient.Embed(query) — embed the query string
   ↓
 db.Tx.SearchSemanticBM25 — PostgreSQL vector + full-text search
   ↓
-sort by hybrid score, apply importance decay
+sort by hybrid score, apply importance decay, optionally enrich connected memories
   ↓
-return SearchResult array
+return either lightweight handles or SearchResult objects depending on recall mode
 ```
 
 ## Key Entry Points
@@ -85,7 +85,7 @@ return SearchResult array
 | `POST /quick-recall` | handleQuickRecall | N/A | Sessionless memory recall (for Python/CLI callers) |
 | `GET /health` | handleHealth | N/A | Dependency health probes (PostgreSQL, LiteLLM) |
 | `GET /metrics` | promhttp.Handler | N/A | Prometheus metrics (requires Bearer auth) |
-| `GET /setup-token` | handleSetupToken | N/A | Return current bearer token + SSE endpoint (requires Bearer auth) |
+| `GET /setup-token` | handleSetupToken | N/A | Return current bearer token + SSE endpoint (one-time localhost bootstrap, then Bearer auth) |
 
 ## Concurrency Model
 
@@ -109,8 +109,8 @@ Key variables read at startup (see `cmd/engram/main.go`):
 | `ENGRAM_API_KEY` | (required) | Bearer token for authentication |
 | `ENGRAM_EMBED_MODEL` | (required) | Embedding model name (e.g., `snowflake-arctic-embed2`) |
 | `ENGRAM_CLAUDE_TOOL_TYPE` | `advisor_20260301` | Claude advisor tool type (see issue #485) |
-| `LITELLM_URL` | `http://litellm:4000` | LiteLLM generation endpoint |
-| `ENGRAM_EMBED_URL` | (from LITELLM_URL) | LiteLLM embedding endpoint override |
+| `LITELLM_URL` | `http://olla:40114/olla/openai` | OpenAI-compatible generation endpoint (hybrid default) |
+| `ENGRAM_EMBED_URL` | (from LITELLM_URL) | Embedding endpoint override |
 | `ENGRAM_LOG_FORMAT` | (auto-detect) | `json` or text |
 | `ENGRAM_LOG_LEVEL` | `info` | Structured logging level |
 | `ENGRAM_PORT` | `8788` | SSE bind port |
@@ -139,7 +139,7 @@ Validation failures return HTTP 400 with structured error message.
 - **MCP Tool Errors:** Returned via `CallToolResult.IsError=true` with text content
 - **HTTP Errors:** JSON body with `{"error":"...", "hint":"..."}`
 - **Permanent Embedder Mismatch:** Fast-fail as MCP error (not Go error) via `embed.PermanentError`
-- **Timeout:** 15-second per-tool deadline; logged as warning
+- **Timeout:** 60-second per-tool deadline; logged as warning
 - **Rate Limit:** HTTP 429 with `Retry-After` header
 
 ## Testing Strategy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,22 +1,27 @@
 # Getting Started
 
-When you finish this page, you will have a running memory server, a working IDE connection, and 17 tools visible to every AI assistant you use (21 with `ANTHROPIC_API_KEY` set). A handful of commands get you there (see below; previously this page claimed 'three' but the actual sequence is 4-6 depending on which profile you pick — #697). The whole thing takes about five minutes — slightly longer on first run while your configured embedding model downloads.
+When you finish this page, you will have a running memory server, a working IDE connection, and 18 tools visible to every AI assistant you use (22 with `ANTHROPIC_API_KEY` set). A handful of commands get you there (see below; previously this page claimed 'three' but the actual sequence is 4-6 depending on which profile you pick — #697). The whole thing takes about five minutes.
 
 ---
 
-<p align="center"><img src="assets/svg/quick-start-flow.svg" alt="Quick start: three steps" width="900"></p>
+<p align="center"><img src="assets/svg/quick-start-flow.svg" alt="Quick start flow" width="900"></p>
 
 ---
 
 ## Prerequisites
 
-Engram runs as three Docker containers. Before you start, confirm you have what those containers need:
+Engram supports two local startup profiles:
+
+- Hybrid default: `postgres + engram-go`, with the embed/LLM backend running outside this compose stack and reachable via `LITELLM_URL`
+- Local-only: `postgres + ollama + engram-go` via `docker-compose.local.yml`
+
+Before you start, confirm you have what those profiles need:
 
 - **Docker Engine 20.10 or newer** — check with `docker --version`
 - **Docker Compose 2.0 or newer** — check with `docker compose version` (note: the subcommand, not `docker-compose`)
 - **Go 1.26.3 or newer** (matches `go.mod` — kept in sync via CI doc-lint) — check with `go version`; download from [https://go.dev/dl/](https://go.dev/dl/)
-- **4 GB RAM free** — Ollama loads the embedding model into memory and keeps it there
-- **2 GB disk** — PostgreSQL data volume plus the Ollama model download
+- **4 GB RAM free** — local-only mode keeps the embedding model resident in Ollama
+- **2 GB disk** — PostgreSQL volume plus the optional Ollama model download
 
 Optional: an NVIDIA or AMD GPU. If you have one, embedding inference runs roughly 3× faster. Worth configuring if you plan to store large numbers of memories. Instructions are in the GPU section below.
 
@@ -43,13 +48,13 @@ Generating credentials first rather than shipping defaults means your memory sto
 
 ## Step 2: Create Docker Volumes
 
-Engram uses two external Docker volumes. External volumes survive `docker compose down` — your memories and model weights are never destroyed when containers are recreated.
+Engram always uses one external PostgreSQL volume. The local-only profile also uses an Ollama model volume. External volumes survive `docker compose down` — your memories and model weights are never destroyed when containers are recreated.
 
 ```bash
 docker volume create engram_pgdata
 ```
 
-The Ollama model volume (`ollama_ollama_storage`) is expected to already exist from a standalone Ollama installation. If you do not have Ollama installed separately, create it now:
+If you plan to use the local-only profile, create the Ollama model volume too:
 
 ```bash
 docker volume create ollama_ollama_storage
@@ -77,19 +82,34 @@ You only need to run this on a fresh clone. `make up` will do it automatically i
 make up
 ```
 
-This starts three containers:
+For a predictable first run, use the local-only profile unless you already run
+an external embed/LLM backend and know its `LITELLM_URL`. The default `make up`
+hybrid profile assumes that external dependency already exists.
+
+If your external backend is already configured, `make up` starts the hybrid profile:
 
 - `engram-postgres` — PostgreSQL 16 with the pgvector extension installed
-- `engram-ollama` — Ollama serving the configured embedding model
-- `engram-go-app` — The MCP server, listening on port 8788
+- `engram-go-app` — The MCP server, listening on port 8788 and routing embed/LLM traffic to `LITELLM_URL`
 
-**First start takes 2–3 minutes.** Ollama downloads the configured embedding model before it reports healthy. The `engram-go-app` container will wait for it. Watch progress with:
+For a 100% local stack, start the local-only profile instead:
 
 ```bash
-docker compose logs ollama -f
+docker compose -f docker-compose.local.yml up -d
 ```
 
-Subsequent starts are fast — the model is cached in the Ollama volume.
+That profile starts:
+
+- `engram-postgres`
+- `engram-ollama`
+- `engram-go-app`
+
+**First local-only start takes 2–3 minutes.** Ollama downloads the configured embedding model before it reports healthy. Watch progress with:
+
+```bash
+docker compose -f docker-compose.local.yml logs ollama -f
+```
+
+Subsequent local-only starts are fast — the model is cached in the Ollama volume.
 
 ---
 
@@ -101,7 +121,7 @@ For Claude Code, run `make setup` once the containers are healthy:
 make setup
 ```
 
-This calls the `/setup-token` endpoint on the running server, retrieves the bearer token, and writes it to `~/.claude/mcp_servers.json`. Run `/mcp` in Claude Code afterward to activate the connection.
+This calls the `/setup-token` endpoint on the running server, retrieves the bearer token, and writes it to `~/.claude/mcp_servers.json`. The bootstrap path is one-time localhost setup; after that, the endpoint requires normal bearer-authenticated access. Run `/mcp` in Claude Code afterward to activate the connection.
 
 Re-run `make setup` any time the server restarts (if `ENGRAM_API_KEY` rotates) or after a fresh install.
 
@@ -113,13 +133,16 @@ For Cursor, VS Code, Windsurf, or Claude Desktop, see [Connecting Your IDE](conn
 
 This is the moment it clicks. Run these checks and watch the pieces confirm each other.
 
-Check that all three containers are running and healthy:
+Check that the containers for your chosen profile are running and healthy:
 
 ```bash
 docker compose ps
 ```
 
-All three should show `Up (healthy)`. If any shows `Up (health: starting)`, wait 30 seconds and check again — the health checks run on a short interval.
+In hybrid mode, `engram-postgres` and `engram-go-app` should show `Up (healthy)`.
+In local-only mode, `engram-ollama` should also be present and healthy. If any
+service shows `Up (health: starting)`, wait 30 seconds and check again — the
+health checks run on a short interval.
 
 Confirm the MCP endpoint is reachable:
 
@@ -136,9 +159,9 @@ In Claude Code, confirm the tools loaded:
 /mcp
 ```
 
-You should see `engram` listed with 17 tools (21 if `ANTHROPIC_API_KEY` is set — four optional AI-enhanced tools activate). If it shows fewer, restart Claude Code — IDE MCP clients cache the tool list at startup. See [MCP Tool Reference](tools.md) for the full callable surface (46 default / 50 with API key, including hidden maintenance tools).
+You should see `engram` listed with 18 tools (22 if `ANTHROPIC_API_KEY` is set — four optional AI-enhanced tools activate). If it shows fewer, restart Claude Code — IDE MCP clients cache the tool list at startup. See [MCP Tool Reference](tools.md) for the full callable surface (46 default / 50 with API key, including hidden maintenance tools).
 
-When you see 17 tools (or 21 with `ANTHROPIC_API_KEY`), you are done. The server is running, the embedding model is loaded, and your IDE has a persistent connection to your memory store.
+When you see 18 tools (or 22 with `ANTHROPIC_API_KEY`), you are done. The server is running, and your IDE has a persistent connection to your memory store. In local-only mode that also implies the embedding model is loaded in Ollama.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -101,7 +101,9 @@ At scale, summary mode reduces context consumption by roughly 13× compared to f
 
 Summary mode reduces the size of each result. Handle mode goes further — it does not return content at all. It returns lightweight references instead, leaving the agent in charge of which memories actually deserve context space.
 
-When an agent calls `memory_recall`, the default response contains full memory objects (content, scores, metadata). For high-volume sessions, this inflates context. Handle mode returns lightweight references instead:
+When an agent calls `memory_recall`, the default response is handle mode:
+lightweight references instead of full memory objects. For high-volume
+sessions, this keeps context expansion under caller control:
 
 ```json
 {
@@ -110,11 +112,14 @@ When an agent calls `memory_recall`, the default response contains full memory o
     {"id": "mem-def456", "summary": "Postgres connection pool timeout", "score": 0.87, "memory_type": "error"}
   ],
   "count": 2,
-  "fetch_hint": "call memory_fetch with id and detail=summary|chunk|full"
+  "fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
+  "event_id": "optional-when-record_event-true"
 }
 ```
 
-Handle mode is the **default**. To get full content, pass `detail="full"` explicitly or set `ENGRAM_RECALL_DEFAULT_MODE=full`.
+Handle mode is the **default**. To get full result objects, pass
+`mode="full"`; then use `detail="summary"|"chunk"|"full"` to choose how much
+content each result carries. You can also set `ENGRAM_RECALL_DEFAULT_MODE=full`.
 
 To expand a specific handle into full content, call `memory_fetch` with the ID and the desired detail level:
 
@@ -125,6 +130,11 @@ To expand a specific handle into full content, call `memory_fetch` with the ID a
 | `"full"` | Complete original content |
 
 Handle mode trades recall immediacy for context efficiency: an agent can scan 20 handles for ~1 KB, then fetch only the 2–3 memories it actually needs.
+
+When `record_event=true`, single-project handle mode also returns `event_id`
+and `feedback_hint` so the caller can later use `memory_feedback`. Federated
+recall rejects `record_event=true` because retrieval events are scoped to one
+project.
 
 ### Memory Explore: Iterative Synthesis
 
@@ -155,7 +165,7 @@ The result is a single synthesis response:
 | You know what you're looking for | `memory_recall` — single fast lookup |
 | Open-ended question, uncertain what's stored | `memory_explore` — iterative synthesis |
 | You need a synthesized answer, not a list of memories | `memory_explore` |
-| You want raw memory objects to reason over yourself | `memory_recall` with `detail="full"` |
+| You want raw memory objects to reason over yourself | `memory_recall` with `mode="full"` |
 
 Configuration env vars: `ENGRAM_EXPLORE_MAX_ITERS` (default 5), `ENGRAM_EXPLORE_MAX_WORKERS` (default 8), `ENGRAM_EXPLORE_TOKEN_BUDGET` (default 20000).
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -18,8 +18,8 @@ The three canonical numbers used throughout this doc:
 
 | Term | Default | With `ANTHROPIC_API_KEY` |
 |------|---------|---------------------------|
-| **Visible in `tools/list`** | 17 | 21 |
-| **Hidden (callable via `tools/call`)** | 29 | 29 |
+| **Visible in `tools/list`** | 18 | 22 |
+| **Hidden (callable via `tools/call`)** | 28 | 28 |
 | **Total callable** | <!-- count:total-callable-default -->46<!-- /count --> | <!-- count:total-callable-with-ai -->50<!-- /count --> |
 
 The unconditional registry has <!-- count:unconditional -->46<!-- /count --> entries; subtracting the hidden set yields the visible default.
@@ -161,11 +161,11 @@ Storing is cheap. The value is in retrieval. These tools cover the range from pr
 The main search tool. Runs four signals simultaneously — BM25 keyword, vector semantic, recency decay, and knowledge graph enrichment — and combines their scores into a single ranked list. See [How It Works](how-it-works.md) for the mechanics.
 
 ```python
-# Default: top 5 results as summaries
+# Default: handle-mode references (ENGRAM_RECALL_DEFAULT_MODE defaults to handle)
 memory_recall("authentication JWT", project="my-app")
 
-# Full content, more results
-memory_recall("authentication JWT", project="my-app", detail="full", limit=10)
+# Full result objects, deeper payloads, more results
+memory_recall("authentication JWT", project="my-app", mode="full", detail="full", limit=10)
 
 # Claude re-ranking after retrieval (requires ENGRAM_CLAUDE_RERANK=true)
 memory_recall("auth", project="my-app", rerank=True)
@@ -174,17 +174,26 @@ memory_recall("auth", project="my-app", rerank=True)
 memory_recall("authentication JWT", project="my-app", record_event=True)
 ```
 
-**detail** controls how much text comes back per result:
+By default, `memory_recall` returns lightweight `handles` plus `count` and
+`fetch_hint`. To get full result objects, pass `mode="full"` or set
+`ENGRAM_RECALL_DEFAULT_MODE=full`.
+
+**detail** controls how much text comes back when full results are returned or
+when you later expand a handle with `memory_fetch`:
 
 | Value | What you get | Typical size | When to use |
 | ----- | ------------ | ------------ | ----------- |
-| `"summary"` (default) | Generated 1–2 sentence summary | ~150 chars | AI agents — preserves context window |
+| `"summary"` | Generated 1–2 sentence summary | ~150 chars | AI agents — preserves context window |
 | `"chunk"` | The matched excerpt | ~200 chars | When the specific passage matters |
 | `"full"` | Original content | 200–50,000 chars | Export, debugging, full fidelity |
 
 At scale, summary mode uses roughly 13× less context than full mode. For an agent recalling 10 memories per session, that is the difference between 5% of a context window and 65%.
 
-By default, `memory_recall` is read-only and does not create a retrieval event or increment retrieval counters. Pass `record_event=True` only when you need the returned `event_id` for `memory_feedback`.
+By default, `memory_recall` does not create a retrieval event or increment retrieval counters. Pass `record_event=True` only when you need the returned `event_id` for `memory_feedback`. Handle mode also skips graph-enrichment payloads; full-result modes still refresh access heat (`last_accessed`, `access_count`) and matched-chunk timestamps.
+
+Single-project handle mode returns `event_id` and `feedback_hint` when
+`record_event=True`. Federated recall (`projects=[...]`) rejects
+`record_event=True` because retrieval events are scoped to a single project.
 
 You can filter by memory type. This is a hard filter — it excludes everything else regardless of relevance:
 

--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -80,6 +80,75 @@ func newRecallTrackingPool(t *testing.T, backend *recallTrackingBackend) *Engine
 	return NewEnginePool(factory)
 }
 
+type recallLimitBackend struct {
+	noopBackend
+}
+
+func (b *recallLimitBackend) FTSSearch(_ context.Context, project, _ string, limit int, _, _ *time.Time) ([]db.FTSResult, error) {
+	results := make([]db.FTSResult, 0, limit)
+	now := time.Now().UTC()
+	for i := 0; i < limit; i++ {
+		results = append(results, db.FTSResult{
+			Memory: &types.Memory{
+				ID:        "mem-limit-" + string(rune('a'+i)),
+				Project:   project,
+				Content:   "limit alias regression memory",
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			Score: float64(limit - i),
+		})
+	}
+	return results, nil
+}
+
+type handleFastPathBackend struct {
+	noopBackend
+	relationshipBatchCalls atomic.Int64
+	touchCalls             atomic.Int64
+	updateChunkCalls       atomic.Int64
+}
+
+func (b *handleFastPathBackend) FTSSearch(_ context.Context, project, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	now := time.Now().UTC()
+	return []db.FTSResult{{
+		Memory: &types.Memory{
+			ID:        "mem-handle-fast-path",
+			Project:   project,
+			Content:   "handle mode should stay lightweight",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		Score: 1,
+	}}, nil
+}
+
+func (b *handleFastPathBackend) GetRelationshipsBatch(_ context.Context, _ string, _ []string) (map[string][]types.Relationship, error) {
+	b.relationshipBatchCalls.Add(1)
+	return map[string][]types.Relationship{}, nil
+}
+
+func (b *handleFastPathBackend) TouchMemories(_ context.Context, _ []string) error {
+	b.touchCalls.Add(1)
+	return nil
+}
+
+func (b *handleFastPathBackend) UpdateChunkLastMatched(_ context.Context, _ string) error {
+	b.updateChunkCalls.Add(1)
+	return nil
+}
+
+func newHandleFastPathPool(t *testing.T, backend *handleFastPathBackend) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, backend, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
 // ── execFetch boundary cases not in fetch_exec_test.go ───────────────────────
 
 // TestExecFetch_GetMemoryError: GetMemoryByID returns a non-nil error → error is
@@ -258,6 +327,88 @@ func TestHandleMemoryRecall_RecordEventOptInRecordsRetrievalEvent(t *testing.T) 
 	require.Equal(t, int64(1), backend.increments.Load())
 }
 
+func TestHandleMemoryRecall_HandleModeRecordEventReturnsFeedbackEvent(t *testing.T) {
+	backend := &recallTrackingBackend{}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":      "test",
+		"query":        "record recall telemetry",
+		"record_event": true,
+	}
+
+	cfg := Config{RecallDefaultMode: "handle"}
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(1), out["count"])
+	require.NotEmpty(t, out["event_id"], "handle mode record_event=true should return a feedback event")
+	require.Equal(t, int64(1), backend.storedEvents.Load())
+	require.Equal(t, int64(1), backend.increments.Load())
+}
+
+func TestHandleMemoryRecall_LimitAliasMapsToTopK(t *testing.T) {
+	backend := &recallLimitBackend{}
+	limitPool := NewEnginePool(func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, backend, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	})
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "limit alias",
+		"limit":   3,
+	}
+
+	res, err := handleMemoryRecall(context.Background(), limitPool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+	require.Equal(t, float64(3), out["count"], "memory_recall limit alias must map to top_k")
+}
+
+func TestHandleMemoryRecall_HandleModeSkipsEnrichmentAndWriteback(t *testing.T) {
+	backend := &handleFastPathBackend{}
+	pool := newHandleFastPathPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "lightweight handle mode",
+	}
+	cfg := Config{RecallDefaultMode: "handle"}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+	require.Equal(t, float64(1), out["count"])
+	require.Zero(t, backend.relationshipBatchCalls.Load(), "handle mode must not fetch connected graph payloads")
+	require.Equal(t, int64(1), backend.touchCalls.Load(), "handle mode must still refresh access timestamps for retention/prune safety")
+	require.Zero(t, backend.updateChunkCalls.Load(), "FTS-only handle results must not write chunk match timestamps without a matched chunk id")
+}
+
+func TestHandleMemoryRecall_FederatedHandleModeSkipsEnrichmentAndWriteback(t *testing.T) {
+	backend := &handleFastPathBackend{}
+	pool := newHandleFastPathPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"projects": []any{"test-a", "test-b"},
+		"query":    "lightweight handle mode",
+	}
+	cfg := testConfig()
+	cfg.RecallDefaultMode = "handle"
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+	require.Equal(t, float64(1), out["count"])
+	require.Zero(t, backend.relationshipBatchCalls.Load(), "federated handle mode must not fetch connected graph payloads")
+	require.Equal(t, int64(2), backend.touchCalls.Load(), "federated handle mode must still refresh access timestamps for retention/prune safety")
+	require.Zero(t, backend.updateChunkCalls.Load(), "FTS-only federated handle results must not write chunk match timestamps without a matched chunk id")
+}
+
 func TestHandleMemoryRecall_FederatedDefaultDoesNotRecordRetrievalEvent(t *testing.T) {
 	backend := &recallTrackingBackend{}
 	pool := newRecallTrackingPool(t, backend)
@@ -274,6 +425,40 @@ func TestHandleMemoryRecall_FederatedDefaultDoesNotRecordRetrievalEvent(t *testi
 	require.Equal(t, float64(1), out["count"])
 	require.Zero(t, backend.storedEvents.Load(), "federated read-only recall must not store retrieval events by default")
 	require.Zero(t, backend.increments.Load(), "federated read-only recall must not increment retrieval counters by default")
+}
+
+func TestHandleMemoryRecall_FederatedRecordEventRejected(t *testing.T) {
+	backend := &recallTrackingBackend{}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"projects":     []any{"test-a", "test-b"},
+		"query":        "federated recall telemetry",
+		"record_event": true,
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "federated record_event must return an MCP tool error")
+	require.Zero(t, backend.storedEvents.Load(), "rejected federated record_event must not store retrieval events")
+	require.Zero(t, backend.increments.Load(), "rejected federated record_event must not increment retrieval counters")
+}
+
+func TestHandleMemoryRecall_FederatedInitFailuresReturnError(t *testing.T) {
+	pool := NewEnginePool(func(ctx context.Context, project string) (*EngineHandle, error) {
+		return nil, errors.New("boom")
+	})
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"projects": []any{"test-a", "test-b"},
+		"query":    "federated failure",
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.Contains(t, err.Error(), "failed to initialize any requested federated project")
 }
 
 // TestHandleMemoryRecall_EpisodeContextInjected verifies that

--- a/internal/mcp/readonly_hints_test.go
+++ b/internal/mcp/readonly_hints_test.go
@@ -55,6 +55,8 @@ func TestReadOnlyToolAnnotations(t *testing.T) {
 	// the test stays useful even if new mutating tools are added without updating
 	// the read-only set.
 	mutators := []string{
+		"memory_recall",
+		"memory_query",
 		"memory_store",
 		"memory_correct",
 		"memory_forget",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -249,8 +249,6 @@ type Server struct {
 // and the startup banner (to print a recommended permissions.allow snippet).
 func readOnlyToolNames() map[string]bool {
 	return map[string]bool{
-		"memory_recall":             true,
-		"memory_query":              true,
 		"memory_fetch":              true,
 		"memory_list":               true,
 		"memory_history":            true,
@@ -1153,8 +1151,9 @@ func withWarnLog(name string, h toolHandler) toolHandler {
 // Prevents silent hangs up to the HTTP server WriteTimeout (90s) when a handler
 // blocks on Ollama, a slow DB query, or an unguarded third-party call. (#379)
 //
-// All synchronous handlers return well under 10s in normal operation; 15s gives
-// headroom for transient slowness without ever approaching the 90s HTTP timeout.
+// All synchronous handlers should return well under 10s in normal operation; 60s
+// preserves room for large-project recall while still failing well before the
+// 90s HTTP timeout if a handler wedges.
 // Tools that trigger background work (migrate_embedder, consolidate) also return
 // quickly — the heavy lifting happens in background goroutines, not the handler.
 const defaultToolTimeout = 60 * time.Second
@@ -1271,7 +1270,7 @@ func (s *Server) registerTools() {
 		{"memory_store_batch", "Store multiple memories in one call. Each item supports the same optional fields as memory_store, including pattern_confidence (float 0.0–1.0) for per-item caller-provided confidence. If any item fails validation the entire batch is rejected." + embedSuffix,
 			handleMemoryStoreBatch},
 		// Recall and retrieval
-		{"memory_recall", "Recall memories by semantic + full-text query" + embedSuffix,
+		{"memory_recall", "Recall memories by semantic + full-text query. Accepts top_k or limit; mode=handle returns lightweight handles." + embedSuffix,
 			withWarnLog("memory_recall", handleMemoryRecall)},
 		{"memory_fetch", "Fetch a single memory by ID; detail=summary|chunk|full",
 			handleMemoryFetch},

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -267,11 +267,18 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if query == "" {
 		return mcpgo.NewToolResultError("query: required"), nil
 	}
+	if limit, ok := args["limit"]; ok {
+		if _, hasTopK := args["top_k"]; !hasTopK {
+			args["top_k"] = limit
+		}
+	}
 	topK := clampTopK(getInt(args, "top_k", defaultTopK), recallMaxTopK())
 	detail := getString(args, "detail", "summary")
 	includeConflicts := getBool(args, "include_conflicts", false)
 	recordEvent := getBool(args, "record_event", false)
 	mode := getString(args, "mode", cfg.RecallDefaultMode)
+	var opts search.RecallOpts
+	opts.Mode = mode
 	since, before, err := parseRecallDateBounds(args)
 	if err != nil {
 		return nil, err
@@ -292,6 +299,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if len(projectNames) > 0 {
 		if since != nil || before != nil {
 			return mcpgo.NewToolResultError("since/before date filters are only supported for single-project recall"), nil
+		}
+		if recordEvent {
+			return mcpgo.NewToolResultError("record_event is not supported for federated recall"), nil
 		}
 		// Expand wildcard "*" to all known projects.
 		if len(projectNames) == 1 && projectNames[0] == "*" {
@@ -322,7 +332,10 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			}
 			engines = append(engines, h.Engine)
 		}
-		results, err := search.RecallAcrossEnginesWithEvents(ctx, engines, query, topK, detail, recordEvent)
+		if len(engines) == 0 {
+			return nil, fmt.Errorf("memory_recall: failed to initialize any requested federated project")
+		}
+		results, err := search.RecallAcrossEnginesWithEventsAndOpts(ctx, engines, query, topK, detail, opts, recordEvent)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +380,6 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 	rerank := getBool(args, "rerank", false)
 	exactFactBoost := getBool(args, "exact_fact_boost", false)
-	var opts search.RecallOpts
 	opts.DateSince = since
 	opts.DateBefore = before
 	// H-TAB (LME exp #3): topic-anchor boost for preference queries.
@@ -473,6 +485,10 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		}
 		if embedDegraded {
 			addRecallDegradedWarning(out, cfg.RouterURL, embedDegradeReason)
+		}
+		if eventID != "" {
+			out["event_id"] = eventID
+			out["feedback_hint"] = "Call memory_feedback with this event_id and the memory_ids you used"
 		}
 		return toolResult(out)
 	}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -999,15 +999,15 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		hit := bestHits[id]
 		exactMatch := exactBoostEnabled && ExactIdentifierHit(m.Content, query)
 		input := ScoreInput{
-			Cosine:               hit.cosine,
-			BM25:                 bm25,
-			HoursSince:           temporalAnchorHours(*m),
-			Importance:           m.Importance,
-			DynamicImportance:    m.DynamicImportance,
-			RetrievalPrecision:   m.RetrievalPrecision,
-			EpisodeMatch:         opts.CurrentEpisodeID != "" && m.EpisodeID == opts.CurrentEpisodeID,
-			MemoryType:           m.MemoryType,
-			IsPreferenceQuery:    prefQuery,
+			Cosine:             hit.cosine,
+			BM25:               bm25,
+			HoursSince:         temporalAnchorHours(*m),
+			Importance:         m.Importance,
+			DynamicImportance:  m.DynamicImportance,
+			RetrievalPrecision: m.RetrievalPrecision,
+			EpisodeMatch:       opts.CurrentEpisodeID != "" && m.EpisodeID == opts.CurrentEpisodeID,
+			MemoryType:         m.MemoryType,
+			IsPreferenceQuery:  prefQuery,
 			// H-TAB: set when TopicAnchorBoost is on and the memory content
 			// contains at least one domain token from the recall query.
 			TopicAnchorMatch:     len(topicAnchorTokens) > 0 && contentContainsTopicAnchor(m.Content, topicAnchorTokens),
@@ -1258,50 +1258,54 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		results = results[:topK]
 	}
 
-	// Fetch relationships for the final topK results in a single batch query,
-	// replacing the prior N+1 loop (one GetRelationships call per result).
-	topKIDs := make([]string, len(results))
-	for i, r := range results {
-		topKIDs[i] = r.Memory.ID
-	}
-	relsMap, err := e.backend.GetRelationshipsBatch(ctx, e.project, topKIDs)
-	if err != nil {
-		// best-effort: proceed with empty relationship sets rather than failing recall
-		slog.Warn("GetRelationshipsBatch failed, proceeding without relationships", "err", err)
-		relsMap = make(map[string][]types.Relationship)
-	}
+	if opts.Mode != "handle" {
+		// Fetch relationships for the final topK results in a single batch query,
+		// replacing the prior N+1 loop (one GetRelationships call per result).
+		topKIDs := make([]string, len(results))
+		for i, r := range results {
+			topKIDs[i] = r.Memory.ID
+		}
+		relsMap, err := e.backend.GetRelationshipsBatch(ctx, e.project, topKIDs)
+		if err != nil {
+			// best-effort: proceed with empty relationship sets rather than failing recall
+			slog.Warn("GetRelationshipsBatch failed, proceeding without relationships", "err", err)
+			relsMap = make(map[string][]types.Relationship)
+		}
 
-	var allRels [][]types.Relationship
-	var neighborIDs []string
-	neighborSet := make(map[string]struct{})
-	for i := range results {
-		rels := relsMap[results[i].Memory.ID]
-		allRels = append(allRels, rels)
-		for _, r := range rels {
-			neighborID := r.TargetID
-			if r.TargetID == results[i].Memory.ID {
-				neighborID = r.SourceID
-			}
-			if _, seen := neighborSet[neighborID]; !seen {
-				neighborSet[neighborID] = struct{}{}
-				neighborIDs = append(neighborIDs, neighborID)
+		var allRels [][]types.Relationship
+		var neighborIDs []string
+		neighborSet := make(map[string]struct{})
+		for i := range results {
+			rels := relsMap[results[i].Memory.ID]
+			allRels = append(allRels, rels)
+			for _, r := range rels {
+				neighborID := r.TargetID
+				if r.TargetID == results[i].Memory.ID {
+					neighborID = r.SourceID
+				}
+				if _, seen := neighborSet[neighborID]; !seen {
+					neighborSet[neighborID] = struct{}{}
+					neighborIDs = append(neighborIDs, neighborID)
+				}
 			}
 		}
-	}
-	neighborMap := make(map[string]*types.Memory, len(neighborIDs))
-	if len(neighborIDs) > 0 {
-		fetched, err := e.backend.GetMemoriesByIDs(ctx, e.project, neighborIDs)
-		if err == nil {
-			for _, m := range fetched {
-				neighborMap[m.ID] = m
+		neighborMap := make(map[string]*types.Memory, len(neighborIDs))
+		if len(neighborIDs) > 0 {
+			fetched, err := e.backend.GetMemoriesByIDs(ctx, e.project, neighborIDs)
+			if err == nil {
+				for _, m := range fetched {
+					neighborMap[m.ID] = m
+				}
 			}
 		}
-	}
-	for i := range results {
-		results[i].Connected = toConnectedMemories(allRels[i], results[i].Memory.ID, neighborMap)
+		for i := range results {
+			results[i].Connected = toConnectedMemories(allRels[i], results[i].Memory.ID, neighborMap)
+		}
+
 	}
 
-	// Batch-update access timestamps (#117 — replaces N+1 TouchMemory calls).
+	// Preserve access heat for pruning/retention logic even when handle mode
+	// skips the heavier graph-enrichment path.
 	touchIDs := make([]string, len(results))
 	for i, r := range results {
 		touchIDs[i] = r.Memory.ID
@@ -2214,7 +2218,13 @@ func bigramJaccard(a, b string) float64 {
 // RecallWithEvent is like Recall but also stores a retrieval_event row and returns
 // the event ID. Pass the event ID to FeedbackWithEvent to record which results were useful.
 func (e *SearchEngine) RecallWithEvent(ctx context.Context, query string, topK int, detail string) ([]types.SearchResult, string, error) {
-	results, err := e.RecallWithOpts(ctx, query, topK, detail, RecallOpts{})
+	return e.RecallWithEventAndOpts(ctx, query, topK, detail, RecallOpts{})
+}
+
+// RecallWithEventAndOpts is like RecallWithEvent but preserves RecallOpts such
+// as handle mode while still emitting retrieval telemetry.
+func (e *SearchEngine) RecallWithEventAndOpts(ctx context.Context, query string, topK int, detail string, opts RecallOpts) ([]types.SearchResult, string, error) {
+	results, err := e.RecallWithOpts(ctx, query, topK, detail, opts)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1301,7 +1301,6 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		for i := range results {
 			results[i].Connected = toConnectedMemories(allRels[i], results[i].Memory.ID, neighborMap)
 		}
-
 	}
 
 	// Preserve access heat for pruning/retention logic even when handle mode

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -14,6 +14,11 @@
 // After implementing optimizations, compare with benchstat:
 //
 //	benchstat bench_before.txt bench_after.txt
+//
+// Perf budget for benchmark-facing recall changes:
+//
+//   - warmed handle-mode recall should avoid graph-enrichment/writeback overhead
+//   - warmed summary/full recall should stay within the existing topK scaling envelope
 package search_test
 
 import (
@@ -590,6 +595,25 @@ func BenchmarkRecallWithOpts_10_withRelationships(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		results, err := engine.Recall(ctx, "test query for benchmark", 10, "full")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = results
+	}
+}
+
+// BenchmarkRecallWithOpts_10_handleMode exercises the lightweight handle path.
+// This should stay materially cheaper than the full/relationship path because
+// handle mode is not supposed to build connected-memory payloads or do writeback.
+func BenchmarkRecallWithOpts_10_handleMode(b *testing.B) {
+	engine := newBenchEngine(b, 10, 3)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		results, err := engine.RecallWithOpts(ctx, "test query for benchmark", 10, "summary", search.RecallOpts{Mode: "handle"})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/search/federation.go
+++ b/internal/search/federation.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"sort"
@@ -24,21 +25,30 @@ const maxFederationConcurrency = 4
 // This is the engine-layer primitive for Cross-Project Knowledge Federation (Feature 4).
 // The MCP handler wires project name → engine via EnginePool and calls this function.
 func RecallAcrossEngines(ctx context.Context, engines []*SearchEngine, query string, topK int, detail string) ([]types.SearchResult, error) {
-	return RecallAcrossEnginesWithEvents(ctx, engines, query, topK, detail, true)
+	return RecallAcrossEnginesWithEventsAndOpts(ctx, engines, query, topK, detail, RecallOpts{}, true)
 }
 
 // RecallAcrossEnginesWithEvents is RecallAcrossEngines with explicit retrieval
-// telemetry control. When recordEvents is false, federation is a pure read.
+// telemetry control. When recordEvents is false, federation suppresses
+// retrieval-event writes but still follows the underlying recall mode's normal
+// access-heat behavior.
 func RecallAcrossEnginesWithEvents(ctx context.Context, engines []*SearchEngine, query string, topK int, detail string, recordEvents bool) ([]types.SearchResult, error) {
+	return RecallAcrossEnginesWithEventsAndOpts(ctx, engines, query, topK, detail, RecallOpts{}, recordEvents)
+}
+
+// RecallAcrossEnginesWithEventsAndOpts is RecallAcrossEnginesWithEvents with
+// explicit RecallOpts propagation so federated callers can preserve the same
+// response-mode and post-processing semantics as single-project recall.
+func RecallAcrossEnginesWithEventsAndOpts(ctx context.Context, engines []*SearchEngine, query string, topK int, detail string, opts RecallOpts, recordEvents bool) ([]types.SearchResult, error) {
 	if len(engines) == 0 {
 		return nil, nil
 	}
 	if len(engines) == 1 {
 		if recordEvents {
-			results, _, err := engines[0].RecallWithEvent(ctx, query, topK, detail)
+			results, _, err := engines[0].RecallWithEventAndOpts(ctx, query, topK, detail, opts)
 			return results, err
 		}
-		return engines[0].Recall(ctx, query, topK, detail)
+		return engines[0].RecallWithOpts(ctx, query, topK, detail, opts)
 	}
 
 	type fanResult struct {
@@ -61,12 +71,11 @@ func RecallAcrossEnginesWithEvents(ctx context.Context, engines []*SearchEngine,
 			var res []types.SearchResult
 			var err error
 			if recordEvents {
-				// Use RecallWithEvent so Feature 5 retrieval tracking can be emitted
-				// for cross-project queries too (#92). The event IDs are not returned
-				// to the federated caller — they're stored per-project for local feedback.
-				res, _, err = eng.RecallWithEvent(ctx, query, topK, detail)
+				// Use RecallWithEventAndOpts so cross-project callers keep the same
+				// retrieval-tracking behavior while preserving mode-specific fast paths.
+				res, _, err = eng.RecallWithEventAndOpts(ctx, query, topK, detail, opts)
 			} else {
-				res, err = eng.Recall(ctx, query, topK, detail)
+				res, err = eng.RecallWithOpts(ctx, query, topK, detail, opts)
 			}
 			ch <- fanResult{res, err}
 		}()
@@ -80,8 +89,10 @@ func RecallAcrossEnginesWithEvents(ctx context.Context, engines []*SearchEngine,
 
 	// Collect, dedup by ID (keep highest score), then sort.
 	seen := make(map[string]types.SearchResult, len(engines)*topK)
+	failed := 0
 	for fan := range ch {
 		if fan.err != nil {
+			failed++
 			// Best-effort: log and skip failing engines rather than aborting the whole call.
 			slog.Warn("federation: engine recall failed", "err", fan.err)
 			continue
@@ -91,6 +102,9 @@ func RecallAcrossEnginesWithEvents(ctx context.Context, engines []*SearchEngine,
 				seen[r.Memory.ID] = r
 			}
 		}
+	}
+	if failed == len(engines) {
+		return nil, fmt.Errorf("federated recall failed across %d engines", failed)
 	}
 
 	merged := make([]types.SearchResult, 0, len(seen))

--- a/internal/search/federation_test.go
+++ b/internal/search/federation_test.go
@@ -107,3 +107,18 @@ func TestFederatedRecall_SingleEngine(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, results)
 }
+
+func TestFederatedRecall_AllEnginesFailReturnsError(t *testing.T) {
+	engA := newTestEngine(t, uniqueProject("fed-fail-a"))
+	t.Cleanup(func() { engA.Close() })
+	engB := newTestEngine(t, uniqueProject("fed-fail-b"))
+	t.Cleanup(func() { engB.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results, err := search.RecallAcrossEngines(ctx, []*search.SearchEngine{engA, engB}, "distributed consensus", 10, "normal")
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "federated recall failed across")
+}


### PR DESCRIPTION
## Summary
- honor `limit` as a `top_k` alias in `memory_recall` and propagate recall mode through federated recall
- keep handle mode lightweight by skipping graph enrichment while preserving access heat needed for prune safety
- reject unsupported federated `record_event`, return `event_id` for single-project handle-mode telemetry, and remove stale read-only hints
- update recall/startup docs to match the shipped timeout, mode, tool-count, and setup-token contracts

## Findings
- live LME-style latency spikes were strongly project-cold-start driven; warmed same-project recalls were sub-second while first calls into large projects were ~17-18s
- microbenchmark after the final fix still shows the handle-mode fast path cheaper than full enrichment (`withRelationships`: `42329 ns/op`, `38668 B/op`, `273 allocs/op`; `handleMode`: `36008 ns/op`, `30307 B/op`, `198 allocs/op`)
- follow-up QA issues were filed for remaining non-blocking work: #1042 and #1043

## Verification
- `go test ./internal/mcp ./internal/search -count=1`
- `go test ./... -count=1`
- `go test -bench 'BenchmarkRecallWithOpts_10_(withRelationships|handleMode)' -run '^$' ./internal/search -count=1`
- six-persona QA sweep rerun after blocker fixes; remaining non-blocking items were filed as follow-up issues

## PR Packaging
scope_class: hotfix
merge_order: 1
depends_on: none
conflict_surface: [README.md, docs/architecture.md, docs/getting-started.md, docs/how-it-works.md, docs/tools.md, internal/mcp/fetch_recall_test.go, internal/mcp/readonly_hints_test.go, internal/mcp/server.go, internal/mcp/tools_recall.go, internal/search/engine.go, internal/search/engine_bench_test.go, internal/search/federation.go, internal/search/federation_test.go]
risk: med
rollback: Revert cab311d to restore the previous recall/federation and documentation behavior.

Closes #1022
