### PR TITLE
ops: add manual chunks ANN index options (#1020)

### DIFF
--- a/ops/manual-migrations/20260605_chunks_embedding_ann_rollback.sql
+++ b/ops/manual-migrations/20260605_chunks_embedding_ann_rollback.sql
@@ -1,0 +1,12 @@
+-- Manual rollback companion for issue #1020 ANN index options.
+--
+-- Drops either optional ANN index if present. This is safe to run even if only
+-- one option was built.
+--
+-- Run with psql autocommit enabled. DROP INDEX CONCURRENTLY cannot run inside
+-- an explicit transaction block.
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_chunks_embedding_hnsw;
+DROP INDEX CONCURRENTLY IF EXISTS idx_chunks_embedding_ivfflat;
+
+ANALYZE chunks;

--- a/ops/manual-migrations/20260605_chunks_embedding_ann_rollout.md
+++ b/ops/manual-migrations/20260605_chunks_embedding_ann_rollout.md
@@ -1,0 +1,48 @@
+# chunks.embedding ANN Index Rollout Note
+
+Issue: #1020
+
+These files are manual, founder-gated migration artifacts. They are intentionally
+stored under `ops/manual-migrations/` so the embedded startup migration runner
+cannot execute them automatically.
+
+## Options
+
+### HNSW
+
+File: `20260605_chunks_embedding_hnsw.sql`
+
+- Best recall/latency option for unscoped or federated vector recall.
+- Heavy build on the production corpus: 24.5M rows x 1024 dimensions.
+- Expected to take hours and produce substantial I/O and WAL.
+- Uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.
+- Partial index predicate: `WHERE embedding IS NOT NULL`.
+
+### IVFFlat
+
+File: `20260605_chunks_embedding_ivfflat.sql`
+
+- Faster build, with lower recall quality than HNSW unless tuned.
+- Uses `lists = 4000`, inside the requested 2000-5000 range.
+- Requires `ANALYZE chunks` after build and query-time `ivfflat.probes` tuning.
+- Uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.
+- Partial index predicate: `WHERE embedding IS NOT NULL`.
+
+## Rollback
+
+File: `20260605_chunks_embedding_ann_rollback.sql`
+
+Drops both optional index names with `DROP INDEX CONCURRENTLY IF EXISTS`, then
+runs `ANALYZE chunks`.
+
+## Guardrails
+
+- Do not run any of these files during the active LME campaign.
+- Do not run both HNSW and IVFFlat unless the operator intentionally wants to
+  compare two large ANN indexes on the same column.
+- Run with psql autocommit enabled; `CREATE INDEX CONCURRENTLY` and
+  `DROP INDEX CONCURRENTLY` cannot run inside an explicit transaction block.
+- Monitor `pg_stat_progress_create_index`, disk, WAL, CPU, memory, and recall
+  latency while the build runs.
+- Prefer HNSW if recall quality is the priority and the host can absorb the
+  build cost. Prefer IVFFlat only when build cost is the binding constraint.

--- a/ops/manual-migrations/20260605_chunks_embedding_hnsw.sql
+++ b/ops/manual-migrations/20260605_chunks_embedding_hnsw.sql
@@ -1,0 +1,27 @@
+-- Manual migration option for issue #1020: HNSW index on chunks.embedding.
+--
+-- DO NOT run during the active LME campaign.
+-- DO NOT run from the automatic embedded migration runner.
+-- Requires founder/operator approval before execution.
+--
+-- Expected profile:
+--   - Best recall/latency option for unscoped or federated vector recall.
+--   - Heavy build on the production corpus: 24.5M rows x 1024 dimensions.
+--   - Likely hours of build time with high I/O and maintenance_work_mem demand.
+--   - CREATE INDEX CONCURRENTLY avoids blocking normal reads/writes but still
+--     consumes substantial CPU, memory, disk, and WAL.
+--
+-- Operator preflight:
+--   - Run with psql autocommit enabled. CREATE INDEX CONCURRENTLY cannot run
+--     inside an explicit transaction block.
+--   - Consider increasing maintenance_work_mem for the session, sized to the
+--     host and concurrent workload:
+--       SET maintenance_work_mem = '8GB';
+--   - Monitor pg_stat_progress_create_index, I/O, WAL volume, and recall latency.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunks_embedding_hnsw
+    ON chunks USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64)
+    WHERE embedding IS NOT NULL;
+
+ANALYZE chunks;

--- a/ops/manual-migrations/20260605_chunks_embedding_ivfflat.sql
+++ b/ops/manual-migrations/20260605_chunks_embedding_ivfflat.sql
@@ -1,0 +1,29 @@
+-- Manual migration option for issue #1020: IVFFlat index on chunks.embedding.
+--
+-- DO NOT run during the active LME campaign.
+-- DO NOT run from the automatic embedded migration runner.
+-- Requires founder/operator approval before execution.
+--
+-- Expected profile:
+--   - Faster build than HNSW, typically minutes rather than hours.
+--   - Lower recall quality than HNSW unless probes/lists are tuned carefully.
+--   - Good fallback if HNSW build cost is unacceptable on the live corpus.
+--   - CREATE INDEX CONCURRENTLY avoids blocking normal reads/writes but still
+--     consumes substantial CPU, memory, disk, and WAL.
+--
+-- Tuning note:
+--   - lists=4000 is a middle value in the requested 2000-5000 range for a
+--     24.5M-row corpus. Operators should benchmark recall/latency and tune
+--     ivfflat.probes at query time before choosing this option permanently.
+--
+-- Operator preflight:
+--   - Run with psql autocommit enabled. CREATE INDEX CONCURRENTLY cannot run
+--     inside an explicit transaction block.
+--   - Monitor pg_stat_progress_create_index, I/O, WAL volume, and recall latency.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunks_embedding_ivfflat
+    ON chunks USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 4000)
+    WHERE embedding IS NOT NULL;
+
+ANALYZE chunks;


### PR DESCRIPTION
Adds founder-gated manual migration artifacts for #1020 without touching the embedded migration runner or executing anything against a database.

## Summary
- Added HNSW option: `ops/manual-migrations/20260605_chunks_embedding_hnsw.sql`.
- Added IVFFlat option: `ops/manual-migrations/20260605_chunks_embedding_ivfflat.sql`.
- Added rollback companion: `ops/manual-migrations/20260605_chunks_embedding_ann_rollback.sql`.
- Added rollout note: `ops/manual-migrations/20260605_chunks_embedding_ann_rollout.md`.
- Kept files outside `internal/db/migrations` so startup migrations cannot run the heavy index build automatically.

## Guardrails
- No database execution was performed.
- Do not run during the active LME campaign.
- Run exactly one index option unless deliberately comparing both.
- Requires psql autocommit; `CREATE/DROP INDEX CONCURRENTLY` cannot run inside a transaction.

## Verification
- `git diff --check`
- `rg -n 'CREATE INDEX CONCURRENTLY|DROP INDEX CONCURRENTLY|DO NOT run|manual' ops/manual-migrations -S`
- Confirmed changed files are limited to `ops/manual-migrations/*`.

## PR Packaging
- scope_class: ops
- merge_order: 1
- depends_on: founder/operator approval before any execution
- conflict_surface: [ops/manual-migrations]
- risk: low for repository merge; high operational risk if manually executed without the guardrails
- rollback: run `ops/manual-migrations/20260605_chunks_embedding_ann_rollback.sql` with autocommit after approval

Closes #1020
