### PR TITLE
fix(lme): add HARD EXCLUSION RULE to preference generation prompts (H-PE)

### DIFF
--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -457,7 +457,9 @@ Relevant memory context:
 
 Question (asked on %s): %s
 
-Do NOT answer the question directly. Instead, describe what the user would prefer based on their past conversations. Start your response with "The user would prefer..." and include what they would NOT prefer if the context supports it. Be concise.`, questionDate, ctx, questionDate, question)
+Do NOT answer the question directly. Instead, describe what the user would prefer based on their past conversations. Start your response with "The user would prefer..." and include what they would NOT prefer if the context supports it. Be concise.
+
+HARD EXCLUSION RULE: If the user stated they do NOT want, have moved away from, dislike, or want to avoid any specific brand, item, model, or option, that item is FORBIDDEN — it must not appear in your answer as a suggestion, alternative, or even a passing mention. Stated exclusions override all other considerations.`, questionDate, ctx, questionDate, question)
 	}
 	return GenerationPrompt(question, questionDate, contextBlocks)
 }
@@ -545,7 +547,8 @@ Instructions:
 2. List each one explicitly — do not summarise or generalise. For example: name the specific product, brand, feature, or location rather than saying "functional accessories" or "a pool".
 3. Start your response with "The user prefers:" followed by the enumerated list.
 4. Include what the user would NOT prefer if the context supports it.
-5. Only include preferences found in the memory context. Do not invent items not present in the context.`, questionDate, ctx, questionDate, question)
+5. Only include preferences found in the memory context. Do not invent items not present in the context.
+6. HARD EXCLUSION RULE: Any item, brand, model, or option the user has explicitly stated they dislike, avoid, have moved away from, or do not want is FORBIDDEN. It must not appear anywhere in your answer — not as a suggestion, not as an alternative, not as a passing mention. Exclusions are hard constraints that override all other considerations.`, questionDate, ctx, questionDate, question)
 }
 
 // GenerationPromptEnumerateFirst (H12) returns a generation prompt that

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -438,6 +438,17 @@ func ScoreOAI(ctx context.Context, question, referenceAnswer, hypothesis, baseUR
 	return ScoreResult{Label: label, Explanation: explanation}, nil
 }
 
+// hardExclusionRule is the canonical HARD EXCLUSION RULE text for preference generation.
+// Every code path that generates answers for single-session-preference questions must
+// include this text so that explicitly stated anti-preferences are treated as hard
+// constraints rather than merely described. Defined once so the two prompt paths
+// (GenerationPromptForType and GenerationPromptPreferenceEnumerate) stay in sync.
+//
+// The text intentionally uses a broad verb set ("dislike, avoid, have moved away from,
+// or do not want") to cover the most common natural-language phrasings. Callers that
+// extend or modify the exclusion behaviour must update this single constant.
+const hardExclusionRule = `HARD EXCLUSION RULE: Any item, brand, model, or option the user has explicitly stated they dislike, avoid, have moved away from, or do not want is FORBIDDEN. It must not appear anywhere in your answer — not as a suggestion, not as an alternative, not as a passing mention. Exclusions are hard constraints that override all other considerations.`
+
 // GenerationPromptForType builds a generation prompt tailored to the question type.
 // For single-session-preference questions the model is instructed to describe the
 // user's preferences rather than answer the question directly — answering directly
@@ -459,7 +470,7 @@ Question (asked on %s): %s
 
 Do NOT answer the question directly. Instead, describe what the user would prefer based on their past conversations. Start your response with "The user would prefer..." and include what they would NOT prefer if the context supports it. Be concise.
 
-HARD EXCLUSION RULE: If the user stated they do NOT want, have moved away from, dislike, or want to avoid any specific brand, item, model, or option, that item is FORBIDDEN — it must not appear in your answer as a suggestion, alternative, or even a passing mention. Stated exclusions override all other considerations.`, questionDate, ctx, questionDate, question)
+`+hardExclusionRule, questionDate, ctx, questionDate, question)
 	}
 	return GenerationPrompt(question, questionDate, contextBlocks)
 }
@@ -500,6 +511,13 @@ func GenerationPromptForTypeWithDateInjection(question, questionType, questionDa
 // prepends an enumerate-first instruction when enumerateFirst is true and the
 // question matches the aggregation heuristic. For non-aggregation questions the
 // flag is a no-op so other question types are unaffected.
+//
+// "single-session-preference" is explicitly excluded from the enumerate-first
+// augmentation (even when enumerateFirst is true) because preference questions are
+// handled by GenerationPromptForTypePreferenceEnumerate which routes them to
+// GenerationPromptPreferenceEnumerate — a dedicated enumerate path that already
+// carries its own enumeration instructions and the hardExclusionRule. Applying the
+// generic enumerate-first prefix on top would double-augment those prompts.
 func GenerationPromptForTypeEnumerate(question, questionType, questionDate string, contextBlocks []string, enumerateFirst bool) string {
 	prompt := GenerationPromptForType(question, questionType, questionDate, contextBlocks)
 	if enumerateFirst && questionType != "temporal-reasoning" && questionType != "single-session-preference" && IsAggregationQuestion(question) {
@@ -548,7 +566,7 @@ Instructions:
 3. Start your response with "The user prefers:" followed by the enumerated list.
 4. Include what the user would NOT prefer if the context supports it.
 5. Only include preferences found in the memory context. Do not invent items not present in the context.
-6. HARD EXCLUSION RULE: Any item, brand, model, or option the user has explicitly stated they dislike, avoid, have moved away from, or do not want is FORBIDDEN. It must not appear anywhere in your answer — not as a suggestion, not as an alternative, not as a passing mention. Exclusions are hard constraints that override all other considerations.`, questionDate, ctx, questionDate, question)
+6. `+hardExclusionRule, questionDate, ctx, questionDate, question)
 }
 
 // GenerationPromptEnumerateFirst (H12) returns a generation prompt that

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -854,4 +854,60 @@ func TestPreferenceConstraint_HardExclusionInBasePreferencePrompt(t *testing.T) 
 	if !strings.Contains(lowerPrompt, "forbidden") {
 		t.Errorf("base preference prompt must use the word 'forbidden' for exclusions; prompt:\n%s", prompt)
 	}
+	if !strings.Contains(lowerPrompt, "override") {
+		t.Errorf("base preference prompt must state that exclusions override other considerations; prompt:\n%s", prompt)
+	}
+}
+
+// TestPreferenceConstraint_HardExclusionPreservedThroughTemporalAug verifies that
+// GenerationPromptForTypeWithTemporalAug (the H-M5+H-M1 augmentation wrapper) passes
+// the HARD EXCLUSION RULE through to the output when the question type is
+// "single-session-preference". The temporal-aug flag is a no-op for preference
+// questions and the function delegates to GenerationPromptForType — this test confirms
+// that delegation chain preserves the exclusion rule rather than silently dropping it.
+func TestPreferenceConstraint_HardExclusionPreservedThroughTemporalAug(t *testing.T) {
+	question := "Which phone brand does the user prefer?"
+	contextBlocks := []string{
+		"Session date: 2024-03-15\nUser: I switched from Samsung to iPhone and I'm never going back to Android.",
+	}
+	// temporalPromptAug=true is passed but should be a no-op for preference type.
+	prompt := longmemeval.GenerationPromptForTypeWithTemporalAug(question, "single-session-preference", "2024-06-01", contextBlocks, true)
+
+	lowerPrompt := strings.ToLower(prompt)
+
+	if !strings.Contains(lowerPrompt, "hard exclusion") {
+		t.Errorf("temporal-aug wrapper must preserve HARD EXCLUSION RULE for preference type; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "forbidden") {
+		t.Errorf("temporal-aug wrapper must preserve 'forbidden' keyword for preference type; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "override") {
+		t.Errorf("temporal-aug wrapper must preserve 'override' keyword for preference type; prompt:\n%s", prompt)
+	}
+}
+
+// TestPreferenceConstraint_HardExclusionPreservedThroughDateInjection verifies that
+// GenerationPromptForTypeWithDateInjection (the H16 date-injection wrapper) passes the
+// HARD EXCLUSION RULE through to the output when the question type is
+// "single-session-preference". The date-injection flag is a no-op for preference
+// questions; this test confirms the delegation chain preserves the exclusion rule.
+func TestPreferenceConstraint_HardExclusionPreservedThroughDateInjection(t *testing.T) {
+	question := "What coffee brand does the user drink?"
+	contextBlocks := []string{
+		"Session date: 2024-02-20\nUser: I only drink Onyx Coffee. I tried Blue Bottle once and I won't do that again.",
+	}
+	// injectQuestionDate=true is passed but should be a no-op for preference type.
+	prompt := longmemeval.GenerationPromptForTypeWithDateInjection(question, "single-session-preference", "2024-06-01", contextBlocks, true)
+
+	lowerPrompt := strings.ToLower(prompt)
+
+	if !strings.Contains(lowerPrompt, "hard exclusion") {
+		t.Errorf("date-injection wrapper must preserve HARD EXCLUSION RULE for preference type; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "forbidden") {
+		t.Errorf("date-injection wrapper must preserve 'forbidden' keyword for preference type; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "override") {
+		t.Errorf("date-injection wrapper must preserve 'override' keyword for preference type; prompt:\n%s", prompt)
+	}
 }

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -743,10 +743,55 @@ func TestGenerationPromptForTypeEnumerate_IgnoresEnumerateFirstForNonAggregation
 	}
 }
 
+// TestGenerationPromptForTypeEnumerate_PreferenceType_SkipsEnumerateFirst guards
+// the guard condition on line 523 of claude.go: "single-session-preference" is
+// explicitly excluded from the generic enumerate-first augmentation even when
+// enumerateFirst=true, because preference questions route to the dedicated
+// preference-enumerate path (GenerationPromptPreferenceEnumerate) which carries
+// its own enumeration instructions and the hardExclusionRule.
+//
+// This test verifies two things:
+//  (a) the enumerate-first prefix is NOT injected (guard fires correctly)
+//  (b) the HARD EXCLUSION RULE keywords ARE present (base preference prompt returned)
+func TestGenerationPromptForTypeEnumerate_PreferenceType_SkipsEnumerateFirst(t *testing.T) {
+	question := "What headphone brand does the user prefer?"
+	contextBlocks := []string{
+		"Session date: 2024-01-15\nUser: I love Sony WH-1000XM5. I tried Bose QC45 once and I'm done with Bose forever.",
+	}
+	// enumerateFirst=true but questionType="single-session-preference" — guard must fire.
+	prompt := longmemeval.GenerationPromptForTypeEnumerate(
+		question, "single-session-preference", "2024-06-01",
+		contextBlocks,
+		true,
+	)
+	lowerPrompt := strings.ToLower(prompt)
+
+	// (a) enumerate-first prefix must NOT be injected for preference questions.
+	enumerateFirstHints := []string{"step 1", "list each event", "then sum", "then total", "then count", "enumerate first"}
+	for _, hint := range enumerateFirstHints {
+		if strings.Contains(lowerPrompt, hint) {
+			t.Errorf("GenerationPromptForTypeEnumerate must NOT inject enumerate-first prefix for single-session-preference; found %q in prompt:\n%s", hint, prompt)
+		}
+	}
+
+	// (b) HARD EXCLUSION RULE must be present (base preference prompt was returned).
+	if !strings.Contains(lowerPrompt, "hard exclusion") {
+		t.Errorf("GenerationPromptForTypeEnumerate with preference type must return base preference prompt with HARD EXCLUSION RULE; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "forbidden") {
+		t.Errorf("GenerationPromptForTypeEnumerate with preference type must include 'forbidden' keyword; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "override") {
+		t.Errorf("GenerationPromptForTypeEnumerate with preference type must include 'override' keyword; prompt:\n%s", prompt)
+	}
+}
+
 // TestPreferenceEnumeratePrompt_SelectedForPreferenceType verifies that
 // GenerationPromptForTypePreferenceEnumerate selects the preference-enumerate
 // prompt when preferenceEnumerate=true AND question_type is
 // "single-session-preference". Guards H-PE flag routing.
+// Also verifies the HARD EXCLUSION RULE is present in the routed output,
+// confirming the delegation chain preserves the constraint.
 func TestPreferenceEnumeratePrompt_SelectedForPreferenceType(t *testing.T) {
 	question := "What kind of car accessories does the user prefer?"
 	contextBlocks := []string{
@@ -757,9 +802,10 @@ func TestPreferenceEnumeratePrompt_SelectedForPreferenceType(t *testing.T) {
 		contextBlocks,
 		true,
 	)
+	lowerPrompt := strings.ToLower(prompt)
+
 	// The preference-enumerate prompt must contain enumeration instruction keywords.
 	enumerationHints := []string{"list", "each", "specific", "enumerate", "every"}
-	lowerPrompt := strings.ToLower(prompt)
 	found := false
 	for _, hint := range enumerationHints {
 		if strings.Contains(lowerPrompt, hint) {
@@ -769,6 +815,18 @@ func TestPreferenceEnumeratePrompt_SelectedForPreferenceType(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("preference-enumerate prompt must contain an enumeration instruction; got:\n%s", prompt)
+	}
+
+	// The HARD EXCLUSION RULE must also be present — the wrapper routes to
+	// GenerationPromptPreferenceEnumerate which carries hardExclusionRule.
+	if !strings.Contains(lowerPrompt, "hard exclusion") {
+		t.Errorf("preference-enumerate wrapper must include HARD EXCLUSION RULE; got:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "forbidden") {
+		t.Errorf("preference-enumerate wrapper must include 'forbidden' keyword; got:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "override") {
+		t.Errorf("preference-enumerate wrapper must include 'override' keyword; got:\n%s", prompt)
 	}
 }
 

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -809,3 +809,49 @@ func TestPreferenceEnumeratePrompt_FallsThrough_WhenNonPreferenceType(t *testing
 		t.Errorf("preference-enumerate with non-preference type must return same prompt as GenerationPromptForType; got diff")
 	}
 }
+
+// TestPreferenceConstraint_HardExclusionInEnumeratePrompt verifies that the
+// preference-enumerate prompt contains the HARD EXCLUSION RULE instruction.
+// This guards that stated anti-preferences are treated as hard constraints,
+// not merely described — the fix for the 0/30 preference CORRECT score in v9.
+func TestPreferenceConstraint_HardExclusionInEnumeratePrompt(t *testing.T) {
+	question := "What laptop brand should I buy?"
+	contextBlocks := []string{
+		"Session date: 2024-05-01\nUser: I love Framework laptops. I've completely moved away from Dell — I don't want anything to do with them anymore.",
+	}
+	prompt := longmemeval.GenerationPromptPreferenceEnumerate(question, "2024-06-01", contextBlocks)
+
+	lowerPrompt := strings.ToLower(prompt)
+
+	// Must contain the exclusion instruction keywords.
+	if !strings.Contains(lowerPrompt, "hard exclusion") {
+		t.Errorf("GenerationPromptPreferenceEnumerate must contain HARD EXCLUSION RULE; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "forbidden") {
+		t.Errorf("GenerationPromptPreferenceEnumerate must use the word 'forbidden' for exclusions; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "override") {
+		t.Errorf("GenerationPromptPreferenceEnumerate must state that exclusions override other considerations; prompt:\n%s", prompt)
+	}
+}
+
+// TestPreferenceConstraint_HardExclusionInBasePreferencePrompt verifies that
+// the base single-session-preference prompt (non-enumerate path) also carries
+// the HARD EXCLUSION RULE — so the constraint is enforced regardless of whether
+// --preference-enumerate is set.
+func TestPreferenceConstraint_HardExclusionInBasePreferencePrompt(t *testing.T) {
+	question := "What gym equipment does the user want?"
+	contextBlocks := []string{
+		"Session date: 2024-04-10\nUser: I want a Concept2 rower. I absolutely hate treadmills — never want one.",
+	}
+	prompt := longmemeval.GenerationPromptForType(question, "single-session-preference", "2024-06-01", contextBlocks)
+
+	lowerPrompt := strings.ToLower(prompt)
+
+	if !strings.Contains(lowerPrompt, "hard exclusion") {
+		t.Errorf("base preference prompt must contain HARD EXCLUSION RULE; prompt:\n%s", prompt)
+	}
+	if !strings.Contains(lowerPrompt, "forbidden") {
+		t.Errorf("base preference prompt must use the word 'forbidden' for exclusions; prompt:\n%s", prompt)
+	}
+}


### PR DESCRIPTION
## Summary

- Addresses the 0/30 CORRECT rate on `single-session-preference` questions in LME-M v9 (weighted score 86.5%)
- Both `GenerationPromptForType` (base preference path) and `GenerationPromptPreferenceEnumerate` previously _described_ stated exclusions but contained no enforcement language — the model would correctly surface what the user wants while also suggesting the forbidden item as an alternative
- Appended `HARD EXCLUSION RULE: ... FORBIDDEN` constraint to both prompt paths; excluded items must not appear anywhere in the answer

## Changes

- `internal/longmemeval/claude.go` — two edits: base `single-session-preference` path + `GenerationPromptPreferenceEnumerate` step 6
- `internal/longmemeval/claude_test.go` — two new tests: `TestPreferenceConstraint_HardExclusionInEnumeratePrompt`, `TestPreferenceConstraint_HardExclusionInBasePreferencePrompt`

## Test plan

- [ ] `go test ./internal/longmemeval/... -count=1 -race` — preference constraint tests pass
- [ ] `go test ./... -count=1 -race` — full suite green (verified locally pre-commit, exit 0)
- [ ] Run `longmemeval score-efficient` with `--preference-enumerate` on v10 output to measure delta on preference category (target: 0 PARTIAL → CORRECT conversions lift weighted score ≥ 2pp)

## Review gate (AI PR policy)

This PR requires three rounds of adversarial review before merge:
1. **Correctness** — boundary conditions, logic bugs, error handling
2. **Coverage** — ≥ 70% function coverage on new/changed code
3. **Structural** — fresh-eyes architecture fit, naming clarity

Related: LME-M improvement plan Phase 2 (`specs/engram-lme-m-score-improvement.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01FDMQaqHn8mC9CzZpwBwM6S