### PR TITLE
docs: fix Go badge, embed dims, embed model clarity (#1216 #1220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- verify: review-gate-relaxed 2026-05-24 -->
-![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white) ![License](https://img.shields.io/badge/License-GPL%20v3-blue) ![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white) ![MCP](https://img.shields.io/badge/MCP-SSE-purple) ![Version](https://img.shields.io/badge/Version-3.1.0-green)
+![Go](https://img.shields.io/badge/Go-1.26.3-00ADD8?logo=go&logoColor=white) ![License](https://img.shields.io/badge/License-GPL%20v3-blue) ![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white) ![MCP](https://img.shields.io/badge/MCP-SSE-purple) ![Version](https://img.shields.io/badge/Version-3.1.0-green)
 
 <p align="center"><img src="docs/hero.svg" alt="Engram — Persistent Memory for AI Agents" width="100%"></p>
 
@@ -35,6 +35,8 @@ Both setups share the same PostgreSQL backend, API contract, and tool set. Swap 
 ```bash
 # Fresh-clone default: Local-only (zero external dependencies)
 make init
+docker volume create engram_pgdata
+docker volume create ollama_ollama_storage
 make build-postgres
 docker compose -f docker-compose.local.yml up -d
 go run ./cmd/engram-setup --url http://127.0.0.1:8788

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -218,7 +218,7 @@ ENGRAM_API_KEY=                            # Required: bearer token for all MCP 
 OLLAMA_URL=http://ollama:11434             # Default: Ollama inside Docker
 # OLLAMA_URL=http://host.docker.internal:11434  # Mac: native Ollama outside Docker
 
-ENGRAM_EMBED_MODEL=mxbai-embed-large      # Any 1024-dim compatible embedding model (Ollama or Infinity/olla)
+ENGRAM_EMBED_MODEL=mxbai-embed-large      # Ollama local-only path default; Infinity/olla path uses BAAI/bge-m3
 
 # ============================================================
 # Background summarization

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -145,7 +145,7 @@ Five tables, each playing a specific role in how memories are stored, searched, 
 |---|---|
 | `memories` | Core records: content, type, tags, importance, summary, SHA-256 hash |
 | `memory_fts` | PostgreSQL `tsvector` full-text search index (BM25) |
-| `chunks` | Content chunks with vector embeddings (768-dim float32 array) |
+| `chunks` | Content chunks with vector embeddings (1024-dim float32 array) |
 | `relationships` | Knowledge graph edges: source, target, type, weight, created_at |
 | `project_meta` | Per-project metadata: embedder lock, migration state |
 | `retrieval_events` | Per-recall event log for retrieval quality metrics. Rows older than 90 days are purged automatically by the retention worker. |


### PR DESCRIPTION
## Summary

- **#1216**: Fix Go version badge on README line 2: `Go-1.25` → `Go-1.26.3` (matches `go.mod` and README line 67)
- **#1220 dims**: Fix `chunks` table description in `docs/operations.md` line 148: `768-dim` → `1024-dim` (matches actual pgvector schema and README line 52)
- **#1220 embed model**: Clarify `docs/getting-started.md` line 221 embed model comment to distinguish Ollama local-only (`mxbai-embed-large`) from Infinity/olla path (`BAAI/bge-m3`) — previously the comment implied both paths used the same value
- **#1220 volume create**: Add `docker volume create` prerequisites to README Quick Start local-only block, matching the steps already present in `docs/getting-started.md` lines 57 and 63

## Test plan
- [ ] README badge renders with correct `Go-1.26.3` version
- [ ] `docs/operations.md` table shows `1024-dim` for chunks column
- [ ] `docs/getting-started.md` embed model comment now distinguishes Ollama vs Infinity/olla path
- [ ] README Quick Start shows volume create before compose up

🤖 Generated with [Claude Code](https://claude.com/claude-code)