### PR TITLE
Add session-diversity recall sampling

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -259,7 +259,6 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.DualPreferenceRecall, "dual-preference-recall", false, "H15: opt-in second recall pass for inferred preference questions using a cleaned subject anchor and score-aware union (default off)")
 	// H-TAB: topic-anchor boost (LME experiment #3)
 	fs.BoolVar(&cfg.TopicAnchorBoost, "topic-anchor-boost", false, "H-TAB: server-side topic-anchor scoring boost — preference memories containing domain tokens from the query score 1.25× higher; targets multi-preference-session distraction (default off, composable with --dual-preference-recall)")
-	fs.IntVar(&cfg.SessionDiversityN, "session-diversity-n", envInt("ENGRAM_SESSION_DIVERSITY_N", 0), "per-session recall cap; 0 disables diversity sampling")
 	// H8: exhaustive aggregation recall (lme-h8h12h15 branch)
 	fs.BoolVar(&cfg.ExhaustiveAggregation, "exhaustive-aggregation", false, "H8: run a topK=500 sweep recall for count-shaped questions and union with primary results (default off)")
 	// H12: enumerate-first generation prompt (lme-h8h12h15 branch)

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -82,7 +82,6 @@ type Config struct {
 
 	// H-TAB: topic-anchor boost (LME experiment #3, server-side, flag-gated)
 	TopicAnchorBoost bool // H-TAB: server-side topic-anchor scoring boost for preference questions (default off)
-
 	// H8: exhaustive aggregation recall (lme-h8h12h15 branch)
 	ExhaustiveAggregation bool // run a topK=500 sweep for count-shaped questions and union with primary results
 
@@ -260,6 +259,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.DualPreferenceRecall, "dual-preference-recall", false, "H15: opt-in second recall pass for inferred preference questions using a cleaned subject anchor and score-aware union (default off)")
 	// H-TAB: topic-anchor boost (LME experiment #3)
 	fs.BoolVar(&cfg.TopicAnchorBoost, "topic-anchor-boost", false, "H-TAB: server-side topic-anchor scoring boost — preference memories containing domain tokens from the query score 1.25× higher; targets multi-preference-session distraction (default off, composable with --dual-preference-recall)")
+	fs.IntVar(&cfg.SessionDiversityN, "session-diversity-n", envInt("ENGRAM_SESSION_DIVERSITY_N", 0), "per-session recall cap; 0 disables diversity sampling")
 	// H8: exhaustive aggregation recall (lme-h8h12h15 branch)
 	fs.BoolVar(&cfg.ExhaustiveAggregation, "exhaustive-aggregation", false, "H8: run a topK=500 sweep recall for count-shaped questions and union with primary results (default off)")
 	// H12: enumerate-first generation prompt (lme-h8h12h15 branch)

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -311,6 +311,35 @@ func TestRecall_SetsRecordEventFalse(t *testing.T) {
 	}
 }
 
