### PR TITLE
feat(longmemeval): add preference-ground prompt guard

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -90,6 +90,9 @@ type Config struct {
 
 	// H-PE: preference-enumerate generation prompt
 	PreferenceEnumerate bool // inject exhaustive named-item enumeration instruction for single-session-preference questions (default off)
+
+	// H-PG: grounded preference generation for ss-preference.
+	PreferenceGround bool // forbid unsupported specific additions in preference answers (default off)
 	// Retrieval-fusion flags for issue #938.
 	RetrievalFusion     bool // union multiple query variants (primary/raw/identifier queries)
 	ExactSignalBoost    bool // re-rank candidate IDs by exact identifier/entity overlap
@@ -270,6 +273,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.EnumerateFirst, "enumerate-first", false, "H12: inject enumerate-then-total generation instruction for aggregation questions (default off)")
 	// H-PE: preference-enumerate generation prompt
 	fs.BoolVar(&cfg.PreferenceEnumerate, "preference-enumerate", false, "H-PE: inject exhaustive named-item enumeration instruction for single-session-preference questions; lists every specific item/brand/attribute from context rather than abstractly summarising (default off)")
+	// H-PG: grounded preference generation (issue #1183)
+	fs.BoolVar(&cfg.PreferenceGround, "preference-ground", false, "H-PG: for single-session-preference answers, forbid specific brands/titles/cuisines/ingredients/genres unless they appear explicitly in retrieved context; prefer a short grounded answer over padded specifics (default off)")
 	fs.BoolVar(&cfg.RetrievalFusion, "retrieval-fusion", false, "issue #938: fuse retrieval candidates from primary/raw/identifier query variants")
 	fs.BoolVar(&cfg.ExactSignalBoost, "exact-signal-boost", false, "issue #938: boost candidates that contain exact identifiers/entities from the question")
 	fs.BoolVar(&cfg.EvidenceFirstPacked, "evidence-first-pack", false, "issue #938: pack context in evidence-first order using exact overlap signals")

--- a/cmd/longmemeval/preference_ground_test.go
+++ b/cmd/longmemeval/preference_ground_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPreferenceGround_FlagRegistered verifies that the --preference-ground flag
+// is registered in the dispatch function and backed by a Config field.
+func TestPreferenceGround_FlagRegistered(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "preference-ground") {
+		t.Error("main.go missing 'preference-ground' flag registration — H-PG harness wiring broken")
+	}
+	if !strings.Contains(text, "PreferenceGround") {
+		t.Error("main.go missing PreferenceGround config field — H-PG harness wiring broken")
+	}
+}
+
+// TestPreferenceGround_RunGoWiresPromptSelection verifies that run.go contains
+// the preference-ground prompt selection path.
+func TestPreferenceGround_RunGoWiresPromptSelection(t *testing.T) {
+	src, err := os.ReadFile("run.go")
+	if err != nil {
+		t.Fatalf("read run.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "cfg.PreferenceGround") {
+		t.Error("run.go missing cfg.PreferenceGround check — H-PG flag not applied during prompt selection")
+	}
+	if !strings.Contains(text, "GenerationPromptForTypePreferenceGround") {
+		t.Error("run.go missing GenerationPromptForTypePreferenceGround call — H-PG prompt variant not wired")
+	}
+}

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -764,6 +764,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		prompt = longmemeval.GenerationPromptForTypeWithDateInjection(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.PreferenceEnumerate:
 		prompt = longmemeval.GenerationPromptForTypePreferenceEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
+	case cfg.PreferenceGround:
+		prompt = longmemeval.GenerationPromptForTypePreferenceGround(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	default:
 		prompt = longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, contextBlocks)
 	}

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -534,6 +534,37 @@ func GenerationPromptForTypeWithDateInjection(question, questionType, questionDa
 	return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
 }
 
+// GenerationPromptForTypePreferenceGround (H-PG, issue #1183) is like
+// GenerationPromptForType but, when preferenceGround is true for
+// single-session-preference questions, it injects a grounding rule that forbids
+// specific named items absent from the retrieved context. The intent is to
+// suppress ss-preference confabulation by preferring a short grounded answer
+// over padded near-miss specifics.
+func GenerationPromptForTypePreferenceGround(question, questionType, questionDate string, contextBlocks []string, preferenceGround bool) string {
+	if !preferenceGround || questionType != "single-session-preference" {
+		return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
+	}
+	ctx := strings.Join(contextBlocks, "\n\n---\n\n")
+	return fmt.Sprintf(`You are describing a person's preferences based on their conversation history.
+
+Each memory block may begin with a "Session date: YYYY-MM-DD" header. The question was asked on %s.
+
+Relevant memory context:
+%s
+
+Question (asked on %s): %s
+
+Do NOT answer the question directly. Instead, describe what the user would prefer based on their past conversations. Start your response with "The user would prefer...".
+
+GROUNDING RULE:
+- Use only preferences and specific named items that are explicitly present in the retrieved context above.
+- Do not add any specific brand, title, cuisine, ingredient, genre, package, service, or other named item that is not explicitly present in the context.
+- If the context supports only a general preference category, answer at that general level rather than inventing examples.
+- Mention what the user would NOT prefer only if the context explicitly supports it.
+- Prefer a short grounded answer over a padded one.`, questionDate, ctx, questionDate, question)
+}
+
+
 // GenerationPromptForTypeEnumerate (H12) is like GenerationPromptForType but
 // prepends an enumerate-first instruction when enumerateFirst is true and the
 // question matches the aggregation heuristic. For non-aggregation questions the

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -475,6 +475,43 @@ func TestGenerationPrompt_PreferenceType_DescribesPreference(t *testing.T) {
 	}
 }
 
+func TestGenerationPrompt_PreferenceGround_RequiresGroundedSpecifics(t *testing.T) {
+	prompt := longmemeval.GenerationPromptForTypePreferenceGround(
+		"Can you recommend some resources where I can learn more about video editing?",
+		"single-session-preference",
+		"2024-03-15",
+		[]string{"Session date: 2024-03-10\nUser asked about advanced Adobe Premiere Pro color grading settings."},
+		true,
+	)
+	lower := strings.ToLower(prompt)
+	for _, want := range []string{
+		"do not add any specific",
+		"not explicitly present",
+		"prefer a short grounded answer",
+		"adobe premiere pro",
+	} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("grounded preference prompt must contain %q, got:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestGenerationPrompt_PreferenceGround_DefaultsToStandardPreferencePrompt(t *testing.T) {
+	question := "What kind of restaurant would I like?"
+	context := []string{"Session date: 2024-03-10\nUser said they like quiet ramen spots."}
+	got := longmemeval.GenerationPromptForTypePreferenceGround(
+		question,
+		"single-session-preference",
+		"2024-03-15",
+		context,
+		false,
+	)
+	want := longmemeval.GenerationPromptForType(question, "single-session-preference", "2024-03-15", context)
+	if got != want {
+		t.Errorf("grounding flag off should preserve standard preference prompt\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
 func TestGenerationPrompt_DefaultType_UsesGenericPrompt(t *testing.T) {
 	// Non-preference types must still use the original generic prompt.
 	prompt := longmemeval.GenerationPromptForType(


### PR DESCRIPTION
## Summary - add `--preference-ground` to `longmemeval`; - route `single-session-preference` generation through a grounded prompt variant that forbids unsupported named specifics and prefers short grounded answers; - add TDD coverage for prompt text and CLI/run wiring for issue #1183.