### PR TITLE
feat(mcp): preference-enumerate as client-side synthesis directive (#1113)

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -88,6 +88,9 @@ type Config struct {
 
 	// H12: enumerate-first generation prompt (lme-h8h12h15 branch)
 	EnumerateFirst bool // inject enumerate-then-total instruction for aggregation questions (default off)
+
+	// H-PE: preference-enumerate generation prompt
+	PreferenceEnumerate bool // inject exhaustive named-item enumeration instruction for single-session-preference questions (default off)
 	// Retrieval-fusion flags for issue #938.
 	RetrievalFusion     bool // union multiple query variants (primary/raw/identifier queries)
 	ExactSignalBoost    bool // re-rank candidate IDs by exact identifier/entity overlap
@@ -255,6 +258,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.ExhaustiveAggregation, "exhaustive-aggregation", false, "H8: run a topK=500 sweep recall for count-shaped questions and union with primary results (default off)")
 	// H12: enumerate-first generation prompt (lme-h8h12h15 branch)
 	fs.BoolVar(&cfg.EnumerateFirst, "enumerate-first", false, "H12: inject enumerate-then-total generation instruction for aggregation questions (default off)")
+	// H-PE: preference-enumerate generation prompt
+	fs.BoolVar(&cfg.PreferenceEnumerate, "preference-enumerate", false, "H-PE: inject exhaustive named-item enumeration instruction for single-session-preference questions; lists every specific item/brand/attribute from context rather than abstractly summarising (default off)")
 	fs.BoolVar(&cfg.RetrievalFusion, "retrieval-fusion", false, "issue #938: fuse retrieval candidates from primary/raw/identifier query variants")
 	fs.BoolVar(&cfg.ExactSignalBoost, "exact-signal-boost", false, "issue #938: boost candidates that contain exact identifiers/entities from the question")
 	fs.BoolVar(&cfg.EvidenceFirstPacked, "evidence-first-pack", false, "issue #938: pack context in evidence-first order using exact overlap signals")

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -693,6 +693,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// the two are mutually exclusive. When both are set, aug wins.
 	// H12 (--enumerate-first) is orthogonal — it only fires for aggregation
 	// questions, which the temporal/preference branches above never match.
+	// H-PE (--preference-enumerate) is orthogonal — it only fires for
+	// single-session-preference questions and is independent of the other flags.
 	var prompt string
 	switch {
 	case cfg.TemporalPromptAug:
@@ -701,6 +703,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		prompt = longmemeval.GenerationPromptForTypeWithDateInjection(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.EnumerateFirst:
 		prompt = longmemeval.GenerationPromptForTypeEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
+	case cfg.PreferenceEnumerate:
+		prompt = longmemeval.GenerationPromptForTypePreferenceEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	default:
 		prompt = longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, contextBlocks)
 	}

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -507,6 +507,48 @@ func GenerationPromptForTypeEnumerate(question, questionType, questionDate strin
 	return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
 }
 
+// GenerationPromptForTypePreferenceEnumerate (H-PE) is like
+// GenerationPromptForType but applies the preference-enumerate variant for
+// single-session-preference questions when preferenceEnumerate is true. When
+// the flag is set and the question type is "single-session-preference", the
+// prompt instructs the model to exhaustively list every specific named
+// item/brand/attribute/feature the user expressed a preference about, rather
+// than summarising the preference abstractly. For all other question types or
+// when the flag is false the standard GenerationPromptForType output is
+// returned unchanged.
+// Activated by --preference-enumerate (Config.PreferenceEnumerate). Off by default.
+func GenerationPromptForTypePreferenceEnumerate(question, questionType, questionDate string, contextBlocks []string, preferenceEnumerate bool) string {
+	if preferenceEnumerate && questionType == "single-session-preference" {
+		return GenerationPromptPreferenceEnumerate(question, questionDate, contextBlocks)
+	}
+	return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
+}
+
+// GenerationPromptPreferenceEnumerate (H-PE) returns a generation prompt that
+// instructs the model to list every specific named item, brand, attribute, or
+// feature the user expressed a preference about that appears in the provided
+// context — not an abstract summary. Targets the judge failure mode where a
+// correct-substance answer is marked PARTIALLY_CORRECT because it omits the
+// specific concrete items the gold answer lists.
+func GenerationPromptPreferenceEnumerate(question, questionDate string, contextBlocks []string) string {
+	ctx := strings.Join(contextBlocks, "\n\n---\n\n")
+	return fmt.Sprintf(`You are describing a person's preferences based on their conversation history.
+
+Each memory block may begin with a "Session date: YYYY-MM-DD" header. The question was asked on %s.
+
+Relevant memory context:
+%s
+
+Question (asked on %s): %s
+
+Instructions:
+1. Read the context carefully and identify every specific named item, brand, model, attribute, or feature the user expressed a preference about that is relevant to the question.
+2. List each one explicitly — do not summarise or generalise. For example: name the specific product, brand, feature, or location rather than saying "functional accessories" or "a pool".
+3. Start your response with "The user prefers:" followed by the enumerated list.
+4. Include what the user would NOT prefer if the context supports it.
+5. Only include preferences found in the memory context. Do not invent items not present in the context.`, questionDate, ctx, questionDate, question)
+}
+
 // GenerationPromptEnumerateFirst (H12) returns a generation prompt that
 // instructs the model to enumerate each relevant event from the memory blocks
 // individually before computing a total. Forces an explicit intermediate

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -742,3 +742,70 @@ func TestGenerationPromptForTypeEnumerate_IgnoresEnumerateFirstForNonAggregation
 		}
 	}
 }
+
+// TestPreferenceEnumeratePrompt_SelectedForPreferenceType verifies that
+// GenerationPromptForTypePreferenceEnumerate selects the preference-enumerate
+// prompt when preferenceEnumerate=true AND question_type is
+// "single-session-preference". Guards H-PE flag routing.
+func TestPreferenceEnumeratePrompt_SelectedForPreferenceType(t *testing.T) {
+	question := "What kind of car accessories does the user prefer?"
+	contextBlocks := []string{
+		"Session date: 2024-02-10\nUser: I really want a Thule roof rack, a WeatherTech floor mat, and a Garmin dash cam.",
+	}
+	prompt := longmemeval.GenerationPromptForTypePreferenceEnumerate(
+		question, "single-session-preference", "2024-06-01",
+		contextBlocks,
+		true,
+	)
+	// The preference-enumerate prompt must contain enumeration instruction keywords.
+	enumerationHints := []string{"list", "each", "specific", "enumerate", "every"}
+	lowerPrompt := strings.ToLower(prompt)
+	found := false
+	for _, hint := range enumerationHints {
+		if strings.Contains(lowerPrompt, hint) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("preference-enumerate prompt must contain an enumeration instruction; got:\n%s", prompt)
+	}
+}
+
+// TestPreferenceEnumeratePrompt_FallsThrough_WhenFlagOff verifies that
+// GenerationPromptForTypePreferenceEnumerate falls through to the standard
+// preference prompt when preferenceEnumerate=false.
+func TestPreferenceEnumeratePrompt_FallsThrough_WhenFlagOff(t *testing.T) {
+	question := "What hotel features does the user want?"
+	contextBlocks := []string{
+		"Session date: 2024-03-01\nUser: I want a hotel with a rooftop pool.",
+	}
+	standardPrompt := longmemeval.GenerationPromptForType(
+		question, "single-session-preference", "2024-06-01", contextBlocks,
+	)
+	enumPromptFlagOff := longmemeval.GenerationPromptForTypePreferenceEnumerate(
+		question, "single-session-preference", "2024-06-01", contextBlocks,
+		false,
+	)
+	if standardPrompt != enumPromptFlagOff {
+		t.Errorf("preference-enumerate with flag=false must return same prompt as GenerationPromptForType; got diff")
+	}
+}
+
+// TestPreferenceEnumeratePrompt_FallsThrough_WhenNonPreferenceType verifies
+// that GenerationPromptForTypePreferenceEnumerate does NOT activate for
+// non-preference question types even when the flag is true.
+func TestPreferenceEnumeratePrompt_FallsThrough_WhenNonPreferenceType(t *testing.T) {
+	question := "What restaurant did I visit last?"
+	contextBlocks := []string{"Session date: 2024-04-01\nUser: Went to The French Laundry."}
+	standardPrompt := longmemeval.GenerationPromptForType(
+		question, "single-session-user", "2024-06-01", contextBlocks,
+	)
+	enumPromptWrongType := longmemeval.GenerationPromptForTypePreferenceEnumerate(
+		question, "single-session-user", "2024-06-01", contextBlocks,
+		true,
+	)
+	if standardPrompt != enumPromptWrongType {
+		t.Errorf("preference-enumerate with non-preference type must return same prompt as GenerationPromptForType; got diff")
+	}
+}

--- a/internal/mcp/preference_intent.go
+++ b/internal/mcp/preference_intent.go
@@ -1,0 +1,60 @@
+package mcp
+
+import "strings"
+
+// preferenceSynthesisDirective is the instruction attached to recall responses
+// for preference-intent queries. It is consumed CLIENT-SIDE: the calling agent's
+// model reads it from the tool response and synthesises the answer. engram-go does
+// not generate the answer itself (it has no API key and the subscription CLI is not
+// reachable from the server). The wording is adapted from the eval-proven
+// GenerationPromptPreferenceEnumerate (commit c448829), which lifted single-session
+// preference strict-correct accuracy 16.7% -> 26.7% on LongMemEval.
+//
+// FM-76: the final sentence is a mandatory abstention clause — the directive must
+// not manufacture a confident answer when the memories do not actually express a
+// relevant preference.
+const preferenceSynthesisDirective = "When answering this preference question, identify and list every specific named item, brand, model, attribute, feature, or location the user expressed a preference about in the returned memories. Name each one explicitly rather than summarising (e.g. the specific product or brand, not \"functional accessories\"). Begin your answer with \"The user prefers:\" followed by the enumerated list, and include what they would NOT prefer if the memories support it. Only include preferences actually present in the memories. If the memories do not clearly express a preference relevant to the question, say so rather than guessing."
+
+// preferenceMarkers are strong, observable lexical cues that a query is asking about
+// the user's preferences. The detector is intentionally PRECISION-biased (FM-77 +
+// FM-76): a missed preference query is acceptable, a false fire on a non-preference
+// query is not. Markers are matched against the lower-cased query as substrings, so
+// each must be specific enough that it does not appear incidentally in factual,
+// temporal, or recall-style questions. Bare "like" is deliberately excluded.
+var preferenceMarkers = []string{
+	"prefer",     // prefer, preference, preferred, do I prefer
+	"favorite",   // favorite
+	"favourite",  // favourite (en-GB)
+	"like best",  // what ... do I like best
+	"likes best", // what does the user like best
+	"do i like",  // what ... do I like
+	"do i enjoy", // what ... do I enjoy
+	"fond of",    // what am I fond of
+	"my taste",   // what suits my taste
+	"my go-to",   // what is my go-to ...
+	"i tend to like",
+}
+
+// preferenceIntent reports whether the query is asking about the user's preferences,
+// using only observable lexical features of the query itself — never a question_type
+// label (which does not exist for real production traffic; FM-77). It is conservative
+// by design: it returns true only on explicit preference cues.
+func preferenceIntent(query string) bool {
+	q := strings.ToLower(query)
+	for _, m := range preferenceMarkers {
+		if strings.Contains(q, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// attachSynthesisDirective adds the preference synthesis directive to a recall
+// response map when (and only when) the query shows preference intent. Additive and
+// optional — it never alters ranking, recall, or any existing response field, mirroring
+// the existing fetch_hint / feedback_hint pattern.
+func attachSynthesisDirective(out map[string]any, query string) {
+	if preferenceIntent(query) {
+		out["synthesis_directive"] = preferenceSynthesisDirective
+	}
+}

--- a/internal/mcp/preference_intent_test.go
+++ b/internal/mcp/preference_intent_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import "strings"
+import "testing"
+
+func TestPreferenceIntent_PositiveAndNegative(t *testing.T) {
+	positives := []string{
+		"What kind of coffee do I prefer?",
+		"Which laptop brand is my favorite?",
+		"What's my favourite holiday destination?",
+		"What programming language do I like best?",
+		"Do I like spicy food?",
+		"What desserts do I enjoy the most?", // "do i enjoy" not present; rely on... see ambiguous note
+		"What am I fond of when it comes to music?",
+		"What's my go-to lunch order?",
+	}
+	negatives := []string{
+		"When did I last visit Paris?",
+		"How many siblings do I have?",
+		"What did I say about the Q3 roadmap meeting?",
+		"Summarize my current project status.",
+		"What time is my flight on Friday?",
+		"Who attended the standup yesterday?",
+	}
+	for _, q := range positives {
+		// "What desserts do I enjoy the most?" has no marker substring; exclude it from the
+		// strict positive assertion and treat it as a known precision-miss instead.
+		if q == "What desserts do I enjoy the most?" {
+			continue
+		}
+		if !preferenceIntent(q) {
+			t.Errorf("expected preference intent for %q, got false", q)
+		}
+	}
+	for _, q := range negatives {
+		if preferenceIntent(q) {
+			t.Errorf("expected NO preference intent for %q, got true", q)
+		}
+	}
+}
+
+func TestPreferenceIntent_AmbiguousIsFalse(t *testing.T) {
+	// Precision-biased: borderline phrasing without an explicit preference cue must
+	// return false (FM-76 — never manufacture a forced preference answer).
+	ambiguous := []string{
+		"What should I do today?",
+		"Tell me about my schedule.",
+		"What movies have I liked recently?", // bare "liked", no marker — accepted miss
+		"What do I usually have for breakfast?",
+		"",
+	}
+	for _, q := range ambiguous {
+		if preferenceIntent(q) {
+			t.Errorf("expected ambiguous query %q to be false (precision-biased), got true", q)
+		}
+	}
+}
+
+func TestAttachSynthesisDirective_AttachedOnlyOnPreferenceIntent(t *testing.T) {
+	pref := map[string]any{"results": []any{}, "count": 0}
+	attachSynthesisDirective(pref, "Which laptop brand is my favorite?")
+	if _, ok := pref["synthesis_directive"]; !ok {
+		t.Errorf("expected synthesis_directive attached for preference query")
+	}
+
+	nonpref := map[string]any{"results": []any{}, "count": 0}
+	attachSynthesisDirective(nonpref, "When did I last visit Paris?")
+	if _, ok := nonpref["synthesis_directive"]; ok {
+		t.Errorf("expected NO synthesis_directive for non-preference query")
+	}
+}
+
+func TestPreferenceSynthesisDirective_Content(t *testing.T) {
+	d := preferenceSynthesisDirective
+	// Enumeration anchor.
+	if !strings.Contains(d, "The user prefers:") {
+		t.Errorf("directive missing enumeration anchor 'The user prefers:'")
+	}
+	// FM-76 abstention clause.
+	if !strings.Contains(strings.ToLower(d), "say so rather than guessing") {
+		t.Errorf("directive missing abstention clause (FM-76)")
+	}
+	// Anti-hallucination clause.
+	if !strings.Contains(strings.ToLower(d), "only include preferences actually present") {
+		t.Errorf("directive missing anti-hallucination clause")
+	}
+}

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -443,6 +443,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		if !ok {
 			addRecallDegradedWarning(out, cfg.RouterURL, reason)
 		}
+		attachSynthesisDirective(out, query)
 		return toolResult(out)
 	}
 
@@ -591,6 +592,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 	sanitizeRecallResults(results)
 	out := map[string]any{"results": results, "count": len(results)}
+	attachSynthesisDirective(out, query)
 	if atomPreamble != "" {
 		out["atom_preamble"] = atomPreamble
 	}


### PR DESCRIPTION
Closes #1113. Path B ship of the LME preference-enumerate win (preference strict-correct 16.7%->30.0% in stack validation). engram stays a memory backend; `handleMemoryRecall` attaches an optional `synthesis_directive` on preference-intent queries — gated on observable lexical cues not a question_type label (FM-77), with a mandatory abstention clause (FM-76). Additive only. Also lands the eval-harness preference-enumerate prompt (c448829). Red-teamed three-way (Codex+Hermes); ledger docs/lme-ledger.md.