### PR TITLE
Add dense-stage cross-encoder reranker to hybrid recall (#1091)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -232,6 +232,8 @@ ANTHROPIC_API_KEY=                         # Set this to enable memory_reason an
 ENGRAM_CLAUDE_SUMMARIZE=false             # Use Claude instead of Ollama for summaries
 ENGRAM_CLAUDE_CONSOLIDATE=false           # Use Claude for consolidation analysis
 ENGRAM_CLAUDE_RERANK=false                # Use Claude to rerank results (slower, better)
+ENGRAM_CROSS_ENCODER_RERANK=false         # Use a cross-encoder on top dense hits before hybrid fusion
+ENGRAM_CROSS_ENCODER_URL=                 # TEI-compatible /rerank endpoint, e.g. http://localhost:6006/rerank
 ```
 
 | Variable                   | Default              | Required | Purpose                                               |
@@ -246,6 +248,8 @@ ENGRAM_CLAUDE_RERANK=false                # Use Claude to rerank results (slower
 | `ENGRAM_CLAUDE_SUMMARIZE`  | `false`              | No       | Use Claude for async summaries instead of Ollama      |
 | `ENGRAM_CLAUDE_CONSOLIDATE`| `false`              | No       | Use Claude for graph consolidation                    |
 | `ENGRAM_CLAUDE_RERANK`     | `false`              | No       | Use Claude to rerank search results                   |
+| `ENGRAM_CROSS_ENCODER_RERANK` | `false`           | No       | Enable dense-leg cross-encoder reranking before BM25/recency fusion |
+| `ENGRAM_CROSS_ENCODER_URL` | *(empty)*            | No       | Full TEI-compatible `/rerank` endpoint used when cross-encoder reranking is on |
 | `POSTGRES_DB`              | `engram`             | No       | Database name (rarely needs changing)                 |
 | `POSTGRES_USER`            | `engram`             | No       | Database user (rarely needs changing)                 |
 | `ENGRAM_TRUST_PROXY_HEADERS` | `false`              | No       | Trust `X-Forwarded-For` / `X-Real-IP` for rate limiting. Set to `1` only when a trusted reverse proxy is in front. |

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -318,6 +318,8 @@ All Engram configuration is via environment variables (not CLI flags — secrets
 | `ENGRAM_CLAUDE_SUMMARIZE` | `false` | Use Claude instead of Ollama for summarization |
 | `ENGRAM_CLAUDE_CONSOLIDATE` | `false` | Use Claude for near-duplicate detection in consolidation |
 | `ENGRAM_CLAUDE_RERANK` | `false` | Enable Claude re-ranking of recall results |
+| `ENGRAM_CROSS_ENCODER_RERANK` | `false` | Enable cross-encoder reranking on the top dense hits before hybrid fusion |
+| `ENGRAM_CROSS_ENCODER_URL` | *(empty)* | Full TEI-compatible `/rerank` endpoint used by the cross-encoder reranker |
 | `ENGRAM_DECAY_INTERVAL` | `8h` | How often the importance decay worker runs |
 | `ENGRAM_AUDIT_INTERVAL` | `168h` | How often the decay audit worker snapshots canonical queries |
 | `ENGRAM_WEIGHT_INTERVAL` | `168h` | How often the adaptive weight tuner checks failure-class aggregates |

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -459,10 +459,11 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		opts.Reranker = arReranker
 	}
 	// Cross-encoder reranker (LEVER-2): flag-gated via ENGRAM_CROSS_ENCODER_RERANK=true.
-	// When enabled, replaces any other reranker — cross-encoder is the stronger signal.
 	// ENGRAM_CROSS_ENCODER_URL must be set to the TEI /rerank endpoint.
+	// This reranks the dense/vector leg before hybrid fusion; it does not replace
+	// the final fused-result reranker.
 	if ceReranker := search.NewCrossEncoderRerankerFromEnv(); ceReranker != nil {
-		opts.Reranker = ceReranker
+		opts.DenseReranker = ceReranker
 	}
 	// Inject current session episode for same-session score boosting (Phase 3).
 	if id, ok := episodeIDFromContext(ctx); ok {

--- a/internal/search/cross_encoder_reranker.go
+++ b/internal/search/cross_encoder_reranker.go
@@ -4,10 +4,12 @@ package search
 //
 // # Design
 //
-// After candidate retrieval (any method), this reranker re-scores the top-K
+// After ANN/vector retrieval, this reranker re-scores the top-N dense
 // candidates using a cross-encoder model (e.g. bge-reranker-v2-m3) that
 // JOINTLY encodes (query, chunk) rather than using independent bi-encoder
-// cosine similarity. This directly addresses the "compilation bottleneck":
+// cosine similarity. The engine feeds the reranked dense signal into the
+// hybrid scorer before BM25/recency fusion. This directly addresses the
+// "compilation bottleneck":
 // SmartSearch oracle analysis shows ~22.5% of gold evidence is lost to
 // truncation, and cross-encoder reranking is the dominant SOTA lever
 // (arXiv 2603.15599, +8–14pp).
@@ -41,9 +43,9 @@ package search
 // The endpoint URL is configured via ENGRAM_CROSS_ENCODER_URL.
 // When the URL is empty, the reranker is disabled even if the flag is on.
 //
-// Set RecallOpts.Reranker = NewCrossEncoderRerankerFromEnv() at the call site;
-// when the flag is off (or URL unset), the function returns nil and the hook
-// is a no-op — baseline scores and ordering are unchanged.
+// Set RecallOpts.DenseReranker = NewCrossEncoderRerankerFromEnv() at the call
+// site; when the flag is off (or URL unset), the function returns nil and the
+// hook is a no-op — baseline scores and ordering are unchanged.
 //
 // # Ablation bench command
 //
@@ -132,13 +134,13 @@ func IsCrossEncoderRerankerEnabled() bool {
 //   - ENGRAM_CROSS_ENCODER_URL is non-empty.
 //
 // Returns nil (no-op) when either condition is not met. Assign directly to
-// RecallOpts.Reranker:
+// RecallOpts.DenseReranker:
 //
 //	opts := search.RecallOpts{
-//	    Reranker: search.NewCrossEncoderRerankerFromEnv(),
+//	    DenseReranker: search.NewCrossEncoderRerankerFromEnv(),
 //	}
 //
-// When nil, RecallWithOpts skips re-ranking entirely — baseline unchanged.
+// When nil, RecallWithOpts skips dense-leg reranking entirely — baseline unchanged.
 func NewCrossEncoderRerankerFromEnv() ResultReranker {
 	if !IsCrossEncoderRerankerEnabled() {
 		return nil
@@ -159,8 +161,7 @@ func NewCrossEncoderRerankerFromEnv() ResultReranker {
 // what score order the endpoint returns results in.
 //
 // On HTTP or parse error, the error is returned and the caller falls through
-// to the existing bi-encoder ordering (engine.go: error from Reranker is
-// logged and the original results are used unchanged).
+// to the existing bi-encoder ordering for that dense candidate set.
 func (r *CrossEncoderReranker) RerankResults(
 	ctx context.Context,
 	query string,

--- a/internal/search/dense_rerank_test.go
+++ b/internal/search/dense_rerank_test.go
@@ -1,0 +1,122 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+type denseSpyReranker struct {
+	onCall  func(items []RerankItem)
+	results []RerankResult
+	err     error
+}
+
+func (r *denseSpyReranker) RerankResults(_ context.Context, _ string, items []RerankItem) ([]RerankResult, error) {
+	if r.onCall != nil {
+		r.onCall(items)
+	}
+	if r.err != nil {
+		return nil, r.err
+	}
+	out := make([]RerankResult, len(r.results))
+	copy(out, r.results)
+	return out, nil
+}
+
+func TestApplyDenseRerank_UpdatesOnlyTopDenseCandidates(t *testing.T) {
+	memories := map[string]*types.Memory{
+		"a": {ID: "a", Summary: ptr("summary a")},
+		"b": {ID: "b", Summary: ptr("summary b")},
+		"c": {ID: "c", Summary: ptr("summary c")},
+	}
+	bestHits := map[string]bestHit{
+		"a": {cosine: 0.90, denseScore: 0.90},
+		"b": {cosine: 0.80, denseScore: 0.80},
+		"c": {cosine: 0.20, denseScore: 0.20},
+	}
+
+	var gotIDs []string
+	reranker := &denseSpyReranker{
+		onCall: func(items []RerankItem) {
+			gotIDs = append(gotIDs, items[0].ID, items[1].ID)
+		},
+		results: []RerankResult{
+			{ID: "a", Score: 0.10},
+			{ID: "b", Score: 0.90},
+		},
+	}
+
+	applyDenseRerank(context.Background(), "query", memories, bestHits, reranker, 2)
+
+	if len(gotIDs) != 2 || gotIDs[0] != "a" || gotIDs[1] != "b" {
+		t.Fatalf("dense reranker received ids %v, want [a b]", gotIDs)
+	}
+	if bestHits["a"].cosine != 0.90 || bestHits["b"].cosine != 0.80 {
+		t.Fatalf("dense rerank must not overwrite original cosine scores: got a=%v b=%v", bestHits["a"].cosine, bestHits["b"].cosine)
+	}
+	if bestHits["a"].denseScore != 0.0 {
+		t.Fatalf("denseScore(a) = %v, want 0.0 after normalization", bestHits["a"].denseScore)
+	}
+	if bestHits["b"].denseScore != 1.0 {
+		t.Fatalf("denseScore(b) = %v, want 1.0 after normalization", bestHits["b"].denseScore)
+	}
+	if bestHits["c"].denseScore != 0.20 {
+		t.Fatalf("denseScore(c) = %v, want unchanged 0.20 outside top-N", bestHits["c"].denseScore)
+	}
+}
+
+func TestApplyDenseRerank_DefaultTopNIs20(t *testing.T) {
+	memories := make(map[string]*types.Memory, 25)
+	bestHits := make(map[string]bestHit, 25)
+	for i := 0; i < 25; i++ {
+		id := strconv.Itoa(i)
+		memories[id] = &types.Memory{ID: id, Summary: ptr("summary " + id)}
+		bestHits[id] = bestHit{
+			cosine:     1.0 - (float64(i) / 100.0),
+			denseScore: 1.0 - (float64(i) / 100.0),
+		}
+	}
+
+	gotCount := 0
+	reranker := &denseSpyReranker{
+		onCall: func(items []RerankItem) { gotCount = len(items) },
+		results: func() []RerankResult {
+			out := make([]RerankResult, 20)
+			for i := range out {
+				out[i] = RerankResult{ID: strconv.Itoa(i), Score: float64(20 - i)}
+			}
+			return out
+		}(),
+	}
+
+	applyDenseRerank(context.Background(), "query", memories, bestHits, reranker, 0)
+
+	if gotCount != defaultDenseRerankTopN {
+		t.Fatalf("dense reranker received %d items, want default top-N %d", gotCount, defaultDenseRerankTopN)
+	}
+}
+
+func TestApplyDenseRerank_ErrorLeavesDenseScoresUnchanged(t *testing.T) {
+	memories := map[string]*types.Memory{
+		"a": {ID: "a", Summary: ptr("summary a")},
+		"b": {ID: "b", Summary: ptr("summary b")},
+	}
+	bestHits := map[string]bestHit{
+		"a": {cosine: 0.90, denseScore: 0.90},
+		"b": {cosine: 0.80, denseScore: 0.80},
+	}
+
+	applyDenseRerank(context.Background(), "query", memories, bestHits, &denseSpyReranker{
+		err: errors.New("boom"),
+	}, 2)
+
+	if bestHits["a"].denseScore != 0.90 || bestHits["b"].denseScore != 0.80 {
+		t.Fatalf("dense rerank error must leave scores unchanged; got a=%v b=%v", bestHits["a"].denseScore, bestHits["b"].denseScore)
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -61,6 +61,14 @@ type RerankResult struct {
 // RecallOpts controls optional post-processing for Recall.
 type RecallOpts struct {
 	Reranker ResultReranker // nil = skip re-ranking
+	// DenseReranker re-scores the dense/vector leg before hybrid scoring.
+	// Unlike Reranker, which reorders the final fused result set, DenseReranker
+	// only sees the top-N vector candidates and rewrites their dense score before
+	// BM25/recency/precision fusion. Nil = skip dense-leg reranking.
+	DenseReranker ResultReranker
+	// DenseRerankTopN caps how many vector candidates DenseReranker receives.
+	// 0 uses defaultDenseRerankTopN (20). Ignored when DenseReranker is nil.
+	DenseRerankTopN int
 	// Mode controls response format. "" or "full" returns complete SearchResults;
 	// "handle" returns lightweight Handle references (content omitted).
 	Mode string
@@ -219,6 +227,7 @@ type MergeDecision struct {
 // the function returns.
 type bestHit struct {
 	cosine         float64
+	denseScore     float64
 	chunkText      string
 	chunkIndex     int
 	sectionHeading *string // borrowed; see struct comment
@@ -232,6 +241,10 @@ type bestHit struct {
 // Embed recall timeout used when the env var is unset. This value was restored
 // to 500ms to preserve the production recall SLA contract.
 const defaultEmbedRecallTimeoutMS = 500
+
+// defaultDenseRerankTopN bounds the number of vector candidates sent to a
+// dense-leg reranker (for example a cross-encoder) before hybrid fusion.
+const defaultDenseRerankTopN = 20
 
 // noEmbedTimeout is a sentinel stored in embedRecallTimeout to indicate that
 // no per-embed deadline should be applied. The parent context's deadline (if
@@ -858,6 +871,7 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		if existing, ok := bestHits[h.MemoryID]; !ok || cosine > existing.cosine {
 			bestHits[h.MemoryID] = bestHit{
 				cosine:         cosine,
+				denseScore:     cosine,
 				chunkText:      h.ChunkText,
 				chunkIndex:     h.ChunkIndex,
 				sectionHeading: h.SectionHeading,
@@ -932,6 +946,7 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 						if existing, ok := bestHits[h.MemoryID]; !ok || cosine > existing.cosine {
 							bestHits[h.MemoryID] = bestHit{
 								cosine:         cosine,
+								denseScore:     cosine,
 								chunkText:      h.ChunkText,
 								chunkIndex:     h.ChunkIndex,
 								sectionHeading: h.SectionHeading,
@@ -989,6 +1004,12 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		}
 	}
 
+	// Optional dense-leg reranking: re-score the top vector candidates before
+	// hybrid fusion so the weighted scorer sees a stronger dense signal than raw
+	// cosine alone. This is distinct from opts.Reranker, which reorders the
+	// already-fused final result set.
+	applyDenseRerank(ctx, query, memories, bestHits, opts.DenseReranker, opts.DenseRerankTopN)
+
 	// Detect query type once before the scoring loop.
 	prefQuery := isPreferenceQuery(query)
 	tempQuery := isTemporalQuery(query)
@@ -1000,6 +1021,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	// RRF setup (LME experiment #6, issue #938 improvement #1): pre-compute
 	// per-leg rank positions. applyFusion is a strict no-op when Fusion=false.
 	vecRanks := rankVectorHits(vecHits)
+	if opts.DenseReranker != nil {
+		vecRanks = rankBestHitsByDenseScore(bestHits)
+	}
 	ftsRanks := rankFTSResults(ftsRes.results)
 	applyFusion(opts, memories, bestHits, vecRanks, ftsRanks)
 
@@ -1061,7 +1085,7 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		hit := bestHits[id]
 		exactMatch := exactBoostEnabled && ExactIdentifierHit(m.Content, query)
 		input := ScoreInput{
-			Cosine:             hit.cosine,
+			Cosine:             hit.denseScore,
 			BM25:               bm25,
 			HoursSince:         temporalAnchorHours(*m),
 			Importance:         m.Importance,
@@ -1114,10 +1138,14 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			ScoreBreakdown: func() map[string]float64 {
 				bd := map[string]float64{
 					"cosine":           hit.cosine,
+					"dense_score":      hit.denseScore,
 					"bm25":             bm25,
 					"recency":          RecencyDecay(input.HoursSince),
 					"episode_boost":    1.0,
 					"valid_from_boost": vwBoost,
+				}
+				if hit.denseScore != hit.cosine {
+					bd["cross_encoder_score"] = hit.denseScore
 				}
 				if input.EpisodeMatch {
 					bd["episode_boost"] = 1.15
@@ -1286,18 +1314,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		}
 		items := make([]RerankItem, len(rerankCandidates))
 		for i, r := range rerankCandidates {
-			summary := ""
-			if r.Memory.Summary != nil {
-				summary = *r.Memory.Summary
-			} else {
-				summary = r.Memory.Content
-				if len(summary) > 500 {
-					summary = summary[:500]
-				}
-			}
 			items[i] = RerankItem{
 				ID:      r.Memory.ID,
-				Summary: summary,
+				Summary: rerankTextForMemory(r.Memory),
 				Score:   r.Score,
 			}
 		}
@@ -1457,18 +1476,9 @@ func (e *SearchEngine) maybeRerank(ctx context.Context, query string, topK int, 
 	}
 	items := make([]RerankItem, len(rerankCandidates))
 	for i, r := range rerankCandidates {
-		summary := ""
-		if r.Memory.Summary != nil {
-			summary = *r.Memory.Summary
-		} else {
-			summary = r.Memory.Content
-			if len(summary) > 500 {
-				summary = summary[:500]
-			}
-		}
 		items[i] = RerankItem{
 			ID:      r.Memory.ID,
-			Summary: summary,
+			Summary: rerankTextForMemory(r.Memory),
 			Score:   r.Score,
 		}
 	}
@@ -1486,6 +1496,155 @@ func (e *SearchEngine) maybeRerank(ctx context.Context, query string, topK int, 
 		sortResults(results)
 	}
 	return results
+}
+
+// applyDenseRerank rewrites the dense score for the top vector candidates
+// before hybrid fusion. Original cosine values are preserved for observability
+// and matched-chunk reporting; only denseScore is overwritten.
+func applyDenseRerank(ctx context.Context, query string, memories map[string]*types.Memory, bestHits map[string]bestHit, reranker ResultReranker, topN int) {
+	if reranker == nil || len(memories) == 0 || len(bestHits) == 0 {
+		return
+	}
+	if topN <= 0 {
+		topN = defaultDenseRerankTopN
+	}
+
+	type denseCandidate struct {
+		item   RerankItem
+		cosine float64
+	}
+
+	candidates := make([]denseCandidate, 0, len(bestHits))
+	for id, hit := range bestHits {
+		m := memories[id]
+		if m == nil {
+			continue
+		}
+		candidates = append(candidates, denseCandidate{
+			item: RerankItem{
+				ID:      id,
+				Summary: rerankTextForMemory(m),
+				Score:   hit.cosine,
+			},
+			cosine: hit.cosine,
+		})
+	}
+	if len(candidates) == 0 {
+		return
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].cosine == candidates[j].cosine {
+			return candidates[i].item.ID < candidates[j].item.ID
+		}
+		return candidates[i].cosine > candidates[j].cosine
+	})
+	if len(candidates) > topN {
+		candidates = candidates[:topN]
+	}
+
+	items := make([]RerankItem, len(candidates))
+	for i, c := range candidates {
+		items[i] = c.item
+	}
+
+	reranked, err := reranker.RerankResults(ctx, query, items)
+	if err != nil || len(reranked) == 0 {
+		return
+	}
+
+	normalized := normalizeDenseRerankScores(items, reranked)
+	for _, item := range items {
+		newScore, ok := normalized[item.ID]
+		if !ok {
+			continue
+		}
+		hit := bestHits[item.ID]
+		hit.denseScore = newScore
+		bestHits[item.ID] = hit
+	}
+}
+
+func normalizeDenseRerankScores(items []RerankItem, reranked []RerankResult) map[string]float64 {
+	if len(items) == 0 {
+		return nil
+	}
+
+	raw := make(map[string]float64, len(reranked))
+	minScore := 0.0
+	maxScore := 0.0
+	first := true
+	for _, rr := range reranked {
+		raw[rr.ID] = rr.Score
+		if first {
+			minScore = rr.Score
+			maxScore = rr.Score
+			first = false
+			continue
+		}
+		if rr.Score < minScore {
+			minScore = rr.Score
+		}
+		if rr.Score > maxScore {
+			maxScore = rr.Score
+		}
+	}
+
+	out := make(map[string]float64, len(items))
+	if first || maxScore == minScore {
+		for _, item := range items {
+			out[item.ID] = item.Score
+		}
+		return out
+	}
+
+	for _, item := range items {
+		score, ok := raw[item.ID]
+		if !ok {
+			out[item.ID] = item.Score
+			continue
+		}
+		out[item.ID] = (score - minScore) / (maxScore - minScore)
+	}
+	return out
+}
+
+func rankBestHitsByDenseScore(bestHits map[string]bestHit) map[string]int {
+	type rankedHit struct {
+		id    string
+		dense float64
+	}
+
+	ranked := make([]rankedHit, 0, len(bestHits))
+	for id, hit := range bestHits {
+		ranked = append(ranked, rankedHit{id: id, dense: hit.denseScore})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].dense == ranked[j].dense {
+			return ranked[i].id < ranked[j].id
+		}
+		return ranked[i].dense > ranked[j].dense
+	})
+
+	out := make(map[string]int, len(ranked))
+	for i, hit := range ranked {
+		out[hit.id] = i + 1
+	}
+	return out
+}
+
+func rerankTextForMemory(m *types.Memory) string {
+	if m == nil {
+		return ""
+	}
+	if m.Summary != nil {
+		return *m.Summary
+	}
+	summary := m.Content
+	if len(summary) > 500 {
+		summary = summary[:500]
+	}
+	return summary
 }
 
 // mergeSearchResults unions two result slices, preserving the order of a first and


### PR DESCRIPTION
Recovered from the fleet-dispatch `codex-agent` workspace (impl reached `needs-input` but no PR/branch was pushed — work was stranded in-container). Implements #1091. Draft for review.

Closes #1091.

🤖 Codex implementation, recovered + PR-opened by Claude.