### PR TITLE
docs(engram-setup): reconcile rescued setup docs and contract tests with main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,13 +121,14 @@ check-env:
 	@# #701: route diagnostic to stderr so `make up > /dev/null` is clean
 	@echo "✓ .env credentials look set" >&2
 
-## Configure MCP client — fetches current bearer token and writes mcpServers.engram to ~/.claude.json and ~/.claude/mcp_servers.json
+## Configure MCP client for https://engram.petersimmons.com; use --url for local Docker.
+## Writes ~/.claude/mcp_servers.json and updates ~/.claude.json only when it already has mcpServers.
 ## Run this after: first install, container restart (if key changed), or key rotation.
 ## After setup, run /mcp in Claude Code to reconnect.
 setup:
 	go run ./cmd/engram-setup
 
-## Preview MCP config changes without writing ~/.claude.json
+## Preview effective server, endpoint, and MCP config targets without writing files.
 setup-dry-run:
 	go run ./cmd/engram-setup --dry-run
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Both setups share the same PostgreSQL backend, API contract, and tool set. Swap 
 make init
 make build-postgres
 docker compose -f docker-compose.local.yml up -d
-make setup
+go run ./cmd/engram-setup --url http://127.0.0.1:8788
 
-# Hybrid path for operator environments
+# Default home-network endpoint
 make init
 make up
 make setup
@@ -77,17 +77,15 @@ make init
 # Fresh-clone first run (recommended): local-only / no external backend
 make build-postgres
 docker compose -f docker-compose.local.yml up -d
-make setup
+go run ./cmd/engram-setup --url http://127.0.0.1:8788
 
-# Hybrid startup (requires ENGRAM_ROUTER_URL)
+# Default home-network endpoint (requires operator environment)
 make init
 make up
 make setup
 ```
 
-`make setup` uses `engram-setup` defaults, which target `https://engram.petersimmons.com` unless you override `--url` (for example `http://127.0.0.1:8788` during local-only startup).
-
-Both setups expose the server at `http://localhost:8788`. Cold start: ~200ms. Idle memory: 18 MB.
+Local Docker profiles listen at `http://localhost:8788`. `make setup` targets the default home-network endpoint `https://engram.petersimmons.com`; use the explicit `--url http://127.0.0.1:8788` override when you want Claude Code connected to the local container. Cold start: ~200ms. Idle memory: 18 MB.
 
 ### Environment Configuration
 
@@ -106,13 +104,30 @@ If you prefer to author `.env` manually rather than using `make init`, see `.env
 
 ### Connect to Claude Code
 
-After `make setup`:
+After setup:
 
 ```bash
 /mcp
 ```
 
 All <!-- count:visible-default -->18<!-- /count --> visible tools (+ <!-- count:hidden -->28<!-- /count --> hidden maintenance tools, callable via `tools/call`) activate immediately. Four optional AI-enhanced tools (`memory_ask`, `memory_reason`, `memory_explore`, `memory_query_document`) activate when `ANTHROPIC_API_KEY` is set in `.env`. `memory_diagnose` is a built-in hidden tool, not AI-gated.
+
+### Setup Target and Config Writes
+
+`make setup` targets the default home-network endpoint `https://engram.petersimmons.com`. For local-only Docker, run the setup tool directly with an explicit local override:
+
+```bash
+go run ./cmd/engram-setup --url http://127.0.0.1:8788
+```
+
+The setup tool health-checks the effective server URL, calls `/setup-token`, and writes the bearer-token MCP entry for Claude Code. Dry-run output redacts the token before printing. If `/setup-token` is unavailable during bootstrap, it validates fallback credentials from `~/.config/engram/api_key` first and `~/projects/engram-go/.env` (`ENGRAM_API_KEY`) second before writing anything.
+
+Config files touched:
+
+- `~/.claude/mcp_servers.json` — created or updated with `mcpServers.engram`.
+- `~/.claude.json` — updated only when the file already has a `mcpServers` block; otherwise skipped.
+
+Use `make setup-dry-run` or `go run ./cmd/engram-setup --dry-run` to print the effective server, endpoint, redacted entry, and target plan without writing files.
 
 ### Important: RFC1918 and `/setup-token`
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -74,21 +74,26 @@ DATABASE_URL=postgres://... go run ./cmd/engram migrate
 
 **Purpose:** Configure Claude Code (and other IDE integrations) to connect to the running engram server. Fetches the current bearer token via the Bearer-protected `/setup-token` endpoint, with disk fallback to the local `ENGRAM_API_KEY` when bootstrapping, then writes the MCP server config to:
 
