### PR TITLE
fix(1205): bind MCP port to 127.0.0.1 in docker-compose.local.yml

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -84,7 +84,7 @@ services:
     container_name: engram-go-app
     image: engram-go:latest
     ports:
-      - "${ENGRAM_PORT:-8788}:8788"
+      - "127.0.0.1:${ENGRAM_PORT:-8788}:8788"
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
## Summary

Closes #1205.

`docker-compose.local.yml` mapped port 8788 without a loopback prefix (`"${ENGRAM_PORT:-8788}:8788"`), binding the bearer-token-protected MCP server to all interfaces. Any host on the same LAN could reach the memory store.

`SECURITY.md:57` and `docs/operations.md:91-93` both assert the server binds to loopback by default. The hybrid `docker-compose.yml` already uses `"127.0.0.1:${ENGRAM_PORT:-8788}:8788"` correctly. This one-line fix brings the local profile into agreement with both.

## Files changed

- `docker-compose.local.yml:87` — added `127.0.0.1:` prefix to port mapping

## Test plan

- [x] `go test ./...` — no Go files changed; all tests pass
- [x] `checkin-lint` — 0 new findings
- [x] `grep` confirms `docker-compose.local.yml` now matches the loopback prefix in `docker-compose.yml`