### PR TITLE
fix(longmemeval): include temporal recall in repair preset

### DIFF
--- a/cmd/longmemeval/all_test.go
+++ b/cmd/longmemeval/all_test.go
@@ -78,6 +78,9 @@ func TestApplyRepairPresetRecallRepair(t *testing.T) {
 	if !cfg.TemporalPromptAug {
 		t.Error("recall-repair preset should enable temporal prompt augmentation")
 	}
+	if !cfg.TemporalWindowRecall {
+		t.Error("recall-repair preset should enable server-side temporal window recall")
+	}
 	if !cfg.ChronoSort {
 		t.Error("recall-repair preset should enable chronological context ordering")
 	}
@@ -89,7 +92,7 @@ func TestApplyRepairPresetDefaultBaselineNoop(t *testing.T) {
 		t.Fatalf("applyRepairPreset default: %v", err)
 	}
 	if cfg.DualPreferenceRecall || cfg.ExhaustiveAggregation || cfg.EnumerateFirst ||
-		cfg.TemporalPromptAug || cfg.ChronoSort {
+		cfg.TemporalPromptAug || cfg.TemporalWindowRecall || cfg.ChronoSort {
 		t.Fatalf("default config should leave repair switches off: %+v", cfg)
 	}
 }

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -639,6 +639,7 @@ func applyRepairPreset(cfg *Config) error {
 		cfg.ExhaustiveAggregation = true
 		cfg.EnumerateFirst = true
 		cfg.TemporalPromptAug = true
+		cfg.TemporalWindowRecall = true
 		cfg.ChronoSort = true
 		return nil
 	default:


### PR DESCRIPTION
## Summary<br>- enable H-NEW-1 server-side temporal window recall in the `longmemeval` `recall-repair` preset<br>- add regression coverage so the preset asserts temporal-window recall is on while the baseline remains off<br><br>## Testing<br>- `bash ./bin/checkin-lint.sh`<br>- `/usr/local/go/bin/go test ./cmd/longmemeval -run 'TestApplyRepairPreset'`<br>- `/usr/local/go/bin/go test ./...`<br>- `/usr/local/go/bin/go test -race ./...`<br><br>## Environment notes<br>- `make test` is blocked here because `docker` is not installed in this container<br>- `cargo test` and `cargo clippy` are blocked here because `cargo` is not installed