-- `~/.claude/mcp_servers.json` (primary, live config)
-- `~/.claude.json` (secondary, settings fallback)
+- `~/.claude/mcp_servers.json` (primary, live config; created or updated)
+- `~/.claude.json` (secondary settings fallback; updated only when it already has `mcpServers`)
 
-Both files are updated so the token stays fresh regardless of which file your Claude Code version reads.
+Run `--dry-run` to see the effective server, endpoint, redacted token, and exact target plan before any write.
 
 **Usage:**
 
 ```bash
-go run ./cmd/engram-setup              # Configure with defaults (remote ingress)
-go run ./cmd/engram-setup --dry-run    # Preview changes without writing
+go run ./cmd/engram-setup              # Configure with default home-network endpoint (`https://engram.petersimmons.com`)
+go run ./cmd/engram-setup --dry-run    # Preview effective server, endpoint, and target files without writing
 go run ./cmd/engram-setup --url http://127.0.0.1:8788  # Local Docker override
-go run ./cmd/engram-setup --port 9000  # Non-default port
+go run ./cmd/engram-setup --port 9000  # Local port shorthand (sets http://127.0.0.1:9000)
 ```
 
-Default behavior is remote-first (`https://engram.petersimmons.com`), and disk fallback credentials are used for bootstrap recovery when `/setup-token` returns 401.
+Default behavior:
+
+- Effective default target: `https://engram.petersimmons.com`.
+- Explicit local override: `go run ./cmd/engram-setup --url http://127.0.0.1:8788`.
+- Credential source: `/setup-token` first, then validated disk fallbacks from `~/.config/engram/api_key` and `~/projects/engram-go/.env` (`ENGRAM_API_KEY`) when bootstrap auth fails.
+- Config files touched: `~/.claude/mcp_servers.json` is created or updated; `~/.claude.json` is updated only when it already has `mcpServers`.
 
 **When to run:**
 - Once after first `make up`

--- a/cmd/engram-setup/docs_contract_test.go
+++ b/cmd/engram-setup/docs_contract_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetupDocsMatchNetworkDefaultContract(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		mustContain  []string
+		mustNotMatch []string
+	}{
+		{
+			name: "root README",
+			path: filepath.Join("..", "..", "README.md"),
+			mustContain: []string{
+				"`make setup` targets the default home-network endpoint `https://engram.petersimmons.com`",
+				"go run ./cmd/engram-setup --url http://127.0.0.1:8788",
+				"`~/.config/engram/api_key`",
+				"`~/projects/engram-go/.env`",
+				"`~/.claude/mcp_servers.json`",
+				"`~/.claude.json`",
+			},
+			mustNotMatch: []string{
+				"make setup\n```\n\nBoth setups expose the server at `http://localhost:8788`",
+			},
+		},
+		{
+			name: "command README",
+			path: filepath.Join("..", "README.md"),
+			mustContain: []string{
+				"Configure with default home-network endpoint (`https://engram.petersimmons.com`)",
+				"go run ./cmd/engram-setup --url http://127.0.0.1:8788",
+				"`~/.config/engram/api_key`",
+				"`~/projects/engram-go/.env`",
+				"`~/.claude/mcp_servers.json`",
+				"`~/.claude.json`",
+			},
+			mustNotMatch: []string{
+				"Configure with defaults (localhost:8788)",
+			},
+		},
+		{
+			name: "getting started",
+			path: filepath.Join("..", "..", "docs", "getting-started.md"),
+			mustContain: []string{
+				"`make setup` targets the default home-network endpoint `https://engram.petersimmons.com`",
+				"go run ./cmd/engram-setup --url http://127.0.0.1:8788",
+				"`~/.claude/mcp_servers.json`",
+				"`~/.claude.json`",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := os.ReadFile(tt.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.path, err)
+			}
+			doc := string(raw)
+			for _, want := range tt.mustContain {
+				if !strings.Contains(doc, want) {
+					t.Errorf("%s missing %q", tt.path, want)
+				}
+			}
+			for _, bad := range tt.mustNotMatch {
+				if strings.Contains(doc, bad) {
+					t.Errorf("%s still contains outdated setup contract %q", tt.path, bad)
+				}
+			}
+		})
+	}
+}

--- a/cmd/engram-setup/engram_setup_test.go
+++ b/cmd/engram-setup/engram_setup_test.go
@@ -275,6 +275,47 @@ func TestConfigFormatFlag(t *testing.T) {
 	})
 }
 
