### PR TITLE
fix(mcp): scope memory fetch and project listing to caller project

### DIFF
--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -44,6 +44,9 @@ type Backend interface {
 	// Used by EnrichWithConflicts to fetch cross-project contradicting memories.
 	// Returns nil, nil if not found.
 	GetMemoryByID(ctx context.Context, id string) (*types.Memory, error)
+	// GetMemoryByIDInProject retrieves a memory by ID scoped to the given project.
+	// Returns nil, nil if not found.
+	GetMemoryByIDInProject(ctx context.Context, id, project string) (*types.Memory, error)
 	// GetMemoriesByIDs retrieves multiple memories by ID in a single query.
 	// Only memories belonging to project are returned. Missing IDs are silently omitted.
 	GetMemoriesByIDs(ctx context.Context, project string, ids []string) ([]*types.Memory, error)
@@ -426,4 +429,3 @@ type MemoryCluster struct {
 	Label    string
 	Size     int
 }
-

--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -155,6 +155,35 @@ func (b *PostgresBackend) GetMemoryByID(ctx context.Context, id string) (*types.
 	return m, nil
 }
 
+// GetMemoryByIDInProject retrieves a memory by ID scoped to the given project.
+// Returns nil, nil if not found.
+func (b *PostgresBackend) GetMemoryByIDInProject(ctx context.Context, id, project string) (*types.Memory, error) {
+	row, err := b.pool.Query(ctx,
+		"SELECT * FROM memories WHERE id=$1 AND project=$2 AND valid_to IS NULL", id, project)
+	if err != nil {
+		return nil, err
+	}
+	m, err := pgx.CollectOneRow(row, rowToMemory)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	// Integrity check
+	if m.ContentHash != nil {
+		expected := ContentHash(m.Content)
+		if *m.ContentHash != expected {
+			slog.Warn("INTEGRITY: content_hash mismatch",
+				"id", m.ID,
+				"stored", (*m.ContentHash)[:8],
+				"expected", expected[:8],
+			)
+		}
+	}
+	return m, nil
+}
+
 func (b *PostgresBackend) GetMemoriesByIDs(ctx context.Context, project string, ids []string) ([]*types.Memory, error) {
 	if len(ids) == 0 {
 		return nil, nil

--- a/internal/db/postgres_memory_test.go
+++ b/internal/db/postgres_memory_test.go
@@ -60,3 +60,30 @@ func TestGetMemoryByID_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, retrieved, "GetMemoryByID must return nil for nonexistent IDs")
 }
+
+func TestGetMemoryByIDInProject_SameProject(t *testing.T) {
+	proj := uniqueProject("get-mem-proj-same")
+	b := newTestBackend(t, proj)
+	ctx := context.Background()
+
+	mem := storeMemory(t, b, proj, "same-project scoped memory")
+
+	retrieved, err := b.GetMemoryByIDInProject(ctx, mem.ID, proj)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved, "GetMemoryByIDInProject must return the memory in the matching project")
+	require.Equal(t, mem.ID, retrieved.ID)
+	require.Equal(t, mem.Content, retrieved.Content)
+}
+
+func TestGetMemoryByIDInProject_CrossProjectRejected(t *testing.T) {
+	projA := uniqueProject("get-mem-proj-cross-a")
+	projB := uniqueProject("get-mem-proj-cross-b")
+	bA := newTestBackend(t, projA)
+	ctx := context.Background()
+
+	memA := storeMemory(t, bA, projA, "cross-project scoped memory")
+
+	retrieved, err := bA.GetMemoryByIDInProject(ctx, memA.ID, projB)
+	require.NoError(t, err)
+	require.Nil(t, retrieved, "GetMemoryByIDInProject must not return a memory from another project")
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -40,6 +40,9 @@ func (noopBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) er
 }
 func (noopBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error)     { return nil, nil }
 func (noopBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) { return nil, nil }
+func (noopBackend) GetMemoryByIDInProject(_ context.Context, _, _ string) (*types.Memory, error) {
+	return nil, nil
+}
 func (noopBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
 	return nil, nil
 }

--- a/internal/mcp/fetch_exec_test.go
+++ b/internal/mcp/fetch_exec_test.go
@@ -35,7 +35,7 @@ func TestExecFetch_SummaryDetail(t *testing.T) {
 			Content: "full content that should not appear",
 		},
 	}
-	result, err := execFetch(context.Background(), ff, "m1", "summary", 65536, nil)
+	result, err := execFetch(context.Background(), ff, "default", "m1", "summary", 65536, nil)
 	require.NoError(t, err)
 	require.Equal(t, "m1", result["id"])
 	require.Equal(t, "A brief summary", result["summary"])
