### PR TITLE
fix(lme): add per-request read timeout to all LME HTTP clients

### DIFF
--- a/cmd/longmemeval/route.go
+++ b/cmd/longmemeval/route.go
@@ -62,6 +62,12 @@ type openAIModel struct {
 	ID string `json:"id"`
 }
 
+// routeDiscoverClient is a dedicated http.Client for Olla model enumeration
+// and readiness validation during route discovery. The 30-second Timeout is a
+// transport-layer backstop so a stalled gateway cannot block discovery
+// indefinitely even when the context deadline fires late (#1107).
+var routeDiscoverClient = &http.Client{Timeout: 30 * time.Second}
+
 func discoverRoute(cfg routeDiscoverConfig) (routeDiscoverResult, error) {
 	if cfg.FleetURL == "" {
 		return routeDiscoverResult{}, errors.New("--fleet-url is required")
@@ -88,7 +94,7 @@ func discoverRoute(cfg routeDiscoverConfig) (routeDiscoverResult, error) {
 	if err != nil {
 		return routeDiscoverResult{}, fmt.Errorf("query AI Flight Controller registry: %w", err)
 	}
-	ollaModels, err := fetchOllaModels(ctx, http.DefaultClient, strings.TrimRight(cfg.OllaURL, "/")+"/olla/openai/v1/models")
+	ollaModels, err := fetchOllaModels(ctx, routeDiscoverClient, strings.TrimRight(cfg.OllaURL, "/")+"/olla/openai/v1/models")
 	if err != nil {
 		return routeDiscoverResult{}, fmt.Errorf("query Olla models: %w", err)
 	}
@@ -100,7 +106,7 @@ func discoverRoute(cfg routeDiscoverConfig) (routeDiscoverResult, error) {
 	baseURL := strings.TrimRight(cfg.OllaURL, "/") + "/olla/openai/v1"
 	validated := false
 	if requiresChatReadiness(cfg.Purpose) {
-		if err := validateOllaChatRoute(ctx, http.DefaultClient, baseURL, selected); err != nil {
+		if err := validateOllaChatRoute(ctx, routeDiscoverClient, baseURL, selected); err != nil {
 			return routeDiscoverResult{}, fmt.Errorf("validate Olla chat route for %q: %w", selected, err)
 		}
 		validated = true
@@ -149,7 +155,10 @@ func routeHTTPClient(cfg routeDiscoverConfig) (*http.Client, error) {
 		}
 		tlsCfg.RootCAs = pool
 	}
-	return &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}}, nil
+	return &http.Client{
+		Timeout:   30 * time.Second, // transport-layer backstop for stalled gateways (#1107)
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}, nil
 }
 
 func fetchFleetRegistry(ctx context.Context, client *http.Client, url string) ([]fleetHost, error) {

--- a/cmd/longmemeval/route_test.go
+++ b/cmd/longmemeval/route_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -182,5 +186,62 @@ func TestDiscoverRouteSkipsStoppedFleetModels(t *testing.T) {
 	}
 	if result.LLMModel != "ready" {
 		t.Fatalf("LLMModel = %q, want ready", result.LLMModel)
+	}
+}
+
+// TestRouteDiscoverClientHasTimeout verifies the package-level routeDiscoverClient
+// has a non-zero transport-layer timeout so a stalled gateway cannot block route
+// discovery indefinitely (#1107).
+func TestRouteDiscoverClientHasTimeout(t *testing.T) {
+	if routeDiscoverClient.Timeout == 0 {
+		t.Fatal("routeDiscoverClient.Timeout is zero: stalled gateway will block forever")
+	}
+}
+
+// TestRouteHTTPClientTLSHasTimeout verifies that the mTLS path in routeHTTPClient
+// returns a client with a non-zero Timeout (#1107). Generates a self-signed
+// cert+key pair inline so tls.LoadX509KeyPair can exercise the production code path.
+func TestRouteHTTPClientTLSHasTimeout(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+
+	// Pull a valid cert+key from the httptest TLS server's internal fixtures.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	// httptest.NewTLSServer uses localhostCert/localhostKey from net/http/internal/testcert.
+	// We can't import that package directly, but we can export the cert via tls.Config
+	// and reconstruct PEM for the test.
+	tlsConfig := ts.TLS
+	if len(tlsConfig.Certificates) == 0 {
+		t.Skip("httptest server has no TLS certificate")
+	}
+	// Write the raw DER cert as PEM.
+	certDER := tlsConfig.Certificates[0].Certificate[0]
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write cert PEM: %v", err)
+	}
+	// Export the private key as PKCS8 PEM.
+	privKey := tlsConfig.Certificates[0].PrivateKey
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key PEM: %v", err)
+	}
+
+	client, err := routeHTTPClient(routeDiscoverConfig{
+		FleetCert: certPath,
+		FleetKey:  keyPath,
+	})
+	if err != nil {
+		t.Fatalf("routeHTTPClient (TLS): %v", err)
+	}
+	if client.Timeout == 0 {
+		t.Fatal("routeHTTPClient TLS branch returned client with zero Timeout: stalled gateway will block forever (#1107)")
 	}
 }

