### PR TITLE
fix(rest): structured-error contract — URL+status+body-prefix on wrong-path REST calls (#1192)

### DIFF
--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -743,6 +743,8 @@ const (
 )
 
 // NewRestClient constructs a RestClient pointed at baseURL with Bearer auth.
+// The URL is normalised with baseServerURL so callers may pass the server root,
+// an /mcp suffix, or an /sse suffix interchangeably.
 func NewRestClient(baseURL, token string) *RestClient {
 	return &RestClient{
 		baseURL: baseServerURL(baseURL),

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -736,6 +737,11 @@ type RestClient struct {
 	http    *http.Client
 }
 
+const (
+	restResponsePreviewBytes = 80
+	restBaseURLHint          = "is the base URL the server root rather than /mcp?"
+)
+
 // NewRestClient constructs a RestClient pointed at baseURL with Bearer auth.
 func NewRestClient(baseURL, token string) *RestClient {
 	return &RestClient{
@@ -791,23 +797,24 @@ func (r *RestClient) QuickStore(ctx context.Context, project, content string, ta
 			OK    bool   `json:"ok"`
 			ID    string `json:"id"`
 			Error string `json:"error"`
+			Hint  string `json:"hint"`
 		}
-		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
-		_ = resp.Body.Close()
-		if decodeErr != nil {
-			lastErr = fmt.Errorf("quick-store decode: %w", decodeErr)
-			continue
+		if err := decodeRESTJSONObjectResponse(resp, req.Method, req.URL.String(), &result); err != nil {
+			return "", fmt.Errorf("quick-store decode: %w", err)
 		}
 		if resp.StatusCode == 429 {
-			lastErr = fmt.Errorf("quick-store rate limited (status 429)")
+			lastErr = restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
 			continue
 		}
 		if resp.StatusCode >= 500 {
-			lastErr = fmt.Errorf("quick-store server error (status %d): %s", resp.StatusCode, result.Error)
+			lastErr = restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
 			continue
 		}
+		if resp.StatusCode >= 400 {
+			return "", restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
+		}
 		if !result.OK || result.ID == "" {
-			return "", fmt.Errorf("quick-store failed: %s (status %d)", result.Error, resp.StatusCode)
+			return "", restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
 		}
 		return result.ID, nil
 	}
@@ -836,15 +843,59 @@ func (r *RestClient) QuickRecall(ctx context.Context, project, query string, lim
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
-		IDs []string `json:"ids"`
+		IDs   []string `json:"ids"`
+		Error string   `json:"error"`
+		Hint  string   `json:"hint"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := decodeRESTJSONObjectResponse(resp, req.Method, req.URL.String(), &result); err != nil {
 		return nil, fmt.Errorf("quick-recall decode: %w", err)
 	}
+	if resp.StatusCode >= 400 {
+		return nil, restStatusError("quick-recall", resp.StatusCode, result.Error, result.Hint)
+	}
 	return result.IDs, nil
+}
+
+func decodeRESTJSONObjectResponse(resp *http.Response, method, url string, dst any) error {
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("read response body from %s %s: %w", method, url, err)
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	preview := responseBodyPreview(trimmed)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return fmt.Errorf("unexpected non-object response from %s %s (status %d, first %d bytes: %q): %s",
+			method, url, resp.StatusCode, len(preview), preview, restBaseURLHint)
+	}
+	if err := json.Unmarshal(trimmed, dst); err != nil {
+		return fmt.Errorf("unexpected response object from %s %s (status %d, first %d bytes: %q): %v: %s",
+			method, url, resp.StatusCode, len(preview), preview, err, restBaseURLHint)
+	}
+	return nil
+}
+
+func responseBodyPreview(body []byte) string {
+	if len(body) > restResponsePreviewBytes {
+		body = body[:restResponsePreviewBytes]
+	}
+	return string(body)
+}
+
+func restStatusError(op string, status int, msg, hint string) error {
+	if msg == "" {
+		msg = http.StatusText(status)
+	}
+	if msg == "" {
+		msg = "request failed"
+	}
+	if hint != "" {
+		return fmt.Errorf("%s failed: %s (status %d): %s", op, msg, status, hint)
+	}
+	return fmt.Errorf("%s failed: %s (status %d)", op, msg, status)
 }
 
 // SessionContent concatenates all turns of a session into a single string,

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -175,7 +175,7 @@ func TestRestClient_QuickStore_ServerError(t *testing.T) {
 // /mcp hint instead of the raw Go struct unmarshal error (#1192).
 func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/mcp/quick-store" {
+		if r.URL.Path != "/quick-store" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -184,7 +184,7 @@ func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	rc := longmemeval.NewRestClient(srv.URL, "")
 	_, err := rc.QuickStore(context.Background(), "proj-1", "content here", []string{"tag1"}, nil)
 	if err == nil {
 		t.Fatal("QuickStore error = nil, want non-object response error")
@@ -193,7 +193,7 @@ func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
 	if !strings.Contains(msg, "unexpected non-object response from POST") {
 		t.Fatalf("error = %q, want non-object response framing", msg)
 	}
-	if !strings.Contains(msg, "/mcp/quick-store") {
+	if !strings.Contains(msg, "/quick-store") {
 		t.Fatalf("error = %q, want called URL", msg)
 	}
 	if !strings.Contains(msg, "status 200") {
@@ -232,7 +232,7 @@ func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 // scalar or other non-object body (#1192).
 func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/mcp/quick-recall" {
+		if r.URL.Path != "/quick-recall" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -241,7 +241,7 @@ func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	rc := longmemeval.NewRestClient(srv.URL, "")
 	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
 	if err == nil {
 		t.Fatal("QuickRecall error = nil, want non-object response error")
@@ -250,7 +250,7 @@ func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 	if !strings.Contains(msg, "unexpected non-object response from POST") {
 		t.Fatalf("error = %q, want non-object response framing", msg)
 	}
-	if !strings.Contains(msg, "/mcp/quick-recall") {
+	if !strings.Contains(msg, "/quick-recall") {
 		t.Fatalf("error = %q, want called URL", msg)
 	}
 	if !strings.Contains(msg, "status 404") {
@@ -268,7 +268,7 @@ func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 // JSON error response does not decode as a false success with empty IDs (#1192).
 func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/mcp/quick-recall" {
+		if r.URL.Path != "/quick-recall" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -280,7 +280,7 @@ func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	rc := longmemeval.NewRestClient(srv.URL, "")
 	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
 	if err == nil {
 		t.Fatal("QuickRecall error = nil, want structured 404 error")

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -170,6 +170,43 @@ func TestRestClient_QuickStore_ServerError(t *testing.T) {
 	}
 }
 
+// TestRestClient_QuickStore_NonObjectResponseError verifies that decode
+// failures surface the called URL, HTTP status, body prefix, and the root-vs-
+// /mcp hint instead of the raw Go struct unmarshal error (#1192).
+func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/quick-store" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("42"))
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	_, err := rc.QuickStore(context.Background(), "proj-1", "content here", []string{"tag1"}, nil)
+	if err == nil {
+		t.Fatal("QuickStore error = nil, want non-object response error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unexpected non-object response from POST") {
+		t.Fatalf("error = %q, want non-object response framing", msg)
+	}
+	if !strings.Contains(msg, "/mcp/quick-store") {
+		t.Fatalf("error = %q, want called URL", msg)
+	}
+	if !strings.Contains(msg, "status 200") {
+		t.Fatalf("error = %q, want status code", msg)
+	}
+	if !strings.Contains(msg, "\"42\"") {
+		t.Fatalf("error = %q, want body prefix", msg)
+	}
+	if !strings.Contains(msg, "server root rather than /mcp") {
+		t.Fatalf("error = %q, want base URL hint", msg)
+	}
+}
+
 // TestRestClient_QuickRecall_HappyPath verifies QuickRecall returns IDs.
 func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +224,73 @@ func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 	}
 	if len(ids) != 2 || ids[0] != "id-1" {
 		t.Errorf("ids = %v, want [id-1, id-2]", ids)
+	}
+}
+
+// TestRestClient_QuickRecall_NonObjectResponseError verifies QuickRecall uses
+// the same wrapped decode error shape as QuickStore when the server returns a
+// scalar or other non-object body (#1192).
+func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/quick-recall" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("7"))
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
+	if err == nil {
+		t.Fatal("QuickRecall error = nil, want non-object response error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unexpected non-object response from POST") {
+		t.Fatalf("error = %q, want non-object response framing", msg)
+	}
+	if !strings.Contains(msg, "/mcp/quick-recall") {
+		t.Fatalf("error = %q, want called URL", msg)
+	}
+	if !strings.Contains(msg, "status 404") {
+		t.Fatalf("error = %q, want status code", msg)
+	}
+	if !strings.Contains(msg, "\"7\"") {
+		t.Fatalf("error = %q, want body prefix", msg)
+	}
+	if !strings.Contains(msg, "server root rather than /mcp") {
+		t.Fatalf("error = %q, want base URL hint", msg)
+	}
+}
+
+// TestRestClient_QuickRecall_ObjectErrorResponse verifies that a structured
+// JSON error response does not decode as a false success with empty IDs (#1192).
+func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/quick-recall" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "not found",
+			"hint":  "REST endpoints (/quick-store,/atoms,/quick-recall) are at the server root, not under /mcp",
+		})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
+	if err == nil {
+		t.Fatal("QuickRecall error = nil, want structured 404 error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "quick-recall failed: not found (status 404)") {
+		t.Fatalf("error = %q, want status error framing", msg)
+	}
+	if !strings.Contains(msg, "REST endpoints (/quick-store,/atoms,/quick-recall) are at the server root, not under /mcp") {
+		t.Fatalf("error = %q, want server hint", msg)
 	}
 }
 

--- a/internal/longmemeval/export_test.go
+++ b/internal/longmemeval/export_test.go
@@ -6,5 +6,3 @@ package longmemeval
 // accepts an injected TextGenerator instead of hard-coding GenerateHaiku.
 // Used by tests to inject a fake LLM without spawning a real claude process.
 var GenerateParaphrasesWith = generateParaphrasesWith
-// RestClientBaseURL exposes the normalised base URL of a RestClient for tests.
-func (r *RestClient) BaseURL() string { return r.baseURL }

--- a/internal/longmemeval/export_test.go
+++ b/internal/longmemeval/export_test.go
@@ -6,3 +6,5 @@ package longmemeval
 // accepts an injected TextGenerator instead of hard-coding GenerateHaiku.
 // Used by tests to inject a fake LLM without spawning a real claude process.
 var GenerateParaphrasesWith = generateParaphrasesWith
+// RestClientBaseURL exposes the normalised base URL of a RestClient for tests.
+func (r *RestClient) BaseURL() string { return r.baseURL }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -39,6 +39,8 @@ const (
 	phaseWarm     int32 = 2
 )
 
+const restEndpointRootHint = "REST endpoints (/quick-store,/atoms,/quick-recall) are at the server root, not under /mcp"
+
 // Exported aliases for use by main.go and other external callers that need to
 // advance the server phase without accessing unexported fields directly.
 const (
@@ -806,6 +808,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// Configure in mcp_servers.json: type:"http", url:"http://127.0.0.1:8788/mcp"
 	streamable := buildStreamableHTTPServer(s.mcp)
 	mux.Handle("/mcp", s.applyMiddleware(streamable, apiKey, rl))
+	mux.Handle("/mcp/", s.authenticatedNotFoundHandler(apiKey, rl))
 
 	// /quick-store — sessionless REST endpoint for hook scripts and CLI callers
 	// that cannot establish an SSE session (e.g. PreCompact hooks).
@@ -820,8 +823,10 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// POST {"project":...,"atom_type":...,"top_k":N} → returns {"atoms":[...]} for --atom-mode recall.
 	mux.Handle("/atoms", s.applyMiddleware(http.HandlerFunc(s.handleAtoms), apiKey, rl))
 
-	// All other authenticated routes (including /sse) go through the standard middleware.
-	mux.Handle("/", s.applyMiddleware(sse, apiKey, rl))
+	// All other authenticated routes are either the legacy SSE endpoint or a
+	// structured JSON 404. Unknown paths must not fall through to the SSE
+	// transport, which can emit opaque non-object bodies (#1192).
+	mux.Handle("/", s.authenticatedFallbackHandler(sse, apiKey, rl))
 
 	// Background sweeper closes crash-orphaned open episodes on an hourly interval.
 	go s.sweepStaleEpisodes(ctx)
@@ -865,6 +870,29 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	case err := <-errCh:
 		return err
 	}
+}
+
+func writeRESTEndpointNotFound(w http.ResponseWriter) {
+	writeJSON(w, http.StatusNotFound, map[string]string{
+		"error": "not found",
+		"hint":  restEndpointRootHint,
+	})
+}
+
+func (s *Server) authenticatedNotFoundHandler(apiKey string, rl *rateLimiter) http.Handler {
+	return s.applyMiddlewareWithRL(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeRESTEndpointNotFound(w)
+	}), apiKey, rl)
+}
+
+func (s *Server) authenticatedFallbackHandler(sse http.Handler, apiKey string, rl *rateLimiter) http.Handler {
+	return s.applyMiddlewareWithRL(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/sse" {
+			sse.ServeHTTP(w, r)
+			return
+		}
+		writeRESTEndpointNotFound(w)
+	}), apiKey, rl)
 }
 
 // applyMiddleware chains per-IP rate limiting (#140) and Bearer auth onto next.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -193,6 +194,94 @@ func TestQuickStoreHandler_InvalidJSON_JSONErrorBody(t *testing.T) {
 	// Must not leak internal Go error messages like "invalid character".
 	if strings.Contains(body, "invalid character") || strings.Contains(body, "unexpected end") {
 		t.Fatalf("response body leaks raw Go error: %q", body)
+	}
+}
+
+// TestAuthenticatedWrongRESTPath_JSONNotFound verifies that authenticated
+// wrong-path REST requests under /mcp return a structured JSON 404 instead of
+// falling through to the legacy SSE catch-all (#1192).
+func TestAuthenticatedWrongRESTPath_JSONNotFound(t *testing.T) {
+	s := &Server{}
+	apiKey := "test-secret-key-123"
+	rl := newRateLimiter(context.Background())
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", s.applyMiddlewareWithRL(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}), apiKey, rl))
+	mux.Handle("/mcp/", s.authenticatedNotFoundHandler(apiKey, rl))
+	mux.Handle("/", s.authenticatedFallbackHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("42"))
+		}),
+		apiKey,
+		rl,
+	))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/quick-store", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for wrong-path REST request, got %d body=%q", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected JSON content-type, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal JSON body: %v", err)
+	}
+	if body["error"] != "not found" {
+		t.Fatalf("error = %q, want %q", body["error"], "not found")
+	}
+	if !strings.Contains(body["hint"], "/quick-store") || !strings.Contains(body["hint"], "not under /mcp") {
+		t.Fatalf("hint = %q, want REST root-path guidance", body["hint"])
+	}
+}
+
+// TestAuthenticatedUnknownPath_JSONNotFound verifies that unrouted
+// authenticated paths also return structured JSON 404s instead of whatever the
+// catch-all transport handler emits (#1192).
+func TestAuthenticatedUnknownPath_JSONNotFound(t *testing.T) {
+	s := &Server{}
+	apiKey := "test-secret-key-123"
+	rl := newRateLimiter(context.Background())
+
+	mux := http.NewServeMux()
+	mux.Handle("/", s.authenticatedFallbackHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("42"))
+		}),
+		apiKey,
+		rl,
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/definitely-not-a-route", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown path, got %d body=%q", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected JSON content-type, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal JSON body: %v", err)
+	}
+	if body["error"] != "not found" {
+		t.Fatalf("error = %q, want %q", body["error"], "not found")
+	}
+	if !strings.Contains(body["hint"], "/quick-store") || !strings.Contains(body["hint"], "not under /mcp") {
+		t.Fatalf("hint = %q, want REST root-path guidance", body["hint"])
 	}
 }
 


### PR DESCRIPTION
Rebased version of #1230 (which had a merge conflict on TestNewRestClient_URLNormalization).

**Conflict resolution:** main already contained a more thorough HTTP-server-based URLNormalization test; kept main's version, dropped the simpler BaseURL-only variant from the PR branch.

## Changes
- `internal/longmemeval/engram.go`: REST client surfaces structured errors with URL + HTTP status + body prefix instead of bare EOF / number on wrong-path calls
- `internal/longmemeval/engram_test.go`: regression tests for the new error shape
- `internal/mcp/server.go`: align error handling
- `internal/mcp/server_test.go`: server-side error tests

## Build proof
- `go build ./internal/longmemeval/... ./internal/mcp/...` ✅
- `go test ./internal/longmemeval/... ./internal/mcp/... -count=1 -race` ✅

Closes #1192