### PR TITLE
fix(reembed): next_backoff_ms dead-backend backoff (#1087 Patch B)

### DIFF
--- a/reembed-rs/src/main.rs
+++ b/reembed-rs/src/main.rs
@@ -1057,6 +1057,21 @@ mod backoff_decision_tests {
         let next = next_backoff_ms(&outcome, 5_000, 7_777, 30_000);
         assert_eq!(next, 7_777, "reset must return exactly min_backoff_ms, not a hardcoded sentinel");
     }
+
+    // Short-payload: embed API returned fewer vectors than chunks requested.
+    // claim.rs:160-164 increments failed++ per missing embedding; this is the
+    // third failed-increment site. attempted=32, written=0, failed>0 → Grow.
+    // This test verifies that a partially-truncated payload (backend returning a
+    // short response) is treated as a backend error, not a contention loss.
+    #[test]
+    fn short_payload_grows_backoff() {
+        // Simulate: 32 chunks attempted, API returned fewer vectors → some failed,
+        // none written (short payload means no embeddings were usable)
+        let outcome = ProcessSliceResult { attempted: 32, written: 0, failed: 16 };
+        let next = next_backoff_ms(&outcome, 100, 100, 30_000);
+        assert!(next > 100, "short payload (truncated embed response) must grow backoff");
+        assert_eq!(next, 200, "increase_backoff doubles: 100 → 200");
+    }
 }
 
 // ── Ordering regression tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Lands `feat/reembed-dead-backend-backoff` (base: `271bbbfd`) + 4 narrow amendments per ratified #1087 Patch B execution contract (Opus + Hermes).

**FM-01 fix:** `run_worker` previously reset backoff on any non-empty `Ok` outcome — an all-failed slice reset the backoff → hot loop against a dead backend. `next_backoff_ms()` now gates: `failed > 0` → Grow; `failed == 0` → Reset (regardless of `written` — contention loss is also healthy signal).

## Amendments vs already-satisfied

| # | Amendment | Status |
|---|-----------|--------|
| 1 | `empty_slice_panics_in_debug` (contract-precondition form, not `next_backoff_ms({0,0,0}→Grow)`) | Already satisfied on `271bbbfd` / main (#1086) |
| 2 | Single 4-param signature `(outcome, current, min, max)` | Already satisfied |
| 3 | Short-payload test `{attempted:32, written:0, failed:16}` → Grow | **Applied in this PR** — covers `claim.rs:160-164` third `failed++` increment site |
| 4 | Pure `next_backoff_ms` tests run with plain `cargo test` (no `TEST_DATABASE_URL`) | Already satisfied — all 35 unit tests + 40 integration tests use `wiremock`, 0 DB-gated |

## Test results

```
test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

All 75 tests pass with plain `cargo test`. No `TEST_DATABASE_URL` required for any backoff tests.

## Scope

- Touch: `reembed-rs/src/main.rs` only (one new test function added to `backoff_decision_tests`)
- Not touched: `claim.rs::validate_embeddings` (Patch C), Go null guard (Patch A)

**Patch B ONLY of #1087. DRAFT — no merge, founder-authorized push only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)