### PR TITLE
fix(1209): key /setup-token rate limiter on physical r.RemoteAddr not clientIP

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -731,9 +731,13 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	//
 	// Rate limit: per IP (3 calls per 5-minute window).
 	mux.Handle("/setup-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Rate limit applies unconditionally — security-critical endpoint.
-		if !setupLimiter.allowSetupToken(s.clientIP(r)) {
-			slog.Warn("setup-token rate limited", "remote_ip", s.clientIP(r))
+		// Rate limit must use the physical TCP peer address, not the proxy-aware IP.
+		// Keying on s.clientIP(r) lets an attacker rotate X-Forwarded-For to mint new
+		// rate-limit buckets and exhaust unlimited /setup-token calls. The physical
+		// r.RemoteAddr cannot be forged via request headers. (#1209)
+		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if !setupLimiter.allowSetupToken(rawPeer) {
+			slog.Warn("setup-token rate limited", "physical_remote", rawPeer)
 			w.Header().Set("Retry-After", "100")
 			http.Error(w, "rate limited", http.StatusTooManyRequests)
 			return
@@ -742,7 +746,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 		// TOFU: first unauthenticated request from loopback only.
 		// CRITICAL: use r.RemoteAddr (raw TCP peer), NOT s.clientIP(r),
 		// to prevent X-Forwarded-For spoofing when ENGRAM_TRUST_PROXY_HEADERS=1.
-		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
+		// rawPeer is already extracted above for the rate limit — reuse it here.
 		// Re-grant removed in #1187 — one grant per process lifetime.
 		if isLoopbackIP(rawPeer) && s.tofuGranted.CompareAndSwap(false, true) {
 			s.tofuGrantedAt.Store(time.Now().Unix())
@@ -979,10 +983,13 @@ func (s *Server) setupTokenTOFUHandler(ctx context.Context, apiKey string) http.
 //  4. All subsequent requests require Bearer authentication (unchanged from #540).
 func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey string, rl *rateLimiter) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Rate limit applies unconditionally — security-critical endpoint.
-		// Use clientIP here for rate limiting (proxy headers are fine for rate limits).
-		if !rl.allowSetupToken(s.clientIP(r)) {
-			slog.Warn("setup-token rate limited", "remote_ip", s.clientIP(r))
+		// Rate limit must use the physical TCP peer address, not the proxy-aware IP.
+		// Keying on s.clientIP(r) lets an attacker rotate X-Forwarded-For to mint new
+		// rate-limit buckets and exhaust unlimited /setup-token calls. The physical
+		// r.RemoteAddr cannot be forged via request headers. (#1209)
+		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if !rl.allowSetupToken(rawPeer) {
+			slog.Warn("setup-token rate limited", "physical_remote", rawPeer)
 			w.Header().Set("Retry-After", "100")
 			http.Error(w, "rate limited", http.StatusTooManyRequests)
 			return
@@ -991,7 +998,7 @@ func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey string, rl *rateLimiter
 		// TOFU: first unauthenticated request from loopback only.
 		// CRITICAL: use r.RemoteAddr (raw TCP peer), NOT s.clientIP(r),
 		// to prevent X-Forwarded-For spoofing when ENGRAM_TRUST_PROXY_HEADERS=1.
-		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
+		// rawPeer is already extracted above for the rate limit — reuse it here.
 		// Re-grant removed in #1187 — one grant per process lifetime.
 		if isLoopbackIP(rawPeer) && s.tofuGranted.CompareAndSwap(false, true) {
 			s.tofuGrantedAt.Store(time.Now().Unix())

--- a/internal/mcp/setup_token_tofu_test.go
+++ b/internal/mcp/setup_token_tofu_test.go
@@ -151,6 +151,43 @@ func TestSetupToken_TOFUConcurrentRequests(t *testing.T) {
 		"exactly one concurrent unauthenticated TOFU request must succeed; got %d", successes)
 }
 
+// TestSetupToken_XFFBypassBlocked verifies that a remote caller cannot bypass the
+// /setup-token rate limiter by rotating the X-Forwarded-For header.  Pre-fix,
+// s.clientIP(r) keyed the rate-limit bucket, so each new XFF value minted a fresh
+// bucket; post-fix the bucket key is the physical r.RemoteAddr. (#1209)
+func TestSetupToken_XFFBypassBlocked(t *testing.T) {
+	const apiKey = "test-api-key-xff-bypass"
+	s := newTOFUTestServer(t, apiKey)
+	s.trustProxy = true // honour X-Forwarded-For so clientIP() diverges from RemoteAddr
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Build a limiter and exhaust the setup-token budget for the physical peer "10.0.0.1".
+	// allowSetupToken burst is 3 (see server.go — rate.Every(setupTokenWindow), burst 3).
+	rl := newRateLimiter(ctx)
+	rl.allowSetupToken("10.0.0.1") // #1
+	rl.allowSetupToken("10.0.0.1") // #2
+	rl.allowSetupToken("10.0.0.1") // #3 — budget exhausted
+	if rl.allowSetupToken("10.0.0.1") {
+		t.Fatal("test setup: expected budget to be exhausted after 3 calls but still has tokens")
+	}
+
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, rl)
+
+	// Attacker is physically at 10.0.0.1 but rotates X-Forwarded-For to "5.5.5.5".
+	// Pre-fix: clientIP(r)="5.5.5.5" → new bucket → not rate-limited → TOFU/auth logic runs.
+	// Post-fix: physical peer="10.0.0.1" → exhausted bucket → 429.
+	req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	req.Header.Set("X-Forwarded-For", "5.5.5.5") // spoofed IP — must not mint a new RL bucket
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusTooManyRequests, w.Code,
+		"XFF rotation must not bypass /setup-token rate limit: physical peer 10.0.0.1 is exhausted (#1209)")
+}
+
 // TestSetupToken_TOFURateLimitRunsFirst verifies that rate-limit enforcement (429)
 // takes priority over TOFU grant when the setupLimiter budget is exhausted.
 func TestSetupToken_TOFURateLimitRunsFirst(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1209.

The `/setup-token` rate limiter keyed its bucket on `s.clientIP(r)`, which honours `X-Forwarded-For` when `ENGRAM_TRUST_PROXY_HEADERS=1`. An attacker at a trusted-proxy position could rotate the spoofed source IP to mint unlimited rate-limit buckets and brute-force the TOFU window or exhaust token calls.

**Fix:** extract the physical TCP peer from `r.RemoteAddr` and use it as the rate-limit key in both the inline mux handler (line 735) and `setupTokenTOFUHandlerWithLimiter`. The physical address cannot be forged via request headers. The TOFU loopback check was already using `r.RemoteAddr` correctly (#540); only the rate-limit key is changed.

## Files changed

- `internal/mcp/server.go` — both `/setup-token` rate-limit call sites now key on physical peer from `r.RemoteAddr`
- `internal/mcp/setup_token_tofu_test.go` — adds `TestSetupToken_XFFBypassBlocked` which reproduces the attack (red pre-fix, green post-fix)

## Test plan

- [x] `TestSetupToken_XFFBypassBlocked` — exhausts rate-limit for `10.0.0.1` physical peer, then sends request with `X-Forwarded-For: 5.5.5.5` from same physical address, asserts 429 (not 401)
- [x] All existing TOFU tests (`TestSetupToken_TOFU*`, `TestSetupTokenBudget*`) still pass
- [x] `go test ./internal/mcp/ -race -count=1` — all pass
- [x] `checkin-lint` — 0 new findings