--- a/cmd/longmemeval/score_efficient.go
+++ b/cmd/longmemeval/score_efficient.go
@@ -12,6 +12,12 @@ import (
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
 
+// scorerHTTPClient is a dedicated http.Client for scorer health-checks and the
+// /models endpoint. The 10-second Timeout is a transport-layer backstop so a
+// stalled gateway cannot hold the health-check goroutine indefinitely.
+// Context deadlines in the callers tighten this further per-request.
+var scorerHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 // ollaHealthCheck returns true if the OAI /models endpoint responds with HTTP 200.
 func ollaHealthCheck(baseURL string) bool {
 	url := strings.TrimRight(baseURL, "/") + "/models"
@@ -21,7 +27,7 @@ func ollaHealthCheck(baseURL string) bool {
 	if err != nil {
 		return false
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scorerHTTPClient.Do(req)
 	if err != nil {
 		return false
 	}

--- a/cmd/longmemeval/score_efficient_test.go
+++ b/cmd/longmemeval/score_efficient_test.go
@@ -220,3 +220,12 @@ func TestScoreErrorRetriedThenCounted(t *testing.T) {
 		t.Errorf("score_error_total = %v, want 1", scoreErrorTotal)
 	}
 }
+
+// TestScorerHTTPClientHasTimeout verifies the package-level scorerHTTPClient has
+// a non-zero transport-layer timeout so a stalled health-check endpoint cannot
+// hold the health-check goroutine open indefinitely (#1107).
+func TestScorerHTTPClientHasTimeout(t *testing.T) {
+	if scorerHTTPClient.Timeout == 0 {
+		t.Fatal("scorerHTTPClient.Timeout is zero: stalled gateway will block ollaHealthCheck forever")
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/longmemeval/score_efficient.go`: replaced `http.DefaultClient` (no timeout) with `scorerHTTPClient` (`Timeout: 10s`) — scorer responses are small JSON, no reason to allow indefinite blocking
- `cmd/longmemeval/route.go`: added `Timeout: 30s` to `routeHTTPClient()` return value and replaced `http.DefaultClient` in `discoverRoute` with `routeDiscoverClient` (`Timeout: 30s`) — route discovery should never hang
- `internal/longmemeval/claude.go`: `oaiHTTPClient` already had `Timeout: 15 * time.Minute` — no change needed

Root cause of #1107: 4 established TCP connections to `192.168.0.138:30411` held open 4+ hours with zero bytes moving. `context.WithTimeout` alone is insufficient when a server accepts the connection but never sends bytes — transport-level `http.Client.Timeout` is the reliable backstop.

## Test plan

- [ ] `TestScorerHTTPClientHasTimeout` — asserts `scorerHTTPClient.Timeout != 0`
- [ ] `TestRouteDiscoverClientHasTimeout` — asserts `routeDiscoverClient.Timeout != 0`
- [ ] `TestRouteHTTPClientTLSHasTimeout` — calls `routeHTTPClient` with a real TLS server, asserts returned client `Timeout != 0`
- [ ] `go test ./cmd/longmemeval/... ./internal/longmemeval/... -count=1 -race` — passes clean

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)