### PR TITLE
fix(deploy): pin lme prune CronJob image

### DIFF
--- a/cmd/longmemeval/docs_test.go
+++ b/cmd/longmemeval/docs_test.go
@@ -54,6 +54,55 @@ func TestLMEPruneCronJobUsesSafeExecuteFlags(t *testing.T) {
 	}
 }
 
+func TestLMEPruneCronJobPinsReviewedImage(t *testing.T) {
+	data, err := os.ReadFile("../../deploy/lme-prune-cronjob.yaml")
+	if err != nil {
+		t.Fatalf("read deploy/lme-prune-cronjob.yaml: %v", err)
+	}
+	manifest := string(data)
+	const reviewedImage = "ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0"
+
+	if strings.Contains(manifest, "ghcr.io/petersimmons1972/engram-go/longmemeval:latest") {
+		t.Fatalf("prune CronJob must not use mutable :latest image:\n%s", manifest)
+	}
+	for _, current := range []string{
+		"#   - Image: " + reviewedImage,
+		"image: " + reviewedImage,
+		"Never use :latest for this CronJob.",
+		"update both this comment and the image reference in the same reviewed change",
+		"imagePullPolicy: Always",
+	} {
+		if !strings.Contains(manifest, current) {
+			t.Fatalf("prune CronJob missing reviewed image pin guidance %q:\n%s", current, manifest)
+		}
+	}
+}
+
+func TestLMEBenchmarkLearningsDocumentsPruneImageUpdateProcedure(t *testing.T) {
+	data, err := os.ReadFile("../../docs/lme-benchmark-learnings.md")
+	if err != nil {
+		t.Fatalf("read docs/lme-benchmark-learnings.md: %v", err)
+	}
+	doc := string(data)
+	section := between(t, doc, "### Updating the prune image", "### Backfilling existing runs")
+
+	for _, current := range []string{
+		"v3.2.0",
+		"replace it with the reviewed release tag or immutable digest",
+		"Update `deploy/lme-prune-cronjob.yaml` in the same reviewed change",
+		"kubectl apply -f deploy/lme-prune-cronjob.yaml",
+		"kubectl patch cronjob lme-prune -n engram -p '{\"spec\":{\"suspend\":true}}'",
+		"JOB=lme-prune-manual-$(date +%s)",
+		"kubectl create job --from=cronjob/lme-prune -n engram \"$JOB\"",
+		"kubectl logs -n engram job/\"$JOB\"",
+		"kubectl patch cronjob lme-prune -n engram -p '{\"spec\":{\"suspend\":false}}'",
+	} {
+		if !strings.Contains(section, current) {
+			t.Fatalf("prune image update procedure missing %q:\n%s", current, section)
+		}
+	}
+}
+
 func TestCommandCatalogDocumentsLongMemEval(t *testing.T) {
 	data, err := os.ReadFile("../../cmd/README.md")
 	if err != nil {
@@ -87,6 +136,27 @@ func TestLMEBenchmarkLearningsQuickStartUsesCurrentFlags(t *testing.T) {
 		if !strings.Contains(section, current) {
 			t.Fatalf("quick start missing current text %q:\n%s", current, section)
 		}
+	}
+}
+
+func TestLMEBenchmarkLearningsSummaryUsesCurrentQuestionTypesAndPortableReference(t *testing.T) {
+	data, err := os.ReadFile("../../docs/lme-benchmark-learnings.md")
+	if err != nil {
+		t.Fatalf("read docs/lme-benchmark-learnings.md: %v", err)
+	}
+	doc := string(data)
+
+	for _, current := range []string{
+		"LongMemEval-M (500 questions, 6 types)",
+		"500 questions across six types: knowledge-update, multi-session, single-session-assistant, single-session-user, single-session-preference, and temporal-reasoning.",
+		"`docs/architecture.md`",
+	} {
+		if !strings.Contains(doc, current) {
+			t.Fatalf("benchmark learnings missing current summary/reference text %q", current)
+		}
+	}
+	if strings.Contains(doc, "/home/psimmons/projects/engram-go/docs/architecture.md") {
+		t.Fatalf("benchmark learnings still contains checkout-specific architecture path")
 	}
 }
 

--- a/deploy/lme-prune-cronjob.yaml
+++ b/deploy/lme-prune-cronjob.yaml
@@ -4,7 +4,12 @@
 # Requires:
 #   - Secret "engram-lme" with keys: database-url, engram-url, engram-api-key
 #   - RBAC: no cluster permissions needed (contacts Postgres + Engram HTTP only)
-#   - Image: ghcr.io/petersimmons1972/engram-go/longmemeval:latest (or pin to a SHA)
+#   - Image: ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0
+#
+# Never use :latest for this CronJob. This job runs a destructive `prune --execute`
+# path on a schedule, so image changes must be explicit and reviewable. To update it,
+# replace the pinned tag with the reviewed release tag or immutable digest, then
+# update both this comment and the image reference in the same reviewed change.
 #
 # Tune --limit on first run to verify blast radius before allowing unlimited.
 # Deletion is explicit: --execute, --confirm-prefix, and --use-default-token are
@@ -39,8 +44,8 @@ spec:
             fsGroup: 65532
           containers:
             - name: lme-prune
-              image: ghcr.io/petersimmons1972/engram-go/longmemeval:latest
-              imagePullPolicy: IfNotPresent
+              image: ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0
+              imagePullPolicy: Always
               args:
                 - prune
                 - --prefix=lme-

--- a/docs/lme-benchmark-learnings.md
+++ b/docs/lme-benchmark-learnings.md
@@ -1,7 +1,7 @@
 # LongMemEval Benchmark Learnings
 
 **Date**: May 2026  
-**Benchmark**: LongMemEval-M (500 questions, 4 types)  
+**Benchmark**: LongMemEval-M (500 questions, 6 types)  
 **Memory System**: Engram  
 **LLM Backend**: vLLM with Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4 (FP4 quantized, max_model_len=131072)
 
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-We ran the LongMemEval-M benchmark against Engram to evaluate long-context memory performance. The test dataset contains 500 questions across four types: knowledge-update, multi-session, single-session-assistant, and single-session-user. Initial configuration attempts failed due to vLLM/Nemotron incompatibilities and resource limits. After systematic debugging and optimization, we achieved **~8 completions/minute** (62-minute ETA for full 500-question run) with correct factual answers emerging from the model.
+We ran the LongMemEval-M benchmark against Engram to evaluate long-context memory performance. The test dataset contains 500 questions across six types: knowledge-update, multi-session, single-session-assistant, single-session-user, single-session-preference, and temporal-reasoning. Initial configuration attempts failed due to vLLM/Nemotron incompatibilities and resource limits. After systematic debugging and optimization, we achieved **~8 completions/minute** (62-minute ETA for full 500-question run) with correct factual answers emerging from the model.
 
 Key learnings document nine configuration issues (all resolvable), throughput optimization strategies, and model-specific constraints that future benchmarks should adopt from the start.
 
@@ -457,6 +457,42 @@ Use `--unlimited` only for a deliberately unbounded sweep. If you want prune to 
 
 The sweep is deployed as a weekly K8s CronJob at `deploy/lme-prune-cronjob.yaml`.
 
+### Updating the prune image
+
+The checked-in CronJob pin is currently `ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0`.
+Do not switch this job to `:latest`. For destructive scheduled deletes, replace it with the reviewed release tag or immutable digest you intend to ship, and keep that change visible in git review.
+
+Update `deploy/lme-prune-cronjob.yaml` in the same reviewed change that approves the
+new prune binary. The CronJob uses `imagePullPolicy: Always` so each run resolves the
+currently reviewed reference instead of reusing a cached mutable tag.
+
+After merge, roll it out explicitly:
+
+```bash
+kubectl apply -f deploy/lme-prune-cronjob.yaml
+kubectl -n engram get cronjob lme-prune -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}'
+```
+
+Before the next scheduled destructive run, suspend the CronJob and verify the new image
+through a one-off Job:
+
+```bash
+kubectl patch cronjob lme-prune -n engram -p '{"spec":{"suspend":true}}'
+JOB=lme-prune-manual-$(date +%s)
+kubectl create job --from=cronjob/lme-prune -n engram "$JOB"
+kubectl wait -n engram --for=condition=complete job/"$JOB" --timeout=10m
+kubectl get pods -n engram -l job-name="$JOB" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[0].imageID}{"\n"}{end}'
+kubectl logs -n engram job/"$JOB"
+```
+
+If the manual run is wrong or inconclusive, reapply the previous reviewed image reference,
+leave the CronJob suspended, and inspect the manual Job/Pod events before allowing the
+schedule to resume. When the manual run looks correct, unsuspend the CronJob:
+
+```bash
+kubectl patch cronjob lme-prune -n engram -p '{"spec":{"suspend":false}}'
+```
+
 ### Backfilling existing runs
 
 Existing `lme-*` projects (created before migration 022) have `NULL expires_at`. To opt them into the sweep:
@@ -485,7 +521,7 @@ ON CONFLICT (project) DO NOTHING;
 - **vLLM Repository**: https://github.com/vllm-project/vllm (GH#39103 — Nemotron v3 reasoning parser)
 - **LongMemEval**: https://github.com/microsoft/LongMemEval (benchmark suite)
 - **Nemotron-3 Documentation**: Nvidia AI Enterprise documentation (max_model_len, chat_template_kwargs)
-- **Engram Memory System**: `/home/psimmons/projects/engram-go/docs/architecture.md`
+- **Engram Memory System**: `docs/architecture.md`
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the destructive `lme-prune` CronJob image reference with the reviewed `v3.2.0` pin and force fresh pulls with `imagePullPolicy: Always`
- document the prune image rollout/update procedure, including suspend/manual verification/resume steps
- add regression tests for the prune image policy and clean up stale `docs/lme-benchmark-learnings.md` summary drift

## Testing
- `go test ./cmd/longmemeval -count=1`
- `go test ./... -count=1`

## QA
- Six-persona QA sweep completed
- Round 2 returned zero blocker/critical findings
- Filed residual follow-ups: `#1047`, `#1048`

## PR Packaging
scope_class: ops
merge_order: 1
depends_on: none
conflict_surface: [cmd/longmemeval/docs_test.go, deploy/lme-prune-cronjob.yaml, docs/lme-benchmark-learnings.md]
risk: low
rollback: revert the CronJob/doc/test changes or reapply the prior reviewed prune image reference and suspend the CronJob until verified

Closes #1039
