### PR TITLE
Activate dormant typed-atom subsystem (Phase 1: preference) (#1109)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/petersimmons1972/engram/internal/atom"
 	"github.com/petersimmons1972/engram/internal/audit"
 	"github.com/petersimmons1972/engram/internal/claude"
 	"github.com/petersimmons1972/engram/internal/config"
@@ -641,6 +642,26 @@ func runServer(args []string) error {
 		}
 	}
 
+	if cc != nil && envBool("ENGRAM_ATOM_EXTRACTION_ENABLED", false) {
+		atomBackend, err := db.NewPostgresBackendWithPool(ctx, "_atoms", pgxPool)
+		if err != nil {
+			slog.Warn("atom worker: could not open backend", "err", err)
+		} else {
+			adapter := &atomDBAdapter{backend: atomBackend}
+			extractor := atom.NewClaudeExtractor(cc)
+			w := atom.NewWorker(adapter, extractor, atom.WorkerConfig{
+				Projects: []string{""},
+			})
+			workersWg.Add(1)
+			go func() {
+				defer workersWg.Done()
+				w.Run(ctx)
+				slog.Debug("atom extraction worker shutdown complete")
+			}()
+			slog.Info("atom extraction worker started", "scope", "all-projects")
+		}
+	}
+
 	// Start pprof profiling server on localhost:6060 when ENGRAM_PPROF=1.
 	// Bound to loopback only — not reachable from outside the host.
 	// Operators can SSH-forward if they need remote access.
@@ -893,6 +914,34 @@ func (a *entityDBAdapter) GetEntitiesByProject(ctx context.Context, project stri
 
 func (a *entityDBAdapter) UpsertEntity(ctx context.Context, e *entity.Entity) (string, error) {
 	return a.backend.UpsertEntity(ctx, e)
+}
+
+type atomDBAdapter struct {
+	backend *db.PostgresBackend
+}
+
+func (a *atomDBAdapter) ClaimAtomExtractionJobs(ctx context.Context, project string, limit int) ([]atom.ExtractionJob, error) {
+	return a.backend.ClaimAtomExtractionJobs(ctx, project, limit)
+}
+
+func (a *atomDBAdapter) CompleteAtomExtractionJob(ctx context.Context, jobID string, err error) error {
+	return a.backend.CompleteAtomExtractionJob(ctx, jobID, err)
+}
+
+func (a *atomDBAdapter) GetMemory(ctx context.Context, id string) (*types.Memory, error) {
+	return a.backend.GetMemory(ctx, id)
+}
+
+func (a *atomDBAdapter) GetActiveAtoms(ctx context.Context, project string, atomType string) ([]atom.Atom, error) {
+	return a.backend.GetActiveAtoms(ctx, project, atomType)
+}
+
+func (a *atomDBAdapter) InsertAtom(ctx context.Context, at *atom.Atom) error {
+	return a.backend.InsertAtom(ctx, at)
+}
+
+func (a *atomDBAdapter) RetireAtom(ctx context.Context, atomID string, validTo time.Time) error {
+	return a.backend.RetireAtom(ctx, atomID, validTo)
 }
 
 // auditRecallerAdapter adapts the engine pool to the audit.Recaller interface.

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -366,12 +366,12 @@ func exitCodeForRunOutcome(attempted, errors int64) int {
 	return 0
 }
 
-type dateRangeRecallFunc func(query string, topK int, since, before *time.Time) ([]string, error)
+type dateRangeRecallFunc func(query string, topK int, since, before *time.Time) (longmemeval.RecallResult, error)
 
-func recallWithTemporalFallback(query string, topK int, since, before *time.Time, recall dateRangeRecallFunc) ([]string, []string, error) {
+func recallWithTemporalFallback(query string, topK int, since, before *time.Time, recall dateRangeRecallFunc) (longmemeval.RecallResult, []string, error) {
 	primary, err := recall(query, topK, since, before)
 	if err != nil {
-		return nil, nil, err
+		return longmemeval.RecallResult{}, nil, err
 	}
 	if since == nil && before == nil {
 		return primary, nil, nil
@@ -381,7 +381,8 @@ func recallWithTemporalFallback(query string, topK int, since, before *time.Time
 		log.Printf("WARN temporal fallback recall failed: %v", err)
 		return primary, nil, nil
 	}
-	return longmemeval.UnionMemoryIDs(primary, fallback), fallback, nil
+	primary.IDs = longmemeval.UnionMemoryIDs(primary.IDs, fallback.IDs)
+	return primary, fallback.IDs, nil
 }
 
 // runWorker processes items from work, writing RunEntry results to out and
@@ -469,18 +470,34 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// When --disable-query-rewrite is set, use the raw question unchanged.
 	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
 	since, before := temporalRecallWindow(item.Question, item.QuestionType, item.QuestionDate)
-
-	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
-		if cfg.ExactSignalBoost {
-			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, callSince, callBefore)
+	var atomRecallAsOf *time.Time
+	if cfg.AtomMode {
+		if asOf, ok := parseLongMemEvalQuestionDate(item.QuestionDate); ok {
+			atomRecallAsOf = &asOf
 		}
-		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost)
 	}
-	recallDefault := func(query string, topK int) ([]string, error) {
-		if cfg.ExactSignalBoost {
-			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, since, before)
+
+	recall := func(query string, topK int, callSince, callBefore *time.Time) (longmemeval.RecallResult, error) {
+		if cfg.AtomMode {
+			return mcpClient.RecallWithAtomRecall(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost, cfg.ExactSignalBoost, atomRecallAsOf)
 		}
-		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
+		if cfg.ExactSignalBoost {
+			ids, err := mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, callSince, callBefore)
+			return longmemeval.RecallResult{IDs: ids}, err
+		}
+		ids, err := mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost)
+		return longmemeval.RecallResult{IDs: ids}, err
+	}
+	recallDefault := func(query string, topK int) (longmemeval.RecallResult, error) {
+		if cfg.AtomMode {
+			return mcpClient.RecallWithAtomRecall(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost, cfg.ExactSignalBoost, atomRecallAsOf)
+		}
+		if cfg.ExactSignalBoost {
+			ids, err := mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, since, before)
+			return longmemeval.RecallResult{IDs: ids}, err
+		}
+		ids, err := mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
+		return longmemeval.RecallResult{IDs: ids}, err
 	}
 
 	// H-NEW-1: when --temporal-window-recall is set, hand temporal anchoring to the
@@ -493,6 +510,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	var (
 		retrievedIDs        []string
 		temporalFallbackIDs []string
+		atomPreamble        string
 		err                 error
 	)
 	serverTemporalWindow := cfg.TemporalWindowRecall && item.QuestionType == "temporal-reasoning"
@@ -506,7 +524,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			}
 		}
 	} else {
-		retrievedIDs, temporalFallbackIDs, err = recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)
+		recallResult, fallbackIDs, recallErr := recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)
+		retrievedIDs, temporalFallbackIDs, atomPreamble, err = recallResult.IDs, fallbackIDs, recallResult.AtomPreamble, recallErr
 		if err != nil {
 			return longmemeval.RunEntry{
 				QuestionID: item.QuestionID,
@@ -525,12 +544,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		// fusion candidates to at most 3 swapped-in slots, defeating the lever.
 		variants := buildRecallVariants(item.Question, recallQuery, cfg.DisableQueryRewrite, true)
 		for _, q := range variants[1:] {
-			ids, qErr := recallDefault(q, cfg.RecallTopK)
+			recallResult, qErr := recallDefault(q, cfg.RecallTopK)
 			if qErr != nil {
 				log.Printf("WARN run [%s] fusion recall (%q): %v", item.QuestionID, q, qErr)
 				continue
 			}
-			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, ids)
+			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, recallResult.IDs)
 		}
 	}
 
@@ -539,10 +558,10 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	if cfg.ExhaustiveAggregation && !serverTemporalWindow && longmemeval.IsAggregationQuestion(item.Question) {
 		const aggregationSweepTopK = 500
 		sweepQuery := longmemeval.ExtractAggregationAnchor(item.Question)
-		sweepIDs, sweepErr := recallDefault(sweepQuery, aggregationSweepTopK)
+		sweepResult, sweepErr := recallDefault(sweepQuery, aggregationSweepTopK)
 		if sweepErr == nil {
-			secondaryContextIDs = append(secondaryContextIDs, sweepIDs...)
-			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, sweepIDs)
+			secondaryContextIDs = append(secondaryContextIDs, sweepResult.IDs...)
+			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, sweepResult.IDs)
 		} else {
 			log.Printf("WARN run [%s] H8 aggregation sweep failed: %v", item.QuestionID, sweepErr)
 		}
