### PR TITLE
fix(longmemeval): normalize REST base URL suffixes

### DIFF
--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -523,7 +523,7 @@ type RestClient struct {
 // NewRestClient constructs a RestClient pointed at baseURL with Bearer auth.
 func NewRestClient(baseURL, token string) *RestClient {
 	return &RestClient{
-		baseURL: strings.TrimRight(baseURL, "/"),
+		baseURL: baseServerURL(baseURL),
 		token:   token,
 		http:    &http.Client{Timeout: 30 * time.Second},
 	}

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -64,6 +64,55 @@ func TestRestClient_QuickStore_HappyPath(t *testing.T) {
 	}
 }
 
+func TestNewRestClient_URLNormalization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "bare base URL", path: ""},
+		{name: "trailing slash", path: "/"},
+		{name: "mcp suffix", path: "/mcp"},
+		{name: "sse suffix", path: "/sse"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sawQuickStore bool
+			mux := http.NewServeMux()
+			mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`1`))
+			})
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/quick-store" {
+					sawQuickStore = true
+					_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "mem-normalized"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`1`))
+			})
+
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			rc := longmemeval.NewRestClient(srv.URL+tc.path, "")
+			id, err := rc.QuickStore(context.Background(), "proj", "content", nil, nil)
+			if err != nil {
+				t.Fatalf("QuickStore(%q): %v", tc.path, err)
+			}
+			if !sawQuickStore {
+				t.Fatalf("QuickStore(%q) did not hit /quick-store", tc.path)
+			}
+			if id != "mem-normalized" {
+				t.Fatalf("id = %q, want mem-normalized", id)
+			}
+		})
+	}
+}
+
 // TestRestClient_QuickStore_RateLimitRetry verifies that 429 triggers retry
 // and that a subsequent success is returned.
 func TestRestClient_QuickStore_RateLimitRetry(t *testing.T) {


### PR DESCRIPTION
Codex work for #1168 via fleet-dispatch. Draft — needs review/CI. Closes #1168