### PR TITLE
fix(longmemeval): exact-signal-boost respects --max-block-chars (truncate at storage time)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ infisical/infisical-bin
 /instinct
 /instinct-benchmark
 /longmemeval
+/longmemeval.real
 /starter
 /audit
 # Compiled binaries in bin/ (built by `go build -o bin/...`)

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -575,14 +575,20 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			continue
 		}
 		if content != "" {
+			// Truncate at storage time so contentByID and contextBlocks stay
+			// consistent. If --exact-signal-boost later rebuilds contextBlocks
+			// from contentByID, it gets already-truncated content — preventing
+			// full-length blocks from exceeding the model's context window.
+			if cfg.MaxBlockChars > 0 && len(content) > cfg.MaxBlockChars {
+				content = content[:cfg.MaxBlockChars]
+			}
 			contentByID[id] = content
 			contextBlocks = append(contextBlocks, content)
 		}
 	}
-	// --max-block-chars: truncate each block so the assembled prompt stays within
-	// the model's max_model_len. Applied before chrono-sort so truncation is
-	// independent of ordering. Required when --context-topk is large (e.g. 100)
-	// and the vLLM endpoint has a modest context window (e.g. 131072 tokens).
+	// --max-block-chars: truncation already applied above at storage time.
+	// This loop is now a no-op but kept as a safety net for any path that
+	// populates contextBlocks without going through contentByID.
 	if cfg.MaxBlockChars > 0 {
 		for i, block := range contextBlocks {
 			if len(block) > cfg.MaxBlockChars {


### PR DESCRIPTION
## Problem

`--exact-signal-boost` sent **HTTP 400** on every item: it rebuilt `contextBlocks` from `contentByID`, which held **untruncated** content, bypassing `--max-block-chars` and overflowing vLLM's 32K context window.

Root cause: `contentByID` was populated with full content *before* the `--max-block-chars` loop, which only mutated `contextBlocks`.

## Fix

Truncate `content` at storage time, before writing to `contentByID`, so `contentByID` and `contextBlocks` stay consistent. The later truncation loop becomes a no-op safety net (kept for any path that populates `contextBlocks` directly).

## Validation

LongMemEval `sample100`, fast-inference (Mistral-Small-24B-AWQ, 32K window):

| | before | after |
|---|---|---|
| exact-boost | all HTTP 400 (fails) | **38.5%** (zero 400s) |

38.5% was the **single best fast-inference retrieval strategy** in a 18-experiment sweep — the fix didn't just stop the errors, it unlocked the top strategy.

## Second commit

`chore`: add `/longmemeval.real` to `.gitignore`. The memory-guard wrapper renamed the compiled binary to `longmemeval.real`; the ignore list covered `/longmemeval` but not `.real`, leaving the 23MB binary at risk of accidental commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)