+func TestRecallWithOpts_SendsSessionDiversityN(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got, ok := args["session_diversity_n"].(float64); !ok || got != 2 {
+				t.Fatalf("session_diversity_n = %#v, want 2", args["session_diversity_n"])
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{
+					{"id": "h-aaa", "score": 0.8},
+				},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.RecallWithOpts(ctx, "proj", "query", 5, nil, nil, false); err != nil {
+		t.Fatalf("RecallWithOpts: %v", err)
+	}
+}
+
 // TestFetchContent_HappyPath verifies content fetching.
 func TestFetchContent_HappyPath(t *testing.T) {
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -312,6 +312,7 @@ func TestRecall_SetsRecordEventFalse(t *testing.T) {
 }
 
 func TestRecallWithOpts_SendsSessionDiversityN(t *testing.T) {
+	t.Setenv("ENGRAM_SESSION_DIVERSITY_N", "2")
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
 		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			args := req.GetArguments()

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -422,18 +422,19 @@ func (c *Client) RecallWithAtomRecall(ctx context.Context, project, query string
 
 // recallParams carries the optional knobs for a single memory_recall call.
 type recallParams struct {
-	project          string
-	query            string
-	topK             int
-	since            *time.Time
-	before           *time.Time
-	temporalWindow   bool
-	questionText     string
-	questionDate     string
-	exactFactBoost   bool
-	topicAnchorBoost bool
-	atomRecall       bool
-	atomRecallAsOf   *time.Time
+	project           string
+	query             string
+	topK              int
+	since             *time.Time
+	before            *time.Time
+	temporalWindow    bool
+	questionText      string
+	questionDate      string
+	exactFactBoost    bool
+	topicAnchorBoost  bool
+	atomRecall        bool
+	atomRecallAsOf    *time.Time
+	sessionDiversityN int
 }
 
 func (c *Client) recallResultWithParams(ctx context.Context, p recallParams) (RecallResult, error) {
@@ -535,6 +536,9 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 	}
 	if p.atomRecallAsOf != nil {
 		args["atom_recall_as_of"] = p.atomRecallAsOf.UTC().Format(time.RFC3339)
+	}
+	if p.sessionDiversityN > 0 {
+		args["session_diversity_n"] = p.sessionDiversityN
 	}
 	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -403,9 +404,16 @@ func (c *Client) RecallWithOptsResult(ctx context.Context, project, query string
 }
 
 func (c *Client) RecallScoredWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]ScoredMemoryID, error) {
+	diversityN := 0
+	if v := os.Getenv("ENGRAM_SESSION_DIVERSITY_N"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			diversityN = n
+		}
+	}
 	return c.recallScoredWithParams(ctx, recallParams{
 		project: project, query: query, topK: topK, since: since, before: before,
-		topicAnchorBoost: topicAnchorBoost,
+		topicAnchorBoost:  topicAnchorBoost,
+		sessionDiversityN: diversityN,
 	})
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -141,7 +141,6 @@ type Config struct {
 	// Set via --session-ndcg-agg flag or ENGRAM_SESSION_NDCG_AGG=true env var.
 	// Default false (ablation-safe; identical to baseline when false). (LEVER-8)
 	SessionNDCGAgg bool
-
 	// SessionDiversityN is the LEVER-9 per-session chunk cap for recall results.
 	// When non-zero, recall results are post-processed to ensure no single session
 	// contributes more than N chunks to the returned topK. This surfaces minority-

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -458,6 +458,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	opts.DateBefore = before
 	// H-TAB (LME exp #3): topic-anchor boost for preference queries.
 	opts.TopicAnchorBoost = getBool(args, "topic_anchor_boost", false)
+	opts.SessionDiversityN = getInt(args, "session_diversity_n", cfg.SessionDiversityN)
 	opts.TemporalWindowRecall = temporalWindowRecall
 	opts.QuestionText = questionText
 	opts.QuestionDate = questionDate

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -130,7 +130,6 @@ type RecallOpts struct {
 	// ablatable: when false the code path is entirely bypassed and results are
 	// identical to the baseline. Default false. (LEVER-8)
 	SessionNDCGAgg bool
-
 	// PreferenceMMR enables the H-NEW-2 centroid-MMR diversity pass for preference
 	// queries. When true and the query is preference-shaped, the engine fetches
 	// best-chunk embeddings for top candidates, computes a centroid of the top-10


### PR DESCRIPTION
## Summary\n- add the H-SD rank-preserving capped-prefix session-diversity pass in `RecallWithOpts()` before top-K truncation\n- wire `SessionDiversityN` through `memory_recall`, the longmemeval client, and `--session-diversity-n` / `ENGRAM_SESSION_DIVERSITY_N`\n- add TDD coverage for minority-session promotion, single-session/no-op gates, missing session IDs, multi-minority promotion, and no-mutation behavior\n\n## Testing\n- `/usr/local/go/bin/go test ./internal/search -run 'TestSessionDiversity_' -count=1`\n- `/usr/local/go/bin/go test ./internal/longmemeval -run 'TestRecallWithOpts_SendsSessionDiversityN' -count=1`\n- `/usr/local/go/bin/go test ./cmd/longmemeval ./cmd/engram ./internal/mcp -count=1`\n- `/usr/local/go/bin/go test ./... -count=1 -race`