### PR TITLE
Split live vs reembed embed routing (two embed clients) (#1108)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/embedgateway"
+	"github.com/petersimmons1972/engram/internal/embedmodel"
 	"github.com/petersimmons1972/engram/internal/entity"
 	"github.com/petersimmons1972/engram/internal/ingestqueue"
 	internalmcp "github.com/petersimmons1972/engram/internal/mcp"
@@ -35,6 +36,19 @@ import (
 
 // Version is injected at build time via -ldflags "-X main.Version=$(git describe --tags --always)".
 var Version = "dev"
+
+var newLiteLLMEmbedClient = func(baseURL, model, apiKey string, targetDims int, cbCfg embed.CircuitConfig) embed.Client {
+	return embed.NewLiteLLMClientNoProbeWithCircuitBreaker(baseURL, model, apiKey, targetDims, cbCfg)
+}
+
+func reembedModelFromEnv() string {
+	return envOr("ENGRAM_REEMBED_MODEL", embedmodel.ReembedAlias)
+}
+
+func newEmbedClients(embedURL, liveModel, reembedModel, apiKey string, targetDims int, cbCfg embed.CircuitConfig) (embed.Client, embed.Client) {
+	return newLiteLLMEmbedClient(embedURL, liveModel, apiKey, targetDims, cbCfg),
+		newLiteLLMEmbedClient(embedURL, reembedModel, apiKey, targetDims, cbCfg)
+}
 
 func main() {
 	// Subcommand dispatch for the hook daemon and its shim client (#396).
@@ -140,6 +154,7 @@ func runServer(args []string) error {
 	// embed backend is different from the generation backend (e.g. direct llama.cpp).
 	embedURL := envOr("ENGRAM_EMBED_URL", routerURLFromEnv("http://litellm:4000", slog.Default()))
 	embedModel := fs.String("model", envOr("ENGRAM_EMBED_MODEL", envOr("ENGRAM_OLLAMA_MODEL", "")), "Embedding model (required; set ENGRAM_EMBED_MODEL or --model)")
+	reembedModel := reembedModelFromEnv()
 	embedDims := fs.Int("embed-dims", envInt("ENGRAM_EMBED_DIMENSIONS", 0), "MRL truncation target for embedding model (0 = native output)")
 	summarizeModel := fs.String("summarize-model", envOr("ENGRAM_SUMMARIZE_MODEL", "llama3.2"), "Summarization model")
 	summarizeEnabled := fs.Bool("summarize", envBool("ENGRAM_SUMMARIZE_ENABLED", true), "Enable background summarization")
@@ -319,7 +334,7 @@ func runServer(args []string) error {
 		BackoffMultiplier: *embedCircuitBackoffMultiplier,
 		BackoffCap:        *embedCircuitBackoffCap,
 	}
-	embedClient := embed.Client(embed.NewLiteLLMClientNoProbeWithCircuitBreaker(embedURL, *embedModel, litellmAPIKey, *embedDims, cbCfg))
+	embedClient, reembedClient := newEmbedClients(embedURL, *embedModel, reembedModel, litellmAPIKey, *embedDims, cbCfg)
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	probeVec, probeModelID, probeErr := embedClient.EmbedWithModel(probeCtx, "startup probe")
 	probeCancel()
@@ -414,7 +429,7 @@ func runServer(args []string) error {
 			return fmt.Errorf("embed gateway pool: %w", err)
 		}
 		defer gatewayPool.Close()
-		modelEmbedder, ok := embedClient.(embedgateway.Embedder)
+		modelEmbedder, ok := reembedClient.(embedgateway.Embedder)
 		if !ok {
 			return fmt.Errorf("embed gateway requires an embedder that reports response model IDs")
 		}
@@ -431,7 +446,7 @@ func runServer(args []string) error {
 		reembedInterval := envDuration("ENGRAM_REEMBED_INTERVAL", 10*time.Second)
 		// ENGRAM_REEMBED_BATCH_SIZE=0 disables the GlobalReembedder in this process.
 		// Use this when a dedicated engram-reembed container owns all embedding work.
-		globalReembedder = reembed.NewGlobalReembedder(pgxPool, embedClient, reembedBatchSize, reembedInterval)
+		globalReembedder = reembed.NewGlobalReembedder(pgxPool, reembedClient, reembedBatchSize, reembedInterval)
 		if reembedBatchSize > 0 {
 			globalReembedder.Start(ctx)
 			slog.Info("global reembedder started", "batch_size", reembedBatchSize, "interval", reembedInterval)
@@ -454,6 +469,7 @@ func runServer(args []string) error {
 			return nil, fmt.Errorf("postgres backend for project %q: %w", project, err)
 		}
 		engine := search.New(serverCtx, backend, embedClient, project, routerURLVal, sumModel, sumEnabled, claudeCompleter, *decayInterval, *embedDims)
+		engine.SetReembedEmbedder(reembedClient)
 		engine.SetEmbedRecallTimeout(*embedRecallTimeoutMS)
 		if embedGateway != nil {
 			engine.SetEmbedGateway(embedGateway)

--- a/cmd/engram/main_embed_routing_test.go
+++ b/cmd/engram/main_embed_routing_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/embed"
+)
+
+type constructedEmbedClient struct {
+	model string
+}
+
+func (c *constructedEmbedClient) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{1, 2, 3}, nil
+}
+
+func (c *constructedEmbedClient) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := c.Embed(ctx, text)
+	return vec, c.model, err
+}
+
+func (c *constructedEmbedClient) Name() string    { return c.model }
+func (c *constructedEmbedClient) Dimensions() int { return 3 }
+
+func TestReembedModelEnvDefaultAndOverride(t *testing.T) {
+	orig := newLiteLLMEmbedClient
+	t.Cleanup(func() { newLiteLLMEmbedClient = orig })
+
+	var constructed []string
+	newLiteLLMEmbedClient = func(_ string, model string, _ string, _ int, _ embed.CircuitConfig) embed.Client {
+		constructed = append(constructed, model)
+		return &constructedEmbedClient{model: model}
+	}
+
+	t.Run("default", func(t *testing.T) {
+		constructed = nil
+		t.Setenv("ENGRAM_REEMBED_MODEL", "")
+
+		live, reembed := newEmbedClients("http://litellm:4000", "bge-m3-live", reembedModelFromEnv(), "", 1024, embed.CircuitConfig{})
+
+		if got := live.Name(); got != "bge-m3-live" {
+			t.Fatalf("live.Name() = %q, want %q", got, "bge-m3-live")
+		}
+		if got := reembed.Name(); got != "bge-m3-reembed" {
+			t.Fatalf("reembed.Name() = %q, want %q", got, "bge-m3-reembed")
+		}
+		if live == reembed {
+			t.Fatal("expected distinct live and reembed clients")
+		}
+		if len(constructed) != 2 {
+			t.Fatalf("constructed %d clients, want 2", len(constructed))
+		}
+	})
+
+	t.Run("override", func(t *testing.T) {
+		constructed = nil
+		t.Setenv("ENGRAM_REEMBED_MODEL", "custom-reembed")
+
+		_, reembed := newEmbedClients("http://litellm:4000", "bge-m3-live", reembedModelFromEnv(), "", 1024, embed.CircuitConfig{})
+
+		if got := reembed.Name(); got != "custom-reembed" {
+			t.Fatalf("reembed.Name() = %q, want %q", got, "custom-reembed")
+		}
+		if len(constructed) != 2 {
+			t.Fatalf("constructed %d clients, want 2", len(constructed))
+		}
+	})
+}

--- a/internal/embedmodel/model.go
+++ b/internal/embedmodel/model.go
@@ -6,6 +6,8 @@ const (
 	CanonicalBGEM3  = "BAAI/bge-m3"
 	RequiredDims    = 1024
 	PGNotifyChannel = "embed_queue"
+	LiveAlias       = "bge-m3-live"
+	ReembedAlias    = "bge-m3-reembed"
 )
 
 var AcceptedAliases = []string{
@@ -13,8 +15,8 @@ var AcceptedAliases = []string{
 	"bge-m3",
 	"bge-m3-Q8_0.gguf",
 	"bge-m3-Q4_K_M.gguf",
-	"bge-m3-live",    // olla routing alias: MI-50 burst embedder (gfx906, priority 50)
-	"bge-m3-reembed", // olla routing alias: W6800+leviathan bulk embedder (priority 100)
+	LiveAlias,    // olla routing alias: MI-50 burst embedder (gfx906, priority 50)
+	ReembedAlias, // olla routing alias: W6800+leviathan bulk embedder (priority 100)
 }
 
 var aliasToCanonical = map[string]string{
@@ -22,8 +24,16 @@ var aliasToCanonical = map[string]string{
 	"bge-m3":             CanonicalBGEM3,
 	"bge-m3-Q8_0.gguf":   CanonicalBGEM3,
 	"bge-m3-Q4_K_M.gguf": CanonicalBGEM3,
-	"bge-m3-live":        CanonicalBGEM3, // olla routing alias: MI-50 burst embedder
-	"bge-m3-reembed":     CanonicalBGEM3, // olla routing alias: W6800+leviathan bulk embedder
+	LiveAlias:           CanonicalBGEM3, // olla routing alias: MI-50 burst embedder
+	ReembedAlias:        CanonicalBGEM3, // olla routing alias: W6800+leviathan bulk embedder
+}
+
+func IsLiveAlias(modelID string) bool {
+	return modelID == LiveAlias
+}
+
+func IsReembedAlias(modelID string) bool {
+	return modelID == ReembedAlias
 }
 
 // CanonicalName resolves a model alias to its canonical identifier.

--- a/internal/embedmodel/routing_guard_test.go
+++ b/internal/embedmodel/routing_guard_test.go
@@ -1,0 +1,24 @@
+package embedmodel
+
+import "testing"
+
+func TestLiveAndReembedAliasesDistinct(t *testing.T) {
+	if !IsLiveAlias("bge-m3-live") {
+		t.Fatal("expected bge-m3-live to be classified as the live alias")
+	}
+	if IsLiveAlias("bge-m3-reembed") {
+		t.Fatal("bge-m3-reembed must not be classified as the live alias")
+	}
+	if !IsReembedAlias("bge-m3-reembed") {
+		t.Fatal("expected bge-m3-reembed to be classified as the reembed alias")
+	}
+	if IsReembedAlias("bge-m3-live") {
+		t.Fatal("bge-m3-live must not be classified as the reembed alias")
+	}
+	if got := CanonicalName("bge-m3-live"); got != CanonicalBGEM3 {
+		t.Fatalf("CanonicalName(bge-m3-live) = %q, want %q", got, CanonicalBGEM3)
+	}
+	if got := CanonicalName("bge-m3-reembed"); got != CanonicalBGEM3 {
+		t.Fatalf("CanonicalName(bge-m3-reembed) = %q, want %q", got, CanonicalBGEM3)
+	}
+}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -243,8 +243,9 @@ const noEmbedTimeout = time.Duration(-1)
 // and recalls them via composite vector+FTS scoring.
 type SearchEngine struct {
 	backend             db.Backend
-	embedMu             sync.RWMutex // protects embedder; use getEmbedder() for all reads
+	embedMu             sync.RWMutex // protects live + reembed embedder selection
 	embedder            embed.Client
+	reembedderOverride  embed.Client
 	project             string
 	ollamaURL           string
 	targetDims          int             // MRL truncation target; 0 = model native output
@@ -282,10 +283,51 @@ func (e *SearchEngine) getEmbedder() embed.Client {
 	return e.embedder
 }
 
+// getReembedEmbedder returns the embedder used by reembed workers. By default
+// it follows the live embedder, but main.go may install an override so
+// batch/backfill work routes to a different model alias.
+func (e *SearchEngine) getReembedEmbedder() embed.Client {
+	e.embedMu.RLock()
+	defer e.embedMu.RUnlock()
+	if e.reembedderOverride != nil {
+		return e.reembedderOverride
+	}
+	return e.embedder
+}
+
 // Embedder returns the current embedding client. Used by callers (e.g. consolidate
 // runner) that need the live embedder rather than a nil placeholder (#94).
 func (e *SearchEngine) Embedder() embed.Client {
 	return e.getEmbedder()
+}
+
+// ReembedEmbedder returns the embedder currently used by reembed workers.
+func (e *SearchEngine) ReembedEmbedder() embed.Client {
+	return e.getReembedEmbedder()
+}
+
+// SetReembedEmbedder overrides the embedder used by reembed workers. When not
+// called, reembed work uses the live embedder. The worker is rebuilt so future
+// Notify() calls and embedder migrations use the new routing immediately.
+func (e *SearchEngine) SetReembedEmbedder(client embed.Client) {
+	if client == nil {
+		return
+	}
+	wasActive := e.reembedder != nil && e.reembedder.IsActive()
+	if e.reembedder != nil {
+		e.reembedder.Stop()
+	}
+
+	e.embedMu.Lock()
+	e.reembedderOverride = client
+	e.embedMu.Unlock()
+
+	if wasActive {
+		e.reembedder = reembed.NewWorker(e.backend, client, e.project, true)
+		e.reembedder.StartWithContext(e.ctx)
+		return
+	}
+	e.reembedder = reembed.NewWorkerFromMeta(e.ctx, e.backend, client, e.project)
 }
 
 // SetGlobalReembedder wires the shared GlobalReembedder so StoreWithRawBody and
@@ -2162,7 +2204,7 @@ func (e *SearchEngine) MigrateEmbedder(ctx context.Context, p MigrateParams) (ma
 	e.embedder = newEmbedder
 	e.embedMu.Unlock()
 
-	e.reembedder = reembed.NewWorker(e.backend, newEmbedder, e.project, true)
+	e.reembedder = reembed.NewWorker(e.backend, e.getReembedEmbedder(), e.project, true)
 	e.reembedder.StartWithContext(e.ctx)
 
 	return map[string]any{

--- a/internal/search/engine_reembed_routing_test.go
+++ b/internal/search/engine_reembed_routing_test.go
@@ -1,0 +1,69 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/embed"
+)
+
+type routingEmbedder struct {
+	name string
+	dims int
+}
+
+func (r *routingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, r.dims), nil
+}
+
+func (r *routingEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := r.Embed(ctx, text)
+	return vec, r.name, err
+}
+
+func (r *routingEmbedder) Name() string    { return r.name }
+func (r *routingEmbedder) Dimensions() int { return r.dims }
+
+var _ embed.Client = (*routingEmbedder)(nil)
+
+func TestPerProjectReembedUsesReembedModel(t *testing.T) {
+	ctx := context.Background()
+	live := &routingEmbedder{name: "bge-m3-live", dims: 1024}
+	reembed := &routingEmbedder{name: "bge-m3-reembed", dims: 1024}
+
+	eng := New(ctx, noopBackend{}, live, "routing-project", "http://litellm:4000", "llama3.2", false, nil, 0)
+	t.Cleanup(func() { eng.Close() })
+
+	eng.SetReembedEmbedder(reembed)
+
+	if got := eng.ReembedEmbedder().Name(); got != reembed.Name() {
+		t.Fatalf("ReembedEmbedder().Name() = %q, want %q", got, reembed.Name())
+	}
+}
+
+func TestLiveEmbedUsesLiveModel(t *testing.T) {
+	ctx := context.Background()
+	live := &routingEmbedder{name: "bge-m3-live", dims: 1024}
+	reembed := &routingEmbedder{name: "bge-m3-reembed", dims: 1024}
+
+	eng := New(ctx, noopBackend{}, live, "routing-project", "http://litellm:4000", "llama3.2", false, nil, 0)
+	t.Cleanup(func() { eng.Close() })
+
+	eng.SetReembedEmbedder(reembed)
+
+	if got := eng.Embedder().Name(); got != live.Name() {
+		t.Fatalf("Embedder().Name() = %q, want %q", got, live.Name())
+	}
+}
+
+func TestDefaultReembedEmbedderTracksLiveModel(t *testing.T) {
+	ctx := context.Background()
+	live := &routingEmbedder{name: "bge-m3-live", dims: 1024}
+
+	eng := New(ctx, noopBackend{}, live, "routing-project", "http://litellm:4000", "llama3.2", false, nil, 0)
+	t.Cleanup(func() { eng.Close() })
+
+	if got := eng.ReembedEmbedder().Name(); got != live.Name() {
+		t.Fatalf("ReembedEmbedder().Name() = %q, want %q", got, live.Name())
+	}
+}


### PR DESCRIPTION
Recovered from the fleet-dispatch `codex-agent` workspace (impl reached `needs-input` but no PR/branch was pushed — work was stranded in-container). Implements #1108. Draft for review.

Closes #1108.

🤖 Codex implementation, recovered + PR-opened by Claude.