### PR TITLE
fix(db): global advisory lock for schema migrations prevents concurrent CREATE TABLE race (#1140)

### DIFF
--- a/internal/db/migration_test.go
+++ b/internal/db/migration_test.go
@@ -2,12 +2,57 @@ package db_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// TestConcurrentMigrations_NoRace verifies that concurrent NewPostgresBackend calls
+// using different project slugs do not race on shared DDL and produce pg_type
+// duplicate-key errors (SQLSTATE 23505). This was the bug in #1140: the old
+// per-project advisory lock allowed different project slugs to run CREATE TABLE
+// concurrently; the fix uses a single-arg global lock.
+func TestConcurrentMigrations_NoRace(t *testing.T) {
+	dsn := testutil.DSN(t) // skips test if TEST_DATABASE_URL is not set
+	const n = 5
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proj := fmt.Sprintf("race-test-%d", i)
+			backend, err := db.NewPostgresBackend(ctx, proj, dsn)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			backend.Close()
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err == nil {
+			continue
+		}
+		msg := err.Error()
+		if strings.Contains(msg, "pg_type") || strings.Contains(msg, "23505") {
+			t.Errorf("goroutine %d: concurrent migration race detected (pg_type/23505): %v", i, err)
+		} else {
+			require.NoError(t, err, "goroutine %d: unexpected migration error", i)
+		}
+	}
+}
 
 func TestMigration029AtomsObservedAt(t *testing.T) {
 	proj := uniqueProject("migration-029-atoms")

--- a/internal/db/migrations/015_decay_audit.sql
+++ b/internal/db/migrations/015_decay_audit.sql
@@ -1,7 +1,7 @@
 -- Decay audit system: canonical query registry and retrieval snapshots.
 -- Used to monitor ranking drift over time as embedders and weights change.
 
-CREATE TABLE audit_canonical_queries (
+CREATE TABLE IF NOT EXISTS audit_canonical_queries (
     id          TEXT PRIMARY KEY,
     project     TEXT NOT NULL,
     query       TEXT NOT NULL,
@@ -13,7 +13,7 @@ CREATE TABLE audit_canonical_queries (
 
 CREATE INDEX idx_audit_queries_project ON audit_canonical_queries(project);
 
-CREATE TABLE audit_snapshots (
+CREATE TABLE IF NOT EXISTS audit_snapshots (
     id               TEXT PRIMARY KEY,
     query_id         TEXT NOT NULL REFERENCES audit_canonical_queries(id),
     project          TEXT NOT NULL,

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -237,11 +237,13 @@ func (b *PostgresBackend) PgxPool() *pgxpool.Pool {
 }
 
 func (b *PostgresBackend) runMigrations(ctx context.Context) error {
-	// Serialize concurrent project initialization with a per-project advisory lock (#105).
-	// Two backends for the same project initializing simultaneously would both pass the
-	// "migration already applied?" check and then race to apply the same DDL.
-	// Lock class 1986753120 is an arbitrary constant reserved for engram schema migrations.
-	const lockClass = 1986753120
+	// Serialize ALL concurrent migration runs with a database-global advisory lock (#1140).
+	// Schema migrations are database-global DDL; a per-project lock (the old behaviour)
+	// allowed test packages using different project slugs to race on shared CREATE TABLE
+	// statements, causing pg_type duplicate-key failures (SQLSTATE 23505).
+	// Lock constant 1986753120 (cast to int64 for the single-arg bigint overload) is
+	// reserved for engram schema migrations.
+	const lockClass = int64(1986753120)
 	conn, err := b.pool.Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire connection for advisory lock: %w", err)
@@ -262,14 +264,12 @@ func (b *PostgresBackend) runMigrations(ctx context.Context) error {
 		return fmt.Errorf("set lock_timeout: %w", err)
 	}
 	if _, err := conn.Exec(ctx,
-		`SELECT pg_advisory_lock($1, hashtext($2::text))`, lockClass, b.project,
+		`SELECT pg_advisory_lock($1)`, lockClass,
 	); err != nil {
-		return fmt.Errorf("acquire advisory lock for project %q: %w", b.project, err)
+		return fmt.Errorf("acquire global migration lock: %w", err)
 	}
 	defer func() {
-		_, _ = conn.Exec(ctx,
-			`SELECT pg_advisory_unlock($1, hashtext($2::text))`, lockClass, b.project,
-		)
+		_, _ = conn.Exec(ctx, `SELECT pg_advisory_unlock($1)`, lockClass)
 	}()
 
 	// Ensure the migration tracking table exists. This is always idempotent.
@@ -331,13 +331,13 @@ func (b *PostgresBackend) runMigrations(ctx context.Context) error {
 		// 023_null_embed_covering_idx.sql and 024_reembed_null_partial_index.sql
 		// use CREATE INDEX CONCURRENTLY, which also must run outside a transaction block.
 		if name == "003_pgvector.sql" || name == "023_null_embed_covering_idx.sql" || name == "024_reembed_null_partial_index.sql" {
-			// 003_pgvector.sql calls CREATE EXTENSION, a database-global operation.
-			// The per-project advisory lock above only serializes within a project;
-			// concurrent backends for different projects can race on CREATE EXTENSION
-			// and hit pg_type_typname_nsp_index duplicate-key errors (issue #1104).
-			// Acquire a separate global advisory lock (single-arg form, no project
-			// key) that covers only extension-creating migrations.
-			// Lock constant 1986753121 = lockClass+1, reserved for global extension ops.
+			// 003_pgvector.sql calls CREATE EXTENSION which must run outside a transaction
+			// and needs its own inner lock to cover the backfill that follows (#292).
+			// The outer global advisory lock (1986753120) already serializes all migrations
+			// across projects; lock 1986753121 (= outer+1) is retained here solely to
+			// bound the backfill duration on the same connection (#292). It is NOT used
+			// to fix cross-project races — the outer lock handles that (#1140).
+			// Lock constant 1986753121 is reserved for extension migration + backfill ops.
 			if name == "003_pgvector.sql" {
 				if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock(1986753121)`); err != nil {
 					return fmt.Errorf("acquire global extension lock for %s: %w", name, err)


### PR DESCRIPTION
## Summary

- **Root cause**: `runMigrations` used a per-project advisory lock (`pg_advisory_lock(lockClass, hashtext(project))`). Test packages calling `NewPostgresBackend` with different project slugs hash to different lock values — they never blocked each other. Two packages racing on `015_decay_audit.sql` both issued `CREATE TABLE audit_canonical_queries` concurrently, colliding on the composite row type in `pg_type` (SQLSTATE 23505).
- **Fix**: Switch to the single-arg global form (`pg_advisory_lock(lockClass::bigint)`) — database-global, serializes all migration runs regardless of project slug. Schema migrations are database-global DDL; the lock should match.
- **Belt-and-suspenders**: Added `IF NOT EXISTS` to both `CREATE TABLE` statements in `015_decay_audit.sql`.
- **Test**: `TestConcurrentMigrations_NoRace` — 5 goroutines each calling `NewPostgresBackend` with distinct project slugs concurrently; any "pg_type" or "23505" error fails the test explicitly.

## Test plan

- [ ] CI `Test & Coverage` passes (no SQLSTATE 23505 on concurrent package runs)
- [ ] `go build ./...` clean ✅ (verified locally)
- [ ] `go vet ./...` clean ✅ (verified locally)
- [ ] `TestConcurrentMigrations_NoRace` runs against Postgres CI container

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)