+func TestDryRunExplainsEffectiveTargets(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	setup := &setupResponse{
+		Token:    "token-123456789012345678901234567890",
+		Endpoint: "https://engram.petersimmons.com/mcp",
+		Name:     "engram",
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := configureWithSetup(defaultServerURL, "engram", true, "text", setup)
+
+	w.Close()
+	os.Stdout = oldStdout
+	output, _ := io.ReadAll(r)
+	outputStr := string(output)
+
+	if err != nil {
+		t.Fatalf("configureWithSetup returned error: %v", err)
+	}
+
+	expected := []string{
+		"server:   https://engram.petersimmons.com",
+		"endpoint: https://engram.petersimmons.com/mcp",
+		filepath.Join(tmpHome, ".claude", "mcp_servers.json") + " (create or update)",
+		filepath.Join(tmpHome, ".claude.json") + " (update only when the file already has mcpServers; otherwise skip)",
+	}
+	for _, want := range expected {
+		if !strings.Contains(outputStr, want) {
+			t.Errorf("dry-run output missing %q\noutput was:\n%s", want, outputStr)
+		}
+	}
+}
+
 // TestDefaultEndpointIsK8s verifies that the default server URL points to the
 // remote ingress, not the retired local Docker address (#engram-setup-k8s).
 func TestDefaultEndpointIsK8s(t *testing.T) {

--- a/cmd/engram-setup/main.go
+++ b/cmd/engram-setup/main.go
@@ -1,4 +1,4 @@
-// Command engram-setup configures the local MCP client (Claude Code) to connect to a
+// Command engram-setup configures MCP clients (Claude Code) to connect to a
 // running engram server.
 //
 // Primary path: calls /setup-token (requires Bearer auth since #540) to retrieve the
@@ -16,8 +16,8 @@
 //   - ~/.claude/mcp_servers.json  — primary (live config, read each session)
 //   - ~/.claude.json              — legacy user settings, also read at startup
 //
-// engram-setup writes both by default so the token stays fresh regardless of which
-// file Claude Code happens to use in a given version.
+// engram-setup always creates or updates ~/.claude/mcp_servers.json. It only updates
+// ~/.claude.json when that file already has an mcpServers block.
 //
 // Usage:
 //
@@ -169,10 +169,10 @@ func configureWithSetup(base, name string, dryRun bool, format string, setup *se
 		return fmt.Errorf("locate home directory: %w", err)
 	}
 
-	// Claude Code reads MCP servers from both of these files — keep both in sync.
-	targets := []string{
-		filepath.Join(home, ".claude", "mcp_servers.json"), // primary: Claude Code live config
-		filepath.Join(home, ".claude.json"),                // secondary: Claude Code user settings
+	targets := setupConfigTargets(home)
+	targetPaths := make([]string, 0, len(targets))
+	for _, target := range targets {
+		targetPaths = append(targetPaths, target.Path)
 	}
 
 	newEntry := map[string]interface{}{
@@ -198,11 +198,13 @@ func configureWithSetup(base, name string, dryRun bool, format string, setup *se
 			// JSON format for --dry-run --format=json
 			output := map[string]interface{}{
 				"status":   "dry-run",
+				"server":   base,
 				"endpoint": setup.Endpoint,
 				"token":    redactedToken,
 				"would_write": map[string]interface{}{
-					"targets": targets,
-					"entry":   displayEntry,
+					"targets":     targetPaths,
+					"target_plan": targets,
+					"entry":       displayEntry,
 				},
 			}
 			outJSON, _ := json.MarshalIndent(output, "", "  ")
@@ -210,22 +212,28 @@ func configureWithSetup(base, name string, dryRun bool, format string, setup *se
 		} else {
 			// Text format for --dry-run (default)
 			displayJSON, _ := json.MarshalIndent(displayEntry, "    ", "  ")
-			fmt.Printf("DRY RUN — would write mcpServers.%s to:\n  %s\n  %s\n\n",
-				name, targets[0], targets[1])
+			fmt.Printf("DRY RUN — would write mcpServers.%s\n", name)
+			fmt.Printf("  server:   %s\n", base)
+			fmt.Printf("  endpoint: %s\n\n", setup.Endpoint)
+			fmt.Println("  targets:")
+			for _, target := range targets {
+				fmt.Printf("  - %s (%s)\n", target.Path, target.Behavior)
+			}
+			fmt.Println()
 			fmt.Printf("  entry: %s\n\n(no changes written)\n", string(displayJSON))
 		}
 		return nil
 	}
 
 	var updated []string
-	for _, cfgPath := range targets {
-		action, err := updateMCPConfig(cfgPath, name, newEntry)
+	for _, target := range targets {
+		action, err := updateMCPConfig(target.Path, name, newEntry)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "engram-setup: warning: could not update %s: %v\n", cfgPath, err)
+			fmt.Fprintf(os.Stderr, "engram-setup: warning: could not update %s: %v\n", target.Path, err)
 			continue
 		}
 		if action != "" {
-			updated = append(updated, fmt.Sprintf("%s (%s)", cfgPath, action))
+			updated = append(updated, fmt.Sprintf("%s (%s)", target.Path, action))
 		}
 	}
 
@@ -253,6 +261,24 @@ func configureWithSetup(base, name string, dryRun bool, format string, setup *se
 		fmt.Println("Run /mcp in Claude Code to reconnect.")
 	}
 	return nil
+}
+
+type setupConfigTarget struct {
+	Path     string `json:"path"`
+	Behavior string `json:"behavior"`
+}
+
+func setupConfigTargets(home string) []setupConfigTarget {
+	return []setupConfigTarget{
+		{
+			Path:     filepath.Join(home, ".claude", "mcp_servers.json"),
+			Behavior: "create or update",
+		},
+		{
+			Path:     filepath.Join(home, ".claude.json"),
+			Behavior: "update only when the file already has mcpServers; otherwise skip",
+		},
+	}
 }
 
 func redactToken(token string) string {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,15 +118,21 @@ Subsequent local-only starts are fast — the model is cached in the Ollama volu
 
 ## Step 5: Connect Your IDE
 
-For Claude Code, run `make setup` once the containers are healthy:
+For Claude Code, configure the MCP client once the server is healthy. `make setup` targets the default home-network endpoint `https://engram.petersimmons.com`:
 
 ```bash
 make setup
 ```
 
-This calls the `/setup-token` endpoint on the running server, retrieves the bearer token, and writes it to `~/.claude/mcp_servers.json`. The bootstrap path is one-time localhost setup; after that, the endpoint requires normal bearer-authenticated access. Run `/mcp` in Claude Code afterward to activate the connection.
+For local-only Docker, pass the local server URL explicitly:
 
-Re-run `make setup` any time the server restarts (if `ENGRAM_API_KEY` rotates) or after a fresh install.
+```bash
+go run ./cmd/engram-setup --url http://127.0.0.1:8788
+```
+
+This calls the `/setup-token` endpoint on the effective server, retrieves the bearer token, and writes it to `~/.claude/mcp_servers.json`. It also updates `~/.claude.json` when that file already has a `mcpServers` block. If `/setup-token` is unavailable during bootstrap, setup validates fallback credentials from `~/.config/engram/api_key` first and `~/projects/engram-go/.env` (`ENGRAM_API_KEY`) second before writing anything. Run `/mcp` in Claude Code afterward to activate the connection.
+
+Re-run the same setup command any time the server restarts (if `ENGRAM_API_KEY` rotates) or after a fresh install.
 
 For Cursor, VS Code, Windsurf, or Claude Desktop, see [Connecting Your IDE](connecting.md) — you will need to copy the token from `.env` manually for those clients.
 


### PR DESCRIPTION
closes #1071

## Summary

- Rebased `agent/codex/issue-1038-setup-docs` (1 commit, `e2c1d1a → 6ea0da4`) onto current `origin/main`
- Resolved 4 conflicts (Makefile, README.md, cmd/README.md, cmd/engram-setup/main.go) — all were comment/doc-string divergences; branch content preferred throughout as it accurately describes the conditional `.claude.json` update behavior introduced in the same commit
- No logic conflicts; `cmd/engram-setup/engram_setup_test.go` merged cleanly

## What's on this branch

- `README.md` — "Setup Target and Config Writes" section + accurate local/remote endpoint description
- `cmd/README.md` — expanded `engram-setup` usage with dry-run, `--url`, `--port` examples and conditional-write behavior documentation
- `cmd/engram-setup/docs_contract_test.go` — new contract test (`TestSetupDocsMatchNetworkDefaultContract`) ensuring docs stay in sync with default endpoint
- `cmd/engram-setup/engram_setup_test.go` — expanded coverage: conditional `.claude.json` write, dry-run output, offline flag, JSON format flag
- `cmd/engram-setup/main.go` — `setupConfigTarget` type + `setupConfigTargets()` helper; conditional `.claude.json` update (only when `mcpServers` key already present); richer dry-run output
- `docs/getting-started.md` — updated setup walkthrough
- `Makefile` — updated `setup` / `setup-dry-run` target comments

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./cmd/engram-setup/... -count=1` — 25/25 pass (1 skipped: format-flag recognition, pre-existing)
- [x] `bin/checkin-lint.sh` — 0 findings (73 baselined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)