### PR TITLE
longmemeval: record checkpoint project provenance

### DIFF
--- a/cmd/longmemeval/manifest.go
+++ b/cmd/longmemeval/manifest.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,10 +25,20 @@ type scoreCompleteness struct {
 }
 
 type runStatusSnapshot struct {
-	Completeness   scoreCompleteness
-	IngestRowTotal int
-	RunRowTotal    int
-	ScoreRowTotal  int
+	Completeness        scoreCompleteness
+	IngestRowTotal      int
+	RunRowTotal         int
+	ScoreRowTotal       int
+	QuestionProjects    []questionProjectProvenance
+	ProjectWarningTotal int
+}
+
+type questionProjectProvenance struct {
+	QuestionID         string `json:"question_id"`
+	Project            string `json:"project"`
+	Source             string `json:"source"`
+	ExpectedRunProject string `json:"expected_run_project,omitempty"`
+	Warning            string `json:"warning,omitempty"`
 }
 
 func scoreCompletenessFromScores(scores []longmemeval.ScoreEntry) scoreCompleteness {
@@ -98,6 +109,7 @@ func writeRunManifest(
 	scores []longmemeval.ScoreEntry,
 ) {
 	completeness := scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scores)
+	questionProjects, projectWarningTotal := questionProjectProvenanceFromIngestMap(cfg.RunID, ingestMap)
 	exe, _ := os.Executable()
 	manifest := map[string]any{
 		"run_id":                cfg.RunID,
@@ -110,6 +122,8 @@ func writeRunManifest(
 		"run_error_total":       completeness.RunErrorTotal,
 		"score_error_total":     completeness.ScoreErrorTotal,
 		"complete":              completeness.Complete,
+		"question_projects":     questionProjects,
+		"project_warning_total": projectWarningTotal,
 		"binary_path":           exe,
 		"command_line":          os.Args,
 		"git_sha":               bestEffortGit("rev-parse", "HEAD"),
@@ -156,6 +170,8 @@ func writeRunStatus(cfg *Config, stage string, startedAt, endedAt time.Time, exi
 		"ingest_row_total":      snapshot.IngestRowTotal,
 		"run_row_total":         snapshot.RunRowTotal,
 		"score_row_total":       snapshot.ScoreRowTotal,
+		"question_projects":     snapshot.QuestionProjects,
+		"project_warning_total": snapshot.ProjectWarningTotal,
 		"binary_path":           exe,
 		"command_line":          commandLine,
 		"git_sha":               bestEffortGit("rev-parse", "HEAD"),
@@ -218,12 +234,44 @@ func collectRunStatusSnapshot(cfg *Config) runStatusSnapshot {
 		}
 		runMap[entry.QuestionID] = entry
 	}
+	questionProjects, projectWarningTotal := questionProjectProvenanceFromIngestMap(cfg.RunID, ingestMap)
 	return runStatusSnapshot{
-		Completeness:   scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scoreEntries),
-		IngestRowTotal: len(ingestEntries),
-		RunRowTotal:    len(runEntries),
-		ScoreRowTotal:  len(scoreEntries),
+		Completeness:        scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scoreEntries),
+		IngestRowTotal:      len(ingestEntries),
+		RunRowTotal:         len(runEntries),
+		ScoreRowTotal:       len(scoreEntries),
+		QuestionProjects:    questionProjects,
+		ProjectWarningTotal: projectWarningTotal,
 	}
+}
+
+func questionProjectProvenanceFromIngestMap(runID string, ingestMap map[string]longmemeval.IngestEntry) ([]questionProjectProvenance, int) {
+	questionIDs := make([]string, 0, len(ingestMap))
+	for questionID, entry := range ingestMap {
+		if questionID == "" || entry.Project == "" {
+			continue
+		}
+		questionIDs = append(questionIDs, questionID)
+	}
+	sort.Strings(questionIDs)
+
+	projects := make([]questionProjectProvenance, 0, len(questionIDs))
+	warnings := 0
+	for _, questionID := range questionIDs {
+		project := ingestMap[questionID].Project
+		provenance := questionProjectProvenance{
+			QuestionID: questionID,
+			Project:    project,
+			Source:     "checkpoint-ingest",
+		}
+		if expected := projectName(runID, questionID); expected != project {
+			provenance.ExpectedRunProject = expected
+			provenance.Warning = "checkpoint-ingest project differs from run_id-derived project"
+			warnings++
+		}
+		projects = append(projects, provenance)
+	}
+	return projects, warnings
 }
 
 func loadItemMapForStatus(path string) map[string]longmemeval.Item {

--- a/cmd/longmemeval/orchestration_test.go
+++ b/cmd/longmemeval/orchestration_test.go
@@ -345,6 +345,77 @@ func TestDispatchScoreWritesRunStatus(t *testing.T) {
 	}
 }
 
