### PR TITLE
fix(security): block empty+placeholder passwords in rejectDefaultPassword (#1211)

### DIFF
--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -207,8 +207,9 @@ func NewPostgresBackend(ctx context.Context, project, dsn string) (*PostgresBack
 // The password value is intentionally omitted from the error message to prevent clear-text logging
 // of credentials (CWE-312).
 func rejectDefaultPassword(cfg *pgxpool.Config) error {
-	if cfg.ConnConfig.Password == "engram" || cfg.ConnConfig.Password == "postgres" {
-		return fmt.Errorf("SECURITY: PostgreSQL is using a well-known default password — " +
+	switch cfg.ConnConfig.Password {
+	case "", "engram", "postgres", "change_me_to_a_strong_password":
+		return fmt.Errorf("SECURITY: PostgreSQL is using a well-known default or unset password — " +
 			"set a strong POSTGRES_PASSWORD in your environment before starting engram")
 	}
 	return nil

--- a/internal/db/reject_password_test.go
+++ b/internal/db/reject_password_test.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestRejectDefaultPassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		wantErr  bool
+	}{
+		{name: "empty password blocked", password: "", wantErr: true},
+		{name: "engram default blocked", password: "engram", wantErr: true},
+		{name: "postgres default blocked", password: "postgres", wantErr: true},
+		{name: "env.example placeholder blocked", password: "change_me_to_a_strong_password", wantErr: true},
+		{name: "strong password allowed", password: "str0ng-P@ssw0rd-2024!", wantErr: false},
+	}
+
+	// Parse a base config once; each sub-test overrides just the password field.
+	baseDSN := "postgres://user:placeholder@localhost:5432/engram"
+	baseCfg, err := pgxpool.ParseConfig(baseDSN)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Shallow-copy the pool config so tests don't interfere.
+			cfg := *baseCfg
+			connCfgCopy := *baseCfg.ConnConfig
+			cfg.ConnConfig = &connCfgCopy
+			cfg.ConnConfig.Password = tt.password
+
+			err := rejectDefaultPassword(&cfg)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for password %q, got nil", tt.password)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no error for password %q, got: %v", tt.password, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extends `rejectDefaultPassword` (`internal/db/postgres.go`) with a `switch` statement that additionally blocks an empty password (`""`) and the `.env.example` placeholder `"change_me_to_a_strong_password"`
- The empty-string case catches operators who omit `POSTGRES_PASSWORD` and connect via trust auth without realising it
- The placeholder case catches operators who copy `.env.example` without substituting the default value
- Error message updated from "well-known default password" to "well-known default or unset password" to be accurate for the empty-password case

## Test plan

- [ ] New file `internal/db/reject_password_test.go` — table-driven `TestRejectDefaultPassword`
- [ ] Covers all four blocked values: `""`, `"engram"`, `"postgres"`, `"change_me_to_a_strong_password"`
- [ ] Covers one valid strong password that must pass: `"str0ng-P@ssw0rd-2024!"`
- [ ] `go test ./internal/db/... -count=1 -run TestRejectDefaultPassword -v` → all 5 sub-tests PASS
- [ ] `go build ./internal/db/...` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A