### PR TITLE
fix(1212): remove --database-url flag; move Unsetenv before healthcheck exit

### DIFF
--- a/bin/checkin-lint.baseline
+++ b/bin/checkin-lint.baseline
@@ -312,6 +312,9 @@ P1.hardcoded-dsn::./cmd/engram/main_test.go::332
 P1.hardcoded-dsn::./cmd/engram/main_test.go::339
 P1.hardcoded-dsn::./cmd/engram/main_test.go::365
 P1.hardcoded-dsn::./cmd/engram/main_test.go::388
+P1.hardcoded-dsn::./cmd/engram/db_url_leak_test.go::22
+P1.hardcoded-dsn::./cmd/engram/db_url_leak_test.go::29
+P1.hardcoded-dsn::./cmd/engram/db_url_leak_test.go::47
 P1.hardcoded-dsn::./cmd/longmemeval/prune_test.go::139
 P1.hardcoded-dsn::./cmd/starter/main_test.go::26
 P1.hardcoded-dsn::./cmd/starter/main_test.go::28

--- a/cmd/engram/db_url_leak_test.go
+++ b/cmd/engram/db_url_leak_test.go
@@ -1,0 +1,92 @@
+package main
+
+// Tests for #1212: DB password leaks via --database-url flag.
+//
+// Three attack surfaces eliminated:
+//  1. --database-url flag registers the DSN (with embedded password) as a
+//     positional CLI argument visible in /proc/cmdline, ps aux, and --help.
+//  2. --help PrintDefaults expands the DATABASE_URL env var into the default
+//     value string, printing the DSN in plaintext.
+//  3. runHealthcheckProbe calls os.Exit before the os.Unsetenv block, leaving
+//     ENGRAM_API_KEY / DATABASE_URL / LITELLM_API_KEY in /proc/self/environ.
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestDatabaseURLFlagAbsent verifies that --database-url is not a registered
+// CLI flag in runServer.  Pre-fix: fs.String("database-url", ...) registered
+// the flag so a DSN like "postgres://user:password@host/db" would appear in
+// /proc/cmdline and in --help output.  Post-fix: DATABASE_URL is env-only.
+// (#1212)
+func TestDatabaseURLFlagAbsent(t *testing.T) {
+	// Spin up the binary (via the TestEngramMainHelper subprocess gate) and pass
+	// --database-url; the flag package should reject it with "flag provided but
+	// not defined" if the flag has been removed correctly.
+	out, err := runEngramMainForTest(t, "server", "--database-url", "postgres://user:secret@host/db")
+	if err == nil {
+		t.Fatalf("runServer --database-url unexpectedly succeeded; output:\n%s", out)
+	}
+	if !strings.Contains(out, "flag provided but not defined") {
+		t.Fatalf("expected 'flag provided but not defined' for --database-url, got:\n%s", out)
+	}
+}
+
+// TestDatabaseURLHelpDoesNotExpandSecret verifies that running --help on the
+// server subcommand does not expand the DATABASE_URL environment variable into
+// flag default-value text.  Pre-fix: fs.String("database-url", envOr(...), ...)
+// bakes the env value into the flag default, which PrintDefaults then prints.
+// Post-fix: DATABASE_URL is read directly (not via flag.String), so it never
+// appears in --help output.  (#1212)
+func TestDatabaseURLHelpDoesNotExpandSecret(t *testing.T) {
+	// Inject a recognisable sentinel that would appear in --help if the flag
+	// default expands DATABASE_URL.
+	const sentinelDSN = "postgres://leaktest:SUPER_SECRET_PWD@db.internal/engram"
+
+	// Build the subprocess command with a specific DATABASE_URL value.
+	// We can't use runEngramMainForTest directly because it clears DATABASE_URL.
+	cmd := exec.Command(os.Args[0], "-test.run=TestEngramMainHelper", "--", "server", "--help")
+	cmd.Env = append(os.Environ(),
+		"ENGRAM_TEST_MAIN_HELPER=1",
+		"DATABASE_URL="+sentinelDSN,
+	)
+	out, _ := cmd.CombinedOutput()
+
+	if strings.Contains(string(out), "SUPER_SECRET_PWD") {
+		t.Fatalf("--help output contains embedded DB password from DATABASE_URL; output:\n%s", out)
+	}
+	if strings.Contains(string(out), sentinelDSN) {
+		t.Fatalf("--help output contains full DATABASE_URL DSN; output:\n%s", out)
+	}
+}
+
+// TestUnsetenvBeforeHealthcheck verifies (via source inspection) that the
+// os.Unsetenv block for secret env vars appears before the runHealthcheckProbe
+// call in main.go.  Pre-fix: runHealthcheckProbe called os.Exit, so the Unsetenv
+// block after it was unreachable and secrets remained in /proc/self/environ.
+// Post-fix: Unsetenv block is moved above the healthcheck branch.  (#1212)
+//
+// Source inspection is the right tool here: the behaviour under test is
+// call-ordering across an os.Exit boundary that cannot be exercised in-process.
+func TestUnsetenvBeforeHealthcheck(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+
+	unsetIdx := strings.Index(text, `os.Unsetenv("DATABASE_URL")`)
+	hcIdx := strings.Index(text, "runHealthcheckProbe(")
+	if unsetIdx < 0 {
+		t.Fatal("main.go: os.Unsetenv(\"DATABASE_URL\") not found — has the unset block been removed?")
+	}
+	if hcIdx < 0 {
+		t.Fatal("main.go: runHealthcheckProbe call not found")
+	}
+	if unsetIdx > hcIdx {
+		t.Errorf("os.Unsetenv(\"DATABASE_URL\") (offset %d) appears AFTER runHealthcheckProbe (offset %d) in main.go — secrets remain in /proc/self/environ when healthcheck exits (#1212)", unsetIdx, hcIdx)
+	}
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -121,7 +121,10 @@ func runServer(args []string) error {
 	}
 
 	versionFlag := fs.Bool("version", false, "print version and exit")
-	databaseURL := fs.String("database-url", envOr("DATABASE_URL", ""), "PostgreSQL DSN (required)")
+	// DATABASE_URL is intentionally NOT a CLI flag — a DSN with an embedded password
+	// would appear in /proc/cmdline, ps aux, shell history, and --help PrintDefaults
+	// output if registered as a flag.String.  Read from environment only. (#1212)
+	databaseURL := os.Getenv("DATABASE_URL")
 	routerURL := fs.String("litellm-url", routerURLFromEnv("http://litellm:4000", slog.Default()), "Router base URL (generation); env: ENGRAM_ROUTER_URL (LITELLM_URL accepted as deprecated fallback)")
 	litellmAPIKey := envOr("LITELLM_API_KEY", "")
 	// ENGRAM_EMBED_URL overrides ENGRAM_ROUTER_URL for embeddings only — use when the
@@ -217,6 +220,15 @@ func runServer(args []string) error {
 			"rate_limit", *rateLimit, "rate_limit_rps", *rateLimitRPS)
 	}
 
