### PR TITLE
ops: audit codex branch cleanup (#1029)

### DIFF
--- a/ops/branch-cleanup-codex-20260603.md
+++ b/ops/branch-cleanup-codex-20260603.md
@@ -1,0 +1,102 @@
+# Codex Branch Cleanup Audit - 2026-06-03
+
+Issue: #1029
+
+Executed from branch `agent/codex/branch-cleanup-20260603` on 2026-06-05.
+
+## Summary
+
+- Inventory source: live `git branch`, `git branch -r`, `git worktree list --porcelain`, `gh pr list --head`, and `gh issue view`.
+- Scope: codex-owned refs only: `agent/codex/*`, `codex/*`, and `codex-*`.
+- Local branches classified before deletion: 45.
+- Remote branches classified before deletion: 17.
+- Deleted local branches: 39.
+- Deleted remote branches: 15.
+- Preserved refs: current report branch, open PR branch `agent/codex/issue-1036-poll`, open/worktree issue branch `agent/codex/issue-985-poll`, and worktree-protected branches `codex/agent-p0p1-engram`, `codex/issue-918`, `codex/lme-codex-execution-20260530`.
+
+## Protected Worktrees
+
+Live worktree-derived codex-owned protected branches:
+
+| Branch | Worktree | Reason |
+| --- | --- | --- |
+| `agent/codex/branch-cleanup-20260603` | `/home/psimmons/projects/engram-go` | Current report branch |
+| `agent/codex/issue-985-poll` | `/home/psimmons/projects/.codex-poll-worktrees/engram-go-issue-985-2809418` | Open issue #985 |
+| `codex/agent-p0p1-engram` | `/home/psimmons/worktrees/engram-go-agent-p0p1` | Worktree-protected |
+| `codex/issue-918` | `/home/psimmons/projects/engram-go/.worktrees/issue-918` | Worktree-protected |
+| `codex/lme-codex-execution-20260530` | `/home/psimmons/projects/engram-go/.worktrees/lme-codex-execution-20260530` | Worktree-protected |
+
+## Branch Verdicts
+
+| Branch | Before | Verdict | Evidence |
+| --- | --- | --- | --- |
+| `agent/codex/branch-cleanup-20260603` | local | KEEP | Current report branch |
+| `agent/codex/issue-1021-degraded-reason` | local | DELETE | PR #1035 merged; issue #1021 closed |
+| `agent/codex/issue-1022-poll` | local + remote | DELETE | PR #1044 merged; issue #1022 closed |
+| `agent/codex/issue-1030-lme-judge-harness` | local | DELETE | PR #1031 merged; issue #1030 closed |
+| `agent/codex/issue-1034-poll` | local | DELETE | PR #1046 merged; issue #1034 closed |
+| `agent/codex/issue-1036-poll` | local + remote | KEEP | PR #1053 open |
+| `agent/codex/issue-1037-poll` | local + remote | DELETE | PR #1054 merged; issue #1037 closed |
+| `agent/codex/issue-1039-poll` | local | DELETE | PR #1049 merged; issue #1039 closed |
+| `agent/codex/issue-1040-poll` | local | DELETE | PR #1050 merged; issue #1040 closed |
+| `agent/codex/issue-1051-poll` | local | DELETE | PR #1052 merged; issue #1051 closed |
+| `agent/codex/issue-911-poll` | local + remote | DELETE | PR #953 closed; issue #911 closed |
+| `agent/codex/issue-912-poll` | local | DELETE | PR #945 merged; issue #912 closed |
+| `agent/codex/issue-915-poll` | local | DELETE | Issue #915 closed; no open PR |
+| `agent/codex/issue-918-poll` | local | DELETE | Issue #918 closed; protected worktree uses separate `codex/issue-918` branch |
+| `agent/codex/issue-920-poll` | local | DELETE | PR #922 merged; issue #920 closed |
+| `agent/codex/issue-928-poll` | local | DELETE | Issue #928 closed; no open PR |
+| `agent/codex/issue-929-checkembedder-meta-cache` | local + remote | DELETE | PR #959 closed; issue #929 closed |
+| `agent/codex/issue-929-embedder-meta-cache` | local | DELETE | Issue #929 closed; no open PR |
+| `agent/codex/issue-935` | local | DELETE | PR #963 closed; issue #935 closed |
+| `agent/codex/issue-935-clean` | local + remote | DELETE | PR #965 merged; issue #935 closed |
+| `agent/codex/issue-936-memory-status-backlog` | local | DELETE | Issue #936 closed; no open PR |
+| `agent/codex/issue-936-status-backlog` | local + remote | DELETE | PR #966 merged; issue #936 closed |
+| `agent/codex/issue-938-poll` | remote | DELETE | PR #952 closed; issue #938 closed |
+| `agent/codex/issue-941-poll` | local | DELETE | Issue #941 closed; no open PR |
+| `agent/codex/issue-942-branch-reconciliation-20260531` | local + remote | DELETE | PR #958 merged; issue #942 closed |
+| `agent/codex/issue-942-branch-reconciliation-20260531-clean` | local | DELETE | Issue #942 closed; no open PR |
+| `agent/codex/issue-942-branch-triage-20260531` | local | DELETE | Issue #942 closed; no open PR |
+| `agent/codex/issue-943-poll` | local | DELETE | Issue #943 closed; no open PR |
+| `agent/codex/issue-985-poll` | local | KEEP | Open issue #985 and worktree-protected |
+| `codex-e4-934-fix-infinity-hang-boundary` | local | DELETE | Issue #934 closed; no open PR |
+| `codex-e4-934-queue-hang` | local + remote | DELETE | PR #962 closed; issue #934 closed |
+| `codex-e4-934-queue-hang-clean` | local + remote | DELETE | PR #964 closed; issue #934 closed |
+| `codex-w10-932` | local + remote | DELETE | PR #961 closed; issue #932 closed |
+| `codex-w11-931` | local + remote | DELETE | PR #956 closed; issue #931 closed |
+| `codex-w6-931` | local + remote | DELETE | PR #960 closed; issue #931 closed |
+| `codex-w8-issue-928-bounded-ollama-error-body` | local + remote | DELETE | PR #957 closed; issue #928 closed |
+| `codex-w8-issue-928-limit-ollama-pull-error` | local | DELETE | Issue #928 closed; no open PR |
+| `codex-w9-933` | local + remote | DELETE | PR #967 closed; issue #933 closed |
+| `codex-w9-936` | local | DELETE | Issue #936 closed; no open PR |
+| `codex/agent-p0p1-engram` | local | KEEP | Worktree-protected |
+| `codex/aifleet-240-expose-migrate` | local | DELETE | PR #863 merged; no active Engram issue |
+| `codex/issue-918` | local + remote | KEEP | Worktree-protected |
+| `codex/lme-codex-execution-20260530` | local | KEEP | Worktree-protected |
+| `codex/lme-recall-repair-lane` | local | DELETE | No open issue or PR; leftover LME lane |
+| `codex/lme-score-checkpoint-reliability-881-882` | local | DELETE | No open issue or PR; leftover LME lane |
+| `codex/ops-truth-status-k8s` | local | DELETE | No open issue or PR; leftover ops branch |
+
+## Verification
+
+Commands run after pruning:
+
+```bash
+git branch -a | rg '(agent/codex/|codex/|codex-)'
+git worktree list --porcelain
+```
+
+Remaining codex-owned refs after pruning:
+
+```text
+agent/codex/branch-cleanup-20260603
+agent/codex/issue-1036-poll
+agent/codex/issue-985-poll
+codex/agent-p0p1-engram
+codex/issue-918
+codex/lme-codex-execution-20260530
+origin/agent/codex/issue-1036-poll
+origin/codex/issue-918
+```
+
+These remaining refs are either worktree-protected, tied to open PR #1053, tied to open issue #985, or the report branch for this task.


### PR DESCRIPTION
Documents and completes the verified Codex-owned branch cleanup requested in #1029.

## Summary
- Classified live codex-owned local/remote refs using worktree protection, PR state, issue state, and unique-commit checks.
- Deleted confirmed-leftover local and origin refs.
- Preserved only current/open/protected codex-owned refs.
- Added `ops/branch-cleanup-codex-20260603.md` as the audit report.

## Verification
- `git branch -a | rg '(agent/codex/|codex/|codex-)'`
- `git worktree list --porcelain`
- `test -f ops/branch-cleanup-codex-20260603.md`
- `git diff --check`

Remaining codex-owned refs after pruning are the report branch, open PR #1053 branch, open issue #985 branch, and worktree-protected branches.

## PR Packaging
- scope_class: ops
- merge_order: 1
- depends_on: none
- conflict_surface: [ops/branch-cleanup-codex-20260603.md]
- risk: low for source code; branch deletions already completed and audited
- rollback: recreate any deleted branch from the recorded PR/commit evidence if needed

Closes #1029
