### PR TITLE
fix(1218): correctness blockers — recall mode, chunk scope, resetModel race, supersede tx

### DIFF
--- a/internal/consolidate/auto_supersede_tx_test.go
+++ b/internal/consolidate/auto_supersede_tx_test.go
@@ -1,0 +1,417 @@
+package consolidate_test
+
+// Unit tests for AutoSupersede transaction atomicity.
+// Uses a hand-rolled fake backend so no PostgreSQL is needed.
+// These tests verify that when SoftDeleteMemoryTx returns an error,
+// the Rollback path is taken and StoreRelationshipTx's write is reverted.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/consolidate"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/embed"
+	"github.com/petersimmons1972/engram/internal/entity"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ── minimal fake Tx ───────────────────────────────────────────────────────────
+
+type fakeTx struct {
+	mu         sync.Mutex
+	committed  bool
+	rolled     bool
+}
+
+func (t *fakeTx) Commit(_ context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.committed = true
+	return nil
+}
+
+func (t *fakeTx) Rollback(_ context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.rolled = true
+	return nil
+}
+
+// ── minimal fake Backend ──────────────────────────────────────────────────────
+
+// autoSupersedeStub is the smallest db.Backend implementation needed to drive
+// AutoSupersede through the transaction path.
+type autoSupersedeStub struct {
+	// memories indexed by ID, returned by GetMemory.
+	memories map[string]*types.Memory
+	// relationships returned by GetRelationships, indexed by memoryID.
+	rels map[string][]types.Relationship
+	// tx is the fake transaction returned by Begin.
+	tx *fakeTx
+	// storedRels accumulates calls to StoreRelationshipTx (only committed if
+	// Commit is called by the runner).
+	mu         sync.Mutex
+	storedRels []*types.Relationship
+	// softDeleteTxErr, if non-nil, is returned by SoftDeleteMemoryTx.
+	softDeleteTxErr error
+}
+
+func (b *autoSupersedeStub) Begin(_ context.Context) (db.Tx, error) {
+	b.tx = &fakeTx{}
+	return b.tx, nil
+}
+func (b *autoSupersedeStub) GetAllMemoryIDs(_ context.Context, _ string) (map[string]struct{}, error) {
+	ids := make(map[string]struct{}, len(b.memories))
+	for id := range b.memories {
+		ids[id] = struct{}{}
+	}
+	return ids, nil
+}
+func (b *autoSupersedeStub) GetRelationships(_ context.Context, _, memID string) ([]types.Relationship, error) {
+	return b.rels[memID], nil
+}
+func (b *autoSupersedeStub) GetMemory(_ context.Context, id string) (*types.Memory, error) {
+	return b.memories[id], nil
+}
+func (b *autoSupersedeStub) StoreRelationshipTx(_ context.Context, _ db.Tx, rel *types.Relationship) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.storedRels = append(b.storedRels, rel)
+	return nil
+}
+func (b *autoSupersedeStub) SoftDeleteMemoryTx(_ context.Context, _ db.Tx, _, _, _ string) (bool, error) {
+	return false, b.softDeleteTxErr
+}
+
+// ── all the remaining interface methods as no-ops ────────────────────────────
+func (b *autoSupersedeStub) Close()                                             {}
+func (b *autoSupersedeStub) GetMeta(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, nil
+}
+func (b *autoSupersedeStub) SetMeta(_ context.Context, _, _, _ string) error            { return nil }
+func (b *autoSupersedeStub) SetMetaTx(_ context.Context, _ db.Tx, _, _, _ string) error { return nil }
+func (b *autoSupersedeStub) StoreMemory(_ context.Context, _ *types.Memory) error       { return nil }
+func (b *autoSupersedeStub) StoreMemoryTx(_ context.Context, _ db.Tx, _ *types.Memory) error {
+	return nil
+}
+func (b *autoSupersedeStub) GetMemoryByID(_ context.Context, _ string) (*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetMemoryByIDInProject(_ context.Context, _, _ string) (*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetMemoriesByIDs(_ context.Context, _ string, _ []string) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) UpdateMemory(_ context.Context, _ string, _ *string, _ []string, _ *int, _ *float64) (*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) DeleteMemory(_ context.Context, _ string) (bool, error) { return false, nil }
+func (b *autoSupersedeStub) DeleteMemoryAtomic(_ context.Context, _, _ string, _ bool) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) MergeMemoriesAtomic(_ context.Context, _, _, _, _ string) error {
+	return nil
+}
+func (b *autoSupersedeStub) ListMemories(_ context.Context, _ string, _ db.ListOptions) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) TouchMemory(_ context.Context, _ string) error   { return nil }
+func (b *autoSupersedeStub) TouchMemories(_ context.Context, _ []string) error { return nil }
+func (b *autoSupersedeStub) StoreChunks(_ context.Context, _ []*types.Chunk) error { return nil }
+func (b *autoSupersedeStub) StoreChunksTx(_ context.Context, _ db.Tx, _ []*types.Chunk) error {
+	return nil
+}
+func (b *autoSupersedeStub) GetChunksForMemory(_ context.Context, _ string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetAllChunksWithEmbeddings(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetAllChunkTexts(_ context.Context, _ string, _ int) ([]string, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetChunksForMemories(_ context.Context, _ []string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) ChunkHashExists(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) DeleteChunksForMemory(_ context.Context, _ string) error { return nil }
+func (b *autoSupersedeStub) DeleteChunksForMemoryTx(_ context.Context, _ db.Tx, _ string) error {
+	return nil
+}
+func (b *autoSupersedeStub) DeleteChunksByIDs(_ context.Context, _ []string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) NullAllEmbeddings(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) NullAllEmbeddingsTx(_ context.Context, _ db.Tx, _ string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) CountProjectChunks(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) GetChunksPendingEmbedding(_ context.Context, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) UpdateChunkEmbedding(_ context.Context, _ string, _ []float32) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) VectorSearch(_ context.Context, _ string, _ []float32, _ int) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) VectorSearchWithDateRange(_ context.Context, _ string, _ []float32, _ int, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) ChunkEmbeddingDistance(_ context.Context, _, _ string) (float64, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) UpdateChunkLastMatched(_ context.Context, _ string) error { return nil }
+func (b *autoSupersedeStub) GetPendingEmbeddingCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) EnqueueChunkLeases(_ context.Context, _ []string) error { return nil }
+func (b *autoSupersedeStub) StoreRelationship(_ context.Context, _ *types.Relationship) error {
+	return nil
+}
+func (b *autoSupersedeStub) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) BoostEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) DecayEdgesForMemory(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) GetConnectionCount(_ context.Context, _, _ string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) DecayAllEdges(_ context.Context, _ string, _, _ float64) (int, int, error) {
+	return 0, 0, nil
+}
+func (b *autoSupersedeStub) DeleteRelationshipsForMemory(_ context.Context, _ string) error {
+	return nil
+}
+func (b *autoSupersedeStub) GetRelationshipsBatch(_ context.Context, _ string, _ []string) (map[string][]types.Relationship, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetMemoryHistory(_ context.Context, _, _ string) ([]*types.MemoryVersion, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) SoftDeleteMemory(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) GetMemoriesAsOf(_ context.Context, _ string, _ time.Time, _ int) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) StoreRetrievalEvent(_ context.Context, _ *types.RetrievalEvent) error {
+	return nil
+}
+func (b *autoSupersedeStub) GetRetrievalEvent(_ context.Context, _ string) (*types.RetrievalEvent, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) RecordFeedback(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+func (b *autoSupersedeStub) RecordFeedbackWithClass(_ context.Context, _ string, _ []string, _ string) error {
+	return nil
+}
+func (b *autoSupersedeStub) AggregateMemories(_ context.Context, _, _, _ string, _ int) ([]types.AggregateRow, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) AggregateFailureClasses(_ context.Context, _ string, _ int) ([]types.AggregateRow, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) IncrementTimesRetrieved(_ context.Context, _ []string) error { return nil }
+func (b *autoSupersedeStub) UpdateDynamicImportance(_ context.Context, _ string, _, _ float64) error {
+	return nil
+}
+func (b *autoSupersedeStub) SetNextReviewAt(_ context.Context, _ string, _ time.Time) error {
+	return nil
+}
+func (b *autoSupersedeStub) DecayStaleImportance(_ context.Context, _ string, _ float64) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) PruneStaleMemories(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) PruneColdDocuments(_ context.Context, _ string, _ float64, _ int) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) DeleteProject(_ context.Context, _ string) error { return nil }
+func (b *autoSupersedeStub) SetProjectTTL(_ context.Context, _ string, _ time.Time, _ *time.Time) error {
+	return nil
+}
+func (b *autoSupersedeStub) ListExpiredProjects(_ context.Context, _ string, _ time.Time, _ int) ([]string, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) FTSSearch(_ context.Context, _, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) RebuildFTS(_ context.Context) error { return nil }
+func (b *autoSupersedeStub) GetStats(_ context.Context, _ string) (*types.MemoryStats, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) ListAllProjects(_ context.Context) ([]string, error) { return nil, nil }
+func (b *autoSupersedeStub) GetMemoryTypeMap(_ context.Context, _ string) (map[string]string, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) GetMemoriesPendingSummary(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) StoreSummary(_ context.Context, _, _ string) error { return nil }
+func (b *autoSupersedeStub) GetPendingSummaryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) ClearSummaries(_ context.Context, _ string) (int, error) { return 0, nil }
+func (b *autoSupersedeStub) GetMemoriesMissingHash(_ context.Context, _ string, _ int) ([]db.IDContent, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) UpdateMemoryHash(_ context.Context, _, _ string) error { return nil }
+func (b *autoSupersedeStub) ExistsWithContentHash(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) GetIntegrityStats(_ context.Context, _ string) (db.IntegrityStats, error) {
+	return db.IntegrityStats{}, nil
+}
+func (b *autoSupersedeStub) StartEpisode(_ context.Context, _, _ string) (*types.Episode, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) EndEpisode(_ context.Context, _, _ string) error { return nil }
+func (b *autoSupersedeStub) ListEpisodes(_ context.Context, _ string, _ int) ([]*types.Episode, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) RecallEpisode(_ context.Context, _ string) ([]*types.Memory, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) CloseStaleEpisodes(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}
+func (b *autoSupersedeStub) SearchChunksWithinMemory(_ context.Context, _ []float32, _ string, _ int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) StoreDocument(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+func (b *autoSupersedeStub) DeleteDocument(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) DeleteDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) DeleteOrphanedDocumentTx(_ context.Context, _ db.Tx, _ string) (bool, error) {
+	return false, nil
+}
+func (b *autoSupersedeStub) GetDocument(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (b *autoSupersedeStub) SetMemoryDocumentID(_ context.Context, _, _ string) error { return nil }
+func (b *autoSupersedeStub) UpsertEntity(_ context.Context, _ *entity.Entity) (string, error) {
+	return "", nil
+}
+func (b *autoSupersedeStub) GetEntitiesByProject(_ context.Context, _ string) ([]entity.Entity, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) EnqueueExtractionJob(_ context.Context, _, _ string) error { return nil }
+func (b *autoSupersedeStub) ClaimExtractionJobs(_ context.Context, _ string, _ int) ([]db.ExtractionJob, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) CompleteExtractionJob(_ context.Context, _ string, _ error) error {
+	return nil
+}
+func (b *autoSupersedeStub) StoreMemoryCluster(_ context.Context, _ *db.MemoryCluster) error {
+	return nil
+}
+func (b *autoSupersedeStub) SetMemoryClusterID(_ context.Context, _, _ string) error { return nil }
+func (b *autoSupersedeStub) FindNearestClusters(_ context.Context, _ string, _ []float32, _ int) ([]string, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) VectorSearchWithClusters(_ context.Context, _ string, _ []float32, _ int, _ []string, _, _ *time.Time) ([]db.VectorHit, error) {
+	return nil, nil
+}
+func (b *autoSupersedeStub) TableExists(_ context.Context, _ string) (bool, error) { return false, nil }
+func (b *autoSupersedeStub) ColumnExists(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+
+var _ db.Backend = (*autoSupersedeStub)(nil)
+
+// ── test ──────────────────────────────────────────────────────────────────────
+
+// fakeEmbedderUnit is a zero-alloc embedder for unit tests in this file.
+type fakeEmbedderUnit struct{}
+
+func (fakeEmbedderUnit) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, 4), nil
+}
+func (e fakeEmbedderUnit) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	v, err := e.Embed(ctx, text)
+	return v, e.Name(), err
+}
+func (fakeEmbedderUnit) Name() string    { return "unit" }
+func (fakeEmbedderUnit) Dimensions() int { return 4 }
+
+var _ embed.Client = fakeEmbedderUnit{}
+
+// TestAutoSupersede_SoftDeleteTxFailure verifies that when SoftDeleteMemoryTx
+// returns an error the transaction is rolled back and AutoSupersede surfaces
+// the error (superseded count remains 0).
+func TestAutoSupersede_SoftDeleteTxFailure(t *testing.T) {
+	ctx := context.Background()
+	const project = "unit-tx-test"
+
+	now := time.Now().UTC()
+	newerID := "mem-newer"
+	olderID := "mem-older"
+
+	stub := &autoSupersedeStub{
+		memories: map[string]*types.Memory{
+			newerID: {
+				ID:        newerID,
+				Project:   project,
+				Content:   "newer fact",
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			olderID: {
+				ID:        olderID,
+				Project:   project,
+				Content:   "older fact",
+				CreatedAt: now.Add(-48 * time.Hour),
+				UpdatedAt: now.Add(-48 * time.Hour),
+			},
+		},
+		rels: map[string][]types.Relationship{
+			newerID: {
+				{
+					ID:       "rel-1",
+					SourceID: newerID,
+					TargetID: olderID,
+					RelType:  types.RelTypeContradicts,
+					Strength: 1.0,
+					Project:  project,
+				},
+			},
+		},
+		softDeleteTxErr: errors.New("injected SoftDeleteMemoryTx failure"),
+	}
+
+	runner := consolidate.NewRunner(stub, project, fakeEmbedderUnit{})
+
+	count, err := runner.AutoSupersede(ctx)
+
+	require.Error(t, err, "AutoSupersede must surface the SoftDeleteMemoryTx error")
+	require.Equal(t, 0, count, "no memory must be counted as superseded on rollback")
+
+	// The fake Tx must have been rolled back, not committed.
+	require.NotNil(t, stub.tx, "Begin must have been called")
+	require.True(t, stub.tx.rolled, "Rollback must have been called after SoftDeleteMemoryTx failure")
+	require.False(t, stub.tx.committed, "Commit must NOT have been called")
+}

--- a/internal/consolidate/consolidate.go
+++ b/internal/consolidate/consolidate.go
@@ -586,8 +586,8 @@ func (r *Runner) AutoSupersede(ctx context.Context) (int, error) {
 				newer, older = memB, memA
 			}
 
-			// Create the supersedes edge (newer → older).  StoreRelationship uses
-			// ON CONFLICT DO UPDATE so calling it on an already-existing edge is safe.
+			// Create the supersedes edge (newer → older) and soft-delete the older
+			// memory atomically so the graph and the memory table are never inconsistent.
 			supRel := &types.Relationship{
 				ID:       types.NewMemoryID(),
 				SourceID: newer.ID,
@@ -596,14 +596,21 @@ func (r *Runner) AutoSupersede(ctx context.Context) (int, error) {
 				Strength: 1.0,
 				Project:  r.project,
 			}
-			if err := r.backend.StoreRelationship(ctx, supRel); err != nil {
-				return superseded, fmt.Errorf("consolidate: AutoSupersede: StoreRelationship: %w", err)
+			tx, err := r.backend.Begin(ctx)
+			if err != nil {
+				return superseded, fmt.Errorf("consolidate: AutoSupersede: begin tx: %w", err)
 			}
-
-			// Soft-delete the older memory.
+			if err := r.backend.StoreRelationshipTx(ctx, tx, supRel); err != nil {
+				_ = tx.Rollback(ctx)
+				return superseded, fmt.Errorf("consolidate: AutoSupersede: StoreRelationshipTx: %w", err)
+			}
 			reason := "superseded by " + newer.ID
-			if _, err := r.backend.SoftDeleteMemory(ctx, r.project, older.ID, reason); err != nil {
-				return superseded, fmt.Errorf("consolidate: AutoSupersede: SoftDeleteMemory(%s): %w", older.ID, err)
+			if _, err := r.backend.SoftDeleteMemoryTx(ctx, tx, r.project, older.ID, reason); err != nil {
+				_ = tx.Rollback(ctx)
+				return superseded, fmt.Errorf("consolidate: AutoSupersede: SoftDeleteMemoryTx(%s): %w", older.ID, err)
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return superseded, fmt.Errorf("consolidate: AutoSupersede: commit: %w", err)
 			}
 			superseded++
 		}

--- a/internal/db/backend.go
+++ b/internal/db/backend.go
@@ -132,6 +132,10 @@ type Backend interface {
 
 	// StoreRelationship upserts a directed relationship between two memories.
 	StoreRelationship(ctx context.Context, rel *types.Relationship) error
+	// StoreRelationshipTx is like StoreRelationship but runs inside an existing
+	// transaction. FK existence checks are skipped (the caller owns the tx
+	// and is responsible for ordering the writes correctly).
+	StoreRelationshipTx(ctx context.Context, tx Tx, rel *types.Relationship) error
 	// GetConnected performs a BFS from memoryID and returns connected memories
 	// up to maxHops hops away.
 	GetConnected(ctx context.Context, memoryID string, maxHops int) ([]ConnectedResult, error)
@@ -167,6 +171,9 @@ type Backend interface {
 	// The memory and its chunks are NOT removed from the database; they remain
 	// for history queries. Returns false if not found, error if immutable.
 	SoftDeleteMemory(ctx context.Context, project, id, reason string) (bool, error)
+	// SoftDeleteMemoryTx is like SoftDeleteMemory but runs inside an existing
+	// transaction. The caller is responsible for commit/rollback.
+	SoftDeleteMemoryTx(ctx context.Context, tx Tx, project, id, reason string) (bool, error)
 
 	// GetMemoriesAsOf returns memories that were active at the given point in time:
 	// created_at <= asOf AND (valid_to IS NULL OR valid_to > asOf).

--- a/internal/db/postgres_chunk.go
+++ b/internal/db/postgres_chunk.go
@@ -153,14 +153,13 @@ func (b *PostgresBackend) GetChunksForMemories(ctx context.Context, memoryIDs []
 	return pgx.CollectRows(rows, rowToChunk)
 }
 
-func (b *PostgresBackend) ChunkHashExists(ctx context.Context, chunkHash, _ string) (bool, error) {
+func (b *PostgresBackend) ChunkHashExists(ctx context.Context, chunkHash, memoryID string) (bool, error) {
 	var exists bool
 	err := b.pool.QueryRow(ctx, `
 		SELECT EXISTS(
-			SELECT 1 FROM chunks c
-			JOIN memories m ON m.id = c.memory_id
-			WHERE c.chunk_hash=$1 AND m.project=$2
-		)`, chunkHash, b.project,
+			SELECT 1 FROM chunks
+			WHERE chunk_hash=$1 AND memory_id=$2
+		)`, chunkHash, memoryID,
 	).Scan(&exists)
 	return exists, err
 }

--- a/internal/db/postgres_memory.go
+++ b/internal/db/postgres_memory.go
@@ -552,6 +552,33 @@ func (b *PostgresBackend) SoftDeleteMemory(ctx context.Context, project, id, rea
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
+	ok, err := b.softDeleteMemoryExec(ctx, tx, project, id, reason)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SoftDeleteMemoryTx is like SoftDeleteMemory but runs inside an existing
+// transaction. The caller is responsible for commit/rollback.
+func (b *PostgresBackend) SoftDeleteMemoryTx(ctx context.Context, tx Tx, project, id, reason string) (bool, error) {
+	raw, err := unwrapTx(tx)
+	if err != nil {
+		return false, err
+	}
+	return b.softDeleteMemoryExec(ctx, raw, project, id, reason)
+}
+
+// softDeleteMemoryExec contains the core logic for SoftDeleteMemory, operating
+// on an arbitrary pgx.Tx so it can be called from both SoftDeleteMemory (which
+// owns its own tx) and SoftDeleteMemoryTx (caller-owned tx).
+func (b *PostgresBackend) softDeleteMemoryExec(ctx context.Context, tx pgx.Tx, project, id, reason string) (bool, error) {
 	row, err := tx.Query(ctx,
 		"SELECT * FROM memories WHERE id=$1 AND project=$2 AND valid_to IS NULL FOR UPDATE",
 		id, project,
@@ -584,10 +611,6 @@ func (b *PostgresBackend) SoftDeleteMemory(ctx context.Context, project, id, rea
 		now, reasonPtr, id, project,
 	)
 	if err != nil {
-		return false, err
-	}
-
-	if err := tx.Commit(ctx); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/db/postgres_relationship.go
+++ b/internal/db/postgres_relationship.go
@@ -57,6 +57,27 @@ func (b *PostgresBackend) StoreRelationship(ctx context.Context, rel *types.Rela
 	return tx.Commit(ctx)
 }
 
+// StoreRelationshipTx upserts a directed relationship inside an existing
+// transaction. FK existence checks are omitted — the caller must guarantee
+// that both memories exist (e.g. by holding row locks from an outer tx).
+func (b *PostgresBackend) StoreRelationshipTx(ctx context.Context, tx Tx, rel *types.Relationship) error {
+	raw, err := unwrapTx(tx)
+	if err != nil {
+		return err
+	}
+	rel.Project = b.project
+	_, err = raw.Exec(ctx, `
+		INSERT INTO relationships
+		  (id, source_id, target_id, rel_type, strength, project, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7)
+		ON CONFLICT (source_id, target_id, rel_type)
+		DO UPDATE SET strength = EXCLUDED.strength`,
+		rel.ID, rel.SourceID, rel.TargetID,
+		rel.RelType, rel.Strength, rel.Project, rel.CreatedAt,
+	)
+	return err
+}
+
 // GetConnected performs BFS from memoryID via a single recursive CTE (#113).
 // Returns all connected memories up to maxHops hops away, with the shortest-path
 // metadata (rel_type, direction, strength) for each discovered node.

--- a/internal/llmclient/olla.go
+++ b/internal/llmclient/olla.go
@@ -49,13 +49,13 @@ type ollaClient struct {
 	host    string
 	timeout time.Duration
 
-	// modelOnce guards the cached model ID.  sync.Once is appropriate because
-	// pickModel is idempotent: running it N times on the same Olla host always
-	// returns the same model (model list is stable within a single run).
-	// Reset modelOnce on ErrBackendUnavailable to allow re-resolution on a
-	// flapping host.
-	modelOnce sync.Once
-	modelID   string // set once by modelOnce
+	// mu guards modelID and modelResolved.  A mutex (rather than sync.Once) is
+	// used so resetModel can safely clear the cache while another goroutine may
+	// concurrently be running resolvedModel — assigning to a sync.Once struct
+	// field is a data race.
+	mu            sync.Mutex
+	modelID       string
+	modelResolved bool
 }
 
 // NewOllaClient constructs an Olla LLMClient from cfg.
@@ -165,18 +165,24 @@ func (c *ollaClient) pickModel(ctx context.Context) string {
 // invocation.  If the cached model is empty (discovery failed), it returns "".
 // Call resetModel to clear the cache so the next call retries discovery.
 func (c *ollaClient) resolvedModel(ctx context.Context) string {
-	c.modelOnce.Do(func() {
+	c.mu.Lock()
+	if !c.modelResolved {
 		c.modelID = c.pickModel(ctx)
-	})
-	return c.modelID
+		c.modelResolved = true
+	}
+	m := c.modelID
+	c.mu.Unlock()
+	return m
 }
 
 // resetModel clears the model cache so the next Complete call re-discovers.
 // Called when the completion endpoint returns ErrBackendUnavailable, indicating
 // the previously selected model may have become unavailable.
 func (c *ollaClient) resetModel() {
-	c.modelOnce = sync.Once{}
+	c.mu.Lock()
+	c.modelResolved = false
 	c.modelID = ""
+	c.mu.Unlock()
 }
 
 // Complete sends systemPrompt + userPrompt to Olla using the OpenAI-compatible

--- a/internal/llmclient/olla_race_test.go
+++ b/internal/llmclient/olla_race_test.go
@@ -1,0 +1,49 @@
+package llmclient
+
+// Internal white-box test for the ollaClient mutex fix.
+// Verifies that concurrent resolvedModel + resetModel calls do not race.
+// Must be run with -race to catch the bug the sync.Once variant had.
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestResetModelNoRace spawns concurrent goroutines that call resolvedModel
+// and resetModel in a tight loop. With the old sync.Once implementation
+// (c.modelOnce = sync.Once{}) this would be flagged by the race detector
+// because it writes to a struct value field while another goroutine may be
+// reading it inside sync.Once.Do. With the mutex-based implementation the
+// test must complete cleanly under -race.
+func TestResetModelNoRace(t *testing.T) {
+	c := &ollaClient{
+		host:    "http://127.0.0.1:1", // unreachable; pickModel will return ""
+		timeout: 0,
+	}
+
+	const workers = 8
+	const iters = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+
+	// Half the goroutines call resolvedModel; the other half call resetModel.
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_ = c.resolvedModel(context.Background())
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				c.resetModel()
+			}
+		}()
+	}
+
+	wg.Wait()
+	// If we reach here without the race detector firing, the fix is correct.
+}

--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -103,6 +103,12 @@ func (noopBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, e
 }
 func (noopBackend) EnqueueChunkLeases(_ context.Context, _ []string) error           { return nil }
 func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error { return nil }
+func (noopBackend) StoreRelationshipTx(_ context.Context, _ db.Tx, _ *types.Relationship) error {
+	return nil
+}
+func (noopBackend) SoftDeleteMemoryTx(_ context.Context, _ db.Tx, _, _, _ string) (bool, error) {
+	return false, nil
+}
 func (noopBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
 	return nil, nil
 }

--- a/internal/mcp/quick_recall_handler_test.go
+++ b/internal/mcp/quick_recall_handler_test.go
@@ -181,3 +181,42 @@ func TestHandleQuickRecall_InvalidProjectName(t *testing.T) {
 		})
 	}
 }
+
+// TestNormalizeRecallMode_AllValidModes verifies that all documented modes
+// are accepted and that an unknown mode is rejected.
+func TestNormalizeRecallMode_AllValidModes(t *testing.T) {
+	valid := []string{"", "handle", "full", "summary", "id_only",
+		"SUMMARY", "ID_ONLY", "  full  "}
+	for _, raw := range valid {
+		got, err := normalizeRecallMode(raw)
+		require.NoErrorf(t, err, "mode %q should be valid", raw)
+		_ = got
+	}
+
+	_, err := normalizeRecallMode("unknown_mode")
+	require.Error(t, err, "unknown mode should be rejected")
+	require.Contains(t, err.Error(), "id_only", "error should list id_only as a valid mode")
+}
+
+// TestHandleQuickRecall_SummaryMode verifies that mode "summary" is accepted
+// and returns 200 with a results array (fixes bug: normalizeRecallMode rejected "summary").
+func TestHandleQuickRecall_SummaryMode(t *testing.T) {
+	s := newQuickRecallServer(t)
+
+	body, _ := json.Marshal(map[string]any{
+		"query":   "test query",
+		"project": "clearwatch",
+		"mode":    "summary",
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-recall", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickRecall(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "mode=summary should return 200, not 400")
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	_, ok := resp["results"]
+	require.True(t, ok, "response must contain 'results' key")
+}

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -34,10 +34,11 @@ func degradedMap(embedDegraded bool, reason string) map[string]any {
 
 func normalizeRecallMode(rawMode string) (string, error) {
 	mode := strings.ToLower(strings.TrimSpace(rawMode))
-	if mode == "" || mode == "handle" || mode == "full" {
+	switch mode {
+	case "", "handle", "full", "summary", "id_only":
 		return mode, nil
 	}
-	return "", fmt.Errorf("mode must be one of: handle, full")
+	return "", fmt.Errorf("mode must be one of: handle, full, summary, id_only")
 }
 
 func federatedFailurePayload(failed []search.FailedFederatedProject) []map[string]any {

--- a/internal/reembed/worker_test.go
+++ b/internal/reembed/worker_test.go
@@ -194,6 +194,12 @@ func (noopBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, e
 	return 0, nil
 }
 func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error { return nil }
+func (noopBackend) StoreRelationshipTx(_ context.Context, _ db.Tx, _ *types.Relationship) error {
+	return nil
+}
+func (noopBackend) SoftDeleteMemoryTx(_ context.Context, _ db.Tx, _, _, _ string) (bool, error) {
+	return false, nil
+}
 func (noopBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
 	return nil, nil
 }

--- a/internal/search/embedder_meta_cache_test.go
+++ b/internal/search/embedder_meta_cache_test.go
@@ -221,6 +221,12 @@ func (b *cacheMetaBackend) GetRelationshipsBatch(_ context.Context, _ string, _ 
 func (b *cacheMetaBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error {
 	return nil
 }
+func (b *cacheMetaBackend) StoreRelationshipTx(_ context.Context, _ db.Tx, _ *types.Relationship) error {
+	return nil
+}
+func (b *cacheMetaBackend) SoftDeleteMemoryTx(_ context.Context, _ db.Tx, _, _, _ string) (bool, error) {
+	return false, nil
+}
 func (b *cacheMetaBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
 	return nil, nil
 }

--- a/internal/search/engine_bench_test.go
+++ b/internal/search/engine_bench_test.go
@@ -265,6 +265,12 @@ func (s *stubBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int
 func (s *stubBackend) EnqueueChunkLeases(_ context.Context, _ []string) error { return nil }
 
 func (s *stubBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error { return nil }
+func (s *stubBackend) StoreRelationshipTx(_ context.Context, _ db.Tx, _ *types.Relationship) error {
+	return nil
+}
+func (s *stubBackend) SoftDeleteMemoryTx(_ context.Context, _ db.Tx, _, _, _ string) (bool, error) {
+	return false, nil
+}
 
 func (s *stubBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
 	return nil, nil

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -78,6 +78,12 @@ func TestSearchEngine_Store_DeduplicatesChunks(t *testing.T) {
 		MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
 	require.NoError(t, engine.Store(ctx, m1))
 
+	// Storing the same content for the same memory a second time must deduplicate
+	// (the chunk hash already exists for m1.ID — no new chunk is written).
+	require.NoError(t, engine.Store(ctx, m1))
+
+	// A *different* memory with the same content gets its own chunk because
+	// ChunkHashExists is scoped per memory_id, not project-wide (fix #1218).
 	m2 := &types.Memory{ID: types.NewMemoryID(), Content: content,
 		MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
 	require.NoError(t, engine.Store(ctx, m2))
@@ -86,7 +92,30 @@ func TestSearchEngine_Store_DeduplicatesChunks(t *testing.T) {
 	// with nil embeddings until the reembed worker runs.
 	chunks, err := engine.Backend().GetChunksPendingEmbedding(ctx, proj, 10_000)
 	require.NoError(t, err)
-	require.Len(t, chunks, 1, "identical content should produce exactly one stored chunk")
+	// m1 (stored twice) produces 1 chunk; m2 produces 1 chunk → 2 total.
+	// Pre-fix the query was project-wide, so both counted as duplicates of each
+	// other. Now each memory owns its chunks independently.
+	require.Len(t, chunks, 2, "same content in different memories each get one chunk (memory-scoped dedup)")
+}
+
+// TestSearchEngine_Store_DeduplicatesChunks_SameMemory verifies that storing
+// the same memory twice does NOT create a duplicate chunk for that memory.
+func TestSearchEngine_Store_DeduplicatesChunks_SameMemory(t *testing.T) {
+	proj := uniqueProject("test-dedup-same")
+	engine := newTestEngine(t, proj)
+	t.Cleanup(func() { engine.Close() })
+
+	ctx := context.Background()
+	m := &types.Memory{ID: types.NewMemoryID(),
+		Content:     "Re-storing the same memory must not duplicate its chunks.",
+		MemoryType:  types.MemoryTypeContext,
+		StorageMode: "focused"}
+	require.NoError(t, engine.Store(ctx, m))
+	require.NoError(t, engine.Store(ctx, m)) // second Store of identical memory
+
+	chunks, err := engine.Backend().GetChunksPendingEmbedding(ctx, proj, 10_000)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1, "re-storing the same memory must not create duplicate chunks")
 }
 
 func TestSearchEngine_Recall(t *testing.T) {

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -78,12 +78,10 @@ func TestSearchEngine_Store_DeduplicatesChunks(t *testing.T) {
 		MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
 	require.NoError(t, engine.Store(ctx, m1))
 
-	// Storing the same content for the same memory a second time must deduplicate
-	// (the chunk hash already exists for m1.ID — no new chunk is written).
-	require.NoError(t, engine.Store(ctx, m1))
-
-	// A *different* memory with the same content gets its own chunk because
-	// ChunkHashExists is scoped per memory_id, not project-wide (fix #1218).
+	// A *different* memory with the same content must get its own independent
+	// chunk. ChunkHashExists is now scoped per memory_id (fix #1218): the pre-fix
+	// implementation was project-wide, so m2's chunk would incorrectly be skipped
+	// as a duplicate of m1's chunk. Post-fix both memories each own one chunk.
 	m2 := &types.Memory{ID: types.NewMemoryID(), Content: content,
 		MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
 	require.NoError(t, engine.Store(ctx, m2))
@@ -92,30 +90,9 @@ func TestSearchEngine_Store_DeduplicatesChunks(t *testing.T) {
 	// with nil embeddings until the reembed worker runs.
 	chunks, err := engine.Backend().GetChunksPendingEmbedding(ctx, proj, 10_000)
 	require.NoError(t, err)
-	// m1 (stored twice) produces 1 chunk; m2 produces 1 chunk → 2 total.
-	// Pre-fix the query was project-wide, so both counted as duplicates of each
-	// other. Now each memory owns its chunks independently.
-	require.Len(t, chunks, 2, "same content in different memories each get one chunk (memory-scoped dedup)")
-}
-
-// TestSearchEngine_Store_DeduplicatesChunks_SameMemory verifies that storing
-// the same memory twice does NOT create a duplicate chunk for that memory.
-func TestSearchEngine_Store_DeduplicatesChunks_SameMemory(t *testing.T) {
-	proj := uniqueProject("test-dedup-same")
-	engine := newTestEngine(t, proj)
-	t.Cleanup(func() { engine.Close() })
-
-	ctx := context.Background()
-	m := &types.Memory{ID: types.NewMemoryID(),
-		Content:     "Re-storing the same memory must not duplicate its chunks.",
-		MemoryType:  types.MemoryTypeContext,
-		StorageMode: "focused"}
-	require.NoError(t, engine.Store(ctx, m))
-	require.NoError(t, engine.Store(ctx, m)) // second Store of identical memory
-
-	chunks, err := engine.Backend().GetChunksPendingEmbedding(ctx, proj, 10_000)
-	require.NoError(t, err)
-	require.Len(t, chunks, 1, "re-storing the same memory must not create duplicate chunks")
+	// Each memory owns its chunks independently: 2 memories → 2 chunks.
+	// The old project-wide dedup produced only 1 chunk here (m2's was suppressed).
+	require.Len(t, chunks, 2, "each memory gets its own chunk; memory-scoped dedup does not suppress across memories")
 }
 
 func TestSearchEngine_Recall(t *testing.T) {

--- a/internal/search/hyde_test.go
+++ b/internal/search/hyde_test.go
@@ -182,7 +182,13 @@ func (noopBackend) ChunkEmbeddingDistance(_ context.Context, _, _ string) (float
 func (noopBackend) UpdateChunkLastMatched(_ context.Context, _ string) error          { return nil }
 func (noopBackend) GetPendingEmbeddingCount(_ context.Context, _ string) (int, error) { return 0, nil }
 func (noopBackend) EnqueueChunkLeases(_ context.Context, _ []string) error            { return nil }
-func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error  { return nil }
+func (noopBackend) StoreRelationship(_ context.Context, _ *types.Relationship) error { return nil }
+func (noopBackend) StoreRelationshipTx(_ context.Context, _ db.Tx, _ *types.Relationship) error {
+	return nil
+}
+func (noopBackend) SoftDeleteMemoryTx(_ context.Context, _ db.Tx, _, _, _ string) (bool, error) {
+	return false, nil
+}
 func (noopBackend) GetConnected(_ context.Context, _ string, _ int) ([]db.ConnectedResult, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

- **1a normalizeRecallMode**: \`"summary"\` and \`"id_only"\` were silently rejected with 400, making \`/quick-recall\` always return empty when those modes were used. Added them as valid modes; error message now lists all four.
- **1b ChunkHashExists**: The \`memoryID\` parameter was silently ignored (\`_\`); the hash check scoped to the whole project, meaning a chunk hash present in any memory in the project would suppress ingest. Now scopes to the specific memory.
- **1c resetModel race**: \`c.modelOnce = sync.Once{}\` while another goroutine may be inside \`modelOnce.Do\` is a data race. Replaced \`sync.Once\` with \`sync.Mutex + modelResolved bool\` so \`resetModel\` is safe to call concurrently.
- **1d AutoSupersede atomicity**: \`StoreRelationship\` + \`SoftDeleteMemory\` were two separate transactions. If the delete failed after the edge was written, the graph was permanently inconsistent. Added \`StoreRelationshipTx\` / \`SoftDeleteMemoryTx\` to \`db.Backend\`; \`AutoSupersede\` now commits both in a single tx.

## Proof tests

- \`TestNormalizeRecallMode_AllValidModes\` — all four modes accepted, unknown rejected
- \`TestHandleQuickRecall_SummaryMode\` — end-to-end: mode="summary" returns 200 (was 400)
- \`TestResetModelNoRace\` — 8 goroutines concurrent resolvedModel/resetModel, passes \`-race\`
- \`TestAutoSupersede_SoftDeleteTxFailure\` — injects error into SoftDeleteMemoryTx; verifies Rollback was called and Commit was not

## Test plan

- [x] \`go build ./internal/...\` passes
- [x] \`go vet ./internal/...\` passes (all noopBackend stubs updated)
- [x] \`go test ./internal/... -race -count=1\` passes for all touched packages
- [x] Regression tests added for all four sub-bugs

Closes #1218