### PR TITLE
Harden atom extraction JSON parsing

### DIFF
--- a/internal/atom/extract.go
+++ b/internal/atom/extract.go
@@ -78,14 +78,14 @@ Rules:
 
 // atomResponse is the per-atom JSON object returned by Claude.
 type atomResponse struct {
-	Type        string  `json:"atom_type"`
-	Subject     string  `json:"subject"`
-	Predicate   string  `json:"predicate"`
-	Value       string  `json:"value"`
-	Statement   string  `json:"statement"`
-	Scope       string  `json:"scope"`
-	Confidence  float64 `json:"confidence"`
-	SourceSpan  string  `json:"source_span"`
+	Type       string  `json:"atom_type"`
+	Subject    string  `json:"subject"`
+	Predicate  string  `json:"predicate"`
+	Value      string  `json:"value"`
+	Statement  string  `json:"statement"`
+	Scope      string  `json:"scope"`
+	Confidence float64 `json:"confidence"`
+	SourceSpan string  `json:"source_span"`
 }
 
 // Extract calls Claude and parses the JSON result into Atom slices.
@@ -104,16 +104,9 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string) ([]At
 		return nil, fmt.Errorf("atom extraction: claude call failed: %w", err)
 	}
 
-	raw = strings.TrimSpace(raw)
-	// Claude sometimes wraps JSON in markdown code fences — strip them.
-	if strings.HasPrefix(raw, "```") {
-		if idx := strings.Index(raw, "\n"); idx != -1 {
-			raw = raw[idx+1:]
-		}
-		if idx := strings.LastIndex(raw, "```"); idx != -1 {
-			raw = raw[:idx]
-		}
-		raw = strings.TrimSpace(raw)
+	raw, err = extractAtomJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("atom extraction: failed to parse response JSON: %w", err)
 	}
 
 	var resp []atomResponse
@@ -145,6 +138,108 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string) ([]At
 		atoms = append(atoms, a)
 	}
 	return atoms, nil
+}
+
+func extractAtomJSON(raw string) (string, error) {
+	raw = strings.TrimSpace(stripMarkdownFences(stripThinkBlocks(raw)))
+	if raw == "" {
+		return "", fmt.Errorf("no JSON object or array found in response")
+	}
+	if json.Valid([]byte(raw)) {
+		return raw, nil
+	}
+	if jsonText, ok := firstBalancedJSON(raw); ok {
+		return jsonText, nil
+	}
+	if strings.HasPrefix(raw, "[") || strings.HasPrefix(raw, "{") {
+		return raw, nil
+	}
+	return "", fmt.Errorf("no JSON object or array found in response")
+}
+
+func stripThinkBlocks(raw string) string {
+	const (
+		openTag  = "<think>"
+		closeTag = "</think>"
+	)
+	for {
+		lower := strings.ToLower(raw)
+		start := strings.Index(lower, openTag)
+		if start == -1 {
+			return raw
+		}
+		closeStart := strings.Index(lower[start+len(openTag):], closeTag)
+		if closeStart == -1 {
+			return raw
+		}
+		end := start + len(openTag) + closeStart + len(closeTag)
+		raw = raw[:start] + raw[end:]
+	}
+}
+
+func stripMarkdownFences(raw string) string {
+	lines := strings.Split(raw, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+func firstBalancedJSON(raw string) (string, bool) {
+	for start := 0; start < len(raw); start++ {
+		if raw[start] != '[' && raw[start] != '{' {
+			continue
+		}
+		if jsonText, ok := balancedJSONFrom(raw, start); ok && json.Valid([]byte(jsonText)) {
+			return jsonText, true
+		}
+	}
+	return "", false
+}
+
+func balancedJSONFrom(raw string, start int) (string, bool) {
+	stack := make([]byte, 0, 4)
+	inString := false
+	escaped := false
+
+	for i := start; i < len(raw); i++ {
+		c := raw[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch c {
+		case '"':
+			inString = true
+		case '[':
+			stack = append(stack, ']')
+		case '{':
+			stack = append(stack, '}')
+		case ']', '}':
+			if len(stack) == 0 || c != stack[len(stack)-1] {
+				return "", false
+			}
+			stack = stack[:len(stack)-1]
+			if len(stack) == 0 {
+				return strings.TrimSpace(raw[start : i+1]), true
+			}
+		}
+	}
+	return "", false
 }
 
 // ExtractionPrompt returns the system prompt used for atom extraction.

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -157,6 +157,59 @@ func TestClaudeExtractor_MarkdownFenceStripped(t *testing.T) {
 	assert.Len(t, atoms, 1)
 }
 
+func TestExtract_StripsThinkBlock(t *testing.T) {
+	stub := &stubCompleter{response: "<think>I should return a preference atom.</think>\n" + preferenceAtomJSON}
+	ext := atom.NewClaudeExtractor(stub)
+
+	atoms, err := ext.Extract(context.Background(), "dark chocolate text")
+	require.NoError(t, err)
+	require.Len(t, atoms, 1)
+	assert.Equal(t, atom.TypePreference, atoms[0].Type)
+	assert.Equal(t, "dark chocolate", atoms[0].Value)
+}
+
+func TestExtract_StripsCodeFence(t *testing.T) {
+	stub := &stubCompleter{response: "```json\n" + preferenceAtomJSON + "\n```"}
+	ext := atom.NewClaudeExtractor(stub)
+
+	atoms, err := ext.Extract(context.Background(), "dark chocolate text")
+	require.NoError(t, err)
+	require.Len(t, atoms, 1)
+	assert.Equal(t, atom.TypePreference, atoms[0].Type)
+	assert.Equal(t, "dark chocolate", atoms[0].Value)
+}
+
+func TestExtract_ProsePreambleAndPostamble(t *testing.T) {
+	stub := &stubCompleter{response: "Here are the atoms:\n" + preferenceAtomJSON + "\nHope this helps."}
+	ext := atom.NewClaudeExtractor(stub)
+
+	atoms, err := ext.Extract(context.Background(), "dark chocolate text")
+	require.NoError(t, err)
+	require.Len(t, atoms, 1)
+	assert.Equal(t, atom.TypePreference, atoms[0].Type)
+	assert.Equal(t, "dark chocolate", atoms[0].Value)
+}
+
+func TestExtract_CleanArray(t *testing.T) {
+	stub := &stubCompleter{response: preferenceAtomJSON}
+	ext := atom.NewClaudeExtractor(stub)
+
+	atoms, err := ext.Extract(context.Background(), "dark chocolate text")
+	require.NoError(t, err)
+	require.Len(t, atoms, 1)
+	assert.Equal(t, atom.TypePreference, atoms[0].Type)
+	assert.Equal(t, "dark chocolate", atoms[0].Value)
+}
+
+func TestExtract_NonJSONErrors(t *testing.T) {
+	stub := &stubCompleter{response: "I could not extract any atoms from this text."}
+	ext := atom.NewClaudeExtractor(stub)
+
+	_, err := ext.Extract(context.Background(), "some content")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response JSON")
+}
+
 func TestClaudeExtractor_TruncatesLongContent(t *testing.T) {
 	bigContent := strings.Repeat("a", 20000)
 	stub := &stubCompleter{response: `[]`}


### PR DESCRIPTION
Closes #1063

## Summary
- Added issue #1063 parser acceptance tests for think blocks, markdown fences, prose-wrapped JSON, clean JSON arrays, and non-JSON errors.
- Hardened `internal/atom/extract.go` with stdlib-only response normalization before the existing atom array unmarshal/validation path.
- Strips `<think>...</think>` blocks, removes markdown fence delimiter lines, and extracts the first balanced valid JSON array/object from prose.

## Red test evidence
Command:
```bash
go test ./internal/atom -run 'TestExtract_(StripsThinkBlock|StripsCodeFence|ProsePreambleAndPostamble|CleanArray|NonJSONErrors)$' -count=1
```
Output before implementation:
```text
--- FAIL: TestExtract_StripsThinkBlock (0.00s)
    extract_test.go:165: 
        	Error Trace:	/home/psimmons/projects/engram-go/.worktrees/issue-1063-extract-parser/internal/atom/extract_test.go:165
        	Error:      	Received unexpected error:
        	            	atom extraction: failed to parse response JSON: invalid character '<' looking for beginning of value
        	Test:       	TestExtract_StripsThinkBlock
--- FAIL: TestExtract_ProsePreambleAndPostamble (0.00s)
    extract_test.go:187: 
        	Error Trace:	/home/psimmons/projects/engram-go/.worktrees/issue-1063-extract-parser/internal/atom/extract_test.go:187
        	Error:      	Received unexpected error:
        	            	atom extraction: failed to parse response JSON: invalid character 'H' looking for beginning of value
        	Test:       	TestExtract_ProsePreambleAndPostamble
FAIL
FAIL	github.com/petersimmons1972/engram/internal/atom	0.004s
FAIL
```

## Verification
Command:
```bash
go test ./internal/atom -run 'TestExtract_(StripsThinkBlock|StripsCodeFence|ProsePreambleAndPostamble|CleanArray|NonJSONErrors)$' -count=1
```
Output:
```text
ok  	github.com/petersimmons1972/engram/internal/atom	0.005s
```

Command:
```bash
go test ./internal/atom -count=1
```
Output:
```text
ok  	github.com/petersimmons1972/engram/internal/atom	0.659s
```

Command:
```bash
go test ./... -count=1
```
Output:
```text
ok  	github.com/petersimmons1972/engram/bench	0.004s
ok  	github.com/petersimmons1972/engram/cmd/audit	0.019s
ok  	github.com/petersimmons1972/engram/cmd/benchmark	0.811s
ok  	github.com/petersimmons1972/engram/cmd/engram	0.029s
ok  	github.com/petersimmons1972/engram/cmd/engram-setup	0.014s
?   	github.com/petersimmons1972/engram/cmd/eval	[no test files]
ok  	github.com/petersimmons1972/engram/cmd/instinct	16.515s
ok  	github.com/petersimmons1972/engram/cmd/instinct/consolidator	0.003s
ok  	github.com/petersimmons1972/engram/cmd/longmemeval	5.956s
?   	github.com/petersimmons1972/engram/cmd/migrate-runner	[no test files]
ok  	github.com/petersimmons1972/engram/cmd/starter	0.020s
ok  	github.com/petersimmons1972/engram/internal/atom	0.659s
ok  	github.com/petersimmons1972/engram/internal/audit	0.037s
?   	github.com/petersimmons1972/engram/internal/benchmark	[no test files]
ok  	github.com/petersimmons1972/engram/internal/cache	0.005s
ok  	github.com/petersimmons1972/engram/internal/chunk	0.004s
ok  	github.com/petersimmons1972/engram/internal/claude	0.006s
ok  	github.com/petersimmons1972/engram/internal/config	0.003s
ok  	github.com/petersimmons1972/engram/internal/consolidate	0.061s
ok  	github.com/petersimmons1972/engram/internal/db	0.011s
ok  	github.com/petersimmons1972/engram/internal/embed	8.390s
ok  	github.com/petersimmons1972/engram/internal/embedgateway	0.056s
ok  	github.com/petersimmons1972/engram/internal/embedmodel	0.003s
ok  	github.com/petersimmons1972/engram/internal/entity	3.910s
ok  	github.com/petersimmons1972/engram/internal/envconf	0.003s
ok  	github.com/petersimmons1972/engram/internal/eval	0.003s
ok  	github.com/petersimmons1972/engram/internal/hookdaemon	1.265s
ok  	github.com/petersimmons1972/engram/internal/ingest/chatgpt	0.004s
ok  	github.com/petersimmons1972/engram/internal/ingest/claudeai	0.004s
ok  	github.com/petersimmons1972/engram/internal/ingest/router	0.007s
ok  	github.com/petersimmons1972/engram/internal/ingest/slack	0.005s
ok  	github.com/petersimmons1972/engram/internal/ingestqueue	0.024s
ok  	github.com/petersimmons1972/engram/internal/instinctllm	0.010s
ok  	github.com/petersimmons1972/engram/internal/llm	0.006s
ok  	github.com/petersimmons1972/engram/internal/llmclient	0.015s
ok  	github.com/petersimmons1972/engram/internal/longmemeval	59.603s
ok  	github.com/petersimmons1972/engram/internal/manifest	0.007s
ok  	github.com/petersimmons1972/engram/internal/markdown	0.009s
ok  	github.com/petersimmons1972/engram/internal/mcp	13.822s
ok  	github.com/petersimmons1972/engram/internal/metrics	0.014s
ok  	github.com/petersimmons1972/engram/internal/minhash	0.004s
ok  	github.com/petersimmons1972/engram/internal/netutil	0.004s
ok  	github.com/petersimmons1972/engram/internal/ollama	0.006s
ok  	github.com/petersimmons1972/engram/internal/parse	0.002s
ok  	github.com/petersimmons1972/engram/internal/rag	0.004s
ok  	github.com/petersimmons1972/engram/internal/reembed	0.298s
ok  	github.com/petersimmons1972/engram/internal/reporter	0.003s
ok  	github.com/petersimmons1972/engram/internal/review	0.008s
ok  	github.com/petersimmons1972/engram/internal/runner	2.015s
ok  	github.com/petersimmons1972/engram/internal/scorer	0.004s
ok  	github.com/petersimmons1972/engram/internal/search	1.022s
ok  	github.com/petersimmons1972/engram/internal/summarize	0.060s
?   	github.com/petersimmons1972/engram/internal/testutil	[no test files]
ok  	github.com/petersimmons1972/engram/internal/types	0.004s
ok  	github.com/petersimmons1972/engram/internal/vram	0.113s
ok  	github.com/petersimmons1972/engram/internal/weight	0.006s
```

Command:
```bash
git diff --check
```
Output:
```text
(no output)
```
