### PR TITLE
fix(lme): align H8/H12 aggregation helpers

### DIFF
--- a/cmd/longmemeval/h8h12_test.go
+++ b/cmd/longmemeval/h8h12_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+type h8h12Capture struct {
+	mu      sync.Mutex
+	topKs   []int
+	prompts []string
+}
+
+func (c *h8h12Capture) addTopK(topK int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.topKs = append(c.topKs, topK)
+}
+
+func (c *h8h12Capture) addPrompt(prompt string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.prompts = append(c.prompts, prompt)
+}
+
+func (c *h8h12Capture) gotTopKs() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]int, len(c.topKs))
+	copy(out, c.topKs)
+	return out
+}
+
+func (c *h8h12Capture) lastPrompt(t *testing.T) string {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.prompts) == 0 {
+		t.Fatal("no prompt captured")
+	}
+	return c.prompts[len(c.prompts)-1]
+}
+
+func runOneWithCapture(t *testing.T, cfg *Config, item longmemeval.Item, recallIDs []string) *h8h12Capture {
+	t.Helper()
+
+	capture := &h8h12Capture{}
+	url := newTestEngram(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			topK, _ := args["top_k"].(float64)
+			capture.addTopK(int(topK))
+			results := make([]map[string]any, 0, len(recallIDs))
+			for _, id := range recallIDs {
+				results = append(results, map[string]any{
+					"memory": map[string]any{"id": id},
+					"score":  0.9,
+				})
+			}
+			resp, _ := json.Marshal(map[string]any{"results": results})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+		"memory_fetch": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			id, _ := args["id"].(string)
+			resp, _ := json.Marshal(map[string]any{
+				"memory": map[string]any{"content": fmt.Sprintf("Session date: 2024-05-10\nMemory %s", id)},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var req struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode llm request: %v", err)
+		}
+		for _, msg := range req.Messages {
+			if msg.Role == "user" {
+				capture.addPrompt(msg.Content)
+				break
+			}
+		}
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"2"}}]}`)
+	}))
+	defer llmSrv.Close()
+
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	cfgCopy := *cfg
+	cfgCopy.LLMBaseURL = llmSrv.URL
+	cfgCopy.LLMModel = "test"
+	cfgCopy.Retries = 0
+	if cfgCopy.RecallTopK == 0 {
+		cfgCopy.RecallTopK = 100
+	}
+
+	entry := runOne(ctx, &cfgCopy, c, item, longmemeval.IngestEntry{
+		QuestionID: item.QuestionID,
+		Project:    "lme-r-" + item.QuestionID,
+		Status:     "done",
+	})
+	if entry.Status != "done" {
+		t.Fatalf("runOne status = %q error=%q, want done", entry.Status, entry.Error)
+	}
+
+	return capture
+}
+
+func TestExhaustiveAggregation_UsesSingleTopK500Recall(t *testing.T) {
+	item := longmemeval.Item{
+		QuestionID:   "q-h8-enabled",
+		Question:     "How many times did I call my sister?",
+		QuestionType: "multi-session",
+		QuestionDate: "2024-06-01",
+	}
+	capture := runOneWithCapture(t, &Config{
+		RecallTopK:            100,
+		ExhaustiveAggregation: true,
+	}, item, []string{"m1", "m2"})
+
+	got := capture.gotTopKs()
+	if len(got) != 1 || got[0] != 500 {
+		t.Fatalf("memory_recall topKs = %v, want [500]", got)
+	}
+}
+
+func TestExhaustiveAggregation_UsesFullContextSweep(t *testing.T) {
+	item := longmemeval.Item{
+		QuestionID:   "q-h8-context",
+		Question:     "How many times did I call my sister?",
+		QuestionType: "multi-session",
+		QuestionDate: "2024-06-01",
+	}
+	recallIDs := make([]string, 0, 20)
+	for i := 1; i <= 20; i++ {
+		recallIDs = append(recallIDs, fmt.Sprintf("m%02d", i))
+	}
+	capture := runOneWithCapture(t, &Config{
+		RecallTopK:            100,
+		ExhaustiveAggregation: true,
+	}, item, recallIDs)
+
+	prompt := capture.lastPrompt(t)
+	if !strings.Contains(prompt, "Memory m20") {
+		t.Fatalf("full-context aggregation sweep should include the tail of the recall set in the prompt:\n%s", prompt)
+	}
+}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -468,7 +468,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// Strip leading interrogative phrases for temporal questions so the recall
 	// query matches event noun-phrases rather than "how many weeks ago did...".
 	// When --disable-query-rewrite is set, use the raw question unchanged.
+	runOpts := longmemeval.RunOpts{
+		ExhaustiveAggregation: cfg.ExhaustiveAggregation,
+		EnumerateFirst:        cfg.EnumerateFirst,
+	}
 	recallQuery := buildRecallQuery(item.Question, item.QuestionType, cfg.DisableQueryRewrite)
+	effectiveRecallTopK := runOpts.EffectiveRecallTopK(item.Question, cfg.RecallTopK)
 	since, before := temporalRecallWindow(item.Question, item.QuestionType, item.QuestionDate)
 	var atomRecallAsOf *time.Time
 	if cfg.AtomMode {
@@ -515,7 +520,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	)
 	serverTemporalWindow := cfg.TemporalWindowRecall && item.QuestionType == "temporal-reasoning"
 	if serverTemporalWindow {
-		retrievedIDs, err = mcpClient.RecallWithTemporalWindow(ctx, ingest.Project, recallQuery, cfg.RecallTopK, item.Question, item.QuestionDate)
+		retrievedIDs, err = mcpClient.RecallWithTemporalWindow(ctx, ingest.Project, recallQuery, effectiveRecallTopK, item.Question, item.QuestionDate)
 		if err != nil {
 			return longmemeval.RunEntry{
 				QuestionID: item.QuestionID,
@@ -524,7 +529,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			}
 		}
 	} else {
-		recallResult, fallbackIDs, recallErr := recallWithTemporalFallback(recallQuery, cfg.RecallTopK, since, before, recall)
+		recallResult, fallbackIDs, recallErr := recallWithTemporalFallback(recallQuery, effectiveRecallTopK, since, before, recall)
 		retrievedIDs, temporalFallbackIDs, atomPreamble, err = recallResult.IDs, fallbackIDs, recallResult.AtomPreamble, recallErr
 		if err != nil {
 			return longmemeval.RunEntry{
@@ -544,7 +549,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		// fusion candidates to at most 3 swapped-in slots, defeating the lever.
 		variants := buildRecallVariants(item.Question, recallQuery, cfg.DisableQueryRewrite, true)
 		for _, q := range variants[1:] {
-			recallResult, qErr := recallDefault(q, cfg.RecallTopK)
+			recallResult, qErr := recallDefault(q, effectiveRecallTopK)
 			if qErr != nil {
 				log.Printf("WARN run [%s] fusion recall (%q): %v", item.QuestionID, q, qErr)
 				continue
@@ -553,19 +558,10 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		}
 	}
 
-	// H8 (lme-h8h12h15): exhaustive aggregation recall — run a topK=500 sweep on
-	// the object noun-phrase for count-shaped questions and union with primary.
-	if cfg.ExhaustiveAggregation && !serverTemporalWindow && longmemeval.IsAggregationQuestion(item.Question) {
-		const aggregationSweepTopK = 500
-		sweepQuery := longmemeval.ExtractAggregationAnchor(item.Question)
-		sweepResult, sweepErr := recallDefault(sweepQuery, aggregationSweepTopK)
-		if sweepErr == nil {
-			secondaryContextIDs = append(secondaryContextIDs, sweepResult.IDs...)
-			retrievedIDs = longmemeval.UnionMemoryIDs(retrievedIDs, sweepResult.IDs)
-		} else {
-			log.Printf("WARN run [%s] H8 aggregation sweep failed: %v", item.QuestionID, sweepErr)
-		}
-	}
+	// H8 (lme-h8h12h15): exhaustive aggregation recall is now handled by
+	// RunOpts.EffectiveRecallTopK (deep primary recall for count-shaped questions)
+	// and RunOpts.UseFullAggregationContext (full result set into context), rather
+	// than a separate anchor sweep — see internal/longmemeval/claude_additions.go.
 
 	// H15 (lme-h8h12h15): dual-query preference recall — run a second recall
 	// using the subject-anchor query for preference questions and union results.
@@ -596,7 +592,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			log.Printf("WARN run [%s] paraphrase: %v — falling back to single-pass recall", item.QuestionID, pErr)
 		} else {
 			for _, pq := range paraphrases {
-				pResult, pErr := recallDefault(pq, cfg.RecallTopK)
+				pResult, pErr := recallDefault(pq, effectiveRecallTopK)
 				if pErr != nil {
 					log.Printf("WARN run [%s] paraphrase recall (%q): %v", item.QuestionID, pq, pErr)
 					continue
@@ -613,6 +609,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	var contextLimit int
 	if cfg.ContextTopKOverride > 0 {
 		contextLimit = cfg.ContextTopKOverride
+	} else if runOpts.UseFullAggregationContext(item.Question) {
+		contextLimit = len(retrievedIDs)
 	} else {
 		contextLimit = longmemeval.ContextTopKForTypeWithBump(item.QuestionType, cfg.ContextTopKBump)
 	}
@@ -691,8 +689,9 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 	// Exp-14: --temporal-prompt-aug takes priority over --inject-question-date;
 	// the two are mutually exclusive. When both are set, aug wins.
-	// H12 (--enumerate-first) is orthogonal — it only fires for aggregation
-	// questions, which the temporal/preference branches above never match.
+	// H12 (--enumerate-first) is applied after the per-type prompt is chosen
+	// (via runOpts.ApplyEnumerateFirst below) so it prefixes the baseline prompt
+	// instead of replacing it.
 	// H-PE (--preference-enumerate) is orthogonal — it only fires for
 	// single-session-preference questions and is independent of the other flags.
 	var prompt string
@@ -701,13 +700,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		prompt = longmemeval.GenerationPromptForTypeWithTemporalAug(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.InjectQuestionDate:
 		prompt = longmemeval.GenerationPromptForTypeWithDateInjection(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
-	case cfg.EnumerateFirst:
-		prompt = longmemeval.GenerationPromptForTypeEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.PreferenceEnumerate:
 		prompt = longmemeval.GenerationPromptForTypePreferenceEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	default:
 		prompt = longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, contextBlocks)
 	}
+	prompt = runOpts.ApplyEnumerateFirst(prompt, item.Question, item.QuestionType)
 
 	// #938: prepend atom context block before the memory context when --atom-mode is set.
 	if atomContextBlock != "" {

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -494,17 +494,16 @@ func GenerationPromptForTypeWithDateInjection(question, questionType, questionDa
 	return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
 }
 
-// GenerationPromptForTypeEnumerate (H12, lme-h8h12h15) is like
-// GenerationPromptForType but accepts an enumerateFirst flag. When
-// enumerateFirst is true AND the question matches the aggregation pattern, the
-// generation prompt instructs the model to enumerate each relevant event from
-// the retrieved blocks before stating a count. For non-aggregation questions
-// the flag is a no-op so other question types are unaffected.
+// GenerationPromptForTypeEnumerate (H12) is like GenerationPromptForType but
+// prepends an enumerate-first instruction when enumerateFirst is true and the
+// question matches the aggregation heuristic. For non-aggregation questions the
+// flag is a no-op so other question types are unaffected.
 func GenerationPromptForTypeEnumerate(question, questionType, questionDate string, contextBlocks []string, enumerateFirst bool) string {
+	prompt := GenerationPromptForType(question, questionType, questionDate, contextBlocks)
 	if enumerateFirst && questionType != "temporal-reasoning" && questionType != "single-session-preference" && IsAggregationQuestion(question) {
-		return GenerationPromptEnumerateFirst(question, questionDate, contextBlocks)
+		return prependPromptPrefix(EnumerateFirstPrefix(), prompt)
 	}
-	return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
+	return prompt
 }
 
 // GenerationPromptForTypePreferenceEnumerate (H-PE) is like
@@ -555,21 +554,7 @@ Instructions:
 // enumeration pass that prevents the model from returning a session count
 // instead of an entity count.
 func GenerationPromptEnumerateFirst(question, questionDate string, contextBlocks []string) string {
-	ctx := strings.Join(contextBlocks, "\n\n---\n\n")
-	return fmt.Sprintf(`You are answering questions about a person's conversation history.
-
-Each memory block may begin with a "Session date: YYYY-MM-DD" header. The question was asked on %s.
-
-Relevant memory context:
-%s
-
-Question (asked on %s): %s
-
-Instructions:
-1. First, enumerate each relevant event or entity mentioned across the memory blocks above. List each one separately (e.g. "1. Visit on 2023-03-10", "2. Visit on 2023-07-22"). If the same event appears in multiple blocks, count it only once.
-2. Then, sum or total the distinct items you enumerated to answer the question.
-3. State the final answer concisely. If the answer is a number, return only that number with minimal framing.
-4. If the answer is not present in the memory blocks, say so. Do not invent events or dates not found in the context.`, questionDate, ctx, questionDate, question)
+	return prependPromptPrefix(EnumerateFirstPrefix(), GenerationPrompt(question, questionDate, contextBlocks))
 }
 
 // GenerationPrompt builds the prompt for answer generation.

--- a/internal/longmemeval/claude_additions.go
+++ b/internal/longmemeval/claude_additions.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const exhaustiveAggregationTopK = 500
+
 // preferenceStripRe strips the opening recommendation verb phrase from a question.
 // e.g. "Can you recommend a hotel for Miami?" → "a hotel for Miami?".
 var preferenceStripRe = regexp.MustCompile(
@@ -77,10 +79,49 @@ func PreferenceSubjectAnchorQuery(question string) string {
 	return "user preference " + anchor + " like dislike use avoid"
 }
 
-// aggregationRe (H8) matches count-shaped questions that require
-// population-level retrieval rather than a single top-scoring session.
+// RunOpts carries opt-in H8/H12 switches that alter recall depth and prompt
+// construction without changing the default benchmark path.
+type RunOpts struct {
+	ExhaustiveAggregation bool
+	EnumerateFirst        bool
+}
+
+// EffectiveRecallTopK returns the topK value that should be used for the
+// question. H8 is opt-in and only affects aggregation-shaped questions.
+func (o RunOpts) EffectiveRecallTopK(question string, baseline int) int {
+	if o.ExhaustiveAggregation && IsAggregationQuestion(question) {
+		return exhaustiveAggregationTopK
+	}
+	return baseline
+}
+
+// UseFullAggregationContext reports whether the full recalled result set should
+// be swept into the generation context for this question.
+func (o RunOpts) UseFullAggregationContext(question string) bool {
+	return o.ExhaustiveAggregation && IsAggregationQuestion(question)
+}
+
+// ApplyEnumerateFirst prepends the H12 instruction to an existing prompt when
+// the flag is enabled for an aggregation-shaped question.
+func (o RunOpts) ApplyEnumerateFirst(prompt, question, questionType string) string {
+	if !o.EnumerateFirst || !IsAggregationQuestion(question) {
+		return prompt
+	}
+	if questionType == "temporal-reasoning" || questionType == "single-session-preference" {
+		return prompt
+	}
+	return prependPromptPrefix(EnumerateFirstPrefix(), prompt)
+}
+
+// aggregationRe (H8) matches exhaustive retrieval questions that need all
+// matching sessions, including list/every-time phrasing.
 var aggregationRe = regexp.MustCompile(
-	`(?i)\b(how many|how often|how much total|total number of|sum of|count of)\b`)
+	`(?i)\b(how many(?: times)?|how often|how much total|total number of|sum of|count of|list (?:all|every|everything)|every time|all occasions?)\b`)
+
+// temporalQuantityRe excludes relative-time arithmetic questions like
+// "how many days ago", which are temporal reasoning rather than aggregation.
+var temporalQuantityRe = regexp.MustCompile(
+	`(?i)\bhow many (days?|weeks?|months?|years?) (ago|before|after)\b`)
 
 // aggregationStripRe (H8) strips the counting interrogative phrase so that the
 // remaining tokens describe the object being counted.
@@ -90,7 +131,16 @@ var aggregationStripRe = regexp.MustCompile(
 // IsAggregationQuestion (H8) returns true when the question matches the
 // aggregation pattern that requires exhaustive population recall.
 func IsAggregationQuestion(question string) bool {
+	if temporalQuantityRe.MatchString(question) {
+		return false
+	}
 	return aggregationRe.MatchString(question)
+}
+
+// EnumerateFirstPrefix returns the H12 instruction prepended to aggregation
+// prompts so the model enumerates evidence before synthesizing an answer.
+func EnumerateFirstPrefix() string {
+	return "First, list every relevant event/fact from the context, numbered, and enumerate each distinct item only once. Then synthesize your answer from that list."
 }
 
 // ExtractAggregationAnchor (H8) strips the counting interrogative prefix and
@@ -114,6 +164,19 @@ func ExtractAggregationAnchor(question string) string {
 		return stripped
 	}
 	return strings.Join(keep, " ")
+}
+
+func prependPromptPrefix(prefix, prompt string) string {
+	prefix = strings.TrimSpace(prefix)
+	prompt = strings.TrimSpace(prompt)
+	switch {
+	case prefix == "":
+		return prompt
+	case prompt == "":
+		return prefix
+	default:
+		return prefix + "\n\n" + prompt
+	}
 }
 
 // UnionMemoryIDs (H8/H15) merges primary and secondary ID slices, preserving

--- a/internal/longmemeval/h8h12_test.go
+++ b/internal/longmemeval/h8h12_test.go
@@ -1,0 +1,35 @@
+package longmemeval_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+func TestIsAggregationQuestion_DoesNotMatchTemporalQuantity(t *testing.T) {
+	question := "How many weeks ago did I attend the baking class?"
+	if longmemeval.IsAggregationQuestion(question) {
+		t.Fatalf("IsAggregationQuestion(%q) = true, want false", question)
+	}
+}
+
+func TestGenerationPromptForTypeEnumerate_PrependsInstructionToBaseline(t *testing.T) {
+	question := "How many times did I call my sister?"
+	questionType := "multi-session"
+	questionDate := "2024-06-01"
+	contextBlocks := []string{"Session date: 2024-05-10\nCalled my sister."}
+
+	base := longmemeval.GenerationPromptForType(question, questionType, questionDate, contextBlocks)
+	got := longmemeval.GenerationPromptForTypeEnumerate(question, questionType, questionDate, contextBlocks, true)
+
+	if got == base {
+		t.Fatal("enumerate-first prompt should differ from baseline for aggregation questions")
+	}
+	if !strings.HasSuffix(got, base) {
+		t.Fatalf("enumerate-first prompt must preserve the baseline prompt as a suffix\nbase:\n%s\n\ngot:\n%s", base, got)
+	}
+	if !strings.Contains(got, "First,") {
+		t.Fatalf("enumerate-first prompt missing prefixed instruction:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary - add opt-in H8/H12 `RunOpts` helpers and regression tests for aggregation detection; switch H8 aggregation runs to a single topK=500 recall with full-context sweep; prepend the H12 enumerate-first instruction onto baseline prompts instead of replacing them. ## Testing - `./internal/longmemeval` targeted regressions PASS; `./cmd/longmemeval` H8/H12 integration regressions PASS; `/usr/local/go/bin/go test ./... -count=1 -race` PASS.