### PR TITLE
fix(http): add timeouts to olla client + health probe HTTP clients (#1215)

### DIFF
--- a/internal/llmclient/olla.go
+++ b/internal/llmclient/olla.go
@@ -48,6 +48,7 @@ var skipFamilies = map[string]struct{}{
 type ollaClient struct {
 	host    string
 	timeout time.Duration
+	client  *http.Client
 
 	// mu guards modelID and modelResolved.  A mutex (rather than sync.Once) is
 	// used so resetModel can safely clear the cache while another goroutine may
@@ -71,7 +72,7 @@ func NewOllaClient(cfg Config) (LLMClient, error) {
 	if timeout == 0 {
 		timeout = defaultOllaTimeout
 	}
-	return &ollaClient{host: host, timeout: timeout}, nil
+	return &ollaClient{host: host, timeout: timeout, client: &http.Client{Timeout: timeout}}, nil
 }
 
 // pickModel queries /olla/models and returns the first model id suitable for
@@ -85,7 +86,7 @@ func (c *ollaClient) pickModel(ctx context.Context) string {
 		return ""
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		slog.Warn("llm/olla: cannot reach Olla", "host", c.host, "err", err)
 		return ""
@@ -226,7 +227,7 @@ func (c *ollaClient) Complete(ctx context.Context, systemPrompt, userPrompt stri
 	}
 	req.Header.Set("content-type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		slog.Warn("llm/olla: completion HTTP error", "err", err)
 		c.resetModel() // cached model may be gone; re-resolve next call

--- a/internal/llmclient/olla_race_test.go
+++ b/internal/llmclient/olla_race_test.go
@@ -6,6 +6,7 @@ package llmclient
 
 import (
 	"context"
+	"net/http"
 	"sync"
 	"testing"
 )
@@ -20,6 +21,7 @@ func TestResetModelNoRace(t *testing.T) {
 	c := &ollaClient{
 		host:    "http://127.0.0.1:1", // unreachable; pickModel will return ""
 		timeout: 0,
+		client:  &http.Client{Timeout: 0},
 	}
 
 	const workers = 8

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1503,7 +1503,8 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if s.cfg.RouterURL != "" {
 		embedCtx, embedCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer embedCancel()
-		probeOK, probeReason := embed.InfinityQueueCheck(embedCtx, http.DefaultClient, s.cfg.RouterURL)
+		healthHTTPClient := &http.Client{Timeout: 5 * time.Second}
+		probeOK, probeReason := embed.InfinityQueueCheck(embedCtx, healthHTTPClient, s.cfg.RouterURL)
 		if !probeOK {
 			ollamaStatus = "error" //nolint:ineffassign // overwritten if EmbedDegraded
 			slog.Warn("health: litellm probe failed", "reason", probeReason)


### PR DESCRIPTION
## Summary

- **`internal/llmclient/olla.go`**: Added `client *http.Client` field to `ollaClient` struct, initialized in `NewOllaClient` as `&http.Client{Timeout: timeout}` (using the existing `defaultOllaTimeout = 60s`). Both `http.DefaultClient.Do(req)` calls in `pickModel` (line ~89) and `Complete` (line ~229) replaced with `c.client.Do(req)`.
- **`internal/mcp/server.go`**: Replaced `http.DefaultClient` in the `/health` embed probe with a function-local `&http.Client{Timeout: 5 * time.Second}`, ensuring transport-level deadline enforcement even if context cancellation doesn't drain the TCP connection.
- **`internal/llmclient/olla_race_test.go`**: Added `client` field to the white-box struct literal and imported `net/http` to keep the race-detector test green.

## Test plan

- [x] `go build ./internal/llmclient/... ./internal/mcp/...` — clean
- [x] `go test ./internal/llmclient/... ./internal/mcp/... -count=1 -race -timeout 120s` — both packages pass
- [x] `TestResetModelNoRace` passes under `-race` (was panicking on nil `client` field before the test fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A