+	// Unset secrets from the process environment after reading (#139, #141, #250, #549, #1212).
+	// Must happen before runHealthcheckProbe because that function calls os.Exit, which
+	// would skip the Unsetenv block if it were placed after it — leaving credentials
+	// in /proc/self/environ for any subsequent process lifetime.
+	_ = os.Unsetenv("ENGRAM_API_KEY")
+	_ = os.Unsetenv("ANTHROPIC_API_KEY")
+	_ = os.Unsetenv("DATABASE_URL")
+	_ = os.Unsetenv("LITELLM_API_KEY")
+
 	// Docker HEALTHCHECK support — distroless images have no shell or wget,
 	// so CMD-SHELL form is unusable. This flag lets the binary probe its own
 	// /health endpoint and exit with the appropriate code. See issue #341.
@@ -225,8 +237,8 @@ func runServer(args []string) error {
 		runHealthcheckProbe(*port, apiKey)
 	}
 
-	if *databaseURL == "" {
-		return fmt.Errorf("DATABASE_URL or --database-url is required")
+	if databaseURL == "" {
+		return fmt.Errorf("DATABASE_URL environment variable is required (--database-url flag intentionally omitted — see issue #1212)")
 	}
 	if apiKey == "" {
 		return fmt.Errorf("ENGRAM_API_KEY environment variable is required (--api-key flag intentionally omitted — see issue #136)")
@@ -247,13 +259,6 @@ func runServer(args []string) error {
 	if warn := validateEmbedConfig(*embedModel, *embedDims); warn != "" {
 		slog.Warn("embed config warning", "detail", warn)
 	}
-
-	// Unset secrets from the process environment after reading (#139, #141, #250, #549).
-	// Reduces the exposure window for credentials in /proc/self/environ.
-	_ = os.Unsetenv("ENGRAM_API_KEY")
-	_ = os.Unsetenv("ANTHROPIC_API_KEY")
-	_ = os.Unsetenv("DATABASE_URL")
-	_ = os.Unsetenv("LITELLM_API_KEY")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
@@ -322,7 +327,7 @@ func runServer(args []string) error {
 	// is configured to allow demand-driven probes.
 	startEmbedBackgroundProbe(ctx, embedClient, *embedCircuitOpenDuration)
 
-	dsn := *databaseURL
+	dsn := databaseURL
 	routerURLVal := *routerURL
 	sumModel := *summarizeModel
 	sumEnabled := *summarizeEnabled


### PR DESCRIPTION
## Summary

- Removes the `--database-url` flag from `runServer`. A DSN with an embedded password was visible in `/proc/cmdline`, `ps aux`, shell history, and `--help` output (via `flag.PrintDefaults` expanding the `DATABASE_URL` env default). `DATABASE_URL` is now env-only, matching the established pattern for `ENGRAM_API_KEY` and `ANTHROPIC_API_KEY`.
- Moves the `os.Unsetenv` block (clearing `ENGRAM_API_KEY`, `ANTHROPIC_API_KEY`, `DATABASE_URL`, `LITELLM_API_KEY`) before the `runHealthcheckProbe` call. Previously `runHealthcheckProbe` called `os.Exit`, bypassing the Unsetenv block and leaving credentials in `/proc/self/environ` for the lifetime of the healthcheck process.
- Updates error message to reflect the env-only contract.

## Test plan

- `TestDatabaseURLFlagAbsent`: runs `server --database-url ...` as a subprocess; expects "flag provided but not defined" — confirms the flag is removed.
- `TestDatabaseURLHelpDoesNotExpandSecret`: runs `server --help` with `DATABASE_URL=postgres://leaktest:SUPER_SECRET_PWD@...` set; asserts the password does not appear in stdout.
- `TestUnsetenvBeforeHealthcheck`: source-order check — asserts `os.Unsetenv("DATABASE_URL")` appears before `runHealthcheckProbe(` in main.go (the only correct tool here: the bug is an `os.Exit`-mediated ordering issue that cannot be exercised in-process).

Fixes #1212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A