### PR TITLE
fix(security): gate /health topology behind Bearer auth (#1210)

### DIFF
--- a/internal/mcp/health_test.go
+++ b/internal/mcp/health_test.go
@@ -378,3 +378,109 @@ func TestHealth_CircuitStateOpen(t *testing.T) {
 		t.Errorf("circuit_state: expected %q, got %q", "open", resp.CircuitState)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #1210 — /health topology gated behind Bearer auth
+// ---------------------------------------------------------------------------
+
+// TestHealth_UnauthenticatedReturnsMinimalStatus verifies that an unauthenticated
+// caller receives only {"status":"ok"|"degraded"} with no postgres/ollama/circuit
+// fields, while an authenticated caller receives the full topology (#1210).
+func TestHealth_UnauthenticatedReturnsMinimalStatus(t *testing.T) {
+	// Healthy fake Infinity server.
+	ollamaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  0.10,
+						"queue_absolute":  6,
+						"results_pending": 2,
+						"batch_size":      64,
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ollamaServer.Close()
+
+	const testKey = "health-gate-test-key"
+	s := &Server{
+		cfg:       Config{RouterURL: ollamaServer.URL},
+		embedDegraded: &atomic.Bool{},
+		apiKey:    testKey,
+	}
+
+	t.Run("unauthenticated_gets_minimal", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		// No Authorization header.
+		w := httptest.NewRecorder()
+		s.handleHealth(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["status"] != "ok" {
+			t.Errorf("status: expected ok, got %q", body["status"])
+		}
+		if _, hasPostgres := body["postgres"]; hasPostgres {
+			t.Error("unauthenticated response must not include postgres field")
+		}
+		if _, hasOllama := body["ollama"]; hasOllama {
+			t.Error("unauthenticated response must not include ollama field")
+		}
+		if _, hasCircuit := body["circuit_state"]; hasCircuit {
+			t.Error("unauthenticated response must not include circuit_state field")
+		}
+	})
+
+	t.Run("authenticated_gets_full_topology", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Authorization", "Bearer "+testKey)
+		w := httptest.NewRecorder()
+		s.handleHealth(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp healthResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Status != "ok" {
+			t.Errorf("status: expected ok, got %q", resp.Status)
+		}
+		if resp.Postgres != "ok" {
+			t.Errorf("postgres: expected ok, got %q", resp.Postgres)
+		}
+		if resp.Ollama != "ok" {
+			t.Errorf("ollama: expected ok, got %q", resp.Ollama)
+		}
+		if resp.CircuitState != "closed" {
+			t.Errorf("circuit_state: expected closed, got %q", resp.CircuitState)
+		}
+	})
+
+	t.Run("wrong_token_gets_minimal", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Authorization", "Bearer wrong-token")
+		w := httptest.NewRecorder()
+		s.handleHealth(w, req)
+
+		var body map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, hasPostgres := body["postgres"]; hasPostgres {
+			t.Error("wrong-token response must not include postgres field")
+		}
+	})
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -226,6 +226,11 @@ type Server struct {
 	// Tool handlers read these without locking to avoid contention.
 	runtimeCfg *RuntimeConfig
 
+	// apiKey is the Bearer token required to authenticate requests. Set once by
+	// Start() and never modified afterward. Used by handleHealth to gate the
+	// detailed topology response from unauthenticated callers (#1210).
+	apiKey string
+
 	// tofuGranted tracks whether the one-time localhost bootstrap grant for /setup-token
 	// has been issued (#613). Zero value (false) is the correct initial state — no allocation
 	// needed. CompareAndSwap ensures exactly one unauthenticated loopback request succeeds.
@@ -692,6 +697,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	sse := buildSSEServer(s.mcp, advertised)
 
 	s.registerSessionHooks(apiKey)
+	s.apiKey = apiKey
 
 	// setupTokenLimiter enforces 3 calls per 5-minute window per IP (#243).
 	// Uses a fixed budget regardless of RateLimitDisable — /setup-token is security-sensitive.
@@ -1555,6 +1561,22 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		// statusCode stays 200 — server is operational
 	}
 
+	// Gate the detailed topology (postgres/ollama/circuit_state) behind Bearer
+	// authentication so unauthenticated callers (e.g. K8s readiness probes) only
+	// learn the overall ok/degraded status without internal topology details (#1210).
+	// When s.apiKey is empty (test environments that construct Server without a key),
+	// the full response is returned for backward compatibility.
+	if s.apiKey != "" {
+		got := hmac.New(sha256.New, []byte(s.apiKey))
+		got.Write([]byte(r.Header.Get("Authorization")))
+		want := hmac.New(sha256.New, []byte(s.apiKey))
+		want.Write([]byte("Bearer " + s.apiKey))
+		if subtle.ConstantTimeCompare(got.Sum(nil), want.Sum(nil)) != 1 {
+			// Unauthenticated: return minimal status without internal topology.
+			writeJSON(w, statusCode, map[string]string{"status": res.Status})
+			return
+		}
+	}
 	writeJSON(w, statusCode, res)
 }
 


### PR DESCRIPTION
## Summary

- Unauthenticated callers to `/health` now receive only `{"status":"ok"|"degraded"}` — no postgres/embed/circuit-breaker topology details
- Authenticated callers (correct Bearer token) receive the full struct as before
- K8s readiness probes still get the correct 200/503 status code via the unauthenticated path

## Changes

- Added `apiKey string` field to `Server` struct (set once in `Start()`, never modified after)
- `handleHealth` now gates full topology behind constant-time HMAC Bearer check
- When `s.apiKey` is empty (test environments), full response is returned for backward compat

## Tests

Added `TestHealth_UnauthenticatedReturnsMinimalStatus` with three subtests:
- `unauthenticated_gets_minimal`: no auth header → only `status` field
- `authenticated_gets_full_topology`: correct Bearer → full struct with all fields
- `wrong_token_gets_minimal`: wrong Bearer → minimal response

Closes #1210

🤖 Generated with Claude Code