### PR TITLE
fix(sec-07): check physical RemoteAddr for loopback RL exemption (#1190)

### DIFF
--- a/internal/mcp/rate_limit_spoof_test.go
+++ b/internal/mcp/rate_limit_spoof_test.go
@@ -1,0 +1,151 @@
+package mcp
+
+// Tests for issue #1190 (SEC-07): loopback rate-limit exemption must check
+// the physical network address (r.RemoteAddr), not client-supplied proxy headers.
+//
+// A remote attacker sending "X-Real-IP: 127.0.0.1" with
+// ENGRAM_TRUST_PROXY_HEADERS=1 must NOT bypass rate limiting.
+// A genuine loopback connection (RemoteAddr is 127.0.0.1) remains exempt.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestLoopbackSpoofNotExempted verifies that a remote TCP connection sending
+// "X-Real-IP: 127.0.0.1" is NOT exempt from rate limiting when trustProxy=true.
+//
+// The physical network address (RemoteAddr = "10.0.0.1:12345") is non-loopback,
+// so the rate limiter applies regardless of the header. The RL bucket key is the
+// proxy-header IP (127.0.0.1 from X-Real-IP), so we pre-exhaust that bucket to
+// prove the request goes through the limiter and gets rejected.
+func TestLoopbackSpoofNotExempted(t *testing.T) {
+	s := newTrustProxyServer()
+
+	const apiKey = "test-key-spoof"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// With trustProxy=true, clientIP() returns the X-Real-IP value ("127.0.0.1")
+	// as the RL bucket key. Pre-exhaust that bucket so the next request is rejected.
+	rl := newRateLimiterWithConfig(ctx, 1, 1)
+	rl.allow("127.0.0.1") // consumes the bucket the spoofed header maps to
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.applyMiddlewareWithRL(inner, apiKey, rl)
+
+	// Attacker is physically at 10.0.0.1 but sends spoofed X-Real-IP.
+	// physicalHost = "10.0.0.1" → not loopback → RL applies → bucket "127.0.0.1" is exhausted → 429.
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("X-Real-IP", "127.0.0.1") // spoofed loopback header
+	req.RemoteAddr = "10.0.0.1:12345"         // physical non-loopback address
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// The physical address is non-loopback → limiter is applied → bucket exhausted → 429.
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 (rate limited) for spoofed loopback header, got %d — SEC-07 regression", w.Code)
+	}
+}
+
+// TestLoopbackSpoofXFFNotExempted verifies the same protection applies for
+// X-Forwarded-For: 127.0.0.1. clientIP() returns the XFF value ("127.0.0.1")
+// as the RL bucket key; we pre-exhaust it, then confirm 429 is returned.
+func TestLoopbackSpoofXFFNotExempted(t *testing.T) {
+	s := newTrustProxyServer()
+
+	const apiKey = "test-key-spoof-xff"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// clientIP() will return "127.0.0.1" (from X-Forwarded-For) as the bucket key.
+	rl := newRateLimiterWithConfig(ctx, 1, 1)
+	rl.allow("127.0.0.1") // pre-exhaust the bucket that the spoof maps to
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.applyMiddlewareWithRL(inner, apiKey, rl)
+
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("X-Forwarded-For", "127.0.0.1") // spoofed via XFF
+	req.RemoteAddr = "10.0.0.2:12345"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for XFF-spoofed loopback, got %d — SEC-07 regression", w.Code)
+	}
+}
+
+// TestPhysicalLoopbackExempt verifies that a genuine loopback connection
+// (RemoteAddr is 127.0.0.1) remains exempt from rate limiting regardless of
+// proxy header configuration or limiter state.
+func TestPhysicalLoopbackExempt(t *testing.T) {
+	s := newTrustProxyServer() // trustProxy=true should not affect loopback exemption
+
+	const apiKey = "test-key-phys-loopback"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Exhaust the limiter for 127.0.0.1 so it would reject if not exempt.
+	rl := newRateLimiterWithConfig(ctx, 1, 1)
+	rl.allow("127.0.0.1") // consume burst
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.applyMiddlewareWithRL(inner, apiKey, rl)
+
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.RemoteAddr = "127.0.0.1:54321" // genuine loopback
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusTooManyRequests {
+		t.Fatal("physical loopback connection (RemoteAddr=127.0.0.1) was rate-limited — must remain exempt (#387, #1190)")
+	}
+}
+
+// TestPhysicalLoopbackExemptTrustProxyOff verifies that loopback exemption
+// also works when trustProxy=false (the no-proxy default).
+func TestPhysicalLoopbackExemptTrustProxyOff(t *testing.T) {
+	s := &Server{cfg: Config{}, trustProxy: false}
+
+	const apiKey = "test-key-phys-loopback-noproxy"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rl := newRateLimiterWithConfig(ctx, 1, 1)
+	rl.allow("127.0.0.1")
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := s.applyMiddlewareWithRL(inner, apiKey, rl)
+
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.RemoteAddr = "127.0.0.1:54321"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusTooManyRequests {
+		t.Fatal("physical loopback with trustProxy=false was rate-limited — must remain exempt")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -916,8 +916,14 @@ func (s *Server) applyMiddlewareWithRL(next http.Handler, apiKey string, rl *rat
 		// Rate limit before auth check to prevent timing-based enumeration.
 		// Exempt loopback IPs (127.0.0.1, ::1) — a local process is not a threat.
 		// Also exempt entirely when RateLimitDisable=true (#387).
-		remoteHost := s.clientIP(r)
-		if !s.cfg.RateLimitDisable && !isLoopbackIP(remoteHost) {
+		//
+		// The loopback exemption MUST use the physical network address (r.RemoteAddr),
+		// never a client-supplied header such as X-Real-IP or X-Forwarded-For.
+		// A remote attacker sending "X-Real-IP: 127.0.0.1" must NOT bypass rate
+		// limiting, regardless of the ENGRAM_TRUST_PROXY_HEADERS setting. (#1190)
+		remoteHost := s.clientIP(r) // proxy-aware; used as the per-IP RL bucket key
+		physicalHost, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if !s.cfg.RateLimitDisable && !isLoopbackIP(physicalHost) {
 			if !rl.allow(remoteHost) {
 				w.Header().Set("Retry-After", "1")
 				writeJSON(w, http.StatusTooManyRequests, map[string]string{


### PR DESCRIPTION
## Summary

- **SEC-07 fix**: The loopback rate-limit exemption in `applyMiddlewareWithRL` previously used `clientIP(r)` for the exemption check. When `ENGRAM_TRUST_PROXY_HEADERS=1`, a remote attacker sending `X-Real-IP: 127.0.0.1` could bypass rate limiting entirely.
- **Fix**: Extract `physicalHost` from `r.RemoteAddr` via `net.SplitHostPort` for the `isLoopbackIP` exemption check. The RL bucket key continues to use `clientIP(r)` so per-IP throttling behind a trusted reverse proxy still works correctly.
- **4 new tests** in `internal/mcp/rate_limit_spoof_test.go` covering X-Real-IP spoof, X-Forwarded-For spoof, genuine loopback exempt (trustProxy on/off).

## Files changed

- `internal/mcp/server.go` — loopback exemption check uses `physicalHost` (RemoteAddr) not `clientIP(r)`
- `internal/mcp/rate_limit_spoof_test.go` — new test file (TDD, 4 tests)

## Test proof

```
go test -race -count=1 ./internal/mcp/... → ok (15.1s)
```

Closes #1190

🤖 Generated with Claude Code