### PR TITLE
docs(lme-plan): lock #1181 as resume-point; close #1182 superseded

### DIFF
--- a/docs/lme-campaign/PLAN-2026-06-21.md
+++ b/docs/lme-campaign/PLAN-2026-06-21.md
@@ -5,6 +5,21 @@
 **Baseline:** stack-sonnet-prefenum-0616 = **35.6%** (135-item set, Nemotron judge;
 Sonnet generator + `--preference-enumerate`, reranker OFF). Two runs confirm; ±3.3pp noise.
 
+## RESUME-POINT (locked 2026-06-26)
+
+**Status:** #1182 closed-superseded · **Next action:** [#1181](https://github.com/petersimmons1972/engram-go/issues/1181) — atomic preference extraction at ingest (locked resume-point, founder 2026-06-26).
+
+**Why:** Phase 4 Qwen3-32B lever matrix showed every ss-pref prompt lever (H-PE / H-QF / H-PG /
+topk=20 / pe+ef) hurt 10–20pp across two generators (Nemotron + Qwen3). Prompt-side ss-pref
+levers are exhausted. The failure is structural confabulation (FM-PG); the only remaining
+ss-pref lever is structural atom extraction at ingest.
+
+**Resume sequence:**
+1. Merge any #1181 WIP from the `lme-preference-constraint` worktree branch
+   (polarity/entity/domain schema, 313/462 atoms with entity already tagged).
+2. Re-baseline bench (#1174 LME-S / #1175 LME-M) with the merged extraction.
+3. Complete structural ss-pref extraction and run the full bench suite.
+
 ## What this session established (generator-free, no Claude window burned)
 
 1. **Multi-session is NOT a packing/positioning problem.** Multi-session questions need a


### PR DESCRIPTION
## Summary

- Adds a RESUME-POINT (locked 2026-06-26) section near the top of docs/lme-campaign/PLAN-2026-06-21.md
- Documents that #1182 is closed-superseded (Phase 4 Qwen3-32B lever matrix exhausted all prompt-side ss-pref levers)
- Documents #1181 (atomic preference extraction at ingest) as the locked next action with the full resume sequence
- Docs-only change: no code, no tests, no config
