### PR TITLE
Add strict and lenient LongMemEval score baselines

### DIFF
--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -182,10 +182,18 @@ func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap ma
 }
 
 type scoreReportCounts struct {
-	Correct          int `json:"correct"`
-	PartiallyCorrect int `json:"partially_correct"`
-	Incorrect        int `json:"incorrect"`
-	Total            int `json:"total"`
+	Correct          int                  `json:"correct"`
+	PartiallyCorrect int                  `json:"partially_correct"`
+	Incorrect        int                  `json:"incorrect"`
+	Total            int                  `json:"total"`
+	Strict           scoreAccuracySummary `json:"strict"`
+	Lenient          scoreAccuracySummary `json:"lenient"`
+}
+
+type scoreAccuracySummary struct {
+	CreditedCorrect int     `json:"credited_correct"`
+	Total           int     `json:"total"`
+	Accuracy        float64 `json:"accuracy"`
 }
 
 func writeHypotheses(cfg *Config, scores []longmemeval.ScoreEntry) {
@@ -286,6 +294,11 @@ func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEnt
 		}
 	}
 
+	overall.finalize()
+	for _, row := range byQType {
+		row.finalize()
+	}
+
 	judgedAt := cfg.Now
 	if judgedAt == nil {
 		judgedAt = func() time.Time { return time.Now().UTC() }
@@ -358,9 +371,34 @@ func writeScoreSummary(w io.Writer, mode string, report map[string]any, overall 
 	pct := func(n int) float64 { return float64(n) / float64(overall.Total) * 100 }
 	_, _ = fmt.Fprintf(w, "\n--- Score Report (run-id: %s) ---\n", report["run_id"])
 	_, _ = fmt.Fprintf(w, "Total scored:       %d\n", overall.Total)
+	_, _ = fmt.Fprintf(w, "Strict accuracy:    %d/%d (%.1f%%)\n", overall.Strict.CreditedCorrect, overall.Strict.Total, overall.Strict.Accuracy*100)
+	_, _ = fmt.Fprintf(w, "Lenient accuracy:   %d/%d (%.1f%%)\n", overall.Lenient.CreditedCorrect, overall.Lenient.Total, overall.Lenient.Accuracy*100)
 	_, _ = fmt.Fprintf(w, "Correct:            %d (%.1f%%)\n", overall.Correct, pct(overall.Correct))
 	_, _ = fmt.Fprintf(w, "Partially correct:  %d (%.1f%%)\n", overall.PartiallyCorrect, pct(overall.PartiallyCorrect))
 	_, _ = fmt.Fprintf(w, "Incorrect:          %d (%.1f%%)\n", overall.Incorrect, pct(overall.Incorrect))
+}
+
+func (c *scoreReportCounts) finalize() {
+	if c == nil {
+		return
+	}
+	c.Strict = scoreAccuracySummary{
+		CreditedCorrect: c.Correct,
+		Total:           c.Total,
+		Accuracy:        accuracyRatio(c.Correct, c.Total),
+	}
+	c.Lenient = scoreAccuracySummary{
+		CreditedCorrect: c.Correct + c.PartiallyCorrect,
+		Total:           c.Total,
+		Accuracy:        accuracyRatio(c.Correct+c.PartiallyCorrect, c.Total),
+	}
+}
+
+func accuracyRatio(creditedCorrect, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(creditedCorrect) / float64(total)
 }
 
 // normalizeLabel canonicalises a score label: trims surrounding whitespace

--- a/cmd/longmemeval/score_test.go
+++ b/cmd/longmemeval/score_test.go
@@ -183,6 +183,46 @@ func TestWriteScoreReport_Basic(t *testing.T) {
 	}
 }
 