@@ -47,14 +47,14 @@ func TestExecFetch_SummaryDetail_NilSummary(t *testing.T) {
 	ff := &fakeFetcher{
 		mem: &types.Memory{ID: "m2", Summary: nil, Content: "body"},
 	}
-	result, err := execFetch(context.Background(), ff, "m2", "summary", 65536, nil)
+	result, err := execFetch(context.Background(), ff, "default", "m2", "summary", 65536, nil)
 	require.NoError(t, err)
 	require.Equal(t, "", result["summary"])
 }
 
 func TestExecFetch_IDNotFound(t *testing.T) {
 	ff := &fakeFetcher{mem: nil}
-	_, err := execFetch(context.Background(), ff, "missing", "full", 65536, nil)
+	_, err := execFetch(context.Background(), ff, "default", "missing", "full", 65536, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 }
@@ -64,7 +64,7 @@ func TestExecFetch_FullDetailByteCapApplied(t *testing.T) {
 	ff := &fakeFetcher{
 		mem: &types.Memory{ID: "m3", Content: bigContent},
 	}
-	result, err := execFetch(context.Background(), ff, "m3", "full", 65536, nil)
+	result, err := execFetch(context.Background(), ff, "default", "m3", "full", 65536, nil)
 	require.NoError(t, err)
 	content, ok := result["content"].(string)
 	require.True(t, ok)
@@ -77,7 +77,7 @@ func TestExecFetch_FullDetailUnderCap_NotTruncated(t *testing.T) {
 	ff := &fakeFetcher{
 		mem: &types.Memory{ID: "m4", Content: "short"},
 	}
-	result, err := execFetch(context.Background(), ff, "m4", "full", 65536, nil)
+	result, err := execFetch(context.Background(), ff, "default", "m4", "full", 65536, nil)
 	require.NoError(t, err)
 	require.Equal(t, "short", result["content"])
 	truncated, _ := result["truncated"].(bool)
@@ -92,7 +92,7 @@ func TestExecFetch_ChunkDetail_AllChunks(t *testing.T) {
 			{ID: "c2", ChunkIndex: 1, ChunkText: "chunk one"},
 		},
 	}
-	result, err := execFetch(context.Background(), ff, "m5", "chunk", 65536, nil)
+	result, err := execFetch(context.Background(), ff, "default", "m5", "chunk", 65536, nil)
 	require.NoError(t, err)
 	chunks, ok := result["chunks"].([]*types.Chunk)
 	require.True(t, ok)
@@ -108,11 +108,25 @@ func TestExecFetch_ChunkDetail_FilterByIDs(t *testing.T) {
 			{ID: "c3", ChunkIndex: 2, ChunkText: "two"},
 		},
 	}
-	result, err := execFetch(context.Background(), ff, "m6", "chunk", 65536, []string{"c1", "c3"})
+	result, err := execFetch(context.Background(), ff, "default", "m6", "chunk", 65536, []string{"c1", "c3"})
 	require.NoError(t, err)
 	chunks, ok := result["chunks"].([]*types.Chunk)
 	require.True(t, ok)
 	require.Len(t, chunks, 2)
 	ids := []string{chunks[0].ID, chunks[1].ID}
 	require.ElementsMatch(t, []string{"c1", "c3"}, ids)
+}
+
+func TestExecFetch_CrossProjectIDRejected(t *testing.T) {
+	ff := &fakeFetcher{
+		mem: &types.Memory{
+			ID:      "m-cross",
+			Project: "alpha",
+			Content: "secret memory content",
+		},
+	}
+
+	_, err := execFetch(context.Background(), ff, "beta", "m-cross", "full", 65536, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
 }

--- a/internal/mcp/fetch_exec_test.go
+++ b/internal/mcp/fetch_exec_test.go
@@ -18,7 +18,10 @@ type fakeFetcher struct {
 	chunkErr error
 }
 
-func (f *fakeFetcher) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) {
+func (f *fakeFetcher) GetMemoryByIDInProject(_ context.Context, _ string, project string) (*types.Memory, error) {
+	if f.mem != nil && f.mem.Project != "" && f.mem.Project != project {
+		return nil, nil
+	}
 	return f.mem, f.memErr
 }
 

--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -156,7 +156,7 @@ func newHandleFastPathPool(t *testing.T, backend *handleFastPathBackend) *Engine
 func TestExecFetch_GetMemoryError(t *testing.T) {
 	sentinel := errors.New("db exploded")
 	f := &recallStubFetcher{memErr: sentinel}
-	_, err := execFetch(context.Background(), f, "any-id", "summary", 0, nil)
+	_, err := execFetch(context.Background(), f, "default", "any-id", "summary", 0, nil)
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -169,7 +169,7 @@ func TestExecFetch_FullDetail_ZeroMaxBytes(t *testing.T) {
 		Project: "p",
 		Content: longContent,
 	}}
-	out, err := execFetch(context.Background(), f, "big-mem", "full", 0, nil)
+	out, err := execFetch(context.Background(), f, "default", "big-mem", "full", 0, nil)
 	require.NoError(t, err)
 	content, ok := out["content"].(string)
 	require.True(t, ok)
@@ -675,7 +675,7 @@ func TestExecFetch_CrossProjectFetch_Issue634(t *testing.T) {
 	// crossProjectFetcher.GetMemoryByID always returns the memory; its
 	// GetMemory counterpart (removed from the interface) would have returned nil.
 	f := &crossProjectFetcher{mem: mem}
-	out, err := execFetch(context.Background(), f, mem.ID, "full", 65536, nil)
+	out, err := execFetch(context.Background(), f, "default", mem.ID, "full", 65536, nil)
 	require.NoError(t, err, "cross-project fetch must succeed after #634 fix")
 	require.Equal(t, mem.ID, out["id"], "returned id must match requested id")
 	require.Equal(t, mem.Content, out["content"], "full content must be present")

--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -36,6 +36,13 @@ func (s *recallStubFetcher) GetMemoryByID(_ context.Context, _ string) (*types.M
 	return s.mem, s.memErr
 }
 
+func (s *recallStubFetcher) GetMemoryByIDInProject(_ context.Context, _ string, project string) (*types.Memory, error) {
+	if s.mem != nil && s.mem.Project != "" && s.mem.Project != project {
+		return nil, nil
+	}
+	return s.mem, s.memErr
+}
+
 func (s *recallStubFetcher) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
 	return s.chunks, nil
 }
@@ -169,7 +176,7 @@ func TestExecFetch_FullDetail_ZeroMaxBytes(t *testing.T) {
 		Project: "p",
 		Content: longContent,
 	}}
-	out, err := execFetch(context.Background(), f, "default", "big-mem", "full", 0, nil)
+	out, err := execFetch(context.Background(), f, "p", "big-mem", "full", 0, nil)
 	require.NoError(t, err)
 	content, ok := out["content"].(string)
 	require.True(t, ok)
@@ -638,47 +645,6 @@ func TestHandleMemoryRecall_FullMode_Degraded_AddsWarnings(t *testing.T) {
 	warnings, ok := warningsRaw.([]any)
 	require.True(t, ok)
 	require.Contains(t, warnings, recallEmbedDegradedWarning)
-}
-
-// ── Fix B: cross-project recall→fetch (#634 primary) ─────────────────────────
-
-// crossProjectFetcher simulates a backend pool scoped to project "default"
-// serving a memory that lives in project "global". GetMemoryByID finds it
-// (no project filter); the old GetMemory call would have returned nil.
-type crossProjectFetcher struct {
-	mem    *types.Memory
-	chunks []*types.Chunk
-}
-
-func (c *crossProjectFetcher) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) {
-	return c.mem, nil
-}
-
-func (c *crossProjectFetcher) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
-	return c.chunks, nil
-}
-
-// TestExecFetch_CrossProjectFetch_Issue634 is the regression test for the
-// primary bug in #634: memory_recall(project="global") returned handles that
-// memory_fetch(project="default") could not resolve.
-//
-// Before the fix, execFetch called f.GetMemory which filtered by the pool's
-// project; a backend scoped to "default" would return nil for a memory stored
-// under "global". After the fix, execFetch calls f.GetMemoryByID which omits
-// the project filter, so the memory is found regardless of pool scope.
-func TestExecFetch_CrossProjectFetch_Issue634(t *testing.T) {
-	mem := &types.Memory{
-		ID:      "019d8bae-eeae-7035-b2aa-0d8b764ed6c8", // UUIDv7 from the bug report
-		Project: "global",
-		Content: "Peter's writing style rules — voice and cadence",
-	}
-	// crossProjectFetcher.GetMemoryByID always returns the memory; its
-	// GetMemory counterpart (removed from the interface) would have returned nil.
-	f := &crossProjectFetcher{mem: mem}
-	out, err := execFetch(context.Background(), f, "default", mem.ID, "full", 65536, nil)
-	require.NoError(t, err, "cross-project fetch must succeed after #634 fix")
-	require.Equal(t, mem.ID, out["id"], "returned id must match requested id")
-	require.Equal(t, mem.Content, out["content"], "full content must be present")
 }
 
 // ── Blocker 2: embed-timeout degradation path counter coverage ───────────────

--- a/internal/mcp/issue629_handler_test.go
+++ b/internal/mcp/issue629_handler_test.go
@@ -88,7 +88,7 @@ func TestIssue629_EpisodeHandlersAndAdminHandlers(t *testing.T) {
 
 	res, err = handleMemoryProjects(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
 	require.NoError(t, err)
-	require.Equal(t, float64(2), decodeToolResult(t, res)["count"])
+	require.Equal(t, float64(1), decodeToolResult(t, res)["count"])
 
 	res, err = handleMemoryStatus(context.Background(), pool, mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}}})
 	require.NoError(t, err)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -169,13 +169,10 @@ func (c Config) rateLimitBurst() int {
 // backendFetcher is the narrow interface required by execFetch.
 // Satisfied by db.Backend; declared separately so tests can inject a stub.
 type backendFetcher interface {
-	// GetMemoryByID retrieves a memory by its ID without project filtering.
-	// This is intentional: memory IDs are globally unique UUIDs, and fetch
-	// must work regardless of which project the caller's pool is scoped to.
-	// Using the project-filtered GetMemory here was the root cause of #634,
-	// where memory_recall (project="global") returned handles that
-	// memory_fetch (project="default") could not resolve.
-	GetMemoryByID(ctx context.Context, id string) (*types.Memory, error)
+	// GetMemoryByIDInProject retrieves a memory by ID scoped to the caller's
+	// declared project. The unscoped GetMemoryByID remains available on
+	// db.Backend for internal cross-project reads such as EnrichWithConflicts.
+	GetMemoryByIDInProject(ctx context.Context, id, project string) (*types.Memory, error)
 	GetChunksForMemory(ctx context.Context, id string) ([]*types.Chunk, error)
 }
 

--- a/internal/mcp/tools_admin.go
+++ b/internal/mcp/tools_admin.go
@@ -15,38 +15,23 @@ import (
 
 func handleMemoryProjects(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
-	// Use any project to get a backend connection for the cross-project query.
-	anchorProject, err := getProject(args, "default")
+	project, err := getProject(args, "default")
 	if err != nil {
 		return nil, err
 	}
-	h, err := pool.Get(ctx, anchorProject)
+	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
 	}
-	projects, err := h.Engine.Backend().ListAllProjects(ctx)
+	stats, err := h.Engine.Status(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// Enrich with per-project stats.
 	type projectInfo struct {
 		Project string `json:"project"`
 		Count   int    `json:"count"`
 	}
-	out := make([]projectInfo, 0, len(projects))
-	for _, p := range projects {
-		ph, err := pool.Get(ctx, p)
-		if err != nil {
-			out = append(out, projectInfo{Project: p})
-			continue
-		}
-		stats, err := ph.Engine.Status(ctx)
-		if err != nil {
-			out = append(out, projectInfo{Project: p})
-			continue
-		}
-		out = append(out, projectInfo{Project: p, Count: stats.TotalMemories})
-	}
+	out := []projectInfo{{Project: project, Count: stats.TotalMemories}}
 	return toolResult(map[string]any{"projects": out, "count": len(out)})
 }
 

--- a/internal/mcp/tools_admin_test.go
+++ b/internal/mcp/tools_admin_test.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleMemoryProjects_ScopeToCallerOnly(t *testing.T) {
+	pool := newIssue629Pool(t)
+
+	res, err := handleMemoryProjects(context.Background(), pool, mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{Arguments: map[string]any{"project": "proj"}},
+	})
+	require.NoError(t, err)
+
+	out := decodeToolResult(t, res)
+	require.Equal(t, float64(1), out["count"])
+
+	projects, ok := out["projects"].([]any)
+	require.True(t, ok)
+	require.Len(t, projects, 1)
+
+	projectInfo, ok := projects[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "proj", projectInfo["project"])
+	require.Equal(t, float64(3), projectInfo["count"])
+}

--- a/internal/mcp/tools_reason.go
+++ b/internal/mcp/tools_reason.go
@@ -168,8 +168,8 @@ type exploreMemFetcher struct {
 	backend backendFetcher
 }
 
-func (f *exploreMemFetcher) FetchMemory(ctx context.Context, _ string, id string) (*types.Memory, error) {
-	return f.backend.GetMemoryByID(ctx, id)
+func (f *exploreMemFetcher) FetchMemory(ctx context.Context, project, id string) (*types.Memory, error) {
+	return f.backend.GetMemoryByIDInProject(ctx, id, project)
 }
 
 // parseExploreScope extracts the optional scope sub-object from MCP args.

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -131,7 +131,7 @@ func sanitizeConflictingResults(conflicts []types.ConflictingResult) {
 	}
 }
 
-func execFetch(ctx context.Context, f backendFetcher, id, detail string, maxBytes int, requestedChunkIDs []string) (map[string]any, error) {
+func execFetch(ctx context.Context, f backendFetcher, project, id, detail string, maxBytes int, requestedChunkIDs []string) (map[string]any, error) {
 	m, err := f.GetMemoryByID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func handleMemoryFetch(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 	if err != nil {
 		return nil, err
 	}
-	result, err := execFetch(ctx, h.Engine.Backend(), id, detail, maxBytes, chunkIDs)
+	result, err := execFetch(ctx, h.Engine.Backend(), project, id, detail, maxBytes, chunkIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -132,7 +132,7 @@ func sanitizeConflictingResults(conflicts []types.ConflictingResult) {
 }
 
 func execFetch(ctx context.Context, f backendFetcher, project, id, detail string, maxBytes int, requestedChunkIDs []string) (map[string]any, error) {
-	m, err := f.GetMemoryByID(ctx, id)
+	m, err := f.GetMemoryByIDInProject(ctx, id, project)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -96,6 +96,9 @@ func (noopBackend) StoreMemory(_ context.Context, _ *types.Memory) error        
 func (noopBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error  { return nil }
 func (noopBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error)     { return nil, nil }
 func (noopBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) { return nil, nil }
+func (noopBackend) GetMemoryByIDInProject(_ context.Context, _, _ string) (*types.Memory, error) {
+	return nil, nil
+}
 func (noopBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
 	return nil, nil
 }

--- a/internal/search/embedder_meta_cache_test.go
+++ b/internal/search/embedder_meta_cache_test.go
@@ -62,8 +62,8 @@ type cacheMetaBackend struct {
 	mu           sync.Mutex
 	meta         map[string]string // key: "project:key"
 	getMetaCalls atomic.Int64
-	nullAllCalls atomic.Int32          // counts NullAllEmbeddingsTx calls
-	chunkCounts  map[string]int        // project → chunk count for volume guard
+	nullAllCalls atomic.Int32   // counts NullAllEmbeddingsTx calls
+	chunkCounts  map[string]int // project → chunk count for volume guard
 }
 
 func newCacheMetaBackend() *cacheMetaBackend {
@@ -118,6 +118,9 @@ func (b *cacheMetaBackend) GetMemory(_ context.Context, _ string) (*types.Memory
 	return nil, nil
 }
 func (b *cacheMetaBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) {
+	return nil, nil
+}
+func (b *cacheMetaBackend) GetMemoryByIDInProject(_ context.Context, _, _ string) (*types.Memory, error) {
 	return nil, nil
 }
 func (b *cacheMetaBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
@@ -372,8 +375,10 @@ func (b *cacheMetaBackend) FindNearestClusters(_ context.Context, _ string, _ []
 func (b *cacheMetaBackend) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
 	return nil, nil
 }
-func (b *cacheMetaBackend) TableExists(_ context.Context, _ string) (bool, error)     { return false, nil }
-func (b *cacheMetaBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) { return false, nil }
+func (b *cacheMetaBackend) TableExists(_ context.Context, _ string) (bool, error) { return false, nil }
+func (b *cacheMetaBackend) ColumnExists(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
 
 // compile-time check: cacheMetaBackend must satisfy db.Backend.
 var _ db.Backend = (*cacheMetaBackend)(nil)

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -185,6 +185,10 @@ func (s *stubBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory,
 	return nil, nil
 }
 
+func (s *stubBackend) GetMemoryByIDInProject(_ context.Context, _, _ string) (*types.Memory, error) {
+	return nil, nil
+}
+
 func (s *stubBackend) UpdateMemory(_ context.Context, _ string, _ *string, _ []string, _ *int, _ *float64) (*types.Memory, error) {
 	return nil, nil
 }

--- a/internal/search/hyde_test.go
+++ b/internal/search/hyde_test.go
@@ -119,6 +119,9 @@ func (noopBackend) StoreMemory(_ context.Context, _ *types.Memory) error        
 func (noopBackend) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error  { return nil }
 func (noopBackend) GetMemory(_ context.Context, _ string) (*types.Memory, error)     { return nil, nil }
 func (noopBackend) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) { return nil, nil }
+func (noopBackend) GetMemoryByIDInProject(_ context.Context, _, _ string) (*types.Memory, error) {
+	return nil, nil
+}
 func (noopBackend) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Codex work for #1188 via fleet-dispatch. Draft — needs review/CI. Closes #1188