### PR TITLE
fix(supply-chain): digest-pin Chainguard base images (closes #1189)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: build engram + starter
-FROM cgr.dev/chainguard/go:latest AS build
+# Pinned 2026-06-26: re-pin when Go minor version changes (crane digest cgr.dev/chainguard/go:latest)
+FROM cgr.dev/chainguard/go:latest@sha256:faf3f70ddc6b4780f0506724bdd813f91511b253b76c4a2c6e94a01f99130219 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -12,7 +13,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w -X main.Version=
 # Stage 2: minimal runtime — no shell, no OS tools, CA certs only
 # starter (the ENTRYPOINT) authenticates to Infisical, injects ENGRAM_API_KEY,
 # then exec-replaces itself with /engram. No secrets on disk.
-FROM cgr.dev/chainguard/static:latest
+# Pinned 2026-06-26: re-pin on Chainguard static updates (crane digest cgr.dev/chainguard/static:latest)
+FROM cgr.dev/chainguard/static:latest@sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b
 COPY --from=build /engram /engram
 COPY --from=build /starter /starter
 COPY --from=build /engram-setup /engram-setup


### PR DESCRIPTION
## Summary

- Pin `cgr.dev/chainguard/go:latest` to `sha256:faf3f70ddc6b4780f0506724bdd813f91511b253b76c4a2c6e94a01f99130219` (resolved 2026-06-26)
- Pin `cgr.dev/chainguard/static:latest` to `sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b` (resolved 2026-06-26)
- Add re-pin comments above each FROM line noting the resolution date

Prevents silent supply-chain updates via mutable `:latest` tags without any git-visible diff. No functional change — only the digest pins are added.

## Test plan

- [ ] Existing CI (`go test ./... -count=1 -race`, coverage ≥55%) passes unchanged
- [ ] checkin-lint passes (✓ already verified pre-commit)
- [ ] No `:latest` unpinned tags remain in Dockerfile (`grep '^FROM.*:latest$' Dockerfile` → no matches)

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)