+func TestWriteScoreReport_IncludesStrictAndLenientAccuracy(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{OutDir: dir, RunID: "accuracy-breakdown-test"}
+
+	scores := []longmemeval.ScoreEntry{
+		{QuestionID: "q1", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+		{QuestionID: "q2", QuestionType: "single-session-user", ScoreLabel: "PARTIALLY_CORRECT", Status: "done"},
+		{QuestionID: "q3", QuestionType: "single-session-user", ScoreLabel: "INCORRECT", Status: "done"},
+	}
+
+	writeScoreReport(cfg, scores)
+
+	report := readScoreReport(t, filepath.Join(dir, "score_report.json"))
+	overall := reportMap(t, report["overall"], "overall")
+
+	assertAccuracySummary(t, reportMap(t, overall["strict"], "overall.strict"), 1, 3, 1.0/3.0)
+	assertAccuracySummary(t, reportMap(t, overall["lenient"], "overall.lenient"), 2, 3, 2.0/3.0)
+}
+
+func TestWriteScoreReport_SingleSessionPreferenceLenientCountsPartialCredit(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{OutDir: dir, RunID: "ss-preference-lenient-test"}
+
+	scores := []longmemeval.ScoreEntry{
+		{QuestionID: "q1", QuestionType: "single-session-preference", ScoreLabel: "PARTIALLY_CORRECT", Status: "done"},
+		{QuestionID: "q2", QuestionType: "single-session-preference", ScoreLabel: "PARTIALLY_CORRECT", Status: "done"},
+		{QuestionID: "q3", QuestionType: "single-session-preference", ScoreLabel: "INCORRECT", Status: "done"},
+		{QuestionID: "q4", QuestionType: "single-session-preference", ScoreLabel: "CORRECT", Status: "done"},
+	}
+
+	writeScoreReport(cfg, scores)
+
+	report := readScoreReport(t, filepath.Join(dir, "score_report.json"))
+	byType := reportMap(t, report["by_type"], "by_type")
+	row := reportMap(t, byType["single-session-preference"], "by_type.single-session-preference")
+
+	assertAccuracySummary(t, reportMap(t, row["strict"], "by_type.single-session-preference.strict"), 1, 4, 0.25)
+	assertAccuracySummary(t, reportMap(t, row["lenient"], "by_type.single-session-preference.lenient"), 3, 4, 0.75)
+}
+
 func TestWriteScoreReport_RecordsJudgeAttributionMetadata(t *testing.T) {
 	const fixed = "2026-06-03T10:00:00Z"
 	cfg := &Config{
@@ -394,6 +434,45 @@ func TestNormalizeLabel(t *testing.T) {
 		if got != c.want {
 			t.Errorf("normalizeLabel(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+func readScoreReport(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", filepath.Base(path), err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse %s: %v", filepath.Base(path), err)
+	}
+	return report
+}
+
+func reportMap(t *testing.T, v any, name string) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("%s not a map: %T (%v)", name, v, v)
+	}
+	return m
+}
+
+func assertAccuracySummary(t *testing.T, got map[string]any, wantCredited, wantTotal int, wantAccuracy float64) {
+	t.Helper()
+	if credited := int(got["credited_correct"].(float64)); credited != wantCredited {
+		t.Fatalf("credited_correct = %d, want %d", credited, wantCredited)
+	}
+	if total := int(got["total"].(float64)); total != wantTotal {
+		t.Fatalf("total = %d, want %d", total, wantTotal)
+	}
+	accuracy, ok := got["accuracy"].(float64)
+	if !ok {
+		t.Fatalf("accuracy not a number: %T (%v)", got["accuracy"], got["accuracy"])
+	}
+	if diff := accuracy - wantAccuracy; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("accuracy = %.12f, want %.12f", accuracy, wantAccuracy)
 	}
 }
 

--- a/docs/lme-judging.md
+++ b/docs/lme-judging.md
@@ -63,6 +63,17 @@ The judge report is scored in two ways:
 - `strict`: `CORRECT / total`
 - `lenient`: `(CORRECT + PARTIALLY_CORRECT) / total`
 
+`score_report.json` now records both summaries in machine-readable form under
+`overall.{strict,lenient}` and `by_type.<question_type>.{strict,lenient}`. This
+keeps the frozen phase-0 strict counts intact while exposing a separate
+partial-credit baseline for categories such as `single-session-preference`.
+
+When publishing benchmark updates:
+
+- Keep the original strict baseline for backward comparability.
+- Treat the lenient/partial-credit view as a new baseline artifact, not a
+  rewrite of the existing phase-0 scores.
+
 Use both when comparing checkpoints, and keep `compare` deltas in CI notes.
 
 ## Recommended workflow


### PR DESCRIPTION
## Summary - Add machine-readable `strict` and `lenient` accuracy summaries to `score_report.json` for `overall` and `by_type` while preserving existing `correct` / `partially_correct` / `incorrect` buckets. - Surface the same strict vs lenient view in text score summaries so partial-credit benchmark changes are visible during runs. - Document lenient partial-credit scoring as a new additive baseline that does not overwrite frozen phase-0 strict scores. ## Testing - `/usr/local/go/bin/go test ./cmd/longmemeval ./internal/longmemeval`