### PR TITLE
fix(hookdaemon): log silent error drops in WriteRecallSection/QuickStore/Tokens.Store (#1219)

### DIFF
--- a/internal/hookdaemon/daemon.go
+++ b/internal/hookdaemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -137,7 +138,9 @@ func (d *Daemon) setToken(tok string) {
 	}
 	d.mu.Unlock()
 	if changed && d.cfg.Tokens != nil {
-		_ = d.cfg.Tokens.Store(tok)
+		if err := d.cfg.Tokens.Store(tok); err != nil {
+			slog.Warn("hookdaemon: Tokens.Store failed — token not persisted; next session may have stale auth", "err", err)
+		}
 	}
 }
 

--- a/internal/hookdaemon/daemon_test.go
+++ b/internal/hookdaemon/daemon_test.go
@@ -36,6 +36,7 @@ type fakeEngram struct {
 	authErr      error
 	recallByProj map[string][]byte
 	recallErr    error
+	storeErr     error
 
 	authCalls  int
 	storeCalls int
@@ -66,14 +67,15 @@ func (f *fakeEngram) QuickStore(_ context.Context, _ string, body []byte) error 
 	defer f.mu.Unlock()
 	f.storeCalls++
 	f.storeBody = body
-	return nil
+	return f.storeErr
 }
 
 type fakeTokens struct {
-	mu      sync.Mutex
-	token   string
-	stored  []string
-	loadErr error
+	mu       sync.Mutex
+	token    string
+	stored   []string
+	loadErr  error
+	storeErr error
 }
 
 func (t *fakeTokens) Load() (string, error) {
@@ -86,19 +88,20 @@ func (t *fakeTokens) Store(tok string) error {
 	defer t.mu.Unlock()
 	t.stored = append(t.stored, tok)
 	t.token = tok
-	return nil
+	return t.storeErr
 }
 
 type fakeMemory struct {
 	mu       sync.Mutex
 	sections []string
+	writeErr error
 }
 
 func (m *fakeMemory) WriteRecallSection(s string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sections = append(m.sections, s)
-	return nil
+	return m.writeErr
 }
 
 type fakeFallback struct {
@@ -454,5 +457,44 @@ func TestExtractFallbackEntry(t *testing.T) {
 				t.Fatalf("want failure=%v, got entry=%q", c.want, got)
 			}
 		})
+	}
+}
+
+// ---- error-path resilience tests --------------------------------------------
+
+// When WriteRecallSection returns an error the handler must not panic and must
+// still return exit code 0 (best-effort, degrades gracefully).
+func TestInjectRecall_WriteRecallSectionErrorIsResilient(t *testing.T) {
+	d, eng, _, mem, _, _ := newTestDaemon(t, Config{})
+	eng.recallByProj["global"] = []byte(`{"results":[{"id":"g1","summary":"global one","score":0.5,"tags":["a"]}]}`)
+	mem.writeErr = errors.New("disk full")
+
+	resp := d.Handle(context.Background(), Request{Hook: HookSessionStart})
+	if resp.ExitCode != 0 {
+		t.Fatalf("WriteRecallSection failure must not set exit code, got %d", resp.ExitCode)
+	}
+}
+
+// When QuickStore returns an error the Stop handler must not panic and must
+// still return exit code 0 (lifecycle event logged, not fatal).
+func TestHandleStop_QuickStoreErrorIsResilient(t *testing.T) {
+	d, eng, _, _, _, _ := newTestDaemon(t, Config{})
+	eng.storeErr = errors.New("network error")
+
+	resp := d.Handle(context.Background(), Request{Hook: HookStop})
+	if resp.ExitCode != 0 {
+		t.Fatalf("QuickStore failure must not set exit code, got %d", resp.ExitCode)
+	}
+}
+
+// When Tokens.Store returns an error setToken must not panic and the in-memory
+// token must still be updated (best-effort persistence).
+func TestSetToken_StoreErrorIsResilient(t *testing.T) {
+	d, _, tok, _, _, _ := newTestDaemon(t, Config{})
+	tok.storeErr = errors.New("permission denied")
+
+	d.setToken("tok-new") // should not panic
+	if d.currentToken() != "tok-new" {
+		t.Fatalf("in-memory token must be updated even when Store fails, got %q", d.currentToken())
 	}
 }

--- a/internal/hookdaemon/handlers.go
+++ b/internal/hookdaemon/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 )
@@ -78,7 +79,9 @@ func (d *Daemon) injectRecall(ctx context.Context, tok string) {
 	if section == "" {
 		return
 	}
-	_ = d.cfg.Memory.WriteRecallSection(section)
+	if err := d.cfg.Memory.WriteRecallSection(section); err != nil {
+		slog.Warn("hookdaemon: WriteRecallSection failed — recall may be stale", "err", err)
+	}
 }
 
 // handleUserPromptSubmit ports engram-auth-check: a fast per-message auth check
@@ -151,7 +154,9 @@ func (d *Daemon) handleStop(ctx context.Context, _ Request) Response {
 				"tags":       []string{"session-end", "lifecycle"},
 				"importance": 1,
 			})
-			_ = d.cfg.Engram.QuickStore(ctx, tok, body)
+			if err := d.cfg.Engram.QuickStore(ctx, tok, body); err != nil {
+				slog.Warn("hookdaemon: QuickStore session-end marker failed — lifecycle event lost", "err", err)
+			}
 		}
 		summary = d.sessionSummary()
 	}


### PR DESCRIPTION
## Summary

- Replaces three silent `_ = <expr>` error discards in `internal/hookdaemon/` with `slog.Warn` calls so failures surface in logs rather than causing invisible data loss
- `handlers.go:81` (`WriteRecallSection`): disk/permission failures now log a warning instead of silently producing stale/empty recall
- `handlers.go:154` (`QuickStore` session-end): network/auth failures now log a warning instead of silently dropping the lifecycle event
- `daemon.go:140` (`Tokens.Store`): persistence failures now log a warning; in-memory token still updated (best-effort)
- Adds `"log/slog"` import to both files (previously only `server.go` imported it)
- Extends `fakeEngram`, `fakeTokens`, and `fakeMemory` test doubles with error injection fields
- Adds three new resilience tests confirming each error path degrades to exit code 0 with no panic

## Test plan

- [x] `go build ./internal/hookdaemon/...` passes
- [x] `go test ./internal/hookdaemon/... -count=1 -race -timeout 60s` passes (all existing tests + 3 new)
- [x] `TestInjectRecall_WriteRecallSectionErrorIsResilient` — WriteRecallSection error → exit 0, no panic
- [x] `TestHandleStop_QuickStoreErrorIsResilient` — QuickStore error → exit 0, no panic
- [x] `TestSetToken_StoreErrorIsResilient` — Tokens.Store error → no panic, in-memory token updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A