@@ -556,10 +575,10 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			anchorTopK = 1
 		}
 		anchor := longmemeval.PreferenceSubjectAnchorQuery(item.Question)
-		anchorIDs, anchorErr := recallDefault(anchor, anchorTopK)
+		anchorResult, anchorErr := recallDefault(anchor, anchorTopK)
 		if anchorErr == nil {
-			secondaryContextIDs = append(secondaryContextIDs, anchorIDs...)
-			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, anchorIDs)
+			secondaryContextIDs = append(secondaryContextIDs, anchorResult.IDs...)
+			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, anchorResult.IDs)
 		} else {
 			log.Printf("WARN run [%s] H15 anchor recall failed: %v", item.QuestionID, anchorErr)
 		}
@@ -577,13 +596,13 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			log.Printf("WARN run [%s] paraphrase: %v — falling back to single-pass recall", item.QuestionID, pErr)
 		} else {
 			for _, pq := range paraphrases {
-				pIDs, pErr := recallDefault(pq, cfg.RecallTopK)
+				pResult, pErr := recallDefault(pq, cfg.RecallTopK)
 				if pErr != nil {
 					log.Printf("WARN run [%s] paraphrase recall (%q): %v", item.QuestionID, pq, pErr)
 					continue
 				}
-				secondaryContextIDs = append(secondaryContextIDs, pIDs...)
-				retrievedIDs = append(retrievedIDs, pIDs...)
+				secondaryContextIDs = append(secondaryContextIDs, pResult.IDs...)
+				retrievedIDs = append(retrievedIDs, pResult.IDs...)
 			}
 			retrievedIDs = longmemeval.DeduplicateIDs(retrievedIDs)
 		}
@@ -663,13 +682,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		contextBlocks = orderContextEvidenceFirst(contextBlocks, item.Question)
 	}
 
-	// #938: --atom-mode: fetch extracted preference atoms for the project and
-	// prepend them as a labeled block in the generation prompt. This code path
-	// is OFF by default. It is the Milestone 1 eval gate switch; enable ONLY
-	// after the post-reset atom extraction pass has been completed.
 	var atomContextBlock string
 	if cfg.AtomMode {
-		atomContextBlock = fetchAtomContextBlock(ctx, mcpClient, ingest.Project, item.QuestionID, cfg.AtomCacheDir)
+		atomContextBlock = atomPreamble
+		if atomContextBlock == "" {
+			atomContextBlock = fetchAtomContextBlock(ctx, mcpClient, ingest.Project, item.QuestionID, cfg.AtomCacheDir)
+		}
 	}
 	// Exp-14: --temporal-prompt-aug takes priority over --inject-question-date;
 	// the two are mutually exclusive. When both are set, aug wins.
@@ -712,10 +730,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 
 	return longmemeval.RunEntry{
-		QuestionID:   item.QuestionID,
-		Hypothesis:   hypothesis,
-		RetrievedIDs: retrievedIDs,
-		Status:       "done",
+		QuestionID:     item.QuestionID,
+		Hypothesis:     hypothesis,
+		RetrievedIDs:   retrievedIDs,
+		Status:         "done",
+		AtomRetrieved:  atomPreamble != "",
+		AtomInContext:  atomContextBlock != "",
 	}
 }
 

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -730,12 +730,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 
 	return longmemeval.RunEntry{
-		QuestionID:     item.QuestionID,
-		Hypothesis:     hypothesis,
-		RetrievedIDs:   retrievedIDs,
-		Status:         "done",
-		AtomRetrieved:  atomPreamble != "",
-		AtomInContext:  atomContextBlock != "",
+		QuestionID:    item.QuestionID,
+		Hypothesis:    hypothesis,
+		RetrievedIDs:  retrievedIDs,
+		Status:        "done",
+		AtomRetrieved: atomPreamble != "",
+		AtomInContext: atomContextBlock != "",
 	}
 }
 

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -757,13 +757,13 @@ func TestRecallWithTemporalFallbackAddsUnfilteredSafetyLane(t *testing.T) {
 	since := time.Date(2023, 5, 8, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2023, 5, 11, 0, 0, 0, 0, time.UTC)
 	var calls []string
-	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
+	recall := func(query string, topK int, callSince, callBefore *time.Time) (longmemeval.RecallResult, error) {
 		if callSince != nil || callBefore != nil {
 			calls = append(calls, "filtered")
-			return []string{"dated-a", "dated-b"}, nil
+			return longmemeval.RecallResult{IDs: []string{"dated-a", "dated-b"}}, nil
 		}
 		calls = append(calls, "unfiltered")
-		return []string{"undated-answer", "dated-a"}, nil
+		return longmemeval.RecallResult{IDs: []string{"undated-answer", "dated-a"}}, nil
 	}
 
 	retrieved, secondary, err := recallWithTemporalFallback("recent concert", 10, &since, &before, recall)
@@ -773,7 +773,7 @@ func TestRecallWithTemporalFallbackAddsUnfilteredSafetyLane(t *testing.T) {
 	if got, want := strings.Join(calls, ","), "filtered,unfiltered"; got != want {
 		t.Fatalf("calls = %s, want %s", got, want)
 	}
-	if got, want := strings.Join(retrieved, ","), "dated-a,dated-b,undated-answer"; got != want {
+	if got, want := strings.Join(retrieved.IDs, ","), "dated-a,dated-b,undated-answer"; got != want {
 		t.Fatalf("retrieved = %s, want %s", got, want)
 	}
 	if got, want := strings.Join(secondary, ","), "undated-answer,dated-a"; got != want {
@@ -783,12 +783,12 @@ func TestRecallWithTemporalFallbackAddsUnfilteredSafetyLane(t *testing.T) {
 
 func TestRecallWithTemporalFallbackSkipsSafetyLaneWithoutDateBounds(t *testing.T) {
 	var calls int
-	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
+	recall := func(query string, topK int, callSince, callBefore *time.Time) (longmemeval.RecallResult, error) {
 		calls++
 		if callSince != nil || callBefore != nil {
 			t.Fatal("non-temporal recall should not pass date bounds")
 		}
-		return []string{"a"}, nil
+		return longmemeval.RecallResult{IDs: []string{"a"}}, nil
 	}
 
 	retrieved, secondary, err := recallWithTemporalFallback("plain query", 10, nil, nil, recall)
@@ -798,7 +798,7 @@ func TestRecallWithTemporalFallbackSkipsSafetyLaneWithoutDateBounds(t *testing.T
 	if calls != 1 {
 		t.Fatalf("calls = %d, want 1", calls)
 	}
-	if got := strings.Join(retrieved, ","); got != "a" {
+	if got := strings.Join(retrieved.IDs, ","); got != "a" {
 		t.Fatalf("retrieved = %s, want a", got)
 	}
 	if len(secondary) != 0 {

--- a/internal/atom/atom.go
+++ b/internal/atom/atom.go
@@ -16,6 +16,8 @@ const (
 	TypeEvent        = "event"
 	TypeAttribute    = "attribute"
 	TypeRelationship = "relationship"
+	TypeProfile      = "profile"
+	TypeStatusChange = "status_change"
 )
 
 // Scope prefixes for the scope column.
@@ -46,6 +48,7 @@ type Atom struct {
 	// Bi-temporal columns (nil = unbounded).
 	ValidFrom *time.Time `json:"valid_from,omitempty"`
 	ValidTo   *time.Time `json:"valid_to,omitempty"`
+	ObservedAt *time.Time `json:"observed_at,omitempty"`
 
 	// Confidence in [0,1] range; defaults to 1.0 when not specified.
 	Confidence float64 `json:"confidence"`
@@ -68,7 +71,7 @@ func (a *Atom) IsValid() bool {
 		return false
 	}
 	switch a.Type {
-	case TypePreference, TypeFact, TypeEvent, TypeAttribute, TypeRelationship:
+	case TypePreference, TypeFact, TypeEvent, TypeAttribute, TypeRelationship, TypeProfile, TypeStatusChange:
 	default:
 		return false
 	}

--- a/internal/atom/atom.go
+++ b/internal/atom/atom.go
@@ -29,11 +29,11 @@ const (
 
 // Atom is a single extracted, typed belief or preference.
 type Atom struct {
-	ID     string `json:"id"`
+	ID      string `json:"id"`
 	Project string `json:"project"`
 
 	// Typed triple.
-	Type      string `json:"atom_type"`  // preference|fact|event|attribute|relationship
+	Type      string `json:"atom_type"` // preference|fact|event|attribute|relationship
 	Subject   string `json:"subject"`
 	Predicate string `json:"predicate"`
 	Value     string `json:"value"`
@@ -46,8 +46,8 @@ type Atom struct {
 	Scope string `json:"scope"`
 
 	// Bi-temporal columns (nil = unbounded).
-	ValidFrom *time.Time `json:"valid_from,omitempty"`
-	ValidTo   *time.Time `json:"valid_to,omitempty"`
+	ValidFrom  *time.Time `json:"valid_from,omitempty"`
+	ValidTo    *time.Time `json:"valid_to,omitempty"`
 	ObservedAt *time.Time `json:"observed_at,omitempty"`
 
 	// Confidence in [0,1] range; defaults to 1.0 when not specified.

--- a/internal/atom/extract.go
+++ b/internal/atom/extract.go
@@ -21,8 +21,8 @@ type Extractor interface {
 }
 
 // ClaudeExtractor uses a Claude language model to extract typed atoms from
-// freeform session text. It is preference-focused (Milestone 1): the prompt
-// emphasises casual-language preferences that keyword-based extractors miss.
+// freeform session text. It focuses on preference/profile/status-state signals
+// expressed in casual language that keyword-based extractors miss.
 type ClaudeExtractor struct {
 	client ClaudeCompleter
 }
@@ -40,7 +40,7 @@ const maxSessionChars = 6000
 // Milestone 1 targets casual-language preferences — statements like "I usually
 // prefer X", "I don't really like Y", "I tend to go with Z" — which PatternPreferenceExtractor
 // misses because they don't match keyword anchors.
-const extractionSystem = `You are a precise preference and fact extraction assistant.
+const extractionSystem = `You are a precise preference and state extraction assistant.
 Given a passage of conversational text, identify typed atoms — minimal, self-contained
 beliefs or preferences stated by the user.
 
@@ -52,10 +52,14 @@ Focus especially on PREFERENCES expressed in casual language:
 These casual phrasings are easy to miss — capture them even when they are
 stated indirectly or embedded in a longer sentence.
 
+Also capture stable PROFILE facts and STATUS CHANGES when they are stated plainly:
+  "I'm vegetarian", "I work nights", "I'm based in Seattle",
+  "I started a new job", "I moved to Boston", "I switched to Android"
+
 Return ONLY a JSON array of atom objects — no prose, no markdown fences — in this exact schema:
 [
   {
-    "atom_type": "<preference|fact|event|attribute|relationship>",
+    "atom_type": "<preference|profile|status_change|fact|event|attribute|relationship>",
     "subject":   "<who or what the atom is about>",
     "predicate": "<the property or relationship>",
     "value":     "<the stated value, choice, or belief>",
@@ -67,7 +71,9 @@ Return ONLY a JSON array of atom objects — no prose, no markdown fences — in
 ]
 
 Rules:
-- atom_type must be exactly one of: preference, fact, event, attribute, relationship.
+- atom_type must be exactly one of: preference, profile, status_change, fact, event, attribute, relationship.
+- use profile for relatively stable user descriptors (diet, location, profession, timezone, routine).
+- use status_change for explicit updates or transitions in user state ("started", "moved", "switched", "stopped").
 - subject should be the first-person actor ("the user") or a named entity.
 - Normalise subject to "the user" for first-person statements.
 - statement must be a complete, standalone sentence (no pronouns requiring external context).
@@ -96,7 +102,7 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string) ([]At
 		sessionText = string([]rune(sessionText)[:maxSessionChars])
 	}
 
-	prompt := "Extract typed atoms (focus on preferences) from the following session text:\n\n" + sessionText
+	prompt := "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n" + sessionText
 
 	raw, err := e.client.Complete(ctx, extractionSystem, prompt,
 		"claude-sonnet-4-6", "claude-opus-4-6", 0, 2048)

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -259,6 +259,40 @@ func TestClaudeExtractor_FactAtom(t *testing.T) {
 	assert.Equal(t, "Alice", atoms[0].Subject)
 }
 
+func TestExtractProfileAndStatusChange(t *testing.T) {
+	stub := &stubCompleter{response: `[
+  {
+    "atom_type": "profile",
+    "subject": "the user",
+    "predicate": "diet",
+    "value": "vegetarian",
+    "statement": "The user is vegetarian.",
+    "scope": "global",
+    "confidence": 0.95,
+    "source_span": "I'm vegetarian"
+  },
+  {
+    "atom_type": "status_change",
+    "subject": "the user",
+    "predicate": "job",
+    "value": "started a new role at Acme",
+    "statement": "The user started a new role at Acme.",
+    "scope": "global",
+    "confidence": 0.9,
+    "source_span": "I started a new role at Acme"
+  }
+]`}
+	ext := atom.NewClaudeExtractor(stub)
+
+	atoms, err := ext.Extract(context.Background(), "I'm vegetarian, and I started a new role at Acme.")
+	require.NoError(t, err)
+	require.Len(t, atoms, 2)
+	assert.Equal(t, "profile", atoms[0].Type)
+	assert.Equal(t, "status_change", atoms[1].Type)
+	assert.Contains(t, atom.ExtractionPrompt(), "profile")
+	assert.Contains(t, atom.ExtractionPrompt(), "status_change")
+}
+
 func TestExtractionPrompt_ContainsPreferenceFocus(t *testing.T) {
 	prompt := atom.ExtractionPrompt()
 	// Verify the prompt instructs the model to capture casual preference language.

--- a/internal/atom/worker.go
+++ b/internal/atom/worker.go
@@ -135,6 +135,10 @@ func (w *Worker) processJob(ctx context.Context, job ExtractionJob) {
 	for i := range candidates {
 		candidates[i].Project = job.Project
 		candidates[i].ProvenanceMemoryID = job.MemoryID
+		if !mem.CreatedAt.IsZero() {
+			observedAt := mem.CreatedAt
+			candidates[i].ObservedAt = &observedAt
+		}
 	}
 
 	// Load all active atoms for the project to drive deduplication.

--- a/internal/atom/worker_test.go
+++ b/internal/atom/worker_test.go
@@ -173,3 +173,34 @@ func TestWorker_MarkJobCompleteOnSuccess(t *testing.T) {
 	assert.True(t, seen, "job should be marked complete")
 	assert.NoError(t, jobErr)
 }
+
+func TestWorkerSetsObservedAt(t *testing.T) {
+	backend := newStubBackend()
+	createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
+	backend.jobs = []atom.ExtractionJob{{ID: "job-observed", MemoryID: "mem-observed", Project: "proj"}}
+	backend.memories["mem-observed"] = &types.Memory{
+		ID:        "mem-observed",
+		Content:   "I prefer mint tea.",
+		CreatedAt: createdAt,
+	}
+	ext := &stubExtractor{atoms: []atom.Atom{
+		{
+			Type: atom.TypePreference, Subject: "the user", Predicate: "prefers",
+			Value: "mint tea", Statement: "The user prefers mint tea.", Scope: atom.ScopeGlobal, Confidence: 0.9,
+		},
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	w := atom.NewWorker(backend, ext, atom.WorkerConfig{
+		PollInterval: time.Millisecond,
+		Projects:     []string{"proj"},
+	})
+	go w.Run(ctx)
+	<-ctx.Done()
+	time.Sleep(50 * time.Millisecond)
+
+	require.NotEmpty(t, backend.inserted)
+	require.NotNil(t, backend.inserted[0].ObservedAt)
+	assert.True(t, backend.inserted[0].ObservedAt.Equal(createdAt))
+}

--- a/internal/db/migration_test.go
+++ b/internal/db/migration_test.go
@@ -49,7 +49,7 @@ func TestMigration029AtomsObservedAt(t *testing.T) {
 			FROM pg_indexes
 			WHERE tablename = 'atoms'
 			  AND indexdef ILIKE '%(project, atom_type, observed_at DESC)%'
-			  AND indexdef ILIKE '%WHERE valid_to IS NULL%'
+			  AND indexdef ILIKE '%valid_to IS NULL%'
 		)`).
 		Scan(&hasLatestOnlyIndex)
 	require.NoError(t, err)

--- a/internal/db/migration_test.go
+++ b/internal/db/migration_test.go
@@ -1,0 +1,57 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigration029AtomsObservedAt(t *testing.T) {
+	proj := uniqueProject("migration-029-atoms")
+	ctx := context.Background()
+
+	backend, err := db.NewPostgresBackend(ctx, proj, testutil.DSN(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	var hasObservedAt bool
+	err = backend.Pool().QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_name = 'atoms'
+			  AND column_name = 'observed_at'
+		)`).
+		Scan(&hasObservedAt)
+	require.NoError(t, err)
+	require.True(t, hasObservedAt, "migration 029 must add atoms.observed_at")
+
+	var allowsProfile bool
+	err = backend.Pool().QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_constraint
+			WHERE conrelid = 'atoms'::regclass
+			  AND pg_get_constraintdef(oid) ILIKE '%profile%'
+			  AND pg_get_constraintdef(oid) ILIKE '%status_change%'
+		)`).
+		Scan(&allowsProfile)
+	require.NoError(t, err)
+	require.True(t, allowsProfile, "migration 029 must widen the atom_type CHECK to include profile and status_change")
+
+	var hasLatestOnlyIndex bool
+	err = backend.Pool().QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_indexes
+			WHERE tablename = 'atoms'
+			  AND indexdef ILIKE '%(project, atom_type, observed_at DESC)%'
+			  AND indexdef ILIKE '%WHERE valid_to IS NULL%'
+		)`).
+		Scan(&hasLatestOnlyIndex)
+	require.NoError(t, err)
+	require.True(t, hasLatestOnlyIndex, "migration 029 must create the LatestOnly observed_at index")
+}

--- a/internal/db/migrations/029_atoms_observed_at.sql
+++ b/internal/db/migrations/029_atoms_observed_at.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+ALTER TABLE atoms
+    ADD COLUMN IF NOT EXISTS observed_at TIMESTAMPTZ;
+
+UPDATE atoms
+SET observed_at = created_at
+WHERE observed_at IS NULL;
+
+ALTER TABLE atoms
+    DROP CONSTRAINT IF EXISTS atoms_atom_type_check;
+
+ALTER TABLE atoms
+    ADD CONSTRAINT atoms_atom_type_check CHECK (atom_type IN (
+        'preference', 'profile', 'status_change', 'fact', 'event', 'attribute', 'relationship'
+    ));
+
+CREATE INDEX IF NOT EXISTS idx_atoms_project_type_observed_at
+    ON atoms (project, atom_type, observed_at DESC)
+    WHERE valid_to IS NULL;
+
+COMMIT;

--- a/internal/db/postgres_atom.go
+++ b/internal/db/postgres_atom.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	pgvector "github.com/pgvector/pgvector-go"
 	"github.com/petersimmons1972/engram/internal/atom"
+	pgvector "github.com/pgvector/pgvector-go"
 )
 
 // AtomQueryOpts controls filtered active-atom queries.

--- a/internal/db/postgres_atom.go
+++ b/internal/db/postgres_atom.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,6 +10,13 @@ import (
 	pgvector "github.com/pgvector/pgvector-go"
 	"github.com/petersimmons1972/engram/internal/atom"
 )
+
+// AtomQueryOpts controls filtered active-atom queries.
+type AtomQueryOpts struct {
+	AtomType   string
+	AsOf       *time.Time
+	LatestOnly bool
+}
 
 // InsertAtom inserts a new atom into the atoms table. A UUIDv4 ID is generated
 // if a.ID is empty. The atom's Project must be set by the caller.
@@ -20,20 +28,24 @@ func (p *PostgresBackend) InsertAtom(ctx context.Context, a *atom.Atom) error {
 	if a.CreatedAt.IsZero() {
 		a.CreatedAt = time.Now().UTC()
 	}
+	if a.ObservedAt == nil {
+		observedAt := a.CreatedAt
+		a.ObservedAt = &observedAt
+	}
 	_, err := p.pool.Exec(ctx, `
 		INSERT INTO atoms (
 			id, project, atom_type, subject, predicate, value,
 			statement, scope, valid_from, valid_to, confidence,
-			provenance_memory_id, provenance_span, supersedes, created_at
+			provenance_memory_id, provenance_span, supersedes, observed_at, created_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6,
 			$7, $8, $9, $10, $11,
-			$12, $13, $14, $15
+			$12, $13, $14, $15, $16
 		) ON CONFLICT (id) DO NOTHING`,
 		a.ID, a.Project, a.Type, a.Subject, a.Predicate, a.Value,
 		a.Statement, a.Scope, a.ValidFrom, a.ValidTo, a.Confidence,
 		nullableString(a.ProvenanceMemoryID), nullableString(a.ProvenanceSpan),
-		nullableString(a.Supersedes), a.CreatedAt,
+		nullableString(a.Supersedes), a.ObservedAt, a.CreatedAt,
 	)
 	return err
 }
@@ -71,30 +83,51 @@ func (p *PostgresBackend) RetireAtom(ctx context.Context, atomID string, validTo
 // GetActiveAtoms returns all atoms for the project with valid_to IS NULL.
 // If atomType is non-empty, results are filtered to that type.
 func (p *PostgresBackend) GetActiveAtoms(ctx context.Context, project string, atomType string) ([]atom.Atom, error) {
-	var rows interface{ Close() }
-	var err error
+	return p.GetActiveAtomsFiltered(ctx, project, AtomQueryOpts{AtomType: atomType})
+}
 
-	if atomType == "" {
-		rows, err = p.pool.Query(ctx, `
-			SELECT id, project, atom_type, subject, predicate, value,
-			       statement, scope, valid_from, valid_to, confidence,
-			       COALESCE(provenance_memory_id,''), COALESCE(provenance_span,''),
-			       COALESCE(supersedes,''), created_at
-			FROM atoms
-			WHERE project = $1 AND valid_to IS NULL
-			ORDER BY created_at DESC`,
-			project)
-	} else {
-		rows, err = p.pool.Query(ctx, `
-			SELECT id, project, atom_type, subject, predicate, value,
-			       statement, scope, valid_from, valid_to, confidence,
-			       COALESCE(provenance_memory_id,''), COALESCE(provenance_span,''),
-			       COALESCE(supersedes,''), created_at
-			FROM atoms
-			WHERE project = $1 AND atom_type = $2 AND valid_to IS NULL
-			ORDER BY created_at DESC`,
-			project, atomType)
+// GetActiveAtomsFiltered returns active atoms with optional type/as-of/latest filtering.
+func (p *PostgresBackend) GetActiveAtomsFiltered(ctx context.Context, project string, opts AtomQueryOpts) ([]atom.Atom, error) {
+	where := []string{"project = $1", "valid_to IS NULL"}
+	args := []interface{}{project}
+	nextArg := 2
+
+	if opts.AtomType != "" {
+		where = append(where, fmt.Sprintf("atom_type = $%d", nextArg))
+		args = append(args, opts.AtomType)
+		nextArg++
 	}
+	if opts.AsOf != nil {
+		where = append(where, fmt.Sprintf("observed_at <= $%d", nextArg))
+		args = append(args, *opts.AsOf)
+		nextArg++
+	}
+
+	selectClause := `
+		SELECT id, project, atom_type, subject, predicate, value,
+		       statement, scope, valid_from, valid_to, observed_at, confidence,
+		       COALESCE(provenance_memory_id,''), COALESCE(provenance_span,''),
+		       COALESCE(supersedes,''), created_at
+		FROM atoms`
+	if opts.LatestOnly {
+		selectClause = `
+		SELECT DISTINCT ON (subject, predicate)
+		       id, project, atom_type, subject, predicate, value,
+		       statement, scope, valid_from, valid_to, observed_at, confidence,
+		       COALESCE(provenance_memory_id,''), COALESCE(provenance_span,''),
+		       COALESCE(supersedes,''), created_at
+		FROM atoms`
+	}
+
+	orderBy := "ORDER BY observed_at DESC NULLS LAST, created_at DESC"
+	if opts.LatestOnly {
+		orderBy = "ORDER BY subject, predicate, observed_at DESC NULLS LAST, created_at DESC"
+	}
+
+	rows, err := p.pool.Query(ctx, `
+		`+selectClause+`
+		WHERE `+strings.Join(where, " AND ")+`
+		`+orderBy, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -115,17 +148,40 @@ func (p *PostgresBackend) EnqueueAtomExtractionJob(ctx context.Context, memoryID
 // ClaimAtomExtractionJobs atomically marks up to limit pending jobs as
 // 'processing' for the given project and returns them.
 func (p *PostgresBackend) ClaimAtomExtractionJobs(ctx context.Context, project string, limit int) ([]atom.ExtractionJob, error) {
-	pgRows, err := p.pool.Query(ctx, `
-		UPDATE atom_extraction_jobs
-		SET status = 'processing'
-		WHERE id IN (
-			SELECT id FROM atom_extraction_jobs
-			WHERE project = $1 AND status = 'pending'
-			ORDER BY created_at ASC
-			LIMIT $2
-			FOR UPDATE SKIP LOCKED
-		)
-		RETURNING id, memory_id, project`, project, limit)
+	var (
+		pgRows interface {
+			Close()
+			Next() bool
+			Scan(dest ...interface{}) error
+			Err() error
+		}
+		err error
+	)
+	if project == "" {
+		pgRows, err = p.pool.Query(ctx, `
+			UPDATE atom_extraction_jobs
+			SET status = 'processing'
+			WHERE id IN (
+				SELECT id FROM atom_extraction_jobs
+				WHERE status = 'pending'
+				ORDER BY created_at ASC
+				LIMIT $1
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING id, memory_id, project`, limit)
+	} else {
+		pgRows, err = p.pool.Query(ctx, `
+			UPDATE atom_extraction_jobs
+			SET status = 'processing'
+			WHERE id IN (
+				SELECT id FROM atom_extraction_jobs
+				WHERE project = $1 AND status = 'pending'
+				ORDER BY created_at ASC
+				LIMIT $2
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING id, memory_id, project`, project, limit)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +241,7 @@ func scanAtomRows(rows interface{ Close() }) ([]atom.Atom, error) {
 		var a atom.Atom
 		if err := r.Scan(
 			&a.ID, &a.Project, &a.Type, &a.Subject, &a.Predicate, &a.Value,
-			&a.Statement, &a.Scope, &a.ValidFrom, &a.ValidTo, &a.Confidence,
+			&a.Statement, &a.Scope, &a.ValidFrom, &a.ValidTo, &a.ObservedAt, &a.Confidence,
 			&a.ProvenanceMemoryID, &a.ProvenanceSpan,
 			&a.Supersedes, &a.CreatedAt,
 		); err != nil {

--- a/internal/db/postgres_atom.go
+++ b/internal/db/postgres_atom.go
@@ -100,7 +100,8 @@ func (p *PostgresBackend) GetActiveAtomsFiltered(ctx context.Context, project st
 	if opts.AsOf != nil {
 		where = append(where, fmt.Sprintf("observed_at <= $%d", nextArg))
 		args = append(args, *opts.AsOf)
-		nextArg++
+		// nextArg is intentionally not incremented here: AsOf is the last
+		// positional clause. Re-add `nextArg++` if another $-clause is appended below.
 	}
 
 	selectClause := `

--- a/internal/db/postgres_atom_test.go
+++ b/internal/db/postgres_atom_test.go
@@ -1,0 +1,88 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetActiveAtomsFiltered_LatestOnly_AsOf(t *testing.T) {
+	proj := uniqueProject("atoms-filtered")
+	ctx := context.Background()
+
+	backend, err := db.NewPostgresBackend(ctx, proj, testDSN(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	earlier := time.Date(2024, 1, 10, 9, 0, 0, 0, time.UTC)
+	later := time.Date(2024, 2, 20, 9, 0, 0, 0, time.UTC)
+	other := time.Date(2024, 2, 5, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, backend.InsertAtom(ctx, &atom.Atom{
+		Project:    proj,
+		Type:       atom.TypePreference,
+		Subject:    "the user",
+		Predicate:  "prefers_drink",
+		Value:      "coffee",
+		Statement:  "The user prefers coffee.",
+		Scope:      atom.ScopeGlobal,
+		Confidence: 0.9,
+		ObservedAt: &earlier,
+	}))
+	require.NoError(t, backend.InsertAtom(ctx, &atom.Atom{
+		Project:    proj,
+		Type:       atom.TypePreference,
+		Subject:    "the user",
+		Predicate:  "prefers_drink",
+		Value:      "tea",
+		Statement:  "The user prefers tea.",
+		Scope:      atom.ScopeGlobal,
+		Confidence: 0.95,
+		ObservedAt: &later,
+	}))
+	require.NoError(t, backend.InsertAtom(ctx, &atom.Atom{
+		Project:    proj,
+		Type:       atom.TypePreference,
+		Subject:    "the user",
+		Predicate:  "favorite_color",
+		Value:      "green",
+		Statement:  "The user's favorite color is green.",
+		Scope:      atom.ScopeGlobal,
+		Confidence: 0.8,
+		ObservedAt: &other,
+	}))
+
+	atoms, err := backend.GetActiveAtomsFiltered(ctx, proj, db.AtomQueryOpts{
+		AtomType:   atom.TypePreference,
+		LatestOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, atoms, 2, "LatestOnly must return one row per (subject,predicate)")
+	require.Equal(t, "tea", valueForPredicate(t, atoms, "prefers_drink"))
+	require.Equal(t, "green", valueForPredicate(t, atoms, "favorite_color"))
+
+	cutoff := time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)
+	asOfAtoms, err := backend.GetActiveAtomsFiltered(ctx, proj, db.AtomQueryOpts{
+		AtomType:   atom.TypePreference,
+		AsOf:       &cutoff,
+		LatestOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, asOfAtoms, 1, "AsOf must exclude atoms observed after the cutoff")
+	require.Equal(t, "coffee", valueForPredicate(t, asOfAtoms, "prefers_drink"))
+}
+
+func valueForPredicate(t *testing.T, atoms []atom.Atom, predicate string) string {
+	t.Helper()
+	for _, a := range atoms {
+		if a.Predicate == predicate {
+			return a.Value
+		}
+	}
+	t.Fatalf("predicate %q not found in result set", predicate)
+	return ""
+}

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -442,7 +442,7 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 	// Parse both and prefer whichever is populated.
 	var resp struct {
 		AtomPreamble string `json:"atom_preamble"`
-		Results []struct {
+		Results      []struct {
 			Memory struct {
 				ID string `json:"id"`
 			} `json:"memory"`

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -269,6 +269,13 @@ func (c *Client) RecallWithDateRange(ctx context.Context, project, query string,
 	})
 }
 
+// RecallResult is the structured memory_recall response used by LongMemEval
+// when auxiliary metadata such as atom preambles must survive transport.
+type RecallResult struct {
+	IDs          []string
+	AtomPreamble string
+}
+
 // RecallWithTemporalWindow enables the server-side H-NEW-1 two-pass date-windowed
 // recall: the server parses temporal anchors from questionText against questionDate
 // and unions a date-filtered pass with the unfiltered pass. questionText/questionDate
@@ -290,6 +297,17 @@ func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK
 	})
 }
 
+// RecallWithAtomRecall calls memory_recall and preserves any returned atom preamble.
+func (c *Client) RecallWithAtomRecall(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost, exactFactBoost bool, atomRecallAsOf *time.Time) (RecallResult, error) {
+	return c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		topicAnchorBoost: topicAnchorBoost,
+		exactFactBoost:   exactFactBoost,
+		atomRecall:       true,
+		atomRecallAsOf:   atomRecallAsOf,
+	})
+}
+
 // recallParams carries the optional knobs for a single memory_recall call.
 type recallParams struct {
 	project          string
@@ -302,29 +320,39 @@ type recallParams struct {
 	questionDate     string
 	exactFactBoost   bool
 	topicAnchorBoost bool
+	atomRecall       bool
+	atomRecallAsOf   *time.Time
 }
 
 func (c *Client) recallWithParams(ctx context.Context, p recallParams) ([]string, error) {
+	result, err := c.recallResultWithParams(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return result.IDs, nil
+}
+
+func (c *Client) recallResultWithParams(ctx context.Context, p recallParams) (RecallResult, error) {
 	var lastErr error
 	for attempt := 0; attempt <= c.retries; attempt++ {
 		if attempt > 0 {
 			// Reconnect — previous connection may be dead (SSE drop race).
 			if err := c.Connect(ctx); err != nil {
-				return nil, fmt.Errorf("reconnect on retry %d: %w", attempt, err)
+				return RecallResult{}, fmt.Errorf("reconnect on retry %d: %w", attempt, err)
 			}
 			select {
 			case <-time.After(5 * time.Second):
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return RecallResult{}, ctx.Err()
 			}
 		}
-		ids, err := c.recall(ctx, p)
+		result, err := c.recall(ctx, p)
 		if err == nil {
-			return ids, nil
+			return result, nil
 		}
 		lastErr = err
 	}
-	return nil, lastErr
+	return RecallResult{}, lastErr
 }
 
 // RecallOpts holds optional parameters for the LongMemEval recall client.
@@ -343,7 +371,7 @@ func (c *Client) RecallWithExactBoost(ctx context.Context, project, query string
 	})
 }
 
-func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
+func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, error) {
 	args := map[string]any{
 		"query":   p.query,
 		"project": p.project,
@@ -375,6 +403,12 @@ func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 	if p.topicAnchorBoost {
 		args["topic_anchor_boost"] = true
 	}
+	if p.atomRecall {
+		args["atom_recall"] = true
+	}
+	if p.atomRecallAsOf != nil {
+		args["atom_recall_as_of"] = p.atomRecallAsOf.UTC().Format(time.RFC3339)
+	}
 	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name:      "memory_recall",
@@ -382,17 +416,17 @@ func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 		},
 	})
 	if err != nil {
-		return nil, err
+		return RecallResult{}, err
 	}
 	if result.IsError {
-		return nil, toolErrorMsg(result, "memory_recall")
+		return RecallResult{}, toolErrorMsg(result, "memory_recall")
 	}
 	if len(result.Content) == 0 {
-		return nil, fmt.Errorf("memory_recall returned no content")
+		return RecallResult{}, fmt.Errorf("memory_recall returned no content")
 	}
 	tc, ok := result.Content[0].(mcp.TextContent)
 	if !ok {
-		return nil, fmt.Errorf("unexpected content type from memory_recall: %T", result.Content[0])
+		return RecallResult{}, fmt.Errorf("unexpected content type from memory_recall: %T", result.Content[0])
 	}
 	if os.Getenv("LME_DEBUG_RECALL") != "" {
 		preview := tc.Text
@@ -407,6 +441,7 @@ func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 	//   handle: {"handles":[{"id":"...","score":...}, ...]}
 	// Parse both and prefer whichever is populated.
 	var resp struct {
+		AtomPreamble string `json:"atom_preamble"`
 		Results []struct {
 			Memory struct {
 				ID string `json:"id"`
@@ -419,7 +454,7 @@ func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 		} `json:"handles"`
 	}
 	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
-		return nil, fmt.Errorf("parse recall response: %w", err)
+		return RecallResult{}, fmt.Errorf("parse recall response: %w", err)
 	}
 	ids := make([]string, 0, len(resp.Results)+len(resp.Handles))
 	for _, r := range resp.Results {
@@ -432,7 +467,7 @@ func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 			ids = append(ids, h.ID)
 		}
 	}
-	return ids, nil
+	return RecallResult{IDs: ids, AtomPreamble: resp.AtomPreamble}, nil
 }
 
 // FetchContent fetches the full content of a memory by ID within a project.

--- a/internal/longmemeval/types.go
+++ b/internal/longmemeval/types.go
@@ -61,6 +61,8 @@ type RunEntry struct {
 	RetrievedIDs []string `json:"retrieved_ids"` // memory IDs in ranked order
 	Status       string   `json:"status"`
 	Error        string   `json:"error,omitempty"`
+	AtomRetrieved bool    `json:"atom_retrieved,omitempty"`
+	AtomInContext bool    `json:"atom_in_context,omitempty"`
 	// Oracle probe fields (--atom-oracle, Phase 2A #1079). Omitted when zero/false.
 	OracleZeroAtoms bool `json:"oracle_zero_atoms,omitempty"` // set when --atom-oracle extracted zero atoms
 	OracleAtomCount int  `json:"oracle_atom_count,omitempty"` // atoms extracted and injected

--- a/internal/longmemeval/types.go
+++ b/internal/longmemeval/types.go
@@ -56,13 +56,13 @@ type IngestEntry struct {
 
 // RunEntry is one line written to checkpoint-run.jsonl.
 type RunEntry struct {
-	QuestionID   string   `json:"question_id"`
-	Hypothesis   string   `json:"hypothesis"`
-	RetrievedIDs []string `json:"retrieved_ids"` // memory IDs in ranked order
-	Status       string   `json:"status"`
-	Error        string   `json:"error,omitempty"`
-	AtomRetrieved bool    `json:"atom_retrieved,omitempty"`
-	AtomInContext bool    `json:"atom_in_context,omitempty"`
+	QuestionID    string   `json:"question_id"`
+	Hypothesis    string   `json:"hypothesis"`
+	RetrievedIDs  []string `json:"retrieved_ids"` // memory IDs in ranked order
+	Status        string   `json:"status"`
+	Error         string   `json:"error,omitempty"`
+	AtomRetrieved bool     `json:"atom_retrieved,omitempty"`
+	AtomInContext bool     `json:"atom_in_context,omitempty"`
 	// Oracle probe fields (--atom-oracle, Phase 2A #1079). Omitted when zero/false.
 	OracleZeroAtoms bool `json:"oracle_zero_atoms,omitempty"` // set when --atom-oracle extracted zero atoms
 	OracleAtomCount int  `json:"oracle_atom_count,omitempty"` // atoms extracted and injected

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -109,6 +109,15 @@ func sanitizeMemoryFloatFields(m *types.Memory) {
 	}
 }
 
+func atomPreambleForResults(results []types.SearchResult) string {
+	for _, r := range results {
+		if r.AtomPreamble != "" {
+			return r.AtomPreamble
+		}
+	}
+	return ""
+}
+
 func sanitizeRecallResults(results []types.SearchResult) {
 	for i := range results {
 		results[i].Score = finiteOrZero(results[i].Score)
@@ -332,6 +341,12 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	temporalWindowRecall := getBool(args, "temporal_window_recall", false)
 	questionText := getString(args, "question_text", "")
 	questionDate := getString(args, "question_date", "")
+	atomRecallAsOf, err := parseRecallTimeArg(args, "atom_recall_as_of")
+	if err != nil {
+		return nil, err
+	}
+	opts.AtomRecallEnabled = getBool(args, "atom_recall", false)
+	opts.AtomRecallAsOf = atomRecallAsOf
 
 	// Federated path: "projects" overrides the single-project recall.
 	projectNames, err := toStringSlice(args["projects"])
@@ -542,6 +557,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if opts.EvidenceFirstPack {
 		results = search.OrderResultsEvidenceFirst(results, query)
 	}
+	atomPreamble := atomPreambleForResults(results)
 
 	// When ENGRAM_DEGRADED_ERROR_MODE=structured and the embed pipeline degraded,
 	// surface a structured error instead of silently returning BM25 results.
@@ -560,6 +576,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
 			"degraded":   degradedMap(embedDegraded, embedDegradeReason),
 		}
+		if atomPreamble != "" {
+			out["atom_preamble"] = atomPreamble
+		}
 		if embedDegraded {
 			addRecallDegradedWarning(out, cfg.RouterURL, embedDegradeReason)
 		}
@@ -571,6 +590,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 	sanitizeRecallResults(results)
 	out := map[string]any{"results": results, "count": len(results)}
+	if atomPreamble != "" {
+		out["atom_preamble"] = atomPreamble
+	}
 	if eventID != "" {
 		out["event_id"] = eventID
 		out["feedback_hint"] = "Call memory_feedback with this event_id and the memory_ids you used"

--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -24,6 +25,10 @@ import (
 //
 // Declared as a var (not const) so tests can substitute a shorter duration.
 var storeTimeout = 10 * time.Second
+
+type atomJobEnqueuer interface {
+	EnqueueAtomExtractionJob(ctx context.Context, memoryID, project string) error
+}
 
 func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
@@ -105,6 +110,7 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		}
 		return nil, err
 	}
+	enqueueAtomExtractionJob(ctx, h.Engine.Backend(), m.ID, project)
 
 	// Preference extraction: when the memory is not already typed as a preference,
 	// run the extractor and store each discovered fact as a separate short preference
@@ -335,6 +341,9 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 		}
 		return nil, err
 	}
+	for _, m := range memories {
+		enqueueAtomExtractionJob(ctx, h.Engine.Backend(), m.ID, project)
+	}
 
 	ids := make([]string, len(memories))
 	for i, m := range memories {
@@ -410,6 +419,28 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		return nil, fmt.Errorf("memory %q not found or has been soft-deleted", id)
 	}
 	return toolResult(updated)
+}
+
+func enqueueAtomExtractionJob(ctx context.Context, backend interface{}, memoryID, project string) {
+	if !atomExtractionEnabled() {
+		return
+	}
+	enqueuer, ok := backend.(atomJobEnqueuer)
+	if !ok {
+		return
+	}
+	if err := enqueuer.EnqueueAtomExtractionJob(ctx, memoryID, project); err != nil {
+		slog.Warn("failed to enqueue atom extraction job", "memory_id", memoryID, "project", project, "err", err)
+	}
+}
+
+func atomExtractionEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_ATOM_EXTRACTION_ENABLED"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // handleMemoryForget soft-deletes a memory by ID (sets valid_to=NOW(), preserves history).

--- a/internal/mcp/tools_store_test.go
+++ b/internal/mcp/tools_store_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,30 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 	"github.com/stretchr/testify/require"
 )
+
+type atomEnqueueBackend struct {
+	storeCapableBackend
+	mu          sync.Mutex
+	enqueuedIDs []string
+}
+
+func (b *atomEnqueueBackend) EnqueueAtomExtractionJob(_ context.Context, memoryID, _ string) error {
+	b.mu.Lock()
+	b.enqueuedIDs = append(b.enqueuedIDs, memoryID)
+	b.mu.Unlock()
+	return nil
+}
+
+func newAtomEnqueuePool(t *testing.T, back *atomEnqueueBackend) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, back, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
 
 // ── #762: memory_store_batch drops valid_from ─────────────────────────────────
 
@@ -237,6 +262,47 @@ func TestMemoryStoreDocument_PersistsValidFromAndEpisode(t *testing.T) {
 		"ValidFrom must equal 2024-03-20 UTC, got %s", m.ValidFrom)
 
 	require.Equal(t, episodeID, m.EpisodeID, "EpisodeID must be propagated — see issue #763")
+}
+
+func TestStoreEnqueuesAtomJobWhenEnabled(t *testing.T) {
+	t.Run("single store", func(t *testing.T) {
+		back := &atomEnqueueBackend{}
+		pool := newAtomEnqueuePool(t, back)
+
+		t.Setenv("ENGRAM_ATOM_EXTRACTION_ENABLED", "true")
+		req := mcpgo.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"project": "test",
+			"content": "I prefer mint tea.",
+		}
+
+		res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.False(t, res.IsError)
+		require.Len(t, back.enqueuedIDs, 1, "store must enqueue exactly one atom extraction job when enabled")
+	})
+
+	t.Run("batch store gated off by default", func(t *testing.T) {
+		back := &atomEnqueueBackend{}
+		pool := newAtomEnqueuePool(t, back)
+		_ = os.Unsetenv("ENGRAM_ATOM_EXTRACTION_ENABLED")
+
+		req := mcpgo.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"project": "test",
+			"memories": []any{
+				map[string]any{"content": "I prefer tea."},
+				map[string]any{"content": "I prefer coffee."},
+			},
+		}
+
+		res, err := handleMemoryStoreBatch(context.Background(), pool, req, testConfig())
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.False(t, res.IsError)
+		require.Empty(t, back.enqueuedIDs, "atom extraction must stay disabled by default")
+	})
 }
 
 // ── #789: handleMemoryCorrect silently clamps importance; should validate ────────

--- a/internal/search/atom_recall.go
+++ b/internal/search/atom_recall.go
@@ -3,8 +3,10 @@ package search
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/petersimmons1972/engram/internal/db"
 )
 
 // AtomRecallOpts controls atom-level retrieval.
@@ -21,6 +23,7 @@ type AtomRecallOpts struct {
 // cycle in tests).
 type AtomBackend interface {
 	GetActiveAtoms(ctx context.Context, project string, atomType string) ([]atom.Atom, error)
+	GetActiveAtomsFiltered(ctx context.Context, project string, opts db.AtomQueryOpts) ([]atom.Atom, error)
 }
 
 // RecallAtoms returns active atoms for the project, filtered by opts.AtomType
@@ -64,4 +67,36 @@ func FormatAtomsAsContext(atoms []atom.Atom) string {
 		b = append(b, '\n')
 	}
 	return string(b)
+}
+
+// RecallPreferenceAtoms returns the latest active preference atoms as a prompt-ready preamble.
+// Cold-start safe: when no atoms exist it returns "", nil.
+func RecallPreferenceAtoms(ctx context.Context, backend AtomBackend, project, query string, asOf *time.Time) (string, error) {
+	_ = query
+	atoms, err := backend.GetActiveAtomsFiltered(ctx, project, db.AtomQueryOpts{
+		AtomType:   atom.TypePreference,
+		AsOf:       asOf,
+		LatestOnly: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(atoms) == 0 {
+		return "", nil
+	}
+	sort.SliceStable(atoms, func(i, j int) bool {
+		switch {
+		case atoms[i].ObservedAt == nil && atoms[j].ObservedAt == nil:
+			return atoms[i].Confidence > atoms[j].Confidence
+		case atoms[i].ObservedAt == nil:
+			return false
+		case atoms[j].ObservedAt == nil:
+			return true
+		case atoms[i].ObservedAt.Equal(*atoms[j].ObservedAt):
+			return atoms[i].Confidence > atoms[j].Confidence
+		default:
+			return atoms[i].ObservedAt.After(*atoms[j].ObservedAt)
+		}
+	})
+	return FormatAtomsAsContext(atoms), nil
 }

--- a/internal/search/atom_recall_test.go
+++ b/internal/search/atom_recall_test.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/search"
 )
 
 // stubAtomBackend satisfies search.AtomBackend for unit tests.
 type stubAtomBackend struct {
-	atoms []atom.Atom
+	atoms    []atom.Atom
+	filtered []atom.Atom
+	lastOpts db.AtomQueryOpts
 }
 
 func (s *stubAtomBackend) GetActiveAtoms(_ context.Context, _ string, atomType string) ([]atom.Atom, error) {
@@ -28,6 +32,11 @@ func (s *stubAtomBackend) GetActiveAtoms(_ context.Context, _ string, atomType s
 		}
 	}
 	return filtered, nil
+}
+
+func (s *stubAtomBackend) GetActiveAtomsFiltered(_ context.Context, _ string, opts db.AtomQueryOpts) ([]atom.Atom, error) {
+	s.lastOpts = opts
+	return s.filtered, nil
 }
 
 func makeTestAtom(id, atomType, statement string, confidence float64) atom.Atom {
@@ -139,4 +148,37 @@ func TestFormatAtomsAsContext_NoTrailingGarbage(t *testing.T) {
 	result := search.FormatAtomsAsContext(atoms)
 	// Should end cleanly (newline after last atom).
 	assert.True(t, strings.HasSuffix(result, "\n"), "should end with newline")
+}
+
+func TestRecallPreferenceAtoms_LatestAndColdStart(t *testing.T) {
+	observedAt := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	backend := &stubAtomBackend{
+		filtered: []atom.Atom{
+			{
+				ID:         "a1",
+				Type:       atom.TypePreference,
+				Subject:    "the user",
+				Predicate:  "prefers",
+				Value:      "oolong tea",
+				Statement:  "The user prefers oolong tea.",
+				Scope:      atom.ScopeGlobal,
+				Confidence: 0.93,
+				ObservedAt: &observedAt,
+			},
+		},
+	}
+
+	asOf := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	preamble, err := search.RecallPreferenceAtoms(context.Background(), backend, "proj", "what tea do I like", &asOf)
+	require.NoError(t, err)
+	require.Contains(t, preamble, "The user prefers oolong tea.")
+	require.True(t, backend.lastOpts.LatestOnly, "RecallPreferenceAtoms must request LatestOnly")
+	require.Equal(t, atom.TypePreference, backend.lastOpts.AtomType)
+	require.NotNil(t, backend.lastOpts.AsOf)
+	require.True(t, backend.lastOpts.AsOf.Equal(asOf))
+
+	backend.filtered = nil
+	preamble, err = search.RecallPreferenceAtoms(context.Background(), backend, "proj", "what tea do I like", nil)
+	require.NoError(t, err)
+	assert.Empty(t, preamble, "cold start must return an empty preamble, not an error")
 }

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -2129,11 +2129,12 @@ type MigrateParams struct {
 // A background reembed worker will repopulate embeddings after this call.
 //
 // Safety guards (applied in order, highest priority first):
-//  G1 — Same-canonical-identity: returns no-op with chunks_nulled=0.
-//  G2 — Same dimension without force: soft-refused (result["error"] set).
-//  G3 — dry_run: counts affected chunks without nulling.
-//       Large volume without confirm: soft-refused.
-//  G4 — Canonical stamp: stores canonicalEmbedderName(NewModel) in meta.
+//
+//	G1 — Same-canonical-identity: returns no-op with chunks_nulled=0.
+//	G2 — Same dimension without force: soft-refused (result["error"] set).
+//	G3 — dry_run: counts affected chunks without nulling.
+//	     Large volume without confirm: soft-refused.
+//	G4 — Canonical stamp: stores canonicalEmbedderName(NewModel) in meta.
 func (e *SearchEngine) MigrateEmbedder(ctx context.Context, p MigrateParams) (map[string]any, error) {
 	newModel := p.NewModel
 

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -159,6 +159,14 @@ type RecallOpts struct {
 	// ordering is load-bearing (mirrors the run.go precedence rule).
 	// Default false (ablatable — no behavior change until explicitly enabled).
 	EvidenceFirstPack bool
+
+	// AtomRecallEnabled attaches a separate structured atom preamble for
+	// preference-shaped queries. The preamble is additive metadata only and does
+	// not enter composite scoring or the ranked result pool.
+	AtomRecallEnabled bool
+	// AtomRecallAsOf filters recalled atoms to observations at or before this
+	// point in time. Nil means no observed_at cutoff.
+	AtomRecallAsOf *time.Time
 }
 
 // ToHandles projects a slice of SearchResults into lightweight Handle references.
@@ -993,6 +1001,15 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	prefQuery := isPreferenceQuery(query)
 	tempQuery := isTemporalQuery(query)
 	kuQuery := isKnowledgeUpdateQuery(query)
+	atomPreamble := ""
+	if opts.AtomRecallEnabled && prefQuery {
+		if atomBackend, ok := e.backend.(AtomBackend); ok {
+			atomPreamble, err = RecallPreferenceAtoms(ctx, atomBackend, e.project, query, opts.AtomRecallAsOf)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	// Identifier query detection for exact-fact boost (LME #938 improvement #3).
 	// Only active when the caller enables the flag; detection is cheap (regex).
 	exactBoostEnabled := opts.ExactFactBoost && isIdentifierQuery(query)
@@ -1387,6 +1404,12 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 		}
 	}
 
+	if atomPreamble != "" {
+		for i := range results {
+			results[i].AtomPreamble = atomPreamble
+		}
+	}
+
 	return results, nil
 }
 
@@ -1495,6 +1518,10 @@ func (e *SearchEngine) maybeRerank(ctx context.Context, query string, topK int, 
 func mergeSearchResults(a, b []types.SearchResult, limit int) []types.SearchResult {
 	merged := make([]types.SearchResult, 0, len(a)+len(b))
 	seen := make(map[string]struct{}, len(a)+len(b))
+	atomPreamble := firstAtomPreamble(a)
+	if atomPreamble == "" {
+		atomPreamble = firstAtomPreamble(b)
+	}
 	for _, r := range a {
 		if r.Memory == nil {
 			continue
@@ -1518,7 +1545,21 @@ func mergeSearchResults(a, b []types.SearchResult, limit int) []types.SearchResu
 	if limit > 0 && len(merged) > limit {
 		merged = merged[:limit]
 	}
+	if atomPreamble != "" {
+		for i := range merged {
+			merged[i].AtomPreamble = atomPreamble
+		}
+	}
 	return merged
+}
+
+func firstAtomPreamble(results []types.SearchResult) string {
+	for _, r := range results {
+		if r.AtomPreamble != "" {
+			return r.AtomPreamble
+		}
+	}
+	return ""
 }
 
 // RecallWithinMemory returns up to topK chunks from a single memory's document

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/petersimmons1972/engram/internal/atom"
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/embed"
 	"github.com/petersimmons1972/engram/internal/search"
@@ -217,6 +218,55 @@ func TestSearchEngine_Status(t *testing.T) {
 	stats, err := engine.Status(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, stats)
+}
+
+func TestRecallAttachesAtomPreamble(t *testing.T) {
+	engine := newTestEngine(t, uniqueProject("test-atom-preamble"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	mem := &types.Memory{
+		ID:          types.NewMemoryID(),
+		Content:     "The user talks about tea preferences in this session.",
+		MemoryType:  types.MemoryTypePreference,
+		Importance:  2,
+		StorageMode: "focused",
+	}
+	require.NoError(t, engine.Store(ctx, mem))
+
+	observedAt := time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC)
+	pg, ok := engine.Backend().(*db.PostgresBackend)
+	require.True(t, ok, "test engine must use PostgresBackend")
+	require.NoError(t, pg.InsertAtom(ctx, &atom.Atom{
+		Project:    engine.Project(),
+		Type:       atom.TypePreference,
+		Subject:    "the user",
+		Predicate:  "prefers",
+		Value:      "tea",
+		Statement:  "The user prefers tea.",
+		Scope:      atom.ScopeGlobal,
+		Confidence: 0.95,
+		ObservedAt: &observedAt,
+	}))
+
+	results, err := engine.RecallWithOpts(ctx, "what drink do I prefer", 5, "summary", search.RecallOpts{
+		AtomRecallEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	require.Contains(t, results[0].AtomPreamble, "The user prefers tea.")
+
+	noAtom, err := engine.RecallWithOpts(ctx, "what drink do I prefer", 5, "summary", search.RecallOpts{})
+	require.NoError(t, err)
+	require.NotEmpty(t, noAtom)
+	require.Empty(t, noAtom[0].AtomPreamble, "atom preamble must stay disabled by default")
+
+	nonPref, err := engine.RecallWithOpts(ctx, "show my session about tea", 5, "summary", search.RecallOpts{
+		AtomRecallEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, nonPref)
+	require.Empty(t, nonPref[0].AtomPreamble, "non-preference queries must not attach atom preambles")
 }
 
 // TestRecallWithEvent_IncrementsTimesRetrieved verifies that RecallWithEvent

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -334,6 +334,7 @@ type SearchResult struct {
 	MatchedChunk      string             `json:"matched_chunk"`
 	ChunkScore        float64            `json:"chunk_score"`
 	MatchedChunkIndex int                `json:"matched_chunk_index"`
+	AtomPreamble      string             `json:"atom_preamble,omitempty"`
 
 	// Connected holds memories linked via the knowledge graph.
 	Connected []ConnectedMemory `json:"connected"`


### PR DESCRIPTION
Recovered from the fleet-dispatch `codex-agent` workspace (impl reached `needs-input` but no PR/branch was pushed — work was stranded in-container). Implements #1109. Draft for review.

Closes #1109.

🤖 Codex implementation, recovered + PR-opened by Claude.