### PR TITLE
Add session dominance diagnostics to LongMemEval score reports

### DIFF
--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
-	"github.com/petersimmons1972/engram/internal/types"
 )
 
 // preservedLog is a mutex-protected accumulator for project names that were
@@ -806,47 +805,6 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 }
 
-func searchResultIDs(results []types.SearchResult) []string {
-	ids := make([]string, 0, len(results))
-	for _, result := range results {
-		if result.Memory != nil && result.Memory.ID != "" {
-			ids = append(ids, result.Memory.ID)
-		}
-	}
-	return ids
-}
-
-func unionSearchResults(primary, fallback []types.SearchResult) []types.SearchResult {
-	if len(fallback) == 0 {
-		return primary
-	}
-	seen := make(map[string]bool, len(primary)+len(fallback))
-	out := make([]types.SearchResult, 0, len(primary)+len(fallback))
-	for _, result := range primary {
-		key := searchResultKey(result)
-		if key == "" || seen[key] {
-			continue
-		}
-		seen[key] = true
-		out = append(out, result)
-	}
-	for _, result := range fallback {
-		key := searchResultKey(result)
-		if key == "" || seen[key] {
-			continue
-		}
-		seen[key] = true
-		out = append(out, result)
-	}
-	return out
-}
-
-func searchResultKey(result types.SearchResult) string {
-	if result.Memory == nil {
-		return ""
-	}
-	return result.Memory.ID
-}
 
 func buildRecallVariants(question, primary string, disableRewrite, includeIdentifiers bool) []string {
 	seen := map[string]bool{}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 // preservedLog is a mutex-protected accumulator for project names that were
@@ -572,6 +573,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	)
 	serverTemporalWindow := cfg.TemporalWindowRecall && item.QuestionType == "temporal-reasoning"
 	dualPreferenceRecall := cfg.DualPreferenceRecall && !serverTemporalWindow && longmemeval.IsInferredPreferenceQuestion(item.Question)
+	var sessionDominanceRatio float64
+	var contextSessionCount int
 	if serverTemporalWindow {
 		retrievedIDs, err = mcpClient.RecallWithTemporalWindow(ctx, ingest.Project, recallQuery, effectiveRecallTopK, item.Question, item.QuestionDate)
 		if err != nil {
@@ -601,6 +604,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 				Error:      fmt.Sprintf("recall: %v", err),
 			}
 		}
+		sessionDominanceRatio, contextSessionCount = computeSessionDiagnostics(recallResult.Results)
 	}
 	secondaryContextIDs := temporalFallbackIDs
 	if cfg.RetrievalFusion && !serverTemporalWindow {
@@ -791,13 +795,57 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	}
 
 	return longmemeval.RunEntry{
-		QuestionID:    item.QuestionID,
-		Hypothesis:    hypothesis,
-		RetrievedIDs:  retrievedIDs,
-		Status:        "done",
-		AtomRetrieved: atomPreamble != "",
-		AtomInContext: atomContextBlock != "",
+		QuestionID:            item.QuestionID,
+		Hypothesis:            hypothesis,
+		RetrievedIDs:          retrievedIDs,
+		SessionDominanceRatio: sessionDominanceRatio,
+		ContextSessionCount:   contextSessionCount,
+		Status:                "done",
+		AtomRetrieved:         atomPreamble != "",
+		AtomInContext:         atomContextBlock != "",
 	}
+}
+
+func searchResultIDs(results []types.SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, result := range results {
+		if result.Memory != nil && result.Memory.ID != "" {
+			ids = append(ids, result.Memory.ID)
+		}
+	}
+	return ids
+}
+
+func unionSearchResults(primary, fallback []types.SearchResult) []types.SearchResult {
+	if len(fallback) == 0 {
+		return primary
+	}
+	seen := make(map[string]bool, len(primary)+len(fallback))
+	out := make([]types.SearchResult, 0, len(primary)+len(fallback))
+	for _, result := range primary {
+		key := searchResultKey(result)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, result)
+	}
+	for _, result := range fallback {
+		key := searchResultKey(result)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, result)
+	}
+	return out
+}
+
+func searchResultKey(result types.SearchResult) string {
+	if result.Memory == nil {
+		return ""
+	}
+	return result.Memory.ID
 }
 
 func buildRecallVariants(question, primary string, disableRewrite, includeIdentifiers bool) []string {

--- a/cmd/longmemeval/sample.go
+++ b/cmd/longmemeval/sample.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 type samplePrepareConfig struct {
@@ -302,6 +304,30 @@ func hasGoldSession(retrievedIDs []string, memoryMap map[string]string, answerSe
 		}
 	}
 	return false
+}
+
+func computeSessionDiagnostics(results []types.SearchResult) (float64, int) {
+	if len(results) == 0 {
+		return 0.0, 0
+	}
+
+	counts := make(map[string]int, len(results))
+	maxCount := 0
+	for i, result := range results {
+		sid := ""
+		if result.Memory != nil {
+			sid = search.ExtractSessionID(result.Memory.Tags)
+		}
+		if sid == "" {
+			sid = fmt.Sprintf("__missing_%d", i)
+		}
+		counts[sid]++
+		if counts[sid] > maxCount {
+			maxCount = counts[sid]
+		}
+	}
+
+	return float64(maxCount) / float64(len(results)), len(counts)
 }
 
 func loadItemsFile(path string) ([]longmemeval.Item, error) {

--- a/cmd/longmemeval/sample_test.go
+++ b/cmd/longmemeval/sample_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 func TestPrepareSampleFiltersIngestCheckpoint(t *testing.T) {
@@ -273,6 +274,109 @@ func TestAnalyzeSampleWithoutDataSummarizesScoreCheckpoint(t *testing.T) {
 	if summary.RetrievalMiss != 0 || summary.ContextPresentGenerationMiss != 0 {
 		t.Fatalf("gold-session failure clusters = retrieval_miss=%d generation_miss=%d, want zero without data",
 			summary.RetrievalMiss, summary.ContextPresentGenerationMiss)
+	}
+}
+
+func TestSessionDiagnostics_SingleDominantSession(t *testing.T) {
+	results := []types.SearchResult{
+		searchResultWithSession("m1", "s1"),
+		searchResultWithSession("m2", "s1"),
+		searchResultWithSession("m3", "s1"),
+		searchResultWithSession("m4", "s1"),
+		searchResultWithSession("m5", "s1"),
+		searchResultWithSession("m6", "s2"),
+	}
+
+	dominance, count := computeSessionDiagnostics(results)
+
+	if got, want := dominance, 5.0/6.0; got != want {
+		t.Fatalf("dominance = %v, want %v", got, want)
+	}
+	if count != 2 {
+		t.Fatalf("context session count = %d, want 2", count)
+	}
+}
+
+func TestSessionDiagnostics_EvenSplit(t *testing.T) {
+	results := []types.SearchResult{
+		searchResultWithSession("m1", "s1"),
+		searchResultWithSession("m2", "s1"),
+		searchResultWithSession("m3", "s1"),
+		searchResultWithSession("m4", "s2"),
+		searchResultWithSession("m5", "s2"),
+		searchResultWithSession("m6", "s2"),
+	}
+
+	dominance, count := computeSessionDiagnostics(results)
+
+	if dominance != 0.5 {
+		t.Fatalf("dominance = %v, want 0.5", dominance)
+	}
+	if count != 2 {
+		t.Fatalf("context session count = %d, want 2", count)
+	}
+}
+
+func TestSessionDiagnostics_EmptyResults(t *testing.T) {
+	dominance, count := computeSessionDiagnostics(nil)
+
+	if dominance != 0.0 {
+		t.Fatalf("dominance = %v, want 0.0", dominance)
+	}
+	if count != 0 {
+		t.Fatalf("context session count = %d, want 0", count)
+	}
+}
+
+func TestSessionDiagnostics_AllSameSession(t *testing.T) {
+	results := []types.SearchResult{
+		searchResultWithSession("m1", "s1"),
+		searchResultWithSession("m2", "s1"),
+		searchResultWithSession("m3", "s1"),
+		searchResultWithSession("m4", "s1"),
+	}
+
+	dominance, count := computeSessionDiagnostics(results)
+
+	if dominance != 1.0 {
+		t.Fatalf("dominance = %v, want 1.0", dominance)
+	}
+	if count != 1 {
+		t.Fatalf("context session count = %d, want 1", count)
+	}
+}
+
+func TestSessionDiagnostics_MissingSessionIDs(t *testing.T) {
+	results := []types.SearchResult{
+		searchResultWithSession("m1", "s1"),
+		searchResultWithSession("m2", ""),
+		searchResultWithSession("m3", ""),
+		searchResultWithSession("m4", ""),
+		searchResultWithSession("m5", "s2"),
+	}
+
+	dominance, count := computeSessionDiagnostics(results)
+
+	if dominance != 0.2 {
+		t.Fatalf("dominance = %v, want 0.2", dominance)
+	}
+	if count != 5 {
+		t.Fatalf("context session count = %d, want 5", count)
+	}
+}
+
+func searchResultWithSession(memoryID, sessionID string) types.SearchResult {
+	tags := []string{"source:test"}
+	if sessionID != "" {
+		tags = append(tags, "sid:"+sessionID)
+	} else {
+		tags = append(tags, "sid:")
+	}
+	return types.SearchResult{
+		Memory: &types.Memory{
+			ID:   memoryID,
+			Tags: tags,
+		},
 	}
 }
 

--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -177,17 +177,22 @@ func writeOutputs(cfg *Config, itemMap map[string]longmemeval.Item, ingestMap ma
 	writeScoreReportWithCompleteness(
 		cfg,
 		scores,
+		runMap,
 		scoreCompletenessFromMaps(itemMap, ingestMap, runMap, scores),
 	)
 }
 
 type scoreReportCounts struct {
-	Correct          int                  `json:"correct"`
-	PartiallyCorrect int                  `json:"partially_correct"`
-	Incorrect        int                  `json:"incorrect"`
-	Total            int                  `json:"total"`
-	Strict           scoreAccuracySummary `json:"strict"`
-	Lenient          scoreAccuracySummary `json:"lenient"`
+	Correct                  int                  `json:"correct"`
+	PartiallyCorrect         int                  `json:"partially_correct"`
+	Incorrect                int                  `json:"incorrect"`
+	Total                    int                  `json:"total"`
+	Strict                   scoreAccuracySummary `json:"strict"`
+	Lenient                  scoreAccuracySummary `json:"lenient"`
+	AvgSessionDominanceRatio float64              `json:"avg_session_dominance_ratio"`
+	AvgContextSessionCount   float64              `json:"avg_context_session_count"`
+	sessionDominanceRatioSum float64              `json:"-"`
+	contextSessionCountSum   float64              `json:"-"`
 }
 
 type scoreAccuracySummary struct {
@@ -259,10 +264,14 @@ func writeRetrievalLog(cfg *Config, itemMap map[string]longmemeval.Item, ingestM
 }
 
 func writeScoreReport(cfg *Config, scores []longmemeval.ScoreEntry) {
-	writeScoreReportWithCompleteness(cfg, scores, scoreCompletenessFromScores(scores))
+	writeScoreReportWithRunMap(cfg, scores, nil)
 }
 
-func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEntry, completeness scoreCompleteness) {
+func writeScoreReportWithRunMap(cfg *Config, scores []longmemeval.ScoreEntry, runMap map[string]longmemeval.RunEntry) {
+	writeScoreReportWithCompleteness(cfg, scores, runMap, scoreCompletenessFromScores(scores))
+}
+
+func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEntry, runMap map[string]longmemeval.RunEntry, completeness scoreCompleteness) {
 	// Deduplicate by QuestionID — last-write-wins, matching checkpoint append semantics.
 	deduped := make(map[string]longmemeval.ScoreEntry, len(scores))
 	for _, s := range scores {
@@ -281,6 +290,7 @@ func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEnt
 			qbt = &scoreReportCounts{}
 			byQType[s.QuestionType] = qbt
 		}
+		run := runMap[s.QuestionID]
 		for _, bt := range []*scoreReportCounts{overall, qbt} {
 			bt.Total++
 			switch s.ScoreLabel {
@@ -291,7 +301,13 @@ func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEnt
 			default:
 				bt.Incorrect++
 			}
+			bt.sessionDominanceRatioSum += run.SessionDominanceRatio
+			bt.contextSessionCountSum += float64(run.ContextSessionCount)
 		}
+	}
+	finalizeScoreReportCounts(overall)
+	for _, counts := range byQType {
+		finalizeScoreReportCounts(counts)
 	}
 
 	overall.finalize()
@@ -346,6 +362,14 @@ func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEnt
 	log.Printf("wrote %s", path)
 
 	writeScoreSummary(cfg.Output, cfg.ScoreOutput, report, overall)
+}
+
+func finalizeScoreReportCounts(counts *scoreReportCounts) {
+	if counts == nil || counts.Total == 0 {
+		return
+	}
+	counts.AvgSessionDominanceRatio = counts.sessionDominanceRatioSum / float64(counts.Total)
+	counts.AvgContextSessionCount = counts.contextSessionCountSum / float64(counts.Total)
 }
 
 func writeScoreSummary(w io.Writer, mode string, report map[string]any, overall *scoreReportCounts) {

--- a/cmd/longmemeval/score_test.go
+++ b/cmd/longmemeval/score_test.go
@@ -296,6 +296,60 @@ func TestWriteOutputArtifactsArePrivate(t *testing.T) {
 	assertMode(t, filepath.Join(dir, "score_report.json"), 0o600)
 }
 
+func TestScoreReport_SessionDominanceAggregation(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{OutDir: dir, RunID: "session-dominance-test"}
+
+	scores := []longmemeval.ScoreEntry{
+		{QuestionID: "q1", QuestionType: "single-session-user", ScoreLabel: "CORRECT", Status: "done"},
+		{QuestionID: "q2", QuestionType: "single-session-user", ScoreLabel: "INCORRECT", Status: "done"},
+		{QuestionID: "q3", QuestionType: "temporal-reasoning", ScoreLabel: "PARTIALLY_CORRECT", Status: "done"},
+		{QuestionID: "q4", QuestionType: "temporal-reasoning", ScoreLabel: "CORRECT", Status: "error"},
+	}
+	runMap := map[string]longmemeval.RunEntry{
+		"q1": {QuestionID: "q1", SessionDominanceRatio: 1.0, ContextSessionCount: 1},
+		"q2": {QuestionID: "q2", SessionDominanceRatio: 0.5, ContextSessionCount: 2},
+		"q3": {QuestionID: "q3", SessionDominanceRatio: 0.25, ContextSessionCount: 4},
+		"q4": {QuestionID: "q4", SessionDominanceRatio: 0.99, ContextSessionCount: 9},
+	}
+
+	writeScoreReportWithRunMap(cfg, scores, runMap)
+
+	data, err := os.ReadFile(filepath.Join(dir, "score_report.json"))
+	if err != nil {
+		t.Fatalf("read score_report.json: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse score_report.json: %v", err)
+	}
+
+	overall := report["overall"].(map[string]any)
+	if got, want := overall["avg_session_dominance_ratio"].(float64), (1.0+0.5+0.25)/3.0; got != want {
+		t.Fatalf("overall avg_session_dominance_ratio = %v, want %v", got, want)
+	}
+	if got, want := overall["avg_context_session_count"].(float64), (1.0+2.0+4.0)/3.0; got != want {
+		t.Fatalf("overall avg_context_session_count = %v, want %v", got, want)
+	}
+
+	byType := report["by_type"].(map[string]any)
+	single := byType["single-session-user"].(map[string]any)
+	if got, want := single["avg_session_dominance_ratio"].(float64), 0.75; got != want {
+		t.Fatalf("single-session-user avg_session_dominance_ratio = %v, want %v", got, want)
+	}
+	if got, want := single["avg_context_session_count"].(float64), 1.5; got != want {
+		t.Fatalf("single-session-user avg_context_session_count = %v, want %v", got, want)
+	}
+
+	temporal := byType["temporal-reasoning"].(map[string]any)
+	if got, want := temporal["avg_session_dominance_ratio"].(float64), 0.25; got != want {
+		t.Fatalf("temporal-reasoning avg_session_dominance_ratio = %v, want %v", got, want)
+	}
+	if got, want := temporal["avg_context_session_count"].(float64), 4.0; got != want {
+		t.Fatalf("temporal-reasoning avg_context_session_count = %v, want %v", got, want)
+	}
+}
+
 func TestWriteOutputArtifactsTightenExistingFiles(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &Config{OutDir: dir, RunID: "private-artifacts-test"}

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -282,6 +282,53 @@ func TestExtractSessionID_ExportedAccessible(t *testing.T) {
 		t.Fatalf("ExtractSessionID([session:s99]) = %q, want %q", got, "s99")
 	}
 }
+
+func TestRecallResultsWithOpts_FullModeIncludesTags(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got := args["mode"]; got != "full" {
+				t.Fatalf("mode = %#v, want full", got)
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"results": []map[string]any{
+					{
+						"memory": map[string]any{
+							"id":   "mem-111",
+							"tags": []string{"sid:s1", "source:test"},
+						},
+						"score": 0.9,
+					},
+				},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	results, err := c.RecallResultsWithOpts(ctx, "proj", "query", 5, nil, nil, false)
+	if err != nil {
+		t.Fatalf("RecallResultsWithOpts: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Memory == nil || results[0].Memory.ID != "mem-111" {
+		t.Fatalf("memory = %+v, want mem-111", results[0].Memory)
+	}
+	if got := results[0].Memory.Tags; len(got) != 2 || got[0] != "sid:s1" {
+		t.Fatalf("tags = %v, want sid:s1 present", got)
+	}
+}
+
+
 func TestRecall_SetsRecordEventFalse(t *testing.T) {
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
 		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/atom"
 	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 // Client wraps the MCP Streamable HTTP client with retry logic for eval use.
@@ -361,6 +362,10 @@ type RecallResult struct {
 	// MemoryMap maps memory ID to session ID extracted from handle-mode tags.
 	// Populated when handle-mode recall returns tags with a "session:<id>" entry.
 	MemoryMap map[string]string
+	// Results carries the full SearchResult objects when recall was issued in
+	// "full" mode. Populated by RecallResultsWith* wrappers for callers that
+	// need access to memory tags (e.g. session dominance diagnostics).
+	Results []types.SearchResult
 }
 
 // RecallWithTemporalWindow enables the server-side H-NEW-1 two-pass date-windowed
@@ -384,6 +389,18 @@ func (c *Client) RecallWithTemporalWindowResult(ctx context.Context, project, qu
 		project: project, query: query, topK: topK,
 		temporalWindow: true, questionText: questionText, questionDate: questionDate,
 	})
+}
+
+func (c *Client) RecallResultsWithTemporalWindow(ctx context.Context, project, query string, topK int, questionText, questionDate string) ([]types.SearchResult, error) {
+	result, err := c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK,
+		temporalWindow: true, questionText: questionText, questionDate: questionDate,
+		mode: "full",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
 }
 
 // RecallWithOpts calls memory_recall with additional server-side options.
@@ -428,11 +445,24 @@ func (c *Client) RecallWithAtomRecall(ctx context.Context, project, query string
 	})
 }
 
+func (c *Client) RecallResultsWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]types.SearchResult, error) {
+	result, err := c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		topicAnchorBoost: topicAnchorBoost, mode: "full",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
+
 // recallParams carries the optional knobs for a single memory_recall call.
 type recallParams struct {
 	project           string
 	query             string
 	topK              int
+	mode              string
 	since             *time.Time
 	before            *time.Time
 	temporalWindow    bool
@@ -507,6 +537,17 @@ func (c *Client) RecallScoredWithExactBoost(ctx context.Context, project, query 
 	})
 }
 
+func (c *Client) RecallResultsWithExactBoost(ctx context.Context, project, query string, topK int, since, before *time.Time) ([]types.SearchResult, error) {
+	result, err := c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		exactFactBoost: true, mode: "full",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
 func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, error) {
 	args := map[string]any{
 		"query":   p.query,
@@ -516,11 +557,12 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 		// Benchmark retrieval must not mutate retrieval telemetry while
 		// measuring recall quality.
 		"record_event": false,
-		// Handle mode returns lightweight IDs + metadata instead of the
-		// full SearchResult graph. LongMemEval only needs ranked IDs, and
-		// this avoids oversized tool payloads on dense queries.
-		"mode": "handle",
 	}
+	mode := p.mode
+	if mode == "" {
+		mode = "handle"
+	}
+	args["mode"] = mode
 	if p.exactFactBoost {
 		args["exact_fact_boost"] = true
 	}
@@ -580,14 +622,9 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 	//   handle: {"handles":[{"id":"...","score":...}, ...]}
 	// Parse both and prefer whichever is populated.
 	var resp struct {
-		AtomPreamble string `json:"atom_preamble"`
-		Results      []struct {
-			Memory struct {
-				ID string `json:"id"`
-			} `json:"memory"`
-			Score float64 `json:"score"`
-		} `json:"results"`
-		Handles []struct {
+		AtomPreamble string               `json:"atom_preamble"`
+		Results      []types.SearchResult `json:"results"`
+		Handles      []struct {
 			ID    string   `json:"id"`
 			Score float64  `json:"score"`
 			Tags  []string `json:"tags"`
@@ -599,7 +636,7 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 	hits := make([]ScoredMemoryID, 0, len(resp.Results)+len(resp.Handles))
 	memoryMap := make(map[string]string, len(resp.Handles))
 	for _, r := range resp.Results {
-		if r.Memory.ID != "" {
+		if r.Memory != nil && r.Memory.ID != "" {
 			hits = append(hits, ScoredMemoryID{ID: r.Memory.ID, Score: r.Score})
 		}
 	}
@@ -611,7 +648,7 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 			}
 		}
 	}
-	return RecallResult{IDs: IDsFromScoredRecall(hits), AtomPreamble: resp.AtomPreamble, Hits: hits, MemoryMap: memoryMap}, nil
+	return RecallResult{IDs: IDsFromScoredRecall(hits), AtomPreamble: resp.AtomPreamble, Hits: hits, MemoryMap: memoryMap, Results: resp.Results}, nil
 }
 
 // FetchContent fetches the full content of a memory by ID within a project.

--- a/internal/longmemeval/types.go
+++ b/internal/longmemeval/types.go
@@ -56,13 +56,15 @@ type IngestEntry struct {
 
 // RunEntry is one line written to checkpoint-run.jsonl.
 type RunEntry struct {
-	QuestionID    string   `json:"question_id"`
-	Hypothesis    string   `json:"hypothesis"`
-	RetrievedIDs  []string `json:"retrieved_ids"` // memory IDs in ranked order
-	Status        string   `json:"status"`
-	Error         string   `json:"error,omitempty"`
-	AtomRetrieved bool     `json:"atom_retrieved,omitempty"`
-	AtomInContext bool     `json:"atom_in_context,omitempty"`
+	QuestionID            string   `json:"question_id"`
+	Hypothesis            string   `json:"hypothesis"`
+	RetrievedIDs          []string `json:"retrieved_ids"` // memory IDs in ranked order
+	SessionDominanceRatio float64  `json:"session_dominance_ratio"`
+	ContextSessionCount   int      `json:"context_session_count"`
+	Status                string   `json:"status"`
+	Error                 string   `json:"error,omitempty"`
+	AtomRetrieved         bool     `json:"atom_retrieved,omitempty"`
+	AtomInContext         bool     `json:"atom_in_context,omitempty"`
 	// Oracle probe fields (--atom-oracle, Phase 2A #1079). Omitted when zero/false.
 	OracleZeroAtoms bool `json:"oracle_zero_atoms,omitempty"` // set when --atom-oracle extracted zero atoms
 	OracleAtomCount int  `json:"oracle_atom_count,omitempty"` // atoms extracted and injected


### PR DESCRIPTION
## Summary - compute `session_dominance_ratio` and `context_session_count` on LongMemEval run entries from full recall results using the shared session-id extractor; aggregate `avg_session_dominance_ratio` and `avg_context_session_count` into `score_report.json` overall and `by_type`; add coverage for dominant/even/empty/single/missing-session cases and score-report aggregation.