### PR TITLE
docs(mcp): unify onboarding tool-count contract for issue 1040

### DIFF
--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -1,6 +1,6 @@
 # Connecting Your IDE
 
-Engram communicates with your IDE over Server-Sent Events — a persistent HTTP connection where the server pushes data to the client. When you point your IDE at Engram's SSE endpoint, the server sends your IDE the full list of available tools, then keeps the connection alive to carry requests and responses. From your IDE's perspective, 38 new tools just appeared. From Engram's perspective, it now has a client. The connection is live for as long as both sides are running, and your IDE does not need to poll or reconnect to get fresh results.
+Engram communicates with your IDE over Server-Sent Events — a persistent HTTP connection where the server pushes data to the client. When you point your IDE at Engram's SSE endpoint, the server sends your IDE the full list of available tools, then keeps the connection alive to carry requests and responses. From your IDE's perspective, <!-- count:visible-default -->18<!-- /count --> visible tools appear in `tools/list`, with <!-- count:hidden -->28<!-- /count --> hidden maintenance tools still callable via `tools/call` (`<!-- count:visible-with-ai -->22<!-- /count -->` with `ANTHROPIC_API_KEY`). From Engram's perspective, the SSE client has a full tool surface now. The connection is live for as long as both sides are running, and your IDE does not need to poll or reconnect to get fresh results.
 
 The SSE endpoint is `http://localhost:8788/sse`. Everything below is how you tell each IDE to find it.
 
@@ -35,7 +35,7 @@ Verify the tools loaded:
 /mcp
 ```
 
-You should see `engram` listed with 17 tools (21 if `ANTHROPIC_API_KEY` is set — four optional AI-enhanced tools activate). If the count is wrong, restart Claude Code — it reads MCP configs at startup, not on demand. See [MCP Tool Reference](tools.md) for the full callable surface including hidden maintenance tools.
+You should see `engram` listed with <!-- count:visible-default -->18<!-- /count --> tools (<!-- count:visible-with-ai -->22<!-- /count --> if `ANTHROPIC_API_KEY` is set — <!-- count:ai-enhanced -->4<!-- /count --> optional AI-enhanced tools activate). If the count is wrong, restart Claude Code — it reads MCP configs at startup, not on demand. See [MCP Tool Reference](tools.md) for the full callable surface including hidden maintenance tools.
 
 ---
 
@@ -210,8 +210,8 @@ The SSE transport holds an HTTP connection open indefinitely, and some reverse p
 **"Authorization required" error.**
 You have `ENGRAM_API_KEY` set in `.env`, but the IDE is not sending it in the header. Check the IDE config and confirm the header key is exactly `Authorization` and the value starts with `Bearer ` (with a space).
 
-**Wrong number of tools (expect 38 or 43).**
-Four AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) only register when `ANTHROPIC_API_KEY` is set in `.env`. Without it, you see 17 tools visible in `tools/list`. With it, you see 21. (`memory_diagnose` is a hidden+unconditional tool, not AI-gated.) Set the key and restart `engram-go`:
+**Wrong number of tools (expect <!-- count:total-callable-default -->46<!-- /count --> or <!-- count:total-callable-with-ai -->50<!-- /count -->).**
+Four AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) only register when `ANTHROPIC_API_KEY` is set in `.env`. Without it, you see <!-- count:visible-default -->18<!-- /count --> tools visible in `tools/list`. With it, you see <!-- count:visible-with-ai -->22<!-- /count -->. (`memory_diagnose` is a hidden+unconditional tool, not AI-gated.) Set the key and restart `engram-go`:
 
 ```bash
 docker compose restart engram-go
@@ -226,4 +226,4 @@ SSE sessions are bound to the bearer token presented at connection time. After a
 ---
 
 **Previous:** [Getting Started](getting-started.md) — prerequisites, startup, and configuration reference.  