+func TestDispatchScoreRunStatusUsesCheckpointProjectProvenance(t *testing.T) {
+	dir := t.TempDir()
+
+	items := []longmemeval.Item{
+		{QuestionID: "q001", QuestionType: "single-session-user", Question: "?", Answer: "A"},
+	}
+	data, _ := json.Marshal(items)
+	dataPath := filepath.Join(dir, "data.json")
+	if err := os.WriteFile(dataPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-ingest.jsonl"), []any{
+		longmemeval.IngestEntry{QuestionID: "q001", Project: "lme-actualprefix-q001", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-run.jsonl"), []any{
+		longmemeval.RunEntry{QuestionID: "q001", Hypothesis: "A", Status: "done"},
+	})
+	writeCheckpointFile(t, filepath.Join(dir, "checkpoint-score.jsonl"), []any{
+		longmemeval.ScoreEntry{QuestionID: "q001", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	exit := dispatch([]string{
+		"longmemeval",
+		"score",
+		"--data", dataPath,
+		"--out", dir,
+		"--workers", "1",
+		"--run-id", "statusrun",
+		"--score-output", "quiet",
+	}, &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("dispatch exit = %d, want 0; stderr=%s", exit, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "RUN_STATUS.json"))
+	if err != nil {
+		t.Fatalf("read RUN_STATUS.json: %v", err)
+	}
+	var status map[string]any
+	if err := json.Unmarshal(data, &status); err != nil {
+		t.Fatalf("parse RUN_STATUS.json: %v", err)
+	}
+	projects, ok := status["question_projects"].([]any)
+	if !ok || len(projects) != 1 {
+		t.Fatalf("question_projects = %v (%T), want one entry", status["question_projects"], status["question_projects"])
+	}
+	project, ok := projects[0].(map[string]any)
+	if !ok {
+		t.Fatalf("question_projects[0] = %v (%T), want object", projects[0], projects[0])
+	}
+	if project["question_id"] != "q001" {
+		t.Fatalf("question_id = %v, want q001", project["question_id"])
+	}
+	if project["project"] != "lme-actualprefix-q001" {
+		t.Fatalf("project = %v, want checkpoint-ingest project", project["project"])
+	}
+	if project["source"] != "checkpoint-ingest" {
+		t.Fatalf("source = %v, want checkpoint-ingest", project["source"])
+	}
+	if project["expected_run_project"] != "lme-statusrun-q001" {
+		t.Fatalf("expected_run_project = %v, want generated run-id project", project["expected_run_project"])
+	}
+	if project["warning"] == "" {
+		t.Fatalf("warning missing for project provenance mismatch")
+	}
+	if got := int(status["project_warning_total"].(float64)); got != 1 {
+		t.Fatalf("project_warning_total = %d, want 1", got)
+	}
+}
+
 func TestRunScore_AllAttemptedRowsFailReturnsNonZero(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- add checkpoint-ingest-derived question_projects to RUN_STATUS.json and run_manifest.json
- include project_warning_total and per-question mismatch diagnostics when run_id-derived names disagree with checkpoint projects
- add fixture covering RUN_STATUS.run_id vs checkpoint-ingest project-prefix divergence

Closes #1057

## Verification
- go test ./cmd/longmemeval -run TestDispatchScoreRunStatusUsesCheckpointProjectProvenance -count=1
- go test ./cmd/longmemeval -count=1
- go test ./...
- git diff --check
- go build ./...
