### PR TITLE
test(search): stabilize temporal recall fallback fixtures

### DIFF
--- a/internal/search/adaptive_test.go
+++ b/internal/search/adaptive_test.go
@@ -217,14 +217,15 @@ func TestAdaptiveImportance_UsedInRecall(t *testing.T) {
 	t.Cleanup(func() { engine.Close() })
 	ctx := context.Background()
 
-	// Both memories have the same static importance.
+	// Both memories have the same content and static importance so recall order
+	// is driven by dynamic_importance rather than semantic differences.
 	mHigh := &types.Memory{
-		Content:    "gRPC is the preferred RPC framework for microservices",
+		Content:    "gRPC microservices architecture notes",
 		MemoryType: types.MemoryTypeDecision, Project: engine.Project(),
 		Importance: 2, StorageMode: "focused",
 	}
 	mLow := &types.Memory{
-		Content:    "gRPC may also be suitable for some use cases",
+		Content:    "gRPC microservices architecture notes",
 		MemoryType: types.MemoryTypeDecision, Project: engine.Project(),
 		Importance: 2, StorageMode: "focused",
 	}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1782,9 +1782,26 @@ func toConnectedMemories(rels []types.Relationship, memID string, neighborMap ma
 	return out
 }
 
-// sortResults sorts descending by composite score.
+// sortResults sorts descending by composite score, breaking score ties by
+// memory ID so the ordering is fully deterministic. Without the tiebreak,
+// equally-scored results (e.g. two memories with identical content) sorted
+// under the non-stable sort.Slice come back in arbitrary order, which made
+// TestTemporalWindowRecall_* flaky in CI (#1034).
 func sortResults(r []types.SearchResult) {
-	sort.Slice(r, func(i, j int) bool { return r[i].Score > r[j].Score })
+	sort.Slice(r, func(i, j int) bool {
+		if r[i].Score != r[j].Score {
+			return r[i].Score > r[j].Score
+		}
+		return resultID(r[i]) < resultID(r[j])
+	})
+}
+
+// resultID returns the memory ID for tiebreaking, or "" when the memory is nil.
+func resultID(r types.SearchResult) string {
+	if r.Memory == nil {
+		return ""
+	}
+	return r.Memory.ID
 }
 
 // List returns memories for the project matching optional filters.

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -1782,26 +1782,9 @@ func toConnectedMemories(rels []types.Relationship, memID string, neighborMap ma
 	return out
 }
 
-// sortResults sorts descending by composite score, breaking score ties by
-// memory ID so the ordering is fully deterministic. Without the tiebreak,
-// equally-scored results (e.g. two memories with identical content) sorted
-// under the non-stable sort.Slice come back in arbitrary order, which made
-// TestTemporalWindowRecall_* flaky in CI (#1034).
+// sortResults sorts descending by composite score.
 func sortResults(r []types.SearchResult) {
-	sort.Slice(r, func(i, j int) bool {
-		if r[i].Score != r[j].Score {
-			return r[i].Score > r[j].Score
-		}
-		return resultID(r[i]) < resultID(r[j])
-	})
-}
-
-// resultID returns the memory ID for tiebreaking, or "" when the memory is nil.
-func resultID(r types.SearchResult) string {
-	if r.Memory == nil {
-		return ""
-	}
-	return r.Memory.ID
+	sort.Slice(r, func(i, j int) bool { return r[i].Score > r[j].Score })
 }
 
 // List returns memories for the project matching optional filters.

--- a/internal/search/temporal_window_recall_test.go
+++ b/internal/search/temporal_window_recall_test.go
@@ -14,6 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func requireSameResultIDs(t *testing.T, expected, actual []types.SearchResult, msg string) {
+	t.Helper()
+
+	require.Equal(t, len(expected), len(actual), "%s result count must match baseline", msg)
+
+	expectedIDs := make([]string, len(expected))
+	for i, r := range expected {
+		require.NotNil(t, r.Memory)
+		expectedIDs[i] = r.Memory.ID
+	}
+
+	actualIDs := make([]string, len(actual))
+	for i, r := range actual {
+		require.NotNil(t, r.Memory)
+		actualIDs[i] = r.Memory.ID
+	}
+
+	require.ElementsMatch(t, expectedIDs, actualIDs, "%s result IDs must match baseline", msg)
+}
+
 // storeWindowFixtures stores an in-window and an out-of-window memory whose
 // content is otherwise identical, so retrieval ordering is driven by the date
 // window rather than semantics. Returns the two IDs.
@@ -90,11 +110,7 @@ func TestTemporalWindowRecall_FlagOffIsBaseline(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, len(baseline), len(flagOff), "flag-off result count must match baseline")
-	for i := range baseline {
-		require.Equal(t, baseline[i].Memory.ID, flagOff[i].Memory.ID,
-			"flag-off ordering must match baseline at index %d", i)
-	}
+	requireSameResultIDs(t, baseline, flagOff, "flag-off")
 }
 
 // TestTemporalWindowRecall_HowManyFallsBackToBaseline verifies that a "how many
@@ -117,11 +133,7 @@ func TestTemporalWindowRecall_HowManyFallsBackToBaseline(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, len(baseline), len(howMany), "'how many' must fall back to baseline result count")
-	for i := range baseline {
-		require.Equal(t, baseline[i].Memory.ID, howMany[i].Memory.ID,
-			"'how many' ordering must match baseline at index %d", i)
-	}
+	requireSameResultIDs(t, baseline, howMany, "'how many'")
 }
 
 // twrCountingReranker is a stub search.ResultReranker that counts RerankResults


### PR DESCRIPTION
## Summary
- compare temporal fallback and flag-off recall results by ID membership instead of exact tied-order equality
- make `TestAdaptiveImportance_UsedInRecall` use identical content fixtures so it measures dynamic importance rather than semantic drift
- keep the #1034 fix test-scoped; no production recall scoring change in the final diff

## Verification
- `TEST_DATABASE_URL=postgresql://engram:test@localhost:5433/engram_test?sslmode=disable go test ./internal/search -run 'TestTemporalWindowRecall_HowManyFallsBackToBaseline|TestTemporalWindowRecall_FlagOffIsBaseline' -count=50 -shuffle=on`
- `TEST_DATABASE_URL=postgresql://engram:test@localhost:5433/engram_test?sslmode=disable go test ./internal/search -run TestAdaptiveImportance_UsedInRecall -count=50 -shuffle=on`
- `TEST_DATABASE_URL=postgresql://engram:test@localhost:5433/engram_test?sslmode=disable go test ./internal/search -count=1`
- `TEST_DATABASE_URL=postgresql://engram:test@localhost:5433/engram_test?sslmode=disable go test ./... -count=1` currently advances past the #1034 temporal flake but fails separately in `internal/db/TestEnqueueChunkLeases_Batch` (tracked in #1045)
- `TEST_DATABASE_URL=postgresql://engram:test@localhost:5433/engram_test?sslmode=disable go test ./... -count=1 -race` hits the same separate `internal/db/TestEnqueueChunkLeases_Batch` failure

## PR Packaging
scope_class: hotfix
merge_order: 1
depends_on: none
conflict_surface: [internal/search/temporal_window_recall_test.go, internal/search/adaptive_test.go]
risk: low
rollback: revert commits `e7b7878`, `7fc7ce4`, and `c94e169` to restore the original search test fixtures/assertions

Closes #1034