-**Next:** [Tools Reference](tools.md) — 17 visible tools (21 with `ANTHROPIC_API_KEY`), plus 29 hidden maintenance tools, with parameters and examples.
+**Next:** [Tools Reference](tools.md) — <!-- count:visible-default -->18<!-- /count --> visible tools (<!-- count:visible-with-ai -->22<!-- /count --> with `ANTHROPIC_API_KEY`), plus <!-- count:hidden -->28<!-- /count --> hidden maintenance tools, with parameters and examples.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-When you finish this page, you will have a running memory server, a working IDE connection, and 18 tools visible to every AI assistant you use (22 with `ANTHROPIC_API_KEY` set). A handful of commands get you there (see below; previously this page claimed 'three' but the actual sequence is 4-6 depending on which profile you pick — #697). The whole thing takes about five minutes.
+When you finish this page, you will have a running memory server, a working IDE connection, and <!-- count:visible-default -->18<!-- /count --> tools visible to every AI assistant you use (<!-- count:visible-with-ai -->22<!-- /count --> with `ANTHROPIC_API_KEY` set). A handful of commands get you there (see below; previously this page claimed 'three' but the actual sequence is 4-6 depending on which profile you pick — #697). The whole thing takes about five minutes.
 
 ---
 
@@ -159,9 +159,9 @@ In Claude Code, confirm the tools loaded:
 /mcp
 ```
 
-You should see `engram` listed with 18 tools (22 if `ANTHROPIC_API_KEY` is set — four optional AI-enhanced tools activate). If it shows fewer, restart Claude Code — IDE MCP clients cache the tool list at startup. See [MCP Tool Reference](tools.md) for the full callable surface (46 default / 50 with API key, including hidden maintenance tools).
+You should see `engram` listed with <!-- count:visible-default -->18<!-- /count --> tools (<!-- count:visible-with-ai -->22<!-- /count --> if `ANTHROPIC_API_KEY` is set — <!-- count:ai-enhanced -->4<!-- /count --> optional AI-enhanced tools activate). If it shows fewer, restart Claude Code — IDE MCP clients cache the tool list at startup. See [MCP Tool Reference](tools.md) for the full callable surface (<!-- count:total-callable-default -->46<!-- /count --> default with <!-- count:hidden -->28<!-- /count --> hidden maintenance tools / <!-- count:total-callable-with-ai -->50<!-- /count --> with API key, including hidden maintenance tools).
 
-When you see 18 tools (or 22 with `ANTHROPIC_API_KEY`), you are done. The server is running, and your IDE has a persistent connection to your memory store. In local-only mode that also implies the embedding model is loaded in Ollama.
+When you see <!-- count:visible-default -->18<!-- /count --> tools (or <!-- count:visible-with-ai -->22<!-- /count --> with `ANTHROPIC_API_KEY`), you are done. The server is running, and your IDE has a persistent connection to your memory store. In local-only mode that also implies the embedding model is loaded in Ollama.
 
 ---
 

--- a/internal/mcp/tool_count_doc_test.go
+++ b/internal/mcp/tool_count_doc_test.go
@@ -87,7 +87,7 @@ func parseDocCounts(t *testing.T, path string) map[string]int {
 }
 
 // TestToolCountsMatchDocs verifies that every count marker in docs/tools.md
-// and README.md matches the canonical value from code.
+// and the onboarding docs matches the canonical value from code.
 func TestToolCountsMatchDocs(t *testing.T) {
 	c := computeToolCounts(t)
 	visibleDefault := c.unconditional - c.hidden
@@ -113,6 +113,8 @@ func TestToolCountsMatchDocs(t *testing.T) {
 	for _, doc := range []string{
 		filepath.Join("..", "..", "docs", "tools.md"),
 		filepath.Join("..", "..", "README.md"),
+		filepath.Join("..", "..", "docs", "getting-started.md"),
+		filepath.Join("..", "..", "docs", "connecting.md"),
 	} {
 		got := parseDocCounts(t, doc)
 		if len(got) == 0 {
@@ -127,6 +129,36 @@ func TestToolCountsMatchDocs(t *testing.T) {
 			}
 			if n != want {
 				t.Errorf("%s: count:%s = %d, code says %d", doc, name, n, want)
+			}
+		}
+	}
+
+	required := []string{
+		"visible-default",
+		"visible-with-ai",
+		"hidden",
+		"ai-enhanced",
+		"total-callable-default",
+		"total-callable-with-ai",
+	}
+
+	for _, doc := range []string{
+		filepath.Join("..", "..", "docs", "getting-started.md"),
+		filepath.Join("..", "..", "docs", "connecting.md"),
+	} {
+		got := parseDocCounts(t, doc)
+		for _, name := range required {
+			want, ok := expected[name]
+			if !ok {
+				continue
+			}
+			gotName, ok := got[name]
+			if !ok {
+				t.Errorf("%s missing required marker count:%s", doc, name)
+				continue
+			}
+			if gotName != want {
+				t.Errorf("%s: required marker count:%s = %d, code says %d", doc, name, gotName, want)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Picked one canonical MCP tool-count contract from `internal/mcp/server.go` (18 visible default, 22 with AI, 28 hidden, 46 total default, 50 total with AI) and aligned all onboarding/reference documentation to that contract.

## Changes
- Updated `docs/getting-started.md` visible/default/AI/hidden/total MCP tool-count claims to canonical values and embedded count markers.
- Updated `docs/connecting.md` tool-count troubleshooting/verification language to canonical values and embedded count markers.
- Extended `internal/mcp/tool_count_doc_test.go` to validate `docs/getting-started.md` and `docs/connecting.md` against canonical code-derived counts.

## Validation
- Not run (per instruction, no explicit test run request in this issue handoff).

## PR Packaging
scope_class: hotfix
merge_order: 1
depends_on: none
conflict_surface: [docs/connecting.md, docs/getting-started.md, internal/mcp/tool_count_doc_test.go]
risk: low
rollback: Revert commit `e45a77b` on this branch to restore prior docs and remove the expanded onboarding marker checks in `internal/mcp/tool_count_doc_test.go`.

Closes #1040
