### PR TITLE
feat(reembed): atomic pre-persist validate_embeddings (#1087 Patch C)

### DIFF
--- a/reembed-rs/src/claim.rs
+++ b/reembed-rs/src/claim.rs
@@ -9,6 +9,46 @@ use tracing::warn;
 
 use crate::Config;
 
+/// Validate that the embedding response is coherent with the claimed row set before any DB writes.
+///
+/// Contract (all-or-nothing):
+/// - (a) `embeddings.len() == rows` — cardinality: the response must contain exactly one
+///   embedding per claimed row. A shorter payload is truncation; a longer payload is a protocol
+///   deviation. Both are rejected.
+/// - (b) If `expected_dims` is `Some(d)`, every vector must have length `d`. Wrong dimensions
+///   would cause the `::vector` UPDATE to fail at the DB layer; we surface it here instead so
+///   we can reject the whole slice without partial writes.
+///
+/// Returns `Ok(())` if all conditions are met; `Err` with a descriptive message otherwise.
+pub fn validate_embeddings(
+    rows: usize,
+    embeddings: &[Vec<f32>],
+    expected_dims: Option<u32>,
+) -> Result<()> {
+    if embeddings.len() != rows {
+        anyhow::bail!(
+            "embedding cardinality mismatch: expected {} embeddings for {} claimed rows, got {}",
+            rows,
+            rows,
+            embeddings.len()
+        );
+    }
+    if let Some(dims) = expected_dims {
+        let dims = dims as usize;
+        for (i, vec) in embeddings.iter().enumerate() {
+            if vec.len() != dims {
+                anyhow::bail!(
+                    "embedding dimension mismatch at index {}: expected {} dims, got {}",
+                    i,
+                    dims,
+                    vec.len()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 #[derive(Deserialize)]
 struct EmbedResponse {
     data: Vec<EmbedData>,
@@ -149,22 +189,28 @@ pub async fn process_slice(
         Ok(Ok(v)) => v,
     };
 
+    // Atomic pre-persist validation: reject the entire slice if cardinality or dimensions
+    // are wrong. This ensures write semantics are all-or-nothing — partial progress
+    // (where write count depends on response-truncation shape) is never observable.
+    if let Err(e) = validate_embeddings(rows.len(), &embeddings, cfg.embed_dims) {
+        warn!(
+            chunk_count = rows.len(),
+            err = %e,
+            "embedding response failed validation; rejecting entire slice (zero writes)"
+        );
+        return Ok(ProcessSliceResult {
+            attempted: rows.len(),
+            written: 0,
+            failed: rows.len(),
+        });
+    }
+
     let mut written = 0usize;
     let mut failed = 0usize;
 
-    let mut i = 0;
-    while i < rows.len() {
-        let row = &rows[i];
-        let vec = match embeddings.get(i) {
-            Some(v) => v,
-            None => {
-                warn!(chunk_id = %row.id, "embedding payload shorter than claimed chunk set");
-                failed += 1;
-                i += 1;
-                continue;
-            }
-        };
-
+    // At this point embeddings.len() == rows.len() is guaranteed by validate_embeddings,
+    // so indexing by position is safe without bounds checks.
+    for (row, vec) in rows.iter().zip(embeddings.iter()) {
         match sqlx::query(
             "UPDATE chunks SET embedding = $1::vector WHERE id = $2 AND embedding IS NULL",
         )
@@ -183,15 +229,6 @@ pub async fn process_slice(
                 failed += 1;
             }
         }
-        i += 1;
-    }
-
-    if embeddings.len() > rows.len() {
-        warn!(
-            claimed = rows.len(),
-            embeddings = embeddings.len(),
-            "received more embeddings than claimed rows"
-        );
     }
 
     Ok(ProcessSliceResult {
@@ -199,4 +236,110 @@ pub async fn process_slice(
         written,
         failed,
     })
+}
+
+// ── validate_embeddings unit tests ────────────────────────────────────────────
+
+#[cfg(test)]
+mod validate_embeddings_tests {
+    use super::validate_embeddings;
+
+    fn vecs(count: usize, dims: usize) -> Vec<Vec<f32>> {
+        vec![vec![1.0f32; dims]; count]
+    }
+
+    // ── cardinality ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_payload_no_dims_check_returns_ok() {
+        // 3 rows, 3 embeddings, no dimension constraint.
+        let embs = vecs(3, 5);
+        assert!(validate_embeddings(3, &embs, None).is_ok());
+    }
+
+    #[test]
+    fn valid_payload_with_dims_check_returns_ok() {
+        let embs = vecs(4, 8);
+        assert!(validate_embeddings(4, &embs, Some(8)).is_ok());
+    }
+
+    #[test]
+    fn short_payload_is_err() {
+        // 5 rows but only 3 embeddings — truncation case.
+        let embs = vecs(3, 4);
+        let result = validate_embeddings(5, &embs, None);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("cardinality mismatch"),
+            "expected 'cardinality mismatch' in error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn long_payload_is_err() {
+        // 3 rows but 5 embeddings — protocol deviation.
+        let embs = vecs(5, 4);
+        let result = validate_embeddings(3, &embs, None);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("cardinality mismatch"),
+            "expected 'cardinality mismatch' in error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn zero_rows_zero_embeddings_is_ok() {
+        // Edge case: empty slice — nothing to validate.
+        assert!(validate_embeddings(0, &[], None).is_ok());
+    }
+
+    #[test]
+    fn zero_rows_non_empty_embeddings_is_err() {
+        let embs = vecs(1, 4);
+        let result = validate_embeddings(0, &embs, None);
+        assert!(result.is_err());
+    }
+
+    // ── dimension ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn wrong_dimension_first_vec_is_err() {
+        // All embeddings have 4 dims but we expected 8.
+        let embs = vecs(3, 4);
+        let result = validate_embeddings(3, &embs, Some(8));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("dimension mismatch"),
+            "expected 'dimension mismatch' in error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wrong_dimension_only_last_vec_is_err() {
+        // First two correct, last one wrong — partial dimension corruption.
+        let mut embs = vecs(2, 8);
+        embs.push(vec![1.0f32; 4]); // wrong dims on the third
+        let result = validate_embeddings(3, &embs, Some(8));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("index 2"), "expected index 2 in error; got: {msg}");
+    }
+
+    #[test]
+    fn correct_dims_all_vecs_ok() {
+        let embs = vecs(10, 1536);
+        assert!(validate_embeddings(10, &embs, Some(1536)).is_ok());
+    }
+
+    // ── none dims skips dimension check ──────────────────────────────────────
+
+    #[test]
+    fn none_dims_skips_dimension_check_for_mixed_sizes() {
+        // Without expected_dims, varying vector lengths are accepted (cardinality only).
+        let embs = vec![vec![1.0f32; 4], vec![1.0f32; 8], vec![1.0f32; 2]];
+        assert!(validate_embeddings(3, &embs, None).is_ok());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `validate_embeddings(rows, embeddings, expected_dims) -> Result<()>` pure helper in `reembed-rs/src/claim.rs`
- Validates cardinality (embed count == row count) and optionally dimension before any DB writes
- On mismatch: returns `ProcessSliceResult { attempted: N, written: 0, failed: N }` — zero writes, full-slice counted failure
- Removes partial-progress short-payload path (per-row `embeddings.get(i) == None` skip) and the over-count warning (both superseded by the atomic gate)
- Wires `cfg.embed_dims` (already `Option<u32>` in `Config`) as `expected_dims` — both cardinality and dimension validated when configured; cardinality-only when `embed_dims` is `None`
- Patch C ONLY of #1087 — does not touch Patch A (Go guard) or Patch B (main.rs backoff)

## Test results

10 new unit tests in `claim::validate_embeddings_tests` covering:
- valid payload (cardinality only) → Ok
- valid payload (cardinality + dims) → Ok
- short payload (truncation) → Err("cardinality mismatch")
- long payload (extra embeddings) → Err("cardinality mismatch")
- zero rows, zero embeddings → Ok
- zero rows, non-empty embeddings → Err
- wrong dimension on first vec → Err("dimension mismatch")
- wrong dimension on last vec only → Err (includes index)
- correct dims on all vecs → Ok
- None dims skips dimension check → Ok for mixed-size vecs

All 44 unit tests + 49 integration tests pass (`cargo test` — 93 total, 0 failed).

note: all-or-nothing on cardinality/dim mismatch, replaces partial-progress; Patch C ONLY of #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)