### PR TITLE
fix(embed): guard memory_migrate_embedder against spurious mass re-embed (G1-G4)

### DIFF
--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -118,6 +118,9 @@ type Backend interface {
 	UpdateChunkLastMatched(ctx context.Context, chunkID string) error
 	// GetPendingEmbeddingCount returns the count of chunks with NULL embedding.
 	GetPendingEmbeddingCount(ctx context.Context, project string) (int, error)
+	// CountProjectChunks returns the total number of chunks for a project.
+	// Used by MigrateEmbedder's volume guard before nulling embeddings.
+	CountProjectChunks(ctx context.Context, project string) (int, error)
 	// EnqueueChunkLeases sets initial leases on chunks with NULL embeddings,
 	// marking them for async re-embedding by the reembed worker. Idempotent.
 	EnqueueChunkLeases(ctx context.Context, chunkIDs []string) error

--- a/internal/db/postgres_chunk.go
+++ b/internal/db/postgres_chunk.go
@@ -384,6 +384,15 @@ func (b *PostgresBackend) GetPendingEmbeddingCount(ctx context.Context, project 
 
 // EnqueueChunkLeases sets initial leases on chunks with NULL embeddings.
 // Idempotent — calling it multiple times on the same chunks is safe.
+func (b *PostgresBackend) CountProjectChunks(ctx context.Context, project string) (int, error) {
+	var count int
+	err := b.pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM chunks c JOIN memories m ON m.id = c.memory_id WHERE m.project=$1",
+		project,
+	).Scan(&count)
+	return count, err
+}
+
 func (b *PostgresBackend) EnqueueChunkLeases(ctx context.Context, chunkIDs []string) error {
 	if len(chunkIDs) == 0 {
 		return nil

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -78,6 +78,7 @@ func (noopBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error)  
 func (noopBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
 	return 0, nil
 }
+func (noopBackend) CountProjectChunks(_ context.Context, _ string) (int, error) { return 0, nil }
 func (noopBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
 	return nil, nil
 }

--- a/internal/mcp/migrate_embedder_test.go
+++ b/internal/mcp/migrate_embedder_test.go
@@ -187,7 +187,7 @@ func TestHandleMemoryMigrateEmbedder_MigrateError(t *testing.T) {
 	cfg := Config{
 		RouterURL: "http://ollama-test:11434",
 		testHooks: &testHooks{
-			migrateFunc: func(_ context.Context, _ string) (map[string]any, error) {
+			migrateFunc: func(_ context.Context, _ search.MigrateParams) (map[string]any, error) {
 				return nil, fmt.Errorf("db unavailable")
 			},
 			onPostMigrate: func(_ context.Context, _ string) {
@@ -217,8 +217,8 @@ func TestHandleMemoryMigrateEmbedder_HappyPath(t *testing.T) {
 			embedProbe: func(_ context.Context, _, _ string) (embed.Client, error) {
 				return dimEmbedder{dims: 384}, nil // pre-flight passes
 			},
-			migrateFunc: func(_ context.Context, _ string) (map[string]any, error) {
-				return map[string]any{"nulled": 0, "model": "same-dim-model"}, nil
+			migrateFunc: func(_ context.Context, _ search.MigrateParams) (map[string]any, error) {
+				return map[string]any{"nulled": 0, "model": "same-dim-model", "status": "migration queued"}, nil
 			},
 			onPostMigrate: func(_ context.Context, _ string) {
 				postMigrateFired = true
@@ -312,9 +312,9 @@ func TestHandleMemoryMigrateEmbedder_OllamaURL_HostnameResolvingPrivateBlocked(t
 }
 
 // TestHandleMemoryMigrateEmbedder_DimsMatch_ProceedToMigrate verifies that when
-// probe succeeds and dimensions match, the pre-flight passes and execution reaches
-// MigrateEmbedder. The noop backend panics there — we recover and assert we got
-// past the pre-flight without a dimension or probe error.
+// probe succeeds and dimensions match, the pre-flight passes (no dim-mismatch error).
+// Since G2 was added, same-dim without force is a soft refusal from MigrateEmbedder —
+// the call reaches MigrateEmbedder and returns a tool error, NOT a Go error.
 func TestHandleMemoryMigrateEmbedder_DimsMatch_ProceedToMigrate(t *testing.T) {
 	pool := newDimPool(t, "384", 384) // stored: 384-dim
 	req := makeMigrateRequest("proj", "same-dim-model")
@@ -327,19 +327,10 @@ func TestHandleMemoryMigrateEmbedder_DimsMatch_ProceedToMigrate(t *testing.T) {
 		},
 	}
 
-	var reachedMigrate bool
-	var preflightErr error
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				reachedMigrate = true // noop backend panics in MigrateEmbedder — expected
-			}
-		}()
-		_, preflightErr = handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
-	}()
-	if preflightErr != nil {
-		require.NotContains(t, preflightErr.Error(), "dimension mismatch",
-			"matching dims must not produce a pre-flight error")
-	}
-	require.True(t, reachedMigrate, "pre-flight passed, execution should reach MigrateEmbedder")
+	// Pre-flight passes (384==384), then G2 in MigrateEmbedder soft-refuses same-dim.
+	// Expect a tool-error result (not a Go error) mentioning "force".
+	result, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err, "same-dim refusal is a soft refusal, not a Go error")
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "same-dim without force must surface as MCP tool error")
 }

--- a/internal/mcp/migrate_guards_test.go
+++ b/internal/mcp/migrate_guards_test.go
@@ -1,0 +1,237 @@
+package mcp
+
+// Tests for handleMemoryMigrateEmbedder safety guards (#spurious-reembed).
+//
+// Guards tested here at the MCP-handler level:
+//   G1: Same-canonical-identity no-op response surfaces correctly (status unchanged)
+//   G2: Same-dimension soft refusal surfaced as MCP tool error
+//   G3: dry_run arg passthrough; large volume refusal surfaced as MCP tool error
+//   G4: force/confirm arg passthrough verified via MigrateParams in migrateFunc
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+// makeMigrateRequestFull builds a CallToolRequest with the full set of new args.
+func makeMigrateRequestFull(project, newModel string, extras map[string]any) mcpgo.CallToolRequest {
+	var req mcpgo.CallToolRequest
+	args := map[string]any{
+		"project":   project,
+		"new_model": newModel,
+	}
+	for k, v := range extras {
+		args[k] = v
+	}
+	req.Params.Arguments = args
+	return req
+}
+
+// noopProbe is a test embedProbe that returns a dimEmbedder without hitting Ollama.
+// Used in tests that have stored dims and need to bypass the real probe.
+func noopProbeWithDims(dims int) func(ctx context.Context, baseURL, model string) (embed.Client, error) {
+	return func(_ context.Context, _, _ string) (embed.Client, error) {
+		return dimEmbedder{dims: dims}, nil
+	}
+}
+
+// ── G1: MCP no-op on same-canonical-identity ─────────────────────────────────
+
+// TestMCPMigrateSameCanonicalIdentityIsNoop verifies that when migrateFunc
+// returns status="identity unchanged" and chunks_nulled=0, the handler surfaces
+// that response as a non-error result and does NOT fire onPostMigrate.
+func TestMCPMigrateSameCanonicalIdentityIsNoop(t *testing.T) {
+	// newDimPool with stored=384 so embedProbe is needed to bypass real Ollama.
+	pool := newDimPool(t, "1024", 1024)
+	req := makeMigrateRequestFull("proj", "bge-m3", nil)
+
+	postMigrateFired := false
+	cfg := Config{
+		RouterURL: "http://ollama-test:11434",
+		testHooks: &testHooks{
+			embedProbe: noopProbeWithDims(1024),
+			migrateFunc: func(_ context.Context, p search.MigrateParams) (map[string]any, error) {
+				// Simulate identity no-op.
+				return map[string]any{
+					"chunks_nulled": 0,
+					"status":        "identity unchanged",
+					"new_model":     p.NewModel,
+				}, nil
+			},
+			onPostMigrate: func(_ context.Context, _ string) {
+				postMigrateFired = true
+			},
+		},
+	}
+
+	result, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// status="identity unchanged" has no "error" key — must NOT be an MCP tool error.
+	require.False(t, result.IsError, "identity no-op must not be an MCP tool error")
+	// onPostMigrate must NOT fire on identity no-op.
+	require.False(t, postMigrateFired, "onPostMigrate must not fire on identity unchanged")
+}
+
+// ── G2: MCP same-dim refusal passthrough ─────────────────────────────────────
+
+// TestMCPMigrateSameDimRefusalPassedThrough verifies that a same-dim refusal
+// from the engine (returned as result["error"]) is surfaced as a tool error,
+// not a Go error.
+func TestMCPMigrateSameDimRefusalPassedThrough(t *testing.T) {
+	pool := newDimPool(t, "1024", 1024)
+	req := makeMigrateRequestFull("proj", "other-1024-model", map[string]any{
+		"force": false,
+	})
+
+	cfg := Config{
+		RouterURL: "http://ollama-test:11434",
+		testHooks: &testHooks{
+			embedProbe: noopProbeWithDims(1024),
+			migrateFunc: func(_ context.Context, _ search.MigrateParams) (map[string]any, error) {
+				return map[string]any{
+					"error":  "same-dim migration requires force=true",
+					"status": "refused",
+				}, nil
+			},
+		},
+	}
+
+	result, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// The handler must surface the engine's soft refusal as an MCP tool error.
+	require.True(t, result.IsError, "same-dim refusal must be surfaced as MCP tool error")
+}
+
+// ── G3: MCP dry_run arg passthrough ──────────────────────────────────────────
+
+// TestMCPMigrateDryRunArgPassedToEngine verifies that dry_run=true in the MCP
+// request is forwarded to MigrateEmbedder as MigrateParams.DryRun=true.
+func TestMCPMigrateDryRunArgPassedToEngine(t *testing.T) {
+	pool := newDimPool(t, "1024", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-768", map[string]any{
+		"dry_run": true,
+	})
+
+	var dryRunSeen bool
+	cfg := Config{
+		RouterURL: "http://ollama-test:11434",
+		testHooks: &testHooks{
+			embedProbe: noopProbeWithDims(768),
+			migrateFunc: func(_ context.Context, p search.MigrateParams) (map[string]any, error) {
+				dryRunSeen = p.DryRun
+				return map[string]any{
+					"chunks_would_null": 999,
+					"status":            "dry_run",
+					"new_model":         p.NewModel,
+				}, nil
+			},
+		},
+	}
+
+	result, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError)
+	require.True(t, dryRunSeen, "dry_run=true must reach migrateFunc as DryRun=true")
+}
+
+// TestMCPMigrateLargeVolumeRefusalPassedThrough: large volume refusal from
+// the engine is surfaced as a tool error.
+func TestMCPMigrateLargeVolumeRefusalPassedThrough(t *testing.T) {
+	// No stored dims — pre-flight skips; this test is about volume-guard passthrough.
+	pool := newDimPool(t, "", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-different", map[string]any{
+		"confirm": false,
+	})
+
+	cfg := Config{
+		RouterURL: "http://ollama-test:11434",
+		testHooks: &testHooks{
+			embedProbe: noopProbeWithDims(1024),
+			migrateFunc: func(_ context.Context, _ search.MigrateParams) (map[string]any, error) {
+				return map[string]any{
+					"error":             "1001 chunks would be nulled; pass confirm=true to proceed",
+					"chunks_would_null": 1001,
+					"status":            "refused",
+				}, nil
+			},
+		},
+	}
+
+	result, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "volume refusal must be surfaced as MCP tool error")
+}
+
+// ── G3: confirm arg passthrough ───────────────────────────────────────────────
+
+// TestMCPMigrateConfirmArgPassedToEngine verifies confirm=true is forwarded.
+func TestMCPMigrateConfirmArgPassedToEngine(t *testing.T) {
+	// No stored dims — pre-flight skips; this test is about confirm-arg passthrough.
+	pool := newDimPool(t, "", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-different", map[string]any{
+		"confirm": true,
+	})
+
+	var confirmSeen bool
+	cfg := Config{
+		RouterURL: "http://ollama-test:11434",
+		testHooks: &testHooks{
+			embedProbe: noopProbeWithDims(1024),
+			migrateFunc: func(_ context.Context, p search.MigrateParams) (map[string]any, error) {
+				confirmSeen = p.Confirm
+				return map[string]any{
+					"chunks_nulled": 5,
+					"status":        "migration queued",
+					"new_model":     p.NewModel,
+				}, nil
+			},
+			onPostMigrate: func(_ context.Context, _ string) {},
+		},
+	}
+
+	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.True(t, confirmSeen, "confirm=true must reach migrateFunc as Confirm=true")
+}
+
+// ── G4: force arg passthrough ─────────────────────────────────────────────────
+
+// TestMCPMigrateForceArgPassedToEngine verifies force=true is forwarded.
+func TestMCPMigrateForceArgPassedToEngine(t *testing.T) {
+	// No stored dims — pre-flight skips; this test is about force-arg passthrough.
+	pool := newDimPool(t, "", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-different", map[string]any{
+		"force":   true,
+		"confirm": true,
+	})
+
+	var forceSeen bool
+	cfg := Config{
+		RouterURL: "http://ollama-test:11434",
+		testHooks: &testHooks{
+			embedProbe: noopProbeWithDims(1024),
+			migrateFunc: func(_ context.Context, p search.MigrateParams) (map[string]any, error) {
+				forceSeen = p.Force
+				return map[string]any{
+					"chunks_nulled": 5,
+					"status":        "migration queued",
+					"new_model":     p.NewModel,
+				}, nil
+			},
+			onPostMigrate: func(_ context.Context, _ string) {},
+		},
+	}
+
+	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
+	require.NoError(t, err)
+	require.True(t, forceSeen, "force=true must reach migrateFunc as Force=true")
+}

