### PR TITLE
fix(embedmodel): emit WARN log for unrecognised model alias in CanonicalName

### DIFF
--- a/internal/embedmodel/model.go
+++ b/internal/embedmodel/model.go
@@ -1,5 +1,7 @@
 package embedmodel
 
+import "log/slog"
+
 const (
 	CanonicalBGEM3  = "BAAI/bge-m3"
 	RequiredDims    = 1024
@@ -24,6 +26,15 @@ var aliasToCanonical = map[string]string{
 	"bge-m3-reembed":     CanonicalBGEM3, // olla routing alias: W6800+leviathan bulk embedder
 }
 
+// CanonicalName resolves a model alias to its canonical identifier.
+// Returns the canonical name, or "" if the alias is not recognised.
+// An unrecognised alias is logged at WARN level to surface audit-trail gaps
+// when a model is renamed or a new alias is introduced without being registered.
 func CanonicalName(modelID string) string {
-	return aliasToCanonical[modelID]
+	c, ok := aliasToCanonical[modelID]
+	if !ok {
+		slog.Warn("embedmodel: unrecognised model alias", "model_id", modelID)
+		return ""
+	}
+	return c
 }

--- a/internal/embedmodel/model_test.go
+++ b/internal/embedmodel/model_test.go
@@ -1,6 +1,11 @@
 package embedmodel
 
-import "testing"
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
 
 func TestCanonicalName_AllAliasesNormalize(t *testing.T) {
 	for _, alias := range AcceptedAliases {
@@ -13,5 +18,29 @@ func TestCanonicalName_AllAliasesNormalize(t *testing.T) {
 func TestCanonicalName_UnknownReturnsEmpty(t *testing.T) {
 	if got := CanonicalName("nomic-embed-text"); got != "" {
 		t.Fatalf("CanonicalName(unknown) = %q, want empty string", got)
+	}
+}
+
+// TestCanonicalName_UnknownEmitsWarn verifies that an unrecognised alias
+// produces a WARN-level log entry containing the alias, ensuring the
+// audit-trail gap is observable.
+func TestCanonicalName_UnknownEmitsWarn(t *testing.T) {
+	var buf bytes.Buffer
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	const unknownAlias = "nomic-embed-text"
+	got := CanonicalName(unknownAlias)
+	if got != "" {
+		t.Fatalf("CanonicalName(unknown) = %q, want empty string", got)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "WARN") {
+		t.Fatalf("expected WARN log for unknown alias, got: %q", logged)
+	}
+	if !strings.Contains(logged, unknownAlias) {
+		t.Fatalf("expected log to contain alias %q, got: %q", unknownAlias, logged)
 	}
 }


### PR DESCRIPTION
## Summary

- `CanonicalName()` in `internal/embedmodel/model.go` silently returned `""` for any unrecognised model alias — no log, no observable signal, creating an audit-trail gap when a model is renamed or a new alias is added without being registered in `aliasToCanonical`.
- Fix: check the map with a two-value lookup; emit `slog.Warn("embedmodel: unrecognised model alias", "model_id", ...)` before returning `""`. Return contract is unchanged.
- Callers (`drain.go:rejectionClass`, `validate.go:ValidateEmbedResponse`, `search/engine.go:canonicalEmbedderName`) all handle `""` correctly — this is a pure observability addition.

## Changes

- `internal/embedmodel/model.go`: add `log/slog` import; expand `CanonicalName` from a bare map index to an explicit two-value lookup with `slog.Warn` on miss; add doc comment.
- `internal/embedmodel/model_test.go`: add `TestCanonicalName_UnknownEmitsWarn` — redirects `slog.Default()` to a buffer, calls `CanonicalName` with an unknown alias, asserts WARN entry containing the alias is emitted.

## Test plan

- [ ] `go build ./...` — green (verified locally)
- [ ] `go test ./internal/embedmodel/...` — 3/3 pass (verified locally)
- [ ] `go test ./internal/embedgateway/...` — all pass, WARN now visible in tests that pass unknown aliases (verified locally)
- [ ] CI green (no deploy — source-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)