### PR TITLE
fix(1213): quote heredoc delimiter in _write_token to prevent shell injection

### DIFF
--- a/bin/checkin-lint.baseline
+++ b/bin/checkin-lint.baseline
@@ -252,7 +252,7 @@ D.exit-zero-wrapper::./hooks/engram/engram-session-end.sh::65
 D.exit-zero-wrapper::./hooks/engram/engram-token-refresh.sh::33
 D.exit-zero-wrapper::./hooks/engram/engram-token-refresh.sh::77
 D.exit-zero-wrapper::./hooks/engram/engram-token-refresh.sh::83
-D.exit-zero-wrapper::./hooks/engram/engram-token-refresh.sh::187
+D.exit-zero-wrapper::./hooks/engram/engram-token-refresh.sh::192
 D.exit-zero-wrapper::./hooks/engram/engram-hook-shim.sh::26
 D.exit-zero-wrapper::./hooks/engram/engram-hook-shim.sh::38
 D.exit-zero-wrapper::./hooks/engram/engram-auth-check.sh::134

--- a/hooks/engram/engram-token-refresh.sh
+++ b/hooks/engram/engram-token-refresh.sh
@@ -88,7 +88,10 @@ fi
 
 # ── 3. Write token to both MCP config files (atomic) ────────────────────────
 _write_token() {
-  python3 - "$1" <<PYEOF
+  # Pass TOKEN and ENDPOINT as positional args so the quoted heredoc ('PYEOF')
+  # never shell-expands them.  A backtick, $(...), newline, or quote in either
+  # value cannot escape into the Python source this way.  (#1213)
+  python3 - "$1" "$TOKEN" "$ENDPOINT" <<'PYEOF'
 import json, os, sys, tempfile
 from urllib.parse import urlparse, urlencode, parse_qs, urlunparse
 
@@ -100,7 +103,10 @@ def merge_url(existing: str, new: str) -> str:
     q = urlencode({k: v[0] for k, v in merged.items()})
     return urlunparse((np.scheme, np.netloc, np.path, '', q, ''))
 
-path = sys.argv[1]
+path     = sys.argv[1]
+token    = sys.argv[2]
+endpoint = sys.argv[3]
+
 if not os.path.exists(path):
     sys.exit(0)
 
@@ -108,17 +114,16 @@ with open(path) as f:
     cfg = json.load(f)
 
 # For .claude.json: only update if engram key already present (#395)
-is_claude_json = "mcpServers" in cfg
 servers = cfg.setdefault("mcpServers", {})
 
 if os.path.basename(path) == ".claude.json" and "engram" not in servers:
     sys.exit(0)
 
-existing_url = servers.get("engram", {}).get("url", "$ENDPOINT")
+existing_url = servers.get("engram", {}).get("url", endpoint)
 servers["engram"] = {
     "type": "sse",
-    "url": merge_url(existing_url, "$ENDPOINT"),
-    "headers": {"Authorization": "Bearer $TOKEN"}
+    "url": merge_url(existing_url, endpoint),
+    "headers": {"Authorization": "Bearer " + token}
 }
 
 dir_ = os.path.dirname(path) or "."


### PR DESCRIPTION
## Summary

Closes #1213.

The `_write_token` function in `hooks/engram/engram-token-refresh.sh` opened its Python heredoc with an unquoted delimiter (`<<PYEOF`). This caused `$TOKEN` and `$ENDPOINT` to shell-expand inside the Python source before the interpreter saw them. A backtick, `$(...)`, newline, or quote in either value (both attacker-observable: `$ENDPOINT` comes from the server JSON response) could escape into or corrupt the generated Python.

**Fix:** change `<<PYEOF` to `<<'PYEOF'` and pass `TOKEN` and `ENDPOINT` as positional arguments (`sys.argv[2]` and `sys.argv[3]`). This matches the pattern already used correctly in `engram-session-recall.sh:102`.

Also updates `bin/checkin-lint.baseline` to shift a pre-existing `D.exit-zero-wrapper` line number by 5 (the only change to that file; the `exit 0` itself is unchanged).

## Files changed

- `hooks/engram/engram-token-refresh.sh` — quoted heredoc delimiter, positional args for token + endpoint
- `bin/checkin-lint.baseline` — shift line 187 → 192 for pre-existing baseline entry

## Test plan

- [x] `shellcheck hooks/engram/engram-token-refresh.sh` — only pre-existing SC1090/SC1091 warnings (dynamic `source` paths), no new findings
- [x] `go test ./internal/... -race -count=1 -timeout 120s` — all packages pass (shell-only change, no Go impact)
- [x] `checkin-lint` pre-commit hook passes with 0 new findings
- [x] Verified `$TOKEN` and `$ENDPOINT` do not appear inside the heredoc body