--- a/internal/mcp/test_hooks.go
+++ b/internal/mcp/test_hooks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/petersimmons1972/engram/internal/audit"
 	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/search"
 	"github.com/petersimmons1972/engram/internal/weight"
 )
 
@@ -20,5 +21,5 @@ type testHooks struct {
 	// onPostMigrate replaces the weight_config reset block after MigrateEmbedder.
 	onPostMigrate func(ctx context.Context, project string)
 	// migrateFunc replaces h.Engine.MigrateEmbedder in handleMemoryMigrateEmbedder.
-	migrateFunc func(ctx context.Context, model string) (map[string]any, error)
+	migrateFunc func(ctx context.Context, p search.MigrateParams) (map[string]any, error)
 }

--- a/internal/mcp/tools_embedder.go
+++ b/internal/mcp/tools_embedder.go
@@ -15,6 +15,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/netutil"
+	"github.com/petersimmons1972/engram/internal/search"
 )
 
 func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
@@ -44,8 +45,16 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 		ollamaURL = raw
 	}
 
+	// Extract new safety-guard args early — dry_run must bypass the dimension
+	// pre-flight since a dry_run only counts; it never nulls anything.
+	force := getBool(args, "force", false)
+	dryRun := getBool(args, "dry_run", false)
+	confirm := getBool(args, "confirm", false)
+
 	// Dimension pre-flight (#251): compare stored dims against the new model's output.
 	// Avoids nulling all embeddings only to discover a dimension mismatch at INSERT.
+	// Skipped for dry_run (informational only — no nulling will occur).
+	if !dryRun {
 	if storedDimsStr, ok, metaErr := h.Engine.Backend().GetMeta(ctx, project, "embedder_dimensions"); metaErr == nil && ok && storedDimsStr != "" {
 		var probeFunc func(ctx context.Context, baseURL, model string) (embed.Client, error)
 		if cfg.testHooks != nil {
@@ -72,15 +81,60 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 			}
 		}
 	}
+	} // end if !dryRun
+
+	// Resolve new model's dimension from the probe client (already probed above).
+	// newDims is 0 when the dimension pre-flight was skipped (no stored dims) —
+	// G2 in MigrateEmbedder skips the same-dim guard when NewDims==0.
+	var newDims int
+	if storedDimsStr, ok, metaErr := h.Engine.Backend().GetMeta(ctx, project, "embedder_dimensions"); metaErr == nil && ok && storedDimsStr != "" {
+		// We already probed the new model above; if probeFunc ran, we have a client.
+		// Re-probe only if we need newDims for G2. Use testHooks path when present.
+		var probeForDims func(ctx context.Context, baseURL, model string) (embed.Client, error)
+		if cfg.testHooks != nil && cfg.testHooks.embedProbe != nil {
+			probeForDims = cfg.testHooks.embedProbe
+		}
+		if probeForDims == nil {
+			targetDims := cfg.EmbedDimensions
+			probeForDims = func(ctx context.Context, baseURL, model string) (embed.Client, error) {
+				return embed.NewLiteLLMClient(ctx, baseURL, model, "", targetDims)
+			}
+		}
+		if pc, probeErr := probeForDims(ctx, ollamaURL, newModel); probeErr == nil && pc != nil {
+			newDims = pc.Dimensions()
+		}
+		_ = storedDimsStr // used only to gate the probe
+	}
+
+	p := search.MigrateParams{
+		NewModel: newModel,
+		NewDims:  newDims,
+		Force:    force,
+		DryRun:   dryRun,
+		Confirm:  confirm,
+	}
 
 	var result map[string]any
 	if cfg.testHooks != nil && cfg.testHooks.migrateFunc != nil {
-		result, err = cfg.testHooks.migrateFunc(ctx, newModel)
+		result, err = cfg.testHooks.migrateFunc(ctx, p)
 	} else {
-		result, err = h.Engine.MigrateEmbedder(ctx, newModel)
+		result, err = h.Engine.MigrateEmbedder(ctx, p)
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	// Surface soft refusals (G1 identity unchanged is NOT an error; G2/G3 ARE).
+	if errMsg, hasErr := result["error"]; hasErr {
+		if s, ok := errMsg.(string); ok && s != "" {
+			return mcpgo.NewToolResultError(s), nil
+		}
+	}
+
+	// Skip post-migrate weight reset for no-op results (identity unchanged, dry_run,
+	// or refused). Only a real NULL operation warrants a weight reset.
+	if status, _ := result["status"].(string); status == "identity unchanged" || status == "dry_run" || status == "refused" {
+		return toolResult(result)
 	}
 
 	// Reset weight_config to defaults for this project: learned weights are

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -134,6 +134,7 @@ func (noopBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error)  
 func (noopBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
 	return 0, nil
 }
+func (noopBackend) CountProjectChunks(_ context.Context, _ string) (int, error) { return 0, nil }
 func (noopBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
 	return nil, nil
 }

--- a/internal/search/embedder_meta_cache_test.go
+++ b/internal/search/embedder_meta_cache_test.go
@@ -62,10 +62,19 @@ type cacheMetaBackend struct {
 	mu           sync.Mutex
 	meta         map[string]string // key: "project:key"
 	getMetaCalls atomic.Int64
+	nullAllCalls atomic.Int32          // counts NullAllEmbeddingsTx calls
+	chunkCounts  map[string]int        // project → chunk count for volume guard
 }
 
 func newCacheMetaBackend() *cacheMetaBackend {
-	return &cacheMetaBackend{meta: make(map[string]string)}
+	return &cacheMetaBackend{meta: make(map[string]string), chunkCounts: make(map[string]int)}
+}
+
+// setChunkCount configures the stub chunk count returned by CountProjectChunks.
+func (b *cacheMetaBackend) setChunkCount(project string, n int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.chunkCounts[project] = n
 }
 
 func metaKey(project, key string) string { return project + ":" + key }
@@ -159,8 +168,17 @@ func (b *cacheMetaBackend) DeleteChunksByIDs(_ context.Context, _ []string) (int
 func (b *cacheMetaBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error) {
 	return 0, nil
 }
-func (b *cacheMetaBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
-	return 0, nil
+func (b *cacheMetaBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, project string) (int, error) {
+	b.nullAllCalls.Add(1)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := b.chunkCounts[project]
+	return n, nil
+}
+func (b *cacheMetaBackend) CountProjectChunks(_ context.Context, project string) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.chunkCounts[project], nil
 }
 func (b *cacheMetaBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
 	return nil, nil
@@ -433,7 +451,7 @@ func TestCheckEmbedderMeta_CacheInvalidatedAfterMigrate_GatewayPath(t *testing.T
 	}
 
 	// Migrate to new model (gateway path — no LiteLLM call needed).
-	if _, err := eng.MigrateEmbedder(ctx, "new-model-v2"); err != nil {
+	if _, err := eng.MigrateEmbedder(ctx, MigrateParams{NewModel: "new-model-v2"}); err != nil {
 		t.Fatalf("MigrateEmbedder: %v", err)
 	}
 
@@ -470,7 +488,7 @@ func TestCheckEmbedderMeta_PostMigrationReadsFreshValues(t *testing.T) {
 	// Migrate (gateway path writes embedder_name=new-model and
 	// embedding_migration_in_progress=true, then invalidates cache).
 	const newModel = "BAAI/bge-m3-v2"
-	if _, err := eng.MigrateEmbedder(ctx, newModel); err != nil {
+	if _, err := eng.MigrateEmbedder(ctx, MigrateParams{NewModel: newModel, Confirm: true}); err != nil {
 		t.Fatalf("MigrateEmbedder: %v", err)
 	}
 

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -2008,10 +2008,98 @@ func (e *SearchEngine) Verify(ctx context.Context) (map[string]any, error) {
 	}, nil
 }
 
+// migrateConfirmThreshold is the chunk count above which an explicit confirm
+// is required before MigrateEmbedder will null all embeddings.
+// At the default 1000-chunk threshold an accidental alias-rename is blocked;
+// a deliberate large migration passes confirm=true.
+const migrateConfirmThreshold = 1000
+
+// MigrateParams holds the arguments for MigrateEmbedder.
+// Separating params from the method signature lets us add guards without
+// changing every call site each time a new safeguard is added.
+type MigrateParams struct {
+	// NewModel is the raw model name (alias or canonical) to migrate to.
+	NewModel string
+	// NewDims is the embedding dimension of the new model.
+	// When non-zero and equal to the stored dimension, Force must be true.
+	// When zero the dimension guard is skipped (dimension pre-flight in the
+	// MCP handler already validated it before calling MigrateEmbedder).
+	NewDims int
+	// Force allows a same-dimension migration to proceed. Without it, a
+	// same-dim migrate is refused to prevent accidental re-embedding when
+	// vectors are still reusable.
+	Force bool
+	// DryRun returns chunks_would_null without nulling anything.
+	DryRun bool
+	// Confirm must be true when the affected chunk count exceeds
+	// migrateConfirmThreshold. Prevents accidental mass-null on large corpora.
+	Confirm bool
+}
+
 // MigrateEmbedder initiates an embedding migration to a new model by nulling all
 // existing embeddings and recording the new model name in project metadata.
 // A background reembed worker will repopulate embeddings after this call.
-func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (map[string]any, error) {
+//
+// Safety guards (applied in order, highest priority first):
+//  G1 — Same-canonical-identity: returns no-op with chunks_nulled=0.
+//  G2 — Same dimension without force: soft-refused (result["error"] set).
+//  G3 — dry_run: counts affected chunks without nulling.
+//       Large volume without confirm: soft-refused.
+//  G4 — Canonical stamp: stores canonicalEmbedderName(NewModel) in meta.
+func (e *SearchEngine) MigrateEmbedder(ctx context.Context, p MigrateParams) (map[string]any, error) {
+	newModel := p.NewModel
+
+	// ── G1: Same-canonical-identity guard ────────────────────────────────────
+	// Read the currently stored embedder name from meta.
+	storedName, _, _ := e.backend.GetMeta(ctx, e.project, "embedder_name")
+	if storedName != "" && canonicalEmbedderName(newModel) == canonicalEmbedderName(storedName) {
+		return map[string]any{
+			"chunks_nulled": 0,
+			"new_model":     canonicalEmbedderName(newModel),
+			"status":        "identity unchanged",
+		}, nil
+	}
+
+	// ── G2: Same-dimension guard ──────────────────────────────────────────────
+	// If caller supplied NewDims and they match the stored dims, require Force.
+	if p.NewDims > 0 && !p.Force {
+		storedDimsStr, ok, _ := e.backend.GetMeta(ctx, e.project, "embedder_dimensions")
+		if ok && storedDimsStr != "" {
+			var storedDims int
+			if _, scanErr := fmt.Sscanf(storedDimsStr, "%d", &storedDims); scanErr == nil && storedDims > 0 {
+				if p.NewDims == storedDims {
+					return map[string]any{
+						"error":  fmt.Sprintf("new model produces %d-dim vectors (same as current) — existing vectors are still reusable; pass force=true to force a full re-embed", p.NewDims),
+						"status": "refused",
+					}, nil
+				}
+			}
+		}
+	}
+
+	// ── G3a: dry_run — count without nulling ──────────────────────────────────
+	chunkCount, countErr := e.backend.CountProjectChunks(ctx, e.project)
+	if countErr != nil {
+		return nil, fmt.Errorf("count chunks for volume guard: %w", countErr)
+	}
+	if p.DryRun {
+		return map[string]any{
+			"chunks_would_null": chunkCount,
+			"new_model":         canonicalEmbedderName(newModel),
+			"status":            "dry_run",
+		}, nil
+	}
+
+	// ── G3b: Volume guard — require confirm for large corpus ──────────────────
+	if chunkCount >= migrateConfirmThreshold && !p.Confirm {
+		return map[string]any{
+			"error":             fmt.Sprintf("%d chunks would be nulled — this is a large corpus; pass confirm=true to proceed", chunkCount),
+			"chunks_would_null": chunkCount,
+			"status":            "refused",
+		}, nil
+	}
+
+	// ── Execute migration ─────────────────────────────────────────────────────
 	// Wrap null + meta writes in a single transaction (#102).
 	// Without this, a crash between NullAllEmbeddings and SetMeta leaves chunks
 	// without embeddings but the migrator flag never set — reembed worker never runs.
@@ -2028,7 +2116,9 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 	if err := e.backend.SetMetaTx(ctx, tx, e.project, "embedding_migration_in_progress", "true"); err != nil {
 		return nil, err
 	}
-	if err := e.backend.SetMetaTx(ctx, tx, e.project, "embedder_name", newModel); err != nil {
+	// ── G4: Stamp canonical, not raw ─────────────────────────────────────────
+	canonicalNewModel := canonicalEmbedderName(newModel)
+	if err := e.backend.SetMetaTx(ctx, tx, e.project, "embedder_name", canonicalNewModel); err != nil {
 		return nil, err
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -2048,7 +2138,7 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 		// gets a clean slate on the next checkEmbedderMeta call (#929).
 		return map[string]any{
 			"chunks_nulled": nulled,
-			"new_model":     newModel,
+			"new_model":     canonicalNewModel,
 			"status":        "migration queued — embed gateway will drain NULL embeddings",
 		}, nil
 	}
@@ -2059,9 +2149,9 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 	e.reembedder.Stop()
 
 	// ctx is used only for the startup probe; the returned client is context-independent.
-	newEmbedder, err := embed.NewLiteLLMClient(ctx, e.ollamaURL, newModel, "", e.targetDims)
+	newEmbedder, err := embed.NewLiteLLMClient(ctx, e.ollamaURL, canonicalNewModel, "", e.targetDims)
 	if err != nil {
-		return nil, fmt.Errorf("create embedder for new model %q: %w", newModel, err)
+		return nil, fmt.Errorf("create embedder for new model %q: %w", canonicalNewModel, err)
 	}
 	e.embedMu.Lock()
 	e.embedder = newEmbedder
@@ -2072,7 +2162,7 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, newModel string) (ma
 
 	return map[string]any{
 		"chunks_nulled": nulled,
-		"new_model":     newModel,
+		"new_model":     canonicalNewModel,
 		"status":        "migration started — reembed worker running with new model",
 	}, nil
 }

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -240,6 +240,7 @@ func (s *stubBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error
 func (s *stubBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
 	return 0, nil
 }
+func (s *stubBackend) CountProjectChunks(_ context.Context, _ string) (int, error) { return 0, nil }
 
 func (s *stubBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
 	return nil, nil

--- a/internal/search/hyde_test.go
+++ b/internal/search/hyde_test.go
@@ -157,6 +157,7 @@ func (noopBackend) NullAllEmbeddings(_ context.Context, _ string) (int, error)  
 func (noopBackend) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
 	return 0, nil
 }
+func (noopBackend) CountProjectChunks(_ context.Context, _ string) (int, error) { return 0, nil }
 func (noopBackend) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
 	return nil, nil
 }

--- a/internal/search/migrate_guards_test.go
+++ b/internal/search/migrate_guards_test.go
@@ -1,0 +1,255 @@
+package search
+
+// Tests for MigrateEmbedder safety guards (#spurious-reembed).
+//
+// Guards implemented here (all TDD: test written before implementation):
+//   G1: Same-canonical-identity → no-op (NULLs 0 chunks)
+//   G2: Same-dimension without force → refused
+//   G3: dry_run counts without nulling; large volume without confirm → refused
+//   G4: Stamp canonical, not raw, in project meta
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// newMigrateGuardEngine builds a SearchEngine backed by cacheMetaBackend with
+// the embed-gateway path enabled (avoids a live Ollama call in MigrateEmbedder).
+// storedName/storedDims pre-populate the project meta so the engine believes a
+// prior embedder has been registered.
+func newMigrateGuardEngine(t *testing.T, storedName string, storedDims int, chunkCount int) (*SearchEngine, *cacheMetaBackend) {
+	t.Helper()
+	backend := newCacheMetaBackend()
+	emb := &cacheTestEmbedder{name: storedName, dims: storedDims}
+
+	ctx := context.Background()
+
+	// Pre-populate meta so MigrateEmbedder's guard reads the right stored model.
+	_ = backend.SetMeta(ctx, "test-project", "embedder_name", canonicalEmbedderName(storedName))
+	_ = backend.SetMeta(ctx, "test-project", "embedder_dimensions", fmt.Sprintf("%d", storedDims))
+
+	// Wire chunk count so the volume guard can read it.
+	backend.setChunkCount("test-project", chunkCount)
+
+	eng := New(ctx, backend, emb, "test-project", "http://localhost:11434", "", false, nil, 0)
+	eng.SetEmbedGateway(&noopGateway{})
+	t.Cleanup(eng.Close)
+	return eng, backend
+}
+
+// ── G1: Same-canonical-identity → no-op ──────────────────────────────────────
+
+// TestMigrateSameCanonicalIdentityIsNoop: migrating to an alias of the current
+// model must return chunks_nulled=0 and status="identity unchanged" without
+// touching any chunk rows.
+func TestMigrateSameCanonicalIdentityIsNoop(t *testing.T) {
+	// Stored model is "BAAI/bge-m3". We migrate to alias "bge-m3" — same canonical.
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, 500)
+	ctx := context.Background()
+
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{NewModel: "bge-m3"})
+	require.NoError(t, err)
+	require.Equal(t, 0, result["chunks_nulled"], "alias migrate must null 0 chunks")
+	require.Equal(t, "identity unchanged", result["status"])
+	require.Equal(t, int32(0), backend.nullAllCalls.Load(), "NullAllEmbeddingsTx must not be called on identity no-op")
+}
+
+// TestMigrateSameCanonicalIdentityIsNoop_OtherAliases checks further aliases.
+func TestMigrateSameCanonicalIdentityIsNoop_OtherAliases(t *testing.T) {
+	aliases := []string{"bge-m3:latest", "BAAI/bge-m3:latest", "bge-m3-Q8_0.gguf", "bge-m3-Q4_K_M.gguf"}
+	for _, alias := range aliases {
+		alias := alias
+		t.Run(alias, func(t *testing.T) {
+			eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, 100)
+			ctx := context.Background()
+
+			result, err := eng.MigrateEmbedder(ctx, MigrateParams{NewModel: alias})
+			require.NoError(t, err)
+			require.Equal(t, 0, result["chunks_nulled"])
+			require.Equal(t, "identity unchanged", result["status"])
+			require.Equal(t, int32(0), backend.nullAllCalls.Load())
+		})
+	}
+}
+
+// ── G2: Same-dimension without force → refused ────────────────────────────────
+
+// TestMigrateSameDimRequiresForce: migrating to a genuinely different model
+// (different canonical name) but same dimension count must be refused unless
+// force=true is passed.
+func TestMigrateSameDimRequiresForce(t *testing.T) {
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, 50)
+	ctx := context.Background()
+
+	// "other-1024-model" is a different model family also producing 1024-dim.
+	// The guard should refuse it without force.
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "other-1024-model",
+		NewDims:  1024,
+		Force:    false,
+	})
+	require.NoError(t, err, "same-dim refusal is a soft refusal, not a Go error")
+	require.NotNil(t, result)
+	errVal, hasErr := result["error"]
+	require.True(t, hasErr, "result must contain 'error' key on same-dim refusal")
+	errStr, _ := errVal.(string)
+	require.Contains(t, errStr, "force", "refusal message must mention 'force'")
+	require.Equal(t, int32(0), backend.nullAllCalls.Load(), "NullAllEmbeddingsTx must not be called on refused migrate")
+}
+
+// TestMigrateSameDimWithForceProceeds: same-dim migrate WITH force=true proceeds
+// to null chunks.
+func TestMigrateSameDimWithForceProceeds(t *testing.T) {
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, 50)
+	ctx := context.Background()
+
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "other-1024-model",
+		NewDims:  1024,
+		Force:    true,
+		Confirm:  true,
+	})
+	require.NoError(t, err)
+	_, hasErr := result["error"]
+	require.False(t, hasErr, "force=true must allow same-dim migration")
+	require.Equal(t, int32(1), backend.nullAllCalls.Load(), "NullAllEmbeddingsTx must be called once")
+}
+
+// ── G3: Volume guard + dry_run ────────────────────────────────────────────────
+
+// TestMigrateDryRunCountsWithoutNulling: dry_run=true returns chunks_would_null
+// without touching any chunk rows.
+func TestMigrateDryRunCountsWithoutNulling(t *testing.T) {
+	const chunkCount = 42
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, chunkCount)
+	ctx := context.Background()
+
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "totally-different-model",
+		NewDims:  768,
+		DryRun:   true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, chunkCount, result["chunks_would_null"], "dry_run must report exact pending chunk count")
+	_, hasNulled := result["chunks_nulled"]
+	require.False(t, hasNulled, "dry_run must NOT have chunks_nulled key")
+	require.Equal(t, int32(0), backend.nullAllCalls.Load(), "NullAllEmbeddingsTx must not be called in dry_run mode")
+}
+
+// TestMigrateLargeVolumeRequiresConfirm: when affected chunks exceed the
+// threshold (migrateConfirmThreshold) and confirm=false, migration is refused
+// with the count in the error message.
+func TestMigrateLargeVolumeRequiresConfirm(t *testing.T) {
+	const overThreshold = migrateConfirmThreshold + 1
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, overThreshold)
+	ctx := context.Background()
+
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "totally-different-model",
+		NewDims:  768,
+		Confirm:  false,
+	})
+	require.NoError(t, err, "volume refusal is a soft refusal, not a Go error")
+	errVal, hasErr := result["error"]
+	require.True(t, hasErr, "must return error key when confirm missing for large corpus")
+	errStr, _ := errVal.(string)
+	require.Contains(t, errStr, "confirm", "error must mention confirm=true requirement")
+	require.Equal(t, int32(0), backend.nullAllCalls.Load(), "NullAllEmbeddingsTx must not be called on unconfirmed large migrate")
+}
+
+// TestMigrateSmallVolumeNoConfirmRequired: chunk count below threshold proceeds
+// without confirm.
+func TestMigrateSmallVolumeNoConfirmRequired(t *testing.T) {
+	const underThreshold = migrateConfirmThreshold - 1
+	eng, _ := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, underThreshold)
+	ctx := context.Background()
+
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "totally-different-model",
+		NewDims:  768,
+		Confirm:  false,
+	})
+	require.NoError(t, err)
+	_, hasErr := result["error"]
+	require.False(t, hasErr, "small corpus must not require confirm")
+}
+
+// TestMigrateLargeVolumeWithConfirmProceeds: confirm=true on large corpus proceeds.
+func TestMigrateLargeVolumeWithConfirmProceeds(t *testing.T) {
+	const overThreshold = migrateConfirmThreshold + 1
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, overThreshold)
+	ctx := context.Background()
+
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "totally-different-model",
+		NewDims:  768,
+		Confirm:  true,
+	})
+	require.NoError(t, err)
+	_, hasErr := result["error"]
+	require.False(t, hasErr, "confirm=true on large corpus must proceed")
+	require.Equal(t, int32(1), backend.nullAllCalls.Load())
+}
+
+// ── G4: Stamp canonical, not raw ──────────────────────────────────────────────
+
+// TestMigrateStampsCanonicalEmbedderName: after a successful migration, the
+// embedder_name stored in project meta must be the canonical form, not the
+// raw alias passed in.
+func TestMigrateStampsCanonicalEmbedderName(t *testing.T) {
+	eng, backend := newMigrateGuardEngine(t, "BAAI/bge-m3", 1024, 10)
+	ctx := context.Background()
+
+	// Migrate to a model with no alias — canonical == raw. Dims differ so no G2.
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "new-model-raw",
+		NewDims:  768,
+		Confirm:  true,
+	})
+	require.NoError(t, err)
+	_, hasErr := result["error"]
+	require.False(t, hasErr)
+
+	storedName, ok, _ := backend.GetMeta(ctx, "test-project", "embedder_name")
+	require.True(t, ok)
+	require.Equal(t, canonicalEmbedderName("new-model-raw"), storedName,
+		"migrate must stamp canonical name, not raw arg")
+}
+
+// TestMigrateStampsCanonicalEmbedderName_AliasInput: when a raw alias IS the
+// input, the stored name must still be the canonical form.
+func TestMigrateStampsCanonicalEmbedderName_AliasInput(t *testing.T) {
+	backend := newCacheMetaBackend()
+	ctx := context.Background()
+
+	// Pre-populate with a different model so migrating to bge-m3-Q8_0.gguf is real.
+	_ = backend.SetMeta(ctx, "test-project", "embedder_name", "old-model-512")
+	_ = backend.SetMeta(ctx, "test-project", "embedder_dimensions", "512")
+	backend.setChunkCount("test-project", 5)
+
+	emb := &cacheTestEmbedder{name: "old-model-512", dims: 512}
+	eng := New(ctx, backend, emb, "test-project", "http://localhost:11434", "", false, nil, 0)
+	eng.SetEmbedGateway(&noopGateway{})
+	defer eng.Close()
+
+	// Migrate using alias "bge-m3-Q8_0.gguf" (canonical: "BAAI/bge-m3").
+	// Dims differ (512→1024), so no G2 trigger.
+	result, err := eng.MigrateEmbedder(ctx, MigrateParams{
+		NewModel: "bge-m3-Q8_0.gguf",
+		NewDims:  1024,
+		Confirm:  true,
+	})
+	require.NoError(t, err)
+	_, hasErr := result["error"]
+	require.False(t, hasErr)
+
+	storedName, ok, _ := backend.GetMeta(ctx, "test-project", "embedder_name")
+	require.True(t, ok)
+	require.Equal(t, "BAAI/bge-m3", storedName,
+		"bge-m3-Q8_0.gguf alias must be stored as canonical BAAI/bge-m3")
+}


### PR DESCRIPTION
## Problem

`memory_migrate_embedder` is the only path that NULLs an entire project's embeddings (`UPDATE chunks SET embedding=NULL WHERE project=$1`), which fires the reembed worker over the whole corpus (259 GB in prod). The only pre-existing guard was a **dimension-change refusal** — it did **not** refuse a migrate to a canonical-equal model. So `new_model: bge-m3-live` (an alias of the current `BAAI/bge-m3`) would NULL the whole corpus and the dim check (1024==1024) would wave it through. A data/label/identity bug could therefore trigger a spurious mass re-embed.

This PR closes the **data-bug-fires-a-reembed** exposure with four layered safety guards.

## Guards (G1–G4)

| Guard | Trigger | Outcome |
|-------|---------|---------|
| **G1 — Same-canonical-identity → no-op** | `canonicalEmbedderName(new) == canonicalEmbedderName(stored)` | Returns `chunks_nulled: 0, status: "identity unchanged"`. Zero rows touched. An alias-rename (e.g. `bge-m3` → `BAAI/bge-m3`) can no longer fire a reembed. |
| **G2 — Same-dimension requires `force`** | `new dims == stored dims && !force` | Soft-refused. A genuine same-dim re-embed (weights changed, dim unchanged) must be deliberate via `force: true`. The existing different-dim refusal is preserved. |
| **G3 — Volume guard + `dry_run`** | `dry_run: true` counts without nulling; `chunk count >= 1000 && !confirm` refuses | `dry_run` returns `chunks_would_null: N` without touching rows. A large corpus (>= `migrateConfirmThreshold` = 1000) is refused unless `confirm: true`, with the count in the message. The dimension pre-flight is also skipped for `dry_run`. |
| **G4 — Stamp canonical, not raw** | every real migration | `MigrateEmbedder` writes `canonicalEmbedderName(newModel)` to `embedder_name` in project meta, matching the registration path (previously stamped the raw arg). |

## New optional tool args (backward-compatible)

`memory_migrate_embedder` now accepts three optional args, all defaulting to safe zero-values:

- `force: bool` — allow a same-dim migration (G2)
- `dry_run: bool` — count affected chunks without nulling (G3)
- `confirm: bool` — required when affected count exceeds the volume threshold (G3)

Existing calls without these args behave as before: small-corpus, different-dim, different-canonical migrations proceed unchanged.

## Tests (16, all TDD — RED before GREEN)

`internal/search/migrate_guards_test.go` (10):
- `TestMigrateSameCanonicalIdentityIsNoop` (+ 4 alias subtests)
- `TestMigrateSameDimRequiresForce`, `TestMigrateSameDimWithForceProceeds`
- `TestMigrateDryRunCountsWithoutNulling`
- `TestMigrateLargeVolumeRequiresConfirm`, `TestMigrateSmallVolumeNoConfirmRequired`, `TestMigrateLargeVolumeWithConfirmProceeds`
- `TestMigrateStampsCanonicalEmbedderName`, `TestMigrateStampsCanonicalEmbedderName_AliasInput`

`internal/mcp/migrate_guards_test.go` (6):
- `TestMCPMigrateSameCanonicalIdentityIsNoop`, `TestMCPMigrateSameDimRefusalPassedThrough`
- `TestMCPMigrateDryRunArgPassedToEngine`, `TestMCPMigrateLargeVolumeRefusalPassedThrough`
- `TestMCPMigrateConfirmArgPassedToEngine`, `TestMCPMigrateForceArgPassedToEngine`

Plus `CountProjectChunks` added to the `db.Backend` interface + postgres impl (for the volume guard), with noop-backend stubs updated, and the existing `TestHandleMemoryMigrateEmbedder_DimsMatch_ProceedToMigrate` updated to reflect G2's same-dim soft-refusal.

`go test ./internal/search/... ./internal/mcp/...` → both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)