### PR TITLE
Preserve session metadata in handle-mode recall

### DIFF
--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/search"
 )
 
 // newTestMCPServer builds a minimal MCP server with stubs for the Engram tools
@@ -215,6 +216,72 @@ func TestRecallScored_HandleMode(t *testing.T) {
 	}
 }
 
+func TestRecall_MemoryMapPopulated(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{
+					{"id": "mem-1", "score": 0.9, "tags": []string{"session:s42"}},
+				},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	result, err := c.RecallWithOptsResult(ctx, "proj", "query", 5, nil, nil, false)
+	if err != nil {
+		t.Fatalf("RecallWithOptsResult: %v", err)
+	}
+	if got := result.MemoryMap["mem-1"]; got != "s42" {
+		t.Fatalf("MemoryMap[mem-1] = %q, want %q", got, "s42")
+	}
+}
+
+func TestRecall_MemoryMapEmpty_NoTags(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{
+					{"id": "mem-1", "score": 0.9},
+				},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	result, err := c.RecallWithOptsResult(ctx, "proj", "query", 5, nil, nil, false)
+	if err != nil {
+		t.Fatalf("RecallWithOptsResult: %v", err)
+	}
+	if result.MemoryMap == nil {
+		t.Fatal("MemoryMap is nil, want non-nil empty map")
+	}
+	if len(result.MemoryMap) != 0 {
+		t.Fatalf("len(MemoryMap) = %d, want 0", len(result.MemoryMap))
+	}
+}
+
+func TestExtractSessionID_ExportedAccessible(t *testing.T) {
+	if got := search.ExtractSessionID([]string{"session:s99"}); got != "s99" {
+		t.Fatalf("ExtractSessionID([session:s99]) = %q, want %q", got, "s99")
+	}
+}
 func TestRecall_SetsRecordEventFalse(t *testing.T) {
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
 		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/petersimmons1972/engram/internal/search"
 )
 
 // Client wraps the MCP Streamable HTTP client with retry logic for eval use.
@@ -272,6 +273,12 @@ func (c *Client) RecallWithDateRange(ctx context.Context, project, query string,
 	return IDsFromScoredRecall(hits), nil
 }
 
+func (c *Client) RecallWithDateRangeResult(ctx context.Context, project, query string, topK int, since, before *time.Time) (RecallResult, error) {
+	return c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+	})
+}
+
 func (c *Client) RecallScored(ctx context.Context, project, query string, topK int) ([]ScoredMemoryID, error) {
 	return c.RecallScoredWithDateRange(ctx, project, query, topK, nil, nil)
 }
@@ -350,6 +357,9 @@ type RecallResult struct {
 	// Hits carries the scored recall results for callers that need score-based
 	// merging (e.g. H15 dual preference recall). IDsFromScoredRecall(Hits) == IDs.
 	Hits []ScoredMemoryID
+	// MemoryMap maps memory ID to session ID extracted from handle-mode tags.
+	// Populated when handle-mode recall returns tags with a "session:<id>" entry.
+	MemoryMap map[string]string
 }
 
 // RecallWithTemporalWindow enables the server-side H-NEW-1 two-pass date-windowed
@@ -368,6 +378,13 @@ func (c *Client) RecallWithTemporalWindow(ctx context.Context, project, query st
 	return IDsFromScoredRecall(hits), nil
 }
 
+func (c *Client) RecallWithTemporalWindowResult(ctx context.Context, project, query string, topK int, questionText, questionDate string) (RecallResult, error) {
+	return c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK,
+		temporalWindow: true, questionText: questionText, questionDate: questionDate,
+	})
+}
+
 // RecallWithOpts calls memory_recall with additional server-side options.
 // topicAnchorBoost=true sets topic_anchor_boost on the server (H-TAB, LME exp #3).
 func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]string, error) {
@@ -376,6 +393,13 @@ func (c *Client) RecallWithOpts(ctx context.Context, project, query string, topK
 		return nil, err
 	}
 	return IDsFromScoredRecall(hits), nil
+}
+
+func (c *Client) RecallWithOptsResult(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) (RecallResult, error) {
+	return c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		topicAnchorBoost: topicAnchorBoost,
+	})
 }
 
 func (c *Client) RecallScoredWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]ScoredMemoryID, error) {
@@ -458,6 +482,13 @@ func (c *Client) RecallWithExactBoost(ctx context.Context, project, query string
 		return nil, err
 	}
 	return IDsFromScoredRecall(hits), nil
+}
+
+func (c *Client) RecallWithExactBoostResult(ctx context.Context, project, query string, topK int, since, before *time.Time) (RecallResult, error) {
+	return c.recallResultWithParams(ctx, recallParams{
+		project: project, query: query, topK: topK, since: since, before: before,
+		exactFactBoost: true,
+	})
 }
 
 func (c *Client) RecallScoredWithExactBoost(ctx context.Context, project, query string, topK int, since, before *time.Time) ([]ScoredMemoryID, error) {
@@ -545,14 +576,16 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 			Score float64 `json:"score"`
 		} `json:"results"`
 		Handles []struct {
-			ID    string  `json:"id"`
-			Score float64 `json:"score"`
+			ID    string   `json:"id"`
+			Score float64  `json:"score"`
+			Tags  []string `json:"tags"`
 		} `json:"handles"`
 	}
 	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
 		return RecallResult{}, fmt.Errorf("parse recall response: %w", err)
 	}
 	hits := make([]ScoredMemoryID, 0, len(resp.Results)+len(resp.Handles))
+	memoryMap := make(map[string]string, len(resp.Handles))
 	for _, r := range resp.Results {
 		if r.Memory.ID != "" {
 			hits = append(hits, ScoredMemoryID{ID: r.Memory.ID, Score: r.Score})
@@ -561,9 +594,12 @@ func (c *Client) recall(ctx context.Context, p recallParams) (RecallResult, erro
 	for _, h := range resp.Handles {
 		if h.ID != "" {
 			hits = append(hits, ScoredMemoryID{ID: h.ID, Score: h.Score})
+			if len(h.Tags) > 0 {
+				memoryMap[h.ID] = search.ExtractSessionID(h.Tags)
+			}
 		}
 	}
-	return RecallResult{IDs: IDsFromScoredRecall(hits), AtomPreamble: resp.AtomPreamble, Hits: hits}, nil
+	return RecallResult{IDs: IDsFromScoredRecall(hits), AtomPreamble: resp.AtomPreamble, Hits: hits, MemoryMap: memoryMap}, nil
 }
 
 // FetchContent fetches the full content of a memory by ID within a project.

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -131,7 +131,14 @@ var _ embed.Client = (*fakeTestEmbedClient)(nil)
 // require a live Ollama instance.
 func NewTestPoolWithDSN(t *testing.T, ctx context.Context, dsn, project string) *EnginePool {
 	t.Helper()
-	embedder := &fakeTestEmbedClient{dims: 1024}
+	return NewTestPoolWithDSNAndEmbedder(t, ctx, dsn, project, &fakeTestEmbedClient{dims: 1024})
+}
+
+// NewTestPoolWithDSNAndEmbedder is like NewTestPoolWithDSN but accepts a custom
+// embedder. Use this when a test needs to simulate a specific embedder behaviour
+// (e.g. transient errors, a deterministic always-error client).
+func NewTestPoolWithDSNAndEmbedder(t *testing.T, ctx context.Context, dsn, project string, embedder embed.Client) *EnginePool {
+	t.Helper()
 	factory := func(factoryCtx context.Context, proj string) (*EngineHandle, error) {
 		backend, err := db.NewPostgresBackend(factoryCtx, proj, dsn)
 		if err != nil {

--- a/internal/mcp/tools_store_decouple_test.go
+++ b/internal/mcp/tools_store_decouple_test.go
@@ -64,8 +64,11 @@ func TestHandleMemoryStore_WritesRowAndEnqueuesLeaseWhenEmbedDown(t *testing.T) 
 	dsn := testDSNDecouple(t)
 	proj := uniqueProjectDecouple("embed-down")
 
-	// Create pool with a real database backend.
-	pool := NewTestPoolWithDSN(t, ctx, dsn, proj)
+	// Create pool with a transient-error embedder to correctly simulate the
+	// "embed down" scenario. The engine must store the memory and chunks with
+	// NULL embeddings regardless of whether the embedder is reachable.
+	pool := NewTestPoolWithDSNAndEmbedder(t, ctx, dsn, proj,
+		transientErrorEmbedder{dims: 1024, name: "noop"})
 
 	// Call handleMemoryStore with test content.
 	req := mcpgo.CallToolRequest{}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -211,6 +211,7 @@ func ToHandles(results []types.SearchResult) []types.Handle {
 			ID:          r.Memory.ID,
 			Project:     r.Memory.Project,
 			Summary:     sum,
+			Tags:        r.Memory.Tags,
 			Score:       r.Score,
 			StorageMode: r.Memory.StorageMode,
 			Bytes:       len(r.Memory.Content),

--- a/internal/search/handle_test.go
+++ b/internal/search/handle_test.go
@@ -58,3 +58,37 @@ func TestToHandles_NilMemorySkipped(t *testing.T) {
 	require.Len(t, handles, 1)
 	require.Equal(t, "y", handles[0].ID)
 }
+
+func TestToHandles_TagsPropagated(t *testing.T) {
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:      "abc-1",
+				Project: "proj",
+				Tags:    []string{"session:s42", "foo:bar"},
+			},
+			Score: 0.85,
+		},
+	}
+
+	handles := search.ToHandles(results)
+	require.Len(t, handles, 1)
+	require.Equal(t, []string{"session:s42", "foo:bar"}, handles[0].Tags)
+}
+
+func TestToHandles_NilTagsOmitted(t *testing.T) {
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:      "abc-1",
+				Project: "proj",
+				Tags:    nil,
+			},
+			Score: 0.85,
+		},
+	}
+
+	handles := search.ToHandles(results)
+	require.Len(t, handles, 1)
+	require.Empty(t, handles[0].Tags)
+}

--- a/internal/search/session_diversity.go
+++ b/internal/search/session_diversity.go
@@ -58,7 +58,7 @@ func applySessionDiversity(results []types.SearchResult, topK, N int) []types.Se
 		}
 		var sid string
 		if r.Memory != nil {
-			sid = extractSessionID(r.Memory.Tags)
+			sid = ExtractSessionID(r.Memory.Tags)
 		}
 		if sessionCount[sid] < N {
 			out = append(out, r)
@@ -73,7 +73,7 @@ func applySessionDiversity(results []types.SearchResult, topK, N int) []types.Se
 // distinct sessions. When all chunks share a session (or N == 0), the pass is a
 // no-op by definition and is skipped entirely to preserve baseline identity.
 //
-// "Distinct session" is determined by extractSessionID on each Memory's Tags slice.
+// "Distinct session" is determined by ExtractSessionID on each Memory's Tags slice.
 // Chunks with no sid: tag (or an empty sid: value) are grouped under the empty-string
 // session ID — they count as one distinct session together.
 func shouldApplySessionDiversity(results []types.SearchResult, N int) bool {
@@ -85,7 +85,7 @@ func shouldApplySessionDiversity(results []types.SearchResult, N int) bool {
 		if r.Memory == nil {
 			continue
 		}
-		seen[extractSessionID(r.Memory.Tags)] = struct{}{}
+		seen[ExtractSessionID(r.Memory.Tags)] = struct{}{}
 		if len(seen) >= 2 {
 			return true
 		}

--- a/internal/search/session_diversity_test.go
+++ b/internal/search/session_diversity_test.go
@@ -35,7 +35,7 @@ func makeDivResultWithTag(tag string, score float64) types.SearchResult {
 func divSessionIDs(results []types.SearchResult) []string {
 	out := make([]string, len(results))
 	for i, r := range results {
-		out[i] = extractSessionID(r.Memory.Tags)
+		out[i] = ExtractSessionID(r.Memory.Tags)
 	}
 	return out
 }
@@ -78,7 +78,7 @@ func TestSessionDiversity_HappyPath_GoldInMinoritySession(t *testing.T) {
 	// s2:gold must appear in the result.
 	found := false
 	for _, r := range got {
-		if extractSessionID(r.Memory.Tags) == "s2" {
+		if ExtractSessionID(r.Memory.Tags) == "s2" {
 			found = true
 			break
 		}
@@ -89,7 +89,7 @@ func TestSessionDiversity_HappyPath_GoldInMinoritySession(t *testing.T) {
 	// No session contributes more than N=2 chunks.
 	count := map[string]int{}
 	for _, r := range got {
-		count[extractSessionID(r.Memory.Tags)]++
+		count[ExtractSessionID(r.Memory.Tags)]++
 	}
 	for sid, n := range count {
 		if n > 2 {
@@ -173,7 +173,7 @@ func TestSessionDiversity_TopK3_N2_TwoSessions(t *testing.T) {
 	}
 	count := map[string]int{}
 	for _, r := range got {
-		count[extractSessionID(r.Memory.Tags)]++
+		count[ExtractSessionID(r.Memory.Tags)]++
 	}
 	for sid, n := range count {
 		if n > 2 {

--- a/internal/search/session_ndcg_agg.go
+++ b/internal/search/session_ndcg_agg.go
@@ -22,15 +22,16 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
-// extractSessionID scans tags for a "sid:<value>" entry and returns the value.
-// Returns "" if no sid: tag is present or the value after the prefix is empty.
-// Used by sessionNDCGRerank to group memories by their originating LME session.
-func extractSessionID(tags []string) string {
-	const prefix = "sid:"
-	for _, tag := range tags {
-		if strings.HasPrefix(tag, prefix) {
-			v := tag[len(prefix):]
-			return v // empty string if tag is exactly "sid:"
+// ExtractSessionID scans tags for a session tag and returns the session ID.
+// "sid:<value>" is the canonical prefix; "session:<value>" is accepted as a
+// compatibility alias for callers that use the longer form.
+func ExtractSessionID(tags []string) string {
+	for _, prefix := range []string{"sid:", "session:"} {
+		for _, tag := range tags {
+			if strings.HasPrefix(tag, prefix) {
+				v := tag[len(prefix):]
+				return v // empty string if tag is exactly the prefix
+			}
 		}
 	}
 	return ""
@@ -68,9 +69,9 @@ func sessionDCG(scores []float64) float64 {
 
 // sessionGroup is one LME session group produced during re-ranking.
 type sessionGroup struct {
-	sessionID  string              // "" for untagged (no sid: tag) memories
-	members    []types.SearchResult // results belonging to this session
-	dcgScore   float64             // aggregate DCG of chunk cosines
+	sessionID string               // "" for untagged (no sid: tag) memories
+	members   []types.SearchResult // results belonging to this session
+	dcgScore  float64              // aggregate DCG of chunk cosines
 }
 
 // sessionNDCGRerank re-ranks results by session-DCG aggregation (LEVER-8).
@@ -122,7 +123,7 @@ func sessionNDCGRerank(results []types.SearchResult, allChunkCosines map[string]
 	for _, r := range results {
 		var sid string
 		if r.Memory != nil {
-			sid = extractSessionID(r.Memory.Tags)
+			sid = ExtractSessionID(r.Memory.Tags)
 		}
 		// Use the memory's ID as a unique singleton key when no sid: tag is present.
 		// This ensures untagged memories each get their own group (no cross-memory

--- a/internal/search/session_ndcg_agg_test.go
+++ b/internal/search/session_ndcg_agg_test.go
@@ -17,33 +17,41 @@ import (
 
 func TestExtractSessionID_Present(t *testing.T) {
 	tags := []string{"lme", "sid:abc123", "date:2024-01-01"}
-	got := extractSessionID(tags)
+	got := ExtractSessionID(tags)
 	if got != "abc123" {
-		t.Errorf("extractSessionID = %q, want %q", got, "abc123")
+		t.Errorf("ExtractSessionID = %q, want %q", got, "abc123")
 	}
 }
 
 func TestExtractSessionID_Missing(t *testing.T) {
 	tags := []string{"lme", "date:2024-01-01"}
-	got := extractSessionID(tags)
+	got := ExtractSessionID(tags)
 	if got != "" {
-		t.Errorf("extractSessionID = %q, want empty string", got)
+		t.Errorf("ExtractSessionID = %q, want empty string", got)
 	}
 }
 
 func TestExtractSessionID_Empty(t *testing.T) {
-	got := extractSessionID(nil)
+	got := ExtractSessionID(nil)
 	if got != "" {
-		t.Errorf("extractSessionID(nil) = %q, want empty string", got)
+		t.Errorf("ExtractSessionID(nil) = %q, want empty string", got)
 	}
 }
 
 func TestExtractSessionID_SidEmptyValue(t *testing.T) {
 	// "sid:" with empty value returns ""
 	tags := []string{"sid:"}
-	got := extractSessionID(tags)
+	got := ExtractSessionID(tags)
 	if got != "" {
-		t.Errorf("extractSessionID([sid:]) = %q, want empty string", got)
+		t.Errorf("ExtractSessionID([sid:]) = %q, want empty string", got)
+	}
+}
+
+func TestExtractSessionID_SessionPrefixAlias(t *testing.T) {
+	tags := []string{"session:s99"}
+	got := ExtractSessionID(tags)
+	if got != "s99" {
+		t.Errorf("ExtractSessionID([session:s99]) = %q, want %q", got, "s99")
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -355,15 +355,16 @@ type ConnectedMemory struct {
 // The caller fetches content on demand via memory_fetch, keeping the transcript
 // free of large memory payloads until they are actually needed.
 type Handle struct {
-	ID          string  `json:"id"`
-	Project     string  `json:"project"`
-	Summary     string  `json:"summary"` // "" if not yet summarized
-	Score       float64 `json:"score"`
-	StorageMode string  `json:"storage_mode"`
-	ChunkCount  int     `json:"chunk_count"` // 0 if unknown at recall time
-	Bytes       int     `json:"bytes"`       // len(content)
-	IsHandle    bool    `json:"is_handle"`   // always true; signals paged-out result
-	FetchHint   string  `json:"fetch_hint"`  // human-readable usage hint
+	ID          string   `json:"id"`
+	Project     string   `json:"project"`
+	Summary     string   `json:"summary"` // "" if not yet summarized
+	Tags        []string `json:"tags,omitempty"`
+	Score       float64  `json:"score"`
+	StorageMode string   `json:"storage_mode"`
+	ChunkCount  int      `json:"chunk_count"` // 0 if unknown at recall time
+	Bytes       int      `json:"bytes"`       // len(content)
+	IsHandle    bool     `json:"is_handle"`   // always true; signals paged-out result
+	FetchHint   string   `json:"fetch_hint"`  // human-readable usage hint
 }
 
 // MemoryStats summarizes the contents of the store. Returned by the status endpoint.


### PR DESCRIPTION
## Summary add `tags` to handle-mode `types.Handle`, propagate memory tags in `search.ToHandles`, export `search.ExtractSessionID` with `sid:` and `session:` support, and preserve handle-derived `MemoryMap` metadata in new longmemeval recall result wrappers while keeping existing `[]string` recall APIs stable. ## Testing `/usr/local/go/bin/go test ./internal/search/... -count=1 -race` and `/usr/local/go/bin/go test ./... -count=1 -race`