### PR TITLE
Add session diversity post-pass to recall ranking

### DIFF
--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/search"
 )
 
 // preservedLog is a mutex-protected accumulator for project names that were
@@ -469,18 +470,17 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// When --disable-query-rewrite is set, use the raw question unchanged.
 	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
 	since, before := temporalRecallWindow(item.Question, item.QuestionType, item.QuestionDate)
+	recallOpts := longmemeval.RecallOpts{
+		ExactFactBoost:    cfg.ExactSignalBoost,
+		TopicAnchorBoost:  cfg.TopicAnchorBoost,
+		SessionDiversityN: search.SessionDiversityNFromEnv(),
+	}
 
 	recall := func(query string, topK int, callSince, callBefore *time.Time) ([]string, error) {
-		if cfg.ExactSignalBoost {
-			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, callSince, callBefore)
-		}
-		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost)
+		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, callSince, callBefore, recallOpts)
 	}
 	recallDefault := func(query string, topK int) ([]string, error) {
-		if cfg.ExactSignalBoost {
-			return mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, since, before)
-		}
-		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
+		return mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, recallOpts)
 	}
 
 	// H-NEW-1: when --temporal-window-recall is set, hand temporal anchoring to the

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -282,26 +282,28 @@ func (c *Client) RecallWithTemporalWindow(ctx context.Context, project, query st
 }
 
 // RecallWithOpts calls memory_recall with additional server-side options.
-// topicAnchorBoost=true sets topic_anchor_boost on the server (H-TAB, LME exp #3).
-func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]string, error) {
+func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, opts RecallOpts) ([]string, error) {
 	return c.recallWithParams(ctx, recallParams{
 		project: project, query: query, topK: topK, since: since, before: before,
-		topicAnchorBoost: topicAnchorBoost,
+		exactFactBoost:    opts.ExactFactBoost,
+		topicAnchorBoost:  opts.TopicAnchorBoost,
+		sessionDiversityN: opts.SessionDiversityN,
 	})
 }
 
 // recallParams carries the optional knobs for a single memory_recall call.
 type recallParams struct {
-	project          string
-	query            string
-	topK             int
-	since            *time.Time
-	before           *time.Time
-	temporalWindow   bool
-	questionText     string
-	questionDate     string
-	exactFactBoost   bool
-	topicAnchorBoost bool
+	project           string
+	query             string
+	topK              int
+	since             *time.Time
+	before            *time.Time
+	temporalWindow    bool
+	questionText      string
+	questionDate      string
+	exactFactBoost    bool
+	topicAnchorBoost  bool
+	sessionDiversityN int
 }
 
 func (c *Client) recallWithParams(ctx context.Context, p recallParams) ([]string, error) {
@@ -332,14 +334,19 @@ type RecallOpts struct {
 	// ExactFactBoost passes exact_fact_boost=true to the server-side memory_recall
 	// handler, enabling the entity-identifier scoring boost (LME #938 improvement #3).
 	ExactFactBoost bool
+	// TopicAnchorBoost passes topic_anchor_boost=true to the server-side
+	// memory_recall handler (H-TAB, LME exp #3).
+	TopicAnchorBoost bool
+	// SessionDiversityN carries the benchmark harness setting for the session-
+	// diversity post-pass. Zero disables it.
+	SessionDiversityN int
 }
 
 // RecallWithExactBoost calls recall with exact_fact_boost enabled.
 // Convenience wrapper for the longmemeval run command.
 func (c *Client) RecallWithExactBoost(ctx context.Context, project, query string, topK int, since, before *time.Time) ([]string, error) {
-	return c.recallWithParams(ctx, recallParams{
-		project: project, query: query, topK: topK, since: since, before: before,
-		exactFactBoost: true,
+	return c.RecallWithOpts(ctx, project, query, topK, since, before, RecallOpts{
+		ExactFactBoost: true,
 	})
 }
 
@@ -374,6 +381,9 @@ func (c *Client) recall(ctx context.Context, p recallParams) ([]string, error) {
 	// H-TAB (LME exp #3): pass topic-anchor boost flag to server.
 	if p.topicAnchorBoost {
 		args["topic_anchor_boost"] = true
+	}
+	if p.sessionDiversityN > 0 {
+		args["session_diversity_n"] = p.sessionDiversityN
 	}
 	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -123,6 +123,11 @@ type RecallOpts struct {
 	// identical to the baseline. Default false. (LEVER-8)
 	SessionNDCGAgg bool
 
+	// SessionDiversityN caps how many results from one session can occupy the
+	// leading window before another distinct session gets a turn. A value of 0
+	// disables the pass. Applied after SessionNDCGAgg and before topK truncation.
+	SessionDiversityN int
+
 	// PreferenceMMR enables the H-NEW-2 centroid-MMR diversity pass for preference
 	// queries. When true and the query is preference-shaped, the engine fetches
 	// best-chunk embeddings for top candidates, computes a centroid of the top-10
@@ -1135,6 +1140,12 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	// preference-first path already produces coherent ordering.
 	results = sessionNDCGRerank(results, allChunkCosines, opts.SessionNDCGAgg && !prefQuery)
 
+	sessionDiversityN := opts.SessionDiversityN
+	if sessionDiversityN == 0 {
+		sessionDiversityN = SessionDiversityNFromEnv()
+	}
+	results = applySessionDiversity(results, topK, sessionDiversityN)
+
 	// Preference-first recall path: when the query is preference-shaped, ensure
 	// preference-typed memories are represented in the top results even if their
 	// raw composite scores are lower than irrelevant context memories.
@@ -2046,11 +2057,12 @@ type MigrateParams struct {
 // A background reembed worker will repopulate embeddings after this call.
 //
 // Safety guards (applied in order, highest priority first):
-//  G1 — Same-canonical-identity: returns no-op with chunks_nulled=0.
-//  G2 — Same dimension without force: soft-refused (result["error"] set).
-//  G3 — dry_run: counts affected chunks without nulling.
-//       Large volume without confirm: soft-refused.
-//  G4 — Canonical stamp: stores canonicalEmbedderName(NewModel) in meta.
+//
+//	G1 — Same-canonical-identity: returns no-op with chunks_nulled=0.
+//	G2 — Same dimension without force: soft-refused (result["error"] set).
+//	G3 — dry_run: counts affected chunks without nulling.
+//	     Large volume without confirm: soft-refused.
+//	G4 — Canonical stamp: stores canonicalEmbedderName(NewModel) in meta.
 func (e *SearchEngine) MigrateEmbedder(ctx context.Context, p MigrateParams) (map[string]any, error) {
 	newModel := p.NewModel
 

--- a/internal/search/session_diversity.go
+++ b/internal/search/session_diversity.go
@@ -1,0 +1,101 @@
+package search
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+const sessionDiversityEnvVar = "ENGRAM_SESSION_DIVERSITY_N"
+
+// SessionDiversityNFromEnv returns the per-session cap for the session-diversity
+// post-pass. Unset, invalid, or negative values disable the pass and return 0.
+func SessionDiversityNFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv(sessionDiversityEnvVar))
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// shouldApplySessionDiversity reports whether the post-pass can change the
+// returned topK window in a meaningful way.
+func shouldApplySessionDiversity(results []types.SearchResult, topK, n int) bool {
+	if n <= 0 || topK <= 0 || len(results) <= 1 || len(results) <= topK || n >= topK {
+		return false
+	}
+
+	distinct := make(map[string]struct{}, 2)
+	for i, r := range results {
+		distinct[sessionDiversityKey(r, i)] = struct{}{}
+		if len(distinct) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// applySessionDiversity limits a dominant session from monopolising the topK
+// window. It preserves session encounter order from the baseline ranking and
+// preserves within-session order from that same ranking.
+func applySessionDiversity(results []types.SearchResult, topK, n int) []types.SearchResult {
+	if !shouldApplySessionDiversity(results, topK, n) {
+		return results
+	}
+
+	type sessionBucket struct {
+		key     string
+		members []types.SearchResult
+	}
+
+	bucketIndex := make(map[string]int, len(results))
+	buckets := make([]sessionBucket, 0, len(results))
+	for i, r := range results {
+		key := sessionDiversityKey(r, i)
+		idx, ok := bucketIndex[key]
+		if !ok {
+			idx = len(buckets)
+			bucketIndex[key] = idx
+			buckets = append(buckets, sessionBucket{key: key})
+		}
+		buckets[idx].members = append(buckets[idx].members, r)
+	}
+
+	out := make([]types.SearchResult, 0, len(results))
+	offsets := make([]int, len(buckets))
+	for {
+		progressed := false
+		for i := range buckets {
+			taken := 0
+			for offsets[i] < len(buckets[i].members) && taken < n {
+				out = append(out, buckets[i].members[offsets[i]])
+				offsets[i]++
+				taken++
+				progressed = true
+			}
+		}
+		if !progressed {
+			break
+		}
+	}
+	return out
+}
+
+func sessionDiversityKey(result types.SearchResult, index int) string {
+	if result.Memory != nil {
+		if sid := extractSessionID(result.Memory.Tags); sid != "" {
+			return sid
+		}
+		if result.Memory.ID != "" {
+			return "\x00session-diversity:" + result.Memory.ID
+		}
+	}
+	return fmt.Sprintf("\x00session-diversity:nil:%d", index)
+}

--- a/internal/search/session_diversity_test.go
+++ b/internal/search/session_diversity_test.go
@@ -1,0 +1,189 @@
+package search
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+func TestSessionDiversity_NZeroIsBaseline(t *testing.T) {
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.98),
+		sessionDiversityResult("s2-1", []string{"sid:s2"}, 0.97),
+		sessionDiversityResult("s1-3", []string{"sid:s1"}, 0.96),
+	}
+
+	before, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+
+	got := applySessionDiversity(results, 4, 0)
+
+	after, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal diversified: %v", err)
+	}
+
+	if string(after) != string(before) {
+		t.Fatalf("N=0 must be byte-identical to baseline\nbefore=%s\nafter=%s", string(before), string(after))
+	}
+}
+
+func TestSessionDiversity_HappyPath_GoldInMinoritySession(t *testing.T) {
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.98),
+		sessionDiversityResult("s1-3", []string{"sid:s1"}, 0.97),
+		sessionDiversityResult("s1-4", []string{"sid:s1"}, 0.96),
+		sessionDiversityResult("gold-s2", []string{"sid:s2"}, 0.95),
+	}
+
+	got := applySessionDiversity(results, 4, 2)
+
+	if len(got) < 4 {
+		t.Fatalf("len(got)=%d, want at least 4", len(got))
+	}
+	if !containsID(got[:4], "gold-s2") {
+		t.Fatalf("minority-session gold must appear in top-4, got ids=%v", resultIDs(got[:4]))
+	}
+}
+
+func TestSessionDiversity_AllChunksSingleSession(t *testing.T) {
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.98),
+		sessionDiversityResult("s1-3", []string{"sid:s1"}, 0.97),
+		sessionDiversityResult("s1-4", []string{"sid:s1"}, 0.96),
+		sessionDiversityResult("s1-5", []string{"sid:s1"}, 0.95),
+	}
+
+	got := applySessionDiversity(results, 5, 2)
+	if !reflect.DeepEqual(got, results) {
+		t.Fatalf("single-session input must be returned unchanged\ngot=%v\nwant=%v", resultIDs(got), resultIDs(results))
+	}
+}
+
+func TestSessionDiversity_MissingOrEmptySessionID(t *testing.T) {
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.98),
+		sessionDiversityResult("untagged", nil, 0.97),
+		sessionDiversityResult("empty-sid", []string{"sid:"}, 0.96),
+		sessionDiversityResult("s2-1", []string{"sid:s2"}, 0.95),
+	}
+
+	got1 := applySessionDiversity(results, 4, 1)
+	got2 := applySessionDiversity(results, 4, 1)
+
+	wantTop4 := []string{"s1-1", "untagged", "empty-sid", "s2-1"}
+	if !reflect.DeepEqual(resultIDs(got1[:4]), wantTop4) {
+		t.Fatalf("unexpected top-4 order: got=%v want=%v", resultIDs(got1[:4]), wantTop4)
+	}
+	if !reflect.DeepEqual(resultIDs(got1), resultIDs(got2)) {
+		t.Fatalf("output must be deterministic across runs: got1=%v got2=%v", resultIDs(got1), resultIDs(got2))
+	}
+}
+
+func TestSessionDiversity_TopK3_N2_TwoSessions(t *testing.T) {
+	// Tie semantics: preserve session encounter order from the baseline ranking,
+	// and preserve within-session order from the baseline ranking.
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.98),
+		sessionDiversityResult("s1-3", []string{"sid:s1"}, 0.97),
+		sessionDiversityResult("s1-4", []string{"sid:s1"}, 0.96),
+		sessionDiversityResult("s2-1", []string{"sid:s2"}, 0.95),
+		sessionDiversityResult("s2-2", []string{"sid:s2"}, 0.94),
+	}
+
+	got := applySessionDiversity(results, 3, 2)
+	wantTop3 := []string{"s1-1", "s1-2", "s2-1"}
+	if !reflect.DeepEqual(resultIDs(got[:3]), wantTop3) {
+		t.Fatalf("unexpected top-3 order: got=%v want=%v", resultIDs(got[:3]), wantTop3)
+	}
+	if countSessionIDs(got[:3], "s1") > 2 {
+		t.Fatalf("top-3 must contain at most 2 results from one session, got ids=%v", resultIDs(got[:3]))
+	}
+}
+
+func TestSessionDiversity_AlreadyDiverseOrShortInput(t *testing.T) {
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s2-1", []string{"sid:s2"}, 0.98),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.97),
+	}
+
+	got := applySessionDiversity(results, 5, 2)
+	if len(got) != len(results) {
+		t.Fatalf("short input length must be preserved: got=%d want=%d", len(got), len(results))
+	}
+	if !reflect.DeepEqual(resultIDs(got), resultIDs(results)) {
+		t.Fatalf("already-diverse short input should keep order: got=%v want=%v", resultIDs(got), resultIDs(results))
+	}
+}
+
+func TestSessionDiversity_DynamicGateSkipsWhenSingleSession(t *testing.T) {
+	results := []types.SearchResult{
+		sessionDiversityResult("s1-1", []string{"sid:s1"}, 0.99),
+		sessionDiversityResult("s1-2", []string{"sid:s1"}, 0.98),
+		sessionDiversityResult("s1-3", []string{"sid:s1"}, 0.97),
+	}
+
+	if shouldApplySessionDiversity(results, 3, 2) {
+		t.Fatal("dynamic gate must return false when all results share one session")
+	}
+
+	got := applySessionDiversity(results, 3, 2)
+	if !reflect.DeepEqual(got, results) {
+		t.Fatalf("single-session result slice must be returned unchanged: got=%v want=%v", resultIDs(got), resultIDs(results))
+	}
+}
+
+func sessionDiversityResult(id string, tags []string, score float64) types.SearchResult {
+	return types.SearchResult{
+		Memory: &types.Memory{
+			ID:      id,
+			Tags:    tags,
+			Content: id,
+		},
+		Score: score,
+	}
+}
+
+func resultIDs(results []types.SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, r := range results {
+		if r.Memory == nil {
+			ids = append(ids, "")
+			continue
+		}
+		ids = append(ids, r.Memory.ID)
+	}
+	return ids
+}
+
+func containsID(results []types.SearchResult, want string) bool {
+	for _, r := range results {
+		if r.Memory != nil && r.Memory.ID == want {
+			return true
+		}
+	}
+	return false
+}
+
+func countSessionIDs(results []types.SearchResult, want string) int {
+	count := 0
+	for _, r := range results {
+		if r.Memory == nil {
+			continue
+		}
+		if extractSessionID(r.Memory.Tags) == want {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary - add a post-ranking session-diversity pass after `SessionNDCGAgg`, gated by `ENGRAM_SESSION_DIVERSITY_N`, `topK`, and distinct-session detection, with singleton fallbacks for missing/empty `sid:` tags; - add 7 TDD tests locking the `N=0` baseline-identity contract and the multi-session promotion/tie semantics; - thread the setting through LongMemEval recall options so the harness carries the lever explicitly. ## Testing - `/usr/local/go/bin/go test ./... -count=1 -race`