### PR TITLE
docs(lme-plan): reconcile after Phase-4 Qwen3 lever matrix + #1185 unblock + issue-board update

### DIFF
--- a/docs/lme-campaign/PLAN-2026-06-21.md
+++ b/docs/lme-campaign/PLAN-2026-06-21.md
@@ -113,3 +113,579 @@ in the aggregation lever.
 - **FM (metric-mismatch rejection):** LEVER-9 session-diversity was rejected on NDCG@5, a metric
   that cannot see multi-gold coverage inside the generation window. A lever's rejection metric
   must measure the lever's actual mechanism. (Preference packing was hidden by this for ~5 days.)
+
+---
+
+## Phase: 500Q full benchmarks — 2026-06-25
+
+**Session established:** LME-S baseline, LME-M v9 best. **Harness consultation:** Hermes (full) +
+Grok (full). Codex consulted but produced PR #1173 (RestClient bug fix) instead of benchmark
+analysis — `consult` routing to Codex does not yet produce text responses; tracked separately.
+**PR #1172 merged** 2026-06-25T00:59: `hardExclusionRule` + `GenerationPromptPreferenceEnumerate`
+enhancement + `--preference-enumerate` wired to new prompt.
+
+### Current baselines (500Q full runs)
+
+| Run | Config | Result dir |
+|-----|--------|------------|
+| **LME-M v9** | h-sd-n5-sonnet (all flags, Sonnet gen) | `results/h-sd-n5-sonnet-20260619` |
+| **LME-S baseline** | vanilla Sonnet, no flags | `results/lme-s-baseline-0622` |
+
+**LME-M v9 results — 66.6% strict / 70.2% lenient:**
+
+| type | strict | n | C | P | I | gold_visible | avg_rank |
+|------|--------|---|---|---|---|--------------|---------|
+| knowledge-update | 70.5% | 78 | 55 | 5 | 18 | 0.99 | 2.0 |
+| multi-session | 55.6% | 133 | 74 | 10 | 49 | 0.95 | 4.1 |
+| single-session-asst | 94.6% | 56 | 53 | 1 | 2 | 0.96 | 4.4 |
+| single-session-pref | 20.0% | 30 | 6 | 11 | 13 | 0.40 | 39.6 |
+| single-session-user | 75.7% | 70 | 53 | 1 | 16 | 0.80 | 15.6 |
+| temporal-reasoning | 69.2% | 133 | 92 | 7 | 34 | 0.92 | 5.9 |
+
+**LME-S baseline results — 81.4% strict / 86.2% lenient:**
+
+| type | strict | lenient | n | note |
+|------|--------|---------|---|------|
+| knowledge-update | 71.8% | — | 78 | ~72% floor same as LME-M |
+| multi-session | 81.2% | — | 133 | |
+| single-session-asst | 91.1% | — | 56 | |
+| single-session-pref | 53.3% | 93.3% | 30 | **40pp gap — #1106 pattern** |
+| single-session-user | 92.9% | — | 70 | |
+| temporal-reasoning | 83.5% | — | 133 | |
+
+**LME-M v9 h-sd-n5-sonnet flags (exact, from RUN_STATUS.json):**
+```
+--url http://127.0.0.1:8788
+--data testdata/longmemeval/longmemeval_m_cleaned.json
+--run-id golden20260602
+--recall-topk 100 --context-topk 15
+--exhaustive-aggregation --enumerate-first --dual-preference-recall
+--preference-enumerate --session-diversity-n 5
+--generation-model sonnet
+--cleanup-policy never --workers 4
+```
+
+**LME-S baseline flags:**
+```
+--data testdata/longmemeval/longmemeval_s.json
+--generation-model sonnet
+--cleanup-policy never --workers 2
+```
+
+### Root cause analysis by failure category (Hermes + Grok synthesis)
+
+| Category | Root cause | Confidence |
+|----------|-----------|------------|
+| **LME-M ss-pref (20.0%)** | Ranking dilution: gold avg rank 63.5 INCORRECT vs 11.7 CORRECT; 0% miss at recall_topk=100; only 40% visible at ctopk=15 | HIGH |
+| **LME-S ss-pref (53.3%)** | Generation specificity: 40pp strict/lenient gap = #1106 pattern; gold ALWAYS present | HIGH |
+| **knowledge-update (~72%, both)** | Recency commitment: gold_visible=0.99, avg_rank=2.0; model picks stale value when both old+new in context | HIGH |
+| **LME-M multi-session (55.6%)** | Cross-session synthesis: 41/47 questions aggregation-shaped; enumerates but never sums; gold_visible=0.95 | HIGH |
+| **temporal (~70%, both)** | CONFLICTING signal on `--inject-question-date`; HOLD pending A/B (#1177) | MEDIUM |
+
+### Key harness divergence
+`--inject-question-date`: Grok cites −8.9pp on 135-item ledger; 30Q mini-test showed +8.9pp.
+**Do NOT stack until isolated A/B on full 133 temporal items resolves the conflict** (issue #1177).
+
+### Issues tracking board (created 2026-06-25)
+
+| Issue | Title | Priority |
+|-------|-------|----------|
+| [#1174](https://github.com/petersimmons1972/engram-go/issues/1174) | R1 — LME-S + `--preference-enumerate` run | 🟢 This week |
+| [#1175](https://github.com/petersimmons1972/engram-go/issues/1175) | R2 — LME-M v10 `--preference-enumerate` + `--enumerate-first` | 🟢 This week |
+| [#1177](https://github.com/petersimmons1972/engram-go/issues/1177) | `--inject-question-date` isolated A/B (133 temporal ×3) | 🟡 Before stacking |
+| [#1178](https://github.com/petersimmons1972/engram-go/issues/1178) | KU recency generation prompt (`--ku-recency-prompt`) | 🟡 Phase 1 |
+| [#1176](https://github.com/petersimmons1972/engram-go/issues/1176) | Per-session diversity cap for ss-pref ranking dilution | 🟡 Phase 1 |
+| [#1179](https://github.com/petersimmons1972/engram-go/issues/1179) | Events-index integration for LME-M multi-session | 🟡 Phase 2 |
+| [#1180](https://github.com/petersimmons1972/engram-go/issues/1180) | DenseReranker gating — retrieval-metrics A/B first | 🟡 Phase 2 |
+| [#1181](https://github.com/petersimmons1972/engram-go/issues/1181) | Atomic preference extraction at ingest (long-term) | ⚫ Long-term |
+
+---
+
+## NEXT EXECUTION — R1 (LME-S) then R2 (LME-M), serial, Nemotron generator
+
+**Token constraint 2026-06-25:** Sonnet budget exhausted. Using Nemotron (free via local Olla,
+`http://192.168.0.138:30411/olla/openai/v1`, model alias `inference`) as generator for both runs.
+Results may NOT be directly comparable to Sonnet baselines — absolute scores expected ~5-15pp lower.
+Use these runs to confirm **directional signal** only. Sonnet re-run planned once budget resets.
+
+**CRITICAL: do NOT use `--enable-thinking`** — flag code says "do NOT use with Nemotron v3".
+**No `--llm-api-key` needed** — Olla endpoint is unauthenticated.
+
+### Pre-flight (both runs)
+
+```bash
+cd ~/projects/engram-go
+# Build fresh binary (picks up PR #1172 changes)
+go build -o ./bin/longmemeval ./cmd/longmemeval
+
+# Verify preference-enumerate flag exists
+./bin/longmemeval run --help | grep preference-enumerate
+
+# Verify hardExclusionRule in prompt code
+grep -n hardExclusionRule internal/longmemeval/claude.go
+
+# Verify Olla/Nemotron is reachable
+curl -s http://192.168.0.138:30411/olla/openai/v1/models | python3 -c "import json,sys; [print(m['id']) for m in json.load(sys.stdin)['data']]"
+# Should show: inference, fast-inference, BAAI/bge-m3
+
+# Verify local engram is up
+curl -s http://127.0.0.1:8788/health
+# Should return: {"status":"ok","postgres":"ok","ollama":"ok","circuit_state":"closed"}
+```
+
+### R1: LME-S + --preference-enumerate (Nemotron) — run first
+
+**Baseline:** 81.4% strict. **Target:** ≥83% overall, ss-pref 53.3%→≥70%.
+
+```bash
+cd ~/projects/engram-go
+OUT=results/lme-s-r1-pref-enum-nemotron-20260625
+mkdir -p $OUT
+# Skip re-ingest — sessions already loaded from baseline run
+cp results/lme-s-baseline-0622/checkpoint-ingest.jsonl $OUT/
+
+setsid bash -c "./bin/longmemeval run \
+  --data testdata/longmemeval/longmemeval_s.json \
+  --out $OUT \
+  --llm-url http://192.168.0.138:30411/olla/openai/v1 \
+  --llm-model inference \
+  --preference-enumerate \
+  --cleanup-policy never \
+  --workers 4 \
+  </dev/null > /tmp/lme-s-r1.log 2>&1" &
+echo "R1 PID=$! — monitor: tail -f /tmp/lme-s-r1.log"
+```
+
+**Monitor:** `wc -l ~/projects/engram-go/$OUT/checkpoint-run.jsonl` → target 500 lines.
+
+**Score (after checkpoint-run.jsonl reaches 500 lines):**
+```bash
+cd ~/projects/engram-go
+OUT=results/lme-s-r1-pref-enum-nemotron-20260625
+nohup systemd-run --user --scope \
+  --unit lme-score-$(date +%s) \
+  -p MemoryMax=64G -p MemorySwapMax=8G \
+  ./bin/longmemeval score-efficient \
+  --data testdata/longmemeval/longmemeval_s.json \
+  --out $OUT \
+  --scorer-url http://192.168.0.138:30411/olla/openai/v1 \
+  --scorer-model inference \
+  --workers 4 \
+  >> $OUT/score-efficient.log 2>&1 &
+echo "scorer PID=$!"
+```
+
+**Read results:** `cat ~/projects/engram-go/$OUT/score_report.json`
+
+**Record in lme-ledger.md.** Closes issue #1174.
+
+### R2: LME-M v10 — full flag stack (Nemotron) — run after R1 completes
+
+**Baseline:** 66.6% strict (h-sd-n5-sonnet). **Key change from baseline:** PR #1172's enhanced
+`GenerationPromptPreferenceEnumerate` (hardExclusionRule + richer enumeration instruction) is now
+in the binary. The `--enumerate-first` prompt was also enhanced per 2026-06-21 plan changes.
+
+```bash
+cd ~/projects/engram-go
+OUT=results/lme-m-v10-nemotron-20260625
+mkdir -p $OUT
+# Skip re-ingest — golden20260602 corpus already loaded
+cp results/h-sd-n5-sonnet-20260619/checkpoint-ingest.jsonl $OUT/
+
+setsid bash -c "./bin/longmemeval run \
+  --url http://127.0.0.1:8788 \
+  --data testdata/longmemeval/longmemeval_m_cleaned.json \
+  --out $OUT \
+  --run-id golden20260602 \
+  --llm-url http://192.168.0.138:30411/olla/openai/v1 \
+  --llm-model inference \
+  --recall-topk 100 \
+  --context-topk 15 \
+  --exhaustive-aggregation \
+  --enumerate-first \
+  --dual-preference-recall \
+  --preference-enumerate \
+  --session-diversity-n 5 \
+  --cleanup-policy never \
+  --workers 4 \
+  </dev/null > /tmp/lme-m-v10.log 2>&1" &
+echo "R2 PID=$! — monitor: tail -f /tmp/lme-m-v10.log"
+```
+
+**Monitor:** `wc -l ~/projects/engram-go/$OUT/checkpoint-run.jsonl` → target 500 lines.
+
+**Score (after checkpoint-run.jsonl reaches 500 lines):**
+```bash
+cd ~/projects/engram-go
+OUT=results/lme-m-v10-nemotron-20260625
+nohup systemd-run --user --scope \
+  --unit lme-score-$(date +%s) \
+  -p MemoryMax=64G -p MemorySwapMax=8G \
+  ./bin/longmemeval score-efficient \
+  --data testdata/longmemeval/longmemeval_m_cleaned.json \
+  --out $OUT \
+  --scorer-url http://192.168.0.138:30411/olla/openai/v1 \
+  --scorer-model inference \
+  --workers 4 \
+  >> $OUT/score-efficient.log 2>&1 &
+```
+
+**Read results:** `cat ~/projects/engram-go/$OUT/score_report.json`
+
+**Record in lme-ledger.md.** Closes issue #1175.
+
+### Interpreting Nemotron results
+
+Nemotron is less capable than Sonnet. Absolute scores will be lower; directional signal matters:
+- ss-pref lifts clearly (>5pp on LME-S, >3pp on LME-M): plan the Sonnet re-run
+- ss-pref flat or regresses: review PR #1172 prompt changes before spending Sonnet budget
+- KU floor (~72%) persists: confirms #1178 (KU recency prompt) is next
+
+After both runs: update `docs/lme-ledger.md`, cross-reference #1174 and #1175, determine next run.
+
+---
+
+## Phase: R1 + R2 Results, Harness Synthesis, Next-Step Decision — 2026-06-25 (night)
+
+**Socialized:** Hermes (full Graybook + R1 data + plan) + Grok (same). Codex dead-lettered
+on `consult` — consistent with prior campaign note; not a blocker.
+
+### R1 Complete Results — LME-S + `--preference-enumerate`, Nemotron generator
+
+| type                      | strict  | lenient | n   | vs Sonnet baseline |
+|---------------------------|---------|---------|-----|-------------------|
+| knowledge-update          | 64.1%   | 66.7%   | 78  | −7.7pp             |
+| multi-session             | 60.2%   | 65.4%   | 133 | −21.0pp            |
+| single-session-assistant  | 89.3%   | 94.6%   | 56  | −1.8pp             |
+| **single-session-pref**   | **23.3%** | **60.0%** | 30 | **−30.0pp**     |
+| single-session-user       | 87.1%   | 92.9%   | 70  | −5.8pp             |
+| temporal-reasoning        | 72.9%   | 75.9%   | 133 | −10.6pp            |
+| **OVERALL**               | **69.0%** | **75.2%** | 500 | **−12.4pp**    |
+
+**Sonnet baselines for reference:** LME-S strict 81.4% / ss-pref 53.3% strict / 93.3% lenient.
+
+### R2 Complete Results — LME-M v10, full flag stack + PR #1172, Nemotron generator
+
+| type                      | strict  | lenient | n   | vs v9 Sonnet baseline |
+|---------------------------|---------|---------|-----|----------------------|
+| knowledge-update          | 55.1%   | 62.8%   | 78  | −15.4pp              |
+| multi-session             | 41.7%   | 51.5%   | 132 | −13.9pp              |
+| single-session-assistant  | 92.9%   | 98.2%   | 56  | −1.7pp               |
+| **single-session-pref**   | **6.9%**  | **13.8%** | 29 | **−13.1pp**        |
+| single-session-user       | 72.9%   | 74.3%   | 70  | −2.8pp               |
+| temporal-reasoning        | 59.4%   | 65.4%   | 133 | −9.8pp               |
+| **OVERALL**               | **56.6%** | **63.3%** | 498 | **−10.0pp**       |
+
+**v9 Sonnet baselines for reference:** 66.6% strict, ss-pref 20.0% strict.
+Note: n=498 (2 items missing from R2 run); n=29 for ss-pref (1 missing).
+
+**Cross-generator comparison is not valid** — v9 used Sonnet, v10 uses Nemotron.
+The −13.1pp ss-pref drop cannot be attributed to PR #1172 alone; Nemotron penalty dominates.
+
+### Critical interpretation caveat (Hermes + Grok consensus, HIGH confidence)
+
+**R1 confounds two changes simultaneously: generator swap (Sonnet→Nemotron) AND
+`--preference-enumerate` flag ON.** We cannot decompose the −30pp ss-pref drop into
+"how much is Nemotron's ceiling" vs "how much is the flag". The R1 data is **directionally
+ambiguous for the flag** until R0 (Nemotron, no flags) establishes the floor.
+
+**Nemotron penalty fingerprint (from R1):**
+- Simple recall tasks (ss-asst −1.8pp, ss-user −5.8pp): nearly intact — Nemotron retrieves fine
+- Complex synthesis (ss-pref −30pp, multi-session −21pp): crushed — model capability ceiling
+- This pattern is a **model capability ceiling**, not a prompt engineering failure
+
+**Grok critical warning (HIGH confidence):** LME-M v9 Sonnet ss-pref = 20.0% with the full
+flag stack (all flags ON). This means the current flag combination may ALREADY hurt ss-pref
+on Sonnet. R2 specifically tests whether PR #1172 (hardExclusionRule + enhanced prompt)
+corrects this.
+
+### Hermes synthesis (key points)
+
+1. **R0 control mandatory before concluding on flag effect.** Without Nemotron-no-flags baseline,
+   we cannot tell if `--preference-enumerate` helps, hurts, or is noise on Nemotron.
+2. **R2 is valid for within-Nemotron comparison** (v9 flags vs v10 flags, same generator).
+   If R2 ss-pref > R1 ss-pref by ≥3pp, the prompt change is directionally positive.
+3. **KU floor is Nemotron-independent:** 64.1% vs Sonnet 71.8% = −7.7pp; #1178 (KU recency)
+   worth running on Nemotron as a free parallel secondary.
+4. **Sonnet spend gate:** Do not trigger Sonnet re-run until R0 + R2 paired analysis confirms
+   the flag is net positive. Current data is insufficient.
+
+### Grok synthesis (key points)
+
+1. **The 40pp strict/lenient gap on ss-pref (23.3% / 60.0%) reveals the problem precisely:**
+   Nemotron IS retrieving the preference (lenient = 60%), but failing at strict discrimination.
+   This is a generation-specificity failure, not a retrieval failure. `--preference-enumerate`
+   was designed to fix exactly this. But we need R0 to see the before-state.
+2. **R0-slice approach (fast floor):** Run 30 ss-pref items only, Nemotron, no flags, ~30-45 min.
+   This closes the R0 question for ss-pref specifically without burning a full 500Q run.
+3. **After R2:** If R2 ss-pref (LME-M) shows improvement vs v9 (20.0%), use that as secondary
+   signal while R0-slice runs. Both R0-slice and R2 must confirm before Sonnet spend.
+4. **KU recency (#1178) as parallel secondary** — non-conflicting with ss-pref work; low cost.
+
+### Harness divergence
+
+| Question | Hermes | Grok | Claude resolution |
+|----------|--------|------|-------------------|
+| R0 approach | Full 500Q run | R0-slice (30 ss-pref only) | **R0-slice first** (fast, diagnostic) then R0-full if needed |
+| When to spend Sonnet | After R0-full | After R0-slice + R2 confirm | After R0-slice + R2 paired confirm |
+
+### Decision tree after R2 scores
+
+**Note:** R2 vs v9 comparison is cross-generator (Nemotron vs Sonnet) — not valid for flag
+attribution. R0-slice is the key comparison: R0-slice (Nemotron, no flags) vs R1 (Nemotron,
+`--preference-enumerate`) on the SAME generator reveals flag effect.
+
+```
+R0-slice ss-pref (Nemotron, no flags) vs R1 ss-pref (Nemotron, --preference-enumerate):
+  ├── R1 > R0-slice by ≥3pp → flag helps on Nemotron; expect same on Sonnet
+  │     └── PLAN Sonnet re-run (ss-pref n=30 + agg ~41 items)
+  ├── R1 ≈ R0-slice (within ±3pp) → flag neutral; Nemotron ceiling is the problem
+  │     └── Sonnet re-run still warranted (flag may help Sonnet even if not Nemotron)
+  └── R1 < R0-slice → flag HURTS ss-pref on Nemotron; review PR #1172 hardExclusionRule
+        └── STOP. Audit prompt before Sonnet spend.
+```
+
+### R0-slice run spec
+
+```bash
+cd ~/projects/engram-go
+OUT=results/lme-s-r0-slice-nemotron-20260625
+mkdir -p $OUT
+# Filter to ss-pref only: 30 items
+python3 -c "
+import json
+data = json.load(open('testdata/longmemeval/longmemeval_s.json'))
+pref = [q for q in data if q.get('question_type') == 'single-session-preference']
+json.dump(pref, open('$OUT/lme-s-pref30.json','w'))
+print(len(pref), 'items')
+"
+cp results/lme-s-baseline-0622/checkpoint-ingest.jsonl $OUT/
+
+setsid bash -c "./bin/longmemeval run \
+  --data $OUT/lme-s-pref30.json \
+  --out $OUT \
+  --llm-url http://192.168.0.138:30411/olla/openai/v1 \
+  --llm-model inference \
+  --cleanup-policy never \
+  --workers 4 \
+  </dev/null > /tmp/lme-s-r0-slice.log 2>&1" &
+echo "R0-slice PID=$!"
+```
+
+Score same as R1 (Nemotron scorer). Compare `single-session-preference` strict/lenient vs R1's
+23.3%/60.0%. If R0-slice strict > 23.3%: `--preference-enumerate` is hurting. If R0-slice strict
+< 23.3%: flag helps. If ≈: flag neutral. Gate Sonnet spend on directional clarity here.
+
+**R0-SLICE COMPLETE — results appended below.**
+
+### R0-slice results — COMPLETE
+
+`results/lme-s-r0-slice-nemotron-20260625/score_report.json`
+
+| type                    | strict  | lenient | n  |
+|-------------------------|---------|---------|-----|
+| single-session-pref     | 37.9%   | 75.9%   | 29  |
+
+### Paired comparison — flag effect isolated (same generator, same dataset)
+
+| Run      | Generator | Flags                    | ss-pref strict | ss-pref lenient |
+|----------|-----------|--------------------------|----------------|-----------------|
+| R0-slice | Nemotron  | none                     | **37.9%**      | **75.9%**       |
+| R1       | Nemotron  | `--preference-enumerate` | 23.3%          | 60.0%           |
+| **Δ**    |           |                          | **−14.6pp**    | **−15.9pp**     |
+
+**`--preference-enumerate` HURTS Nemotron ss-pref by ~15pp (HIGH confidence).**
+
+Decision tree verdict: **STOP. Audit PR #1172 prompt before any Sonnet spend.**
+
+### Interpretation
+
+The flag makes the generation task significantly harder — it adds enumeration steps, the
+`hardExclusionRule` constant, and a structured output format. Nemotron is overwhelmed by
+this complexity. Whether this translates to Sonnet is unknown (Sonnet follows complex
+instructions far better), but the signal is a strong warning.
+
+**What needs auditing before Sonnet spend:**
+1. Does `hardExclusionRule` in `GenerationPromptPreferenceEnumerate` create instruction
+   conflicts or contradictions that degrade even capable models?
+2. Is the enumeration step adding friction for the LME-S single-session case (where gold
+   is always present, the issue is specificity, not retrieval)?
+3. Consider: LME-S ss-pref Sonnet baseline WITHOUT flag = 53.3%. The flag was designed
+   for cases where the preference must be *found* in a crowded session; if gold is always
+   present in LME-S, the enumeration step may add noise rather than signal.
+
+**Recommendation:** Run a Sonnet slice (ss-pref n=30, LME-S) WITHOUT `--preference-enumerate`
+vs WITH to get the Sonnet paired comparison directly. This is the missing data point. Cost:
+~30 items × 2 runs = 60 Sonnet calls. Gate this on next Sonnet budget window.
+
+### KU recency parallel (#1178)
+
+Run as a background secondary once R0-slice scored. Does not gate Sonnet decision.
+Issue #1178 spec: `--ku-recency-prompt` flag, KU-only (78 items), Nemotron, no other flags.
+Expected: break the 64.1% Nemotron KU floor if the recency-commitment failure is prompt-addressable.
+
+### Updated sequence (as of R0-slice scored)
+
+```
+✅ R1 — LME-S, Nemotron + --preference-enumerate: ss-pref 23.3%/60.0%
+✅ R2 — LME-M v10, Nemotron + full stack: ss-pref 6.9%/13.8%
+✅ R0-slice — LME-S, Nemotron, NO flags: ss-pref 37.9%/75.9%
+⛔ STOP — flag hurts Nemotron −14.6pp; audit PR #1172 before Sonnet spend
+  → Next Sonnet window: LME-S ss-pref n=30, Sonnet, WITH vs WITHOUT --preference-enumerate
+  → [parallel] KU #1178 (Nemotron, 78 items) — non-blocking, still valid
+```
+
+### Failure mode registered (2026-06-25)
+
+`mcp__codex-tools__queue_status` reads OLD `.agent-comms` mailboxes (retired polling system),
+NOT fleet-dispatch. Tool name is deceptive. Use fleet-dispatch API directly (`/item/<uuid>`,
+`/item/<uuid>/result`) for fleet queue status. Added hard rule to `~/CLAUDE.md`.
+
+---
+
+## Phase: 2026-06-26 — Qwen3-32B Lever Matrix (Phase 4) + Gap Profile (Phase 5)
+
+**Session type:** LME active (morning). **Hardware:** oblivion/DGX-Spark-GB10 (Qwen3-32B BF16,
+`max_model_len=40960`, free local); Mistral-Small-24B on W6800 for bulk judging. Olla as router
+(`inference`→Spark, `fast-inference`→W6800). Scorer = Olla `inference`.
+
+**Key pivot:** Switched from Nemotron to Qwen3-32B as primary test generator. Qwen3-32B no-levers
+ss-pref baseline = **50.0%** — 12pp above Nemotron (37.9%) and close to Sonnet (53.3%).
+Generator-independent signal is now achievable without burning Sonnet budget.
+
+### #1185 Fix — Fresh Ingest Blocker RESOLVED (commit e8c766d)
+
+`fix(lme): NewRestClient normalizes base URL — fixes #1185 fresh-ingest failure`
+
+Root cause: `RestClient` kept the `/mcp` suffix on the base URL → POSTed to `/mcp/quick-store`
+instead of `/quick-store` → bare JSON number back with 2xx → client `cannot unmarshal number`.
+Fix: normalize URL on construction. Fresh ingest now returns `status=done` (sessions=48/48).
+
+**#1185 is fixed on this branch.** PR in flight (Claude-direct). Unblocks any fresh corpus ingest.
+
+**Misdiagnosis lesson (FM):** Initially diagnosed as a stale deployed server; nearly redeployed
+the container. The deployed `/quick-store` was healthy — the bug was the one-line client URL miss.
+Always capture the actual response from the exact URL the failing client uses before attributing
+failure to infra.
+
+### Phase 4: Qwen3-32B × pref30 Lever Matrix
+
+| Run | Config | ss-pref strict | vs Qwen3 baseline |
+|-----|--------|---------------|-------------------|
+| **A — baseline** | Qwen3-32B, no levers | **50.0%** | ← baseline |
+| B | Qwen3-32B + `--preference-enumerate` (H-PE) | 30.0% | **−20.0pp HURTS** |
+| C | Qwen3-32B + pe + ef | 40.0% | **−10.0pp HURTS** |
+| D | Qwen3-32B, context-topk=20 | 43.3% | −6.7pp HURTS |
+| H-PG | Qwen3-32B + `--preference-ground` | 40.0% | **−10.0pp HURTS** (FM-PG #1183) |
+| H-QF | Qwen3-32B + `--preference-quote-first` | 30.0% | **−20.0pp WORST** |
+| Reference: Sonnet baseline | — | 53.3% / 93.3% lenient | — |
+| Reference: Nemotron R0-slice | — | 37.9% | — |
+
+**Result: ALL prompt-side ss-pref levers HURT consistently across two generators (Nemotron +
+Qwen3-32B).** This closes the prompt-engineering phase for ss-pref. Each lever adds instruction
+complexity that degrades performance vs no levers by 10–20pp.
+
+**Root cause confirmed — FM-PG (#1183):** The generator surfaces the correct preference *category*
+but invents named specifics absent from retrieved context (confabulation). Anti-hallucination
+instructions and grounding levers RAISE confabulation rate (priming effect). Confabulation scales
+with retrieval breadth (topk8→topk20 increases hallucination). **Not prompt-suppressible.** Fix is
+structural → #1181 (atomic preference extraction at ingest), NOT more prompting. PR #1184 open
+for FM-PG.
+
+**Scorer validity confirmed:** Independent taxonomy audit of frozen outputs (Mistral judge):
+**0/60 scorer-undercounts**. The 50% ceiling is real, not a measurement artifact.
+
+### Phase 5: Gap Profile — Other Question Types (Qwen3-32B, config: topk=8, max-block=8000)
+
+| Suite | Strict | n | Notes |
+|-------|--------|---|-------|
+| lme-s-user30     | **86.2%** | 29 | Small gap — low priority |
+| lme-s-multi30    | **62.1%** | 29 | Moderate gap — aggregation lever path |
+| lme-s-temporal30 | **48.3%** | 29 | Large gap — #1177 A/B needed first |
+| lme-s-pref30     | **50.0%** | 30 | Large gap — structural path (#1181) |
+
+**Temporal (48.3%) is the second-priority target** after pref, pending resolution of the
+`--inject-question-date` conflict (#1177). User (86.2%) is effectively at ceiling — deprioritize.
+
+**Context overflow caveat:** Big-context types (user/multi/temporal) overflow Spark's 40960-token
+wall at native topk. Phase 5 used `--context-topk 8 --max-block-chars 8000` as fit config;
+numbers are config-constrained and not directly comparable to pref30's native config. A larger
+backend removes the confound.
+
+### Methodology failure modes registered (2026-06-26) — full detail in lme-benchmark-learnings.md
+
+1. **FM-PG (#1183):** Confabulation scales with retrieval breadth; not prompt-suppressible.
+2. **Context overflow:** 40960-token Spark wall overflows big-context types at native topk.
+3. **Truncation damage:** `--max-block-chars 2500` cut user30 from 87% to 21.4% strict.
+4. **Biased-subset trap:** Scoring only overflow survivors overstates accuracy (denominator < N).
+5. **Spark lock collision (x2):** Overlapping `run` jobs → exclusive-lock starvation → 0/0 garbage.
+6. **atom-build cost:** ~1500 LLM calls for 30Q full extraction; eval-time bulk is wrong vehicle.
+7. **`/quick-store` wrong-path bare-number (#1192):** Structured error needed for wrong-path POSTs.
+8. **Misdiagnosis:** Captured live response BEFORE attributing to infra (saved a needless redeploy).
+9. **Watcher false-positive:** Grep for `status=error` on JSONL (log format) missed JSON format.
+
+---
+
+## Current Status — PAUSED (2026-06-26, this session = fleet bug-hunt)
+
+**This session pivoted to fleet infrastructure bug-hunt; LME work is paused.**
+
+**Best known result:** LME-M v9, h-sd-n5-sonnet = **66.6% strict** / 70.2% lenient (500Q full run).
+H-SD + H-PE together = **+13.6pp** above the 35.6% original baseline (from issue #1161).
+
+**Ingest blocker:** #1185 is fixed on this branch (commit e8c766d). Merge or cherry-pick to main
+before the next LME session if fresh ingest is needed.
+
+### Updated Diagnosis
+
+| Category | Root cause (confirmed) | Primary lever |
+|----------|----------------------|---------------|
+| **ss-pref (LME-M 20%, LME-S 53%, Qwen3 50%)** | FM-PG confabulation; prompt levers exhausted | **#1181 — structural atomic extraction** |
+| **knowledge-update (~72%)** | Recency commitment; model picks stale when both old+new in window | **#1178 — KU recency generation prompt** |
+| **multi-session (55.6%)** | Cross-session aggregation failure; ranking dilution for some items | **#1176 — diversity cap; #1179 — events-index** |
+| **temporal (48–70%)** | Conflicting signal on `--inject-question-date` | **#1177 — isolated A/B (133 items) required first** |
+
+### Reconciled Issue Tracking Board (as of 2026-06-26)
+
+| Issue | Title | State | Action |
+|-------|-------|-------|--------|
+| [#1174](https://github.com/petersimmons1972/engram-go/issues/1174) | R1 — LME-S + `--preference-enumerate` bench | 🟡 Nemotron run complete; superseded by Phase 4 Qwen3 | Close or downgrade — Qwen3 gives cleaner signal |
+| [#1175](https://github.com/petersimmons1972/engram-go/issues/1175) | R2 — LME-M v10 bench (Nemotron) | 🟡 Nemotron run complete; Sonnet re-run pending | Defer until post-#1181 if needed |
+| [#1176](https://github.com/petersimmons1972/engram-go/issues/1176) | Per-session diversity cap (ss-pref ranking dilution) | 🟡 Specced | Phase 1 — valid, supports ss-pref on LME-M |
+| [#1177](https://github.com/petersimmons1972/engram-go/issues/1177) | `--inject-question-date` A/B (133 temporal) | 🟡 Open | Required before stacking any temporal lever |
+| [#1178](https://github.com/petersimmons1972/engram-go/issues/1178) | KU recency generation prompt | 🟡 Needs-design | Phase 1 — parallel secondary |
+| [#1179](https://github.com/petersimmons1972/engram-go/issues/1179) | Events-index for multi-session | 🟡 Needs-design | Phase 2 |
+| [#1180](https://github.com/petersimmons1972/engram-go/issues/1180) | DenseReranker gating | 🟡 Needs-design | Phase 2 |
+| **[#1181](https://github.com/petersimmons1972/engram-go/issues/1181)** | **Atomic preference extraction at ingest** | 🟢 **NOW PRIMARY — specced + partial impl on this branch** | **Next LME lever; atom schema landed (313/462 entities)** |
+| [#1182](https://github.com/petersimmons1972/engram-go/issues/1182) | R1+Nemotron decision (founder branch-point) | ⚫ **Needs founder decision** | See §Founder Decision below |
+| [#1183](https://github.com/petersimmons1972/engram-go/issues/1183) | FM-PG ss-pref confabulation | 🔵 PR #1184 open | Address before or alongside #1181 |
+| [#1185](https://github.com/petersimmons1972/engram-go/issues/1185) | `/quick-store` bare-number ingest blocker | ✅ **FIXED on this branch** (e8c766d) | Merge to main to unblock fresh ingest |
+| [#1106](https://github.com/petersimmons1972/engram-go/issues/1106) | ss-pref scorer calibration | ⚫ Needs-design | Long-term; scorer audited (0/60 undercounts) |
+| #1089, #1151, #1161, #1136 | Various (stale) | ✅ Closed this session | Done |
+
+### Founder Decision Required: #1182 — Pivot to structural or Sonnet flag validation first?
+
+The Nemotron experiment plan (R1/R2/R0-slice) established that `--preference-enumerate` hurts
+on Nemotron (−14.6pp). The Qwen3-32B Phase 4 matrix extends this: ALL prompt-side levers hurt
+across TWO generators. The case for running a Sonnet flag-validation run before #1181 is weak.
+
+**Option A (recommended):** Close #1182 as superseded by Phase 4 data. Proceed to #1181
+structural work. Rationale: four independent runs across two generators (Nemotron + Qwen3) all
+show levers hurt or are noise. Prompt-engineering path is closed. No Sonnet validation needed
+before beginning structural work.
+
+**Option B:** Run Sonnet ss-pref n=30 WITH vs WITHOUT `--preference-enumerate` for completeness
+before spending implementation effort on #1181. Cost: ~60 Sonnet calls, ~1h.
+
+**Claude recommendation: Option A.** The data is decisive. #1181 is the next lever.
+
+### NEXT LME SESSION — Resume Sequence (when founder re-opens LME)
+
+1. **Ensure #1185 fix is in main** — merge or cherry-pick e8c766d before any fresh ingest.
+2. **Decide #1182** — likely Option A (close + proceed to #1181). Note decision in this plan.
+3. **Begin #1181 — atomic preference extraction at ingest.** Partial implementation already on
+   this branch (`feat(atoms): polarity/entity/domain fields` — e794971). Unblock via production
+   async atom worker (not eval-time bulk extraction — too expensive / timeout-prone per FM #6).
+4. **Secondary / parallel:** #1177 A/B (`--inject-question-date`, 133 temporal) + #1178 KU recency
+   (Nemotron, 78 items, free). Neither gates #1181.
+5. **Do NOT run more prompt-side ss-pref levers** — all exhausted per Phase 4 data.


### PR DESCRIPTION
## Summary

- Updates `docs/lme-campaign/PLAN-2026-06-21.md` only — no code changes
- Adds Phase 4 (Qwen3-32B × pref30 lever matrix) results: all prompt-side ss-pref levers HURT across two generators; prompt-engineering path closed
- Records Phase 5 gap profile, #1185 RestClient fix status, and #1182 founder decision (pivot to #1181)
- Reconciles issue-board, diagnosis, and backlog after 2026-06-26 session

## Test plan

- [ ] Diff is docs-only (`docs/lme-campaign/PLAN-2026-06-21.md`, +576 lines)
- [ ] CI passes (no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A