### PR TITLE
fix(deploy): pin lme-prune image to immutable digest

### DIFF
--- a/cmd/longmemeval/docs_test.go
+++ b/cmd/longmemeval/docs_test.go
@@ -60,9 +60,9 @@ func TestLMEPruneCronJobPinsReviewedImage(t *testing.T) {
 		t.Fatalf("read deploy/lme-prune-cronjob.yaml: %v", err)
 	}
 	manifest := string(data)
-	const reviewedImage = "ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0"
+	const reviewedImage = "ghcr.io/petersimmons1972/engram-go/longmemeval@sha256:c51f11f15003768b965774669b753c885c40cfdf13e2bb8b7a42f652143161f3"
 
-	if strings.Contains(manifest, "ghcr.io/petersimmons1972/engram-go/longmemeval:latest") {
+	if strings.Contains(manifest, "ghcr.io/petersimmons1972/engram-go/longmemeval:latest") || strings.Contains(manifest, "ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0") {
 		t.Fatalf("prune CronJob must not use mutable :latest image:\n%s", manifest)
 	}
 	for _, current := range []string{
@@ -76,6 +76,9 @@ func TestLMEPruneCronJobPinsReviewedImage(t *testing.T) {
 			t.Fatalf("prune CronJob missing reviewed image pin guidance %q:\n%s", current, manifest)
 		}
 	}
+	if !strings.Contains(manifest, "@sha256:") {
+		t.Fatalf("prune CronJob image must be immutable by digest:\n%s", manifest)
+	}
 }
 
 func TestLMEBenchmarkLearningsDocumentsPruneImageUpdateProcedure(t *testing.T) {
@@ -87,10 +90,12 @@ func TestLMEBenchmarkLearningsDocumentsPruneImageUpdateProcedure(t *testing.T) {
 	section := between(t, doc, "### Updating the prune image", "### Backfilling existing runs")
 
 	for _, current := range []string{
-		"v3.2.0",
+		"@sha256:c51f11f15003768b965774669b753c885c40cfdf13e2bb8b7a42f652143161f3",
 		"kubectl patch cronjob lme-prune -n engram -p '{\"spec\":{\"suspend\":true}}'",
 		"jsonpath='{.spec.suspend",
 		"command: [\"/engram\"]",
+		"envFrom:",
+		"name: engram-lme",
 		"replace it with the reviewed release tag or immutable digest",
 		"Update `deploy/lme-prune-cronjob.yaml` in the same reviewed change",
 		"kubectl apply -f deploy/lme-prune-cronjob.yaml",

--- a/deploy/lme-prune-cronjob.yaml
+++ b/deploy/lme-prune-cronjob.yaml
@@ -4,7 +4,7 @@
 # Requires:
 #   - Secret "engram-lme" with keys: database-url, engram-url, engram-api-key
 #   - RBAC: no cluster permissions needed (contacts Postgres + Engram HTTP only)
-#   - Image: ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0
+#   - Image: ghcr.io/petersimmons1972/engram-go/longmemeval@sha256:c51f11f15003768b965774669b753c885c40cfdf13e2bb8b7a42f652143161f3
 #
 # Never use :latest for this CronJob. This job runs a destructive `prune --execute`
 # path on a schedule, so image changes must be explicit and reviewable. To update it,
@@ -48,7 +48,7 @@ spec:
               # This avoids starter's subcommand allowlist and makes the
               # execution contract explicit in this manifest.
               command: ["/engram"]
-              image: ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0
+              image: ghcr.io/petersimmons1972/engram-go/longmemeval@sha256:c51f11f15003768b965774669b753c885c40cfdf13e2bb8b7a42f652143161f3
               imagePullPolicy: Always
               args:
                 - prune

--- a/docs/lme-benchmark-learnings.md
+++ b/docs/lme-benchmark-learnings.md
@@ -459,7 +459,7 @@ The sweep is deployed as a weekly K8s CronJob at `deploy/lme-prune-cronjob.yaml`
 
 ### Updating the prune image and rollout controls
 
-The checked-in CronJob pin is currently `ghcr.io/petersimmons1972/engram-go/longmemeval:v3.2.0`.
+The checked-in CronJob pin is currently `ghcr.io/petersimmons1972/engram-go/longmemeval@sha256:c51f11f15003768b965774669b753c885c40cfdf13e2bb8b7a42f652143161f3`.
 Do not switch this job to `:latest`. For destructive scheduled deletes, replace it with the reviewed release tag or immutable digest you intend to ship, and keep that change visible in git review.
 
 Update `deploy/lme-prune-cronjob.yaml` in the same reviewed change that approves the
@@ -498,18 +498,18 @@ spec:
       restartPolicy: Never
       containers:
         - name: lme-prune-canary
-        command: ["/engram"]
-        image: ${IMAGE}
-        envFrom:
-        - secretRef:
-            name: engram-lme
-        args:
-        - prune
-        - --prefix=lme-
-        - --dry-run
-        - --confirm-prefix=lme-
-        - --limit=50
-        - --use-default-token
+          command: ["/engram"]
+          image: ${IMAGE}
+          envFrom:
+            - secretRef:
+                name: engram-lme
+          args:
+            - prune
+            - --prefix=lme-
+            - --dry-run
+            - --confirm-prefix=lme-
+            - --limit=50
+            - --use-default-token
 EOF
 
 kubectl wait -n engram --for=condition=complete job/"$CANARY_JOB" --timeout=10m
@@ -555,15 +555,15 @@ spec:
         command: ["/engram"]
         image: ${IMAGE}
         envFrom:
-        - secretRef:
-            name: engram-lme
+          - secretRef:
+              name: engram-lme
         args:
-        - prune
-        - --prefix=lme-
-        - --execute
-        - --confirm-prefix=lme-
-        - --limit=50
-        - --use-default-token
+          - prune
+          - --prefix=lme-
+          - --execute
+          - --confirm-prefix=lme-
+          - --limit=50
+          - --use-default-token
 EOF
 ```
 


### PR DESCRIPTION
## Summary
- Pin `deploy/lme-prune-cronjob.yaml` to immutable SHA digest from reviewed `v3.2.0` image.
- Update rollback/verification docs so canary snippets are valid YAML and use the same env injection as production.
- Extend docs tests to enforce digest pinning and rollout procedure text, including safe execute guard checks.

## Testing
- `go test ./cmd/longmemeval -count=1`
- `go test ./... -count=1`

- Added digest pin in manifest/comment:
  `ghcr.io/petersimmons1972/engram-go/longmemeval@sha256:c51f11f15003768b965774669b753c885c40cfdf13e2bb8b7a42f652143161f3`

Closes #1047
