### PR TITLE
fix(defaults): remove founder-specific URL/path defaults (#1207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ make up
 make setup
 ```
 
-Local Docker profiles listen at `http://localhost:8788`. `make setup` targets the default home-network endpoint `https://engram.petersimmons.com`; use the explicit `--url http://127.0.0.1:8788` override when you want Claude Code connected to the local container. Cold start: ~200ms. Idle memory: 18 MB.
+Local Docker profiles listen at `http://localhost:8788`. `make setup` defaults to `http://localhost:8788`; pass `--url` to point at a remote host when you want Claude Code connected to an external server. Cold start: ~200ms. Idle memory: 18 MB.
 
 ### Environment Configuration
 
@@ -116,7 +116,7 @@ All <!-- count:visible-default -->18<!-- /count --> visible tools (+ <!-- count:
 
 ### Setup Target and Config Writes
 
-`make setup` targets the default home-network endpoint `https://engram.petersimmons.com`. For local-only Docker, run the setup tool directly with an explicit local override:
+`make setup` defaults to `http://localhost:8788`; pass `--url` to point at a remote host. For local-only Docker, run the setup tool directly:
 
 ```bash
 go run ./cmd/engram-setup --url http://127.0.0.1:8788

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -82,7 +82,7 @@ Run `--dry-run` to see the effective server, endpoint, redacted token, and exact
 **Usage:**
 
 ```bash
-go run ./cmd/engram-setup              # Configure with default home-network endpoint (`https://engram.petersimmons.com`)
+go run ./cmd/engram-setup              # Configure with default local endpoint (`http://localhost:8788`)
 go run ./cmd/engram-setup --dry-run    # Preview effective server, endpoint, and target files without writing
 go run ./cmd/engram-setup --url http://127.0.0.1:8788  # Local Docker override
 go run ./cmd/engram-setup --port 9000  # Local port shorthand (sets http://127.0.0.1:9000)
@@ -90,7 +90,7 @@ go run ./cmd/engram-setup --port 9000  # Local port shorthand (sets http://127.0
 
 Default behavior:
 
-- Effective default target: `https://engram.petersimmons.com`.
+- Effective default target: `http://localhost:8788`. Pass `--url` to point at a remote host.
 - Explicit local override: `go run ./cmd/engram-setup --url http://127.0.0.1:8788`.
 - Credential source: `/setup-token` first, then validated disk fallbacks from `~/.config/engram/api_key` and `~/projects/engram-go/.env` (`ENGRAM_API_KEY`) when bootstrap auth fails.
 - Config files touched: `~/.claude/mcp_servers.json` is created or updated; `~/.claude.json` is updated only when it already has `mcpServers`.

--- a/cmd/engram-setup/docs_contract_test.go
+++ b/cmd/engram-setup/docs_contract_test.go
@@ -18,7 +18,7 @@ func TestSetupDocsMatchNetworkDefaultContract(t *testing.T) {
 			name: "root README",
 			path: filepath.Join("..", "..", "README.md"),
 			mustContain: []string{
-				"`make setup` targets the default home-network endpoint `https://engram.petersimmons.com`",
+				"`make setup` defaults to `http://localhost:8788`; pass `--url` to point at a remote host",
 				"go run ./cmd/engram-setup --url http://127.0.0.1:8788",
 				"`~/.config/engram/api_key`",
 				"`~/projects/engram-go/.env`",
@@ -33,7 +33,7 @@ func TestSetupDocsMatchNetworkDefaultContract(t *testing.T) {
 			name: "command README",
 			path: filepath.Join("..", "README.md"),
 			mustContain: []string{
-				"Configure with default home-network endpoint (`https://engram.petersimmons.com`)",
+				"Configure with default local endpoint (`http://localhost:8788`)",
 				"go run ./cmd/engram-setup --url http://127.0.0.1:8788",
 				"`~/.config/engram/api_key`",
 				"`~/projects/engram-go/.env`",
@@ -48,7 +48,7 @@ func TestSetupDocsMatchNetworkDefaultContract(t *testing.T) {
 			name: "getting started",
 			path: filepath.Join("..", "..", "docs", "getting-started.md"),
 			mustContain: []string{
-				"`make setup` targets the default home-network endpoint `https://engram.petersimmons.com`",
+				"`make setup` defaults to `http://localhost:8788`; pass `--url` to point at a remote host",
 				"go run ./cmd/engram-setup --url http://127.0.0.1:8788",
 				"`~/.claude/mcp_servers.json`",
 				"`~/.claude.json`",

--- a/cmd/engram-setup/engram_setup_test.go
+++ b/cmd/engram-setup/engram_setup_test.go
@@ -304,7 +304,7 @@ func TestDryRunExplainsEffectiveTargets(t *testing.T) {
 	}
 
 	expected := []string{
-		"server:   https://engram.petersimmons.com",
+		"server:   http://localhost:8788",
 		"endpoint: https://engram.petersimmons.com/mcp",
 		filepath.Join(tmpHome, ".claude", "mcp_servers.json") + " (create or update)",
 		filepath.Join(tmpHome, ".claude.json") + " (update only when the file already has mcpServers; otherwise skip)",
@@ -316,11 +316,11 @@ func TestDryRunExplainsEffectiveTargets(t *testing.T) {
 	}
 }
 
-// TestDefaultEndpointIsK8s verifies that the default server URL points to the
-// remote ingress, not the retired local Docker address (#engram-setup-k8s).
-func TestDefaultEndpointIsK8s(t *testing.T) {
-	if defaultServerURL != "https://engram.petersimmons.com" {
-		t.Errorf("defaultServerURL = %q, want %q", defaultServerURL, "https://engram.petersimmons.com")
+// TestDefaultEndpointIsLocalhost verifies that the default server URL points
+// to localhost:8788 for single-host installs (#1207).
+func TestDefaultEndpointIsLocalhost(t *testing.T) {
+	if defaultServerURL != "http://localhost:8788" {
+		t.Errorf("defaultServerURL = %q, want %q", defaultServerURL, "http://localhost:8788")
 	}
 }
 

--- a/cmd/engram-setup/main.go
+++ b/cmd/engram-setup/main.go
@@ -21,7 +21,7 @@
 //
 // Usage:
 //
-//	go run ./cmd/engram-setup              # configure with defaults (remote default: https://engram.petersimmons.com)
+//	go run ./cmd/engram-setup              # configure with defaults (default: http://localhost:8788)
 //	go run ./cmd/engram-setup --dry-run    # preview changes without writing
 //	go run ./cmd/engram-setup --url http://127.0.0.1:8788  # local Docker override
 //	go run ./cmd/engram-setup --port 9000  # local port override (sets base to http://127.0.0.1:<port>)
@@ -50,9 +50,9 @@ func main() {
 	}
 }
 
-// defaultServerURL is the remote ingress endpoint for the engram MCP server.
-// Override with --url for local Docker development, or --port for a local port.
-const defaultServerURL = "https://engram.petersimmons.com"
+// defaultServerURL is the local MCP server endpoint for single-host installs.
+// Override with --url for a remote host, or --port for a different local port.
+const defaultServerURL = "http://localhost:8788"
 
 func run() error {
 	serverURL := flag.String("url", defaultServerURL, "engram server base URL (overrides --port)")

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -453,8 +453,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		rdfs := flag.NewFlagSet("route-discover", flag.ContinueOnError)
 		rdfs.SetOutput(stderr)
 		var rd routeDiscoverConfig
-		rdfs.StringVar(&rd.FleetURL, "fleet-url", envOr("LME_FLEET_URL", "https://ai-fleet.petersimmons.com"), "AI Flight Controller base URL")
-		rdfs.StringVar(&rd.OllaURL, "olla-url", envOr("LME_OLLA_URL", "https://olla.petersimmons.com"), "Olla base URL")
+		rdfs.StringVar(&rd.FleetURL, "fleet-url", envOr("LME_FLEET_URL", ""), "AI Flight Controller base URL")
+		rdfs.StringVar(&rd.OllaURL, "olla-url", envOr("LME_OLLA_URL", ""), "Olla base URL")
 		rdfs.StringVar(&rd.Model, "model", envOr("LME_ROUTE_MODEL", ""), "required model name; empty selects the first compatible live model")
 		rdfs.StringVar(&rd.Purpose, "purpose", envOr("LME_ROUTE_PURPOSE", "generation"), "route purpose: generation, scoring, or embedding")
 		rdfs.StringVar(&rd.FleetCert, "fleet-cert", envOr("LME_FLEET_CERT", ""), "AI Flight Controller mTLS client certificate")

--- a/cmd/starter/main.go
+++ b/cmd/starter/main.go
@@ -152,7 +152,10 @@ func main() {
 	}
 
 	clientSecret := mustEnv("INFISICAL_CLIENT_SECRET")
-	domain := envOr("INFISICAL_DOMAIN", "https://infisical.petersimmons.com")
+	domain := os.Getenv("INFISICAL_DOMAIN")
+	if domain == "" {
+		fatalf("INFISICAL_DOMAIN is not set — set it to your Infisical instance URL (e.g. https://app.infisical.com or your self-hosted domain)")
+	}
 	projectID := mustEnv("INFISICAL_PROJECT_ID")
 	env := envOr("INFISICAL_ENV", "prod")
 	secretPath := envOr("INFISICAL_SECRET_PATH", "/apps/engram")

--- a/cmd/starter/main_test.go
+++ b/cmd/starter/main_test.go
@@ -175,7 +175,7 @@ func TestIsValidInfisicalDomain(t *testing.T) {
 		valid bool
 	}{
 		// Valid Infisical domains
-		{"default self-hosted", "https://infisical.petersimmons.com", true},
+		{"self-hosted FQDN example", "https://infisical.example.com", true},
 		{"official SaaS", "https://app.infisical.com", true},
 		{"custom subdomain", "https://secrets.internal.company.io", true},
 		{"hyphen in label", "https://my-infisical.example.com", true},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,8 @@ services:
       - path: .env.machine-identity
         required: true
     environment:
-      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@trunas.petersimmons.com:5434/engram?sslmode=disable
+      # Set POSTGRES_HOST to your PostgreSQL host in .env
+      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@${POSTGRES_HOST:?POSTGRES_HOST must be set}:${POSTGRES_PORT:-5432}/engram?sslmode=disable
       # OpenAI-compatible upstream (olla load balancer; LiteLLM container retired 2026-05-05)
       # LITELLM_URL is accepted as a deprecated fallback
       - ENGRAM_ROUTER_URL=${ENGRAM_ROUTER_URL:-${LITELLM_URL:-http://olla:40114/olla/openai}}
@@ -187,7 +188,8 @@ services:
     # Secondary GPU: lower CONCURRENCY_MAX (4) and longer idle poll interval (5s)
     # so W6800 wins the FOR UPDATE SKIP LOCKED race on new work. Override via .env.
     environment:
-      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@trunas.petersimmons.com:5434/engram?sslmode=disable
+      # Set POSTGRES_HOST to your PostgreSQL host in .env
+      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@${POSTGRES_HOST:?POSTGRES_HOST must be set}:${POSTGRES_PORT:-5432}/engram?sslmode=disable
       - ENGRAM_ROUTER_URL=${REEMBED_7900XT_URL:-http://172.23.0.1:8004}
       # LITELLM_URL is accepted as a deprecated fallback
       - LITELLM_API_KEY=${LITELLM_API_KEY:-}
@@ -212,7 +214,8 @@ services:
     # Use REEMBED_W6800_SUB_BATCH to override global ENGRAM_EMBED_SUB_BATCH.
     # Default 32 (not 100) — W6800 OOMs with sub_batch=100 at concurrency≥4.
     environment:
-      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@trunas.petersimmons.com:5434/engram?sslmode=disable
+      # Set POSTGRES_HOST to your PostgreSQL host in .env
+      - DATABASE_URL=postgresql://engram:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@${POSTGRES_HOST:?POSTGRES_HOST must be set}:${POSTGRES_PORT:-5432}/engram?sslmode=disable
       # #668: default placeholder — set REEMBED_W6800_URL in .env to your real W6800 host
       - ENGRAM_ROUTER_URL=${REEMBED_W6800_URL:-http://example.invalid:8005}
       # LITELLM_URL is accepted as a deprecated fallback

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,7 @@ Subsequent local-only starts are fast — the model is cached in the Ollama volu
 
 ## Step 5: Connect Your IDE
 
-For Claude Code, configure the MCP client once the server is healthy. `make setup` targets the default home-network endpoint `https://engram.petersimmons.com`:
+For Claude Code, configure the MCP client once the server is healthy. `make setup` defaults to `http://localhost:8788`; pass `--url` to point at a remote host:
 
 ```bash
 make setup

--- a/hooks/engram/engram-session-recall.sh
+++ b/hooks/engram/engram-session-recall.sh
@@ -13,7 +13,9 @@
 set -euo pipefail
 
 PORT=8788
-MEMORY_FILE="$HOME/.claude/projects/-home-psimmons/memory/MEMORY.md"
+# Claude Code project directory derived from $HOME (e.g. /home/user → -home-user)
+CLAUDE_PROJECT_DIR="$HOME/.claude/projects/-$(echo "$HOME" | sed 's|^/||; s|/|-|g')"
+MEMORY_FILE="$CLAUDE_PROJECT_DIR/memory/MEMORY.md"
 MAX_RESULTS=5
 
 # Read token from mcp_servers.json

--- a/internal/llmclient/olla.go
+++ b/internal/llmclient/olla.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	defaultOllaHost    = "https://olla.petersimmons.com"
 	ollaModelsPath     = "/olla/models"
 	ollaCompletePath   = "/v1/chat/completions"
 	defaultOllaTimeout = 60 * time.Second
@@ -60,13 +59,12 @@ type ollaClient struct {
 }
 
 // NewOllaClient constructs an Olla LLMClient from cfg.
-// cfg.Endpoint is the base host (e.g. "https://olla.petersimmons.com").
-// Defaults to defaultOllaHost when empty.
+// cfg.Endpoint is required — set OLLA_URL or pass --olla-url.
 // cfg.APIKey and cfg.Model are ignored; Olla resolves the model dynamically.
 func NewOllaClient(cfg Config) (LLMClient, error) {
 	host := cfg.Endpoint
 	if host == "" {
-		host = defaultOllaHost
+		return nil, fmt.Errorf("llmclient/olla: Endpoint is required — set OLLA_URL or pass --olla-url")
 	}
 	timeout := cfg.Timeout
 	if timeout == 0 {

--- a/internal/llmclient/olla_test.go
+++ b/internal/llmclient/olla_test.go
@@ -364,3 +364,14 @@ func TestOllaPickModelCachedAfterFirstCall(t *testing.T) {
 		t.Errorf("model discovery endpoint called %d times for %d Complete calls, want 1", discoveryCount, calls)
 	}
 }
+
+// TestNewOllaClient_RequiresEndpoint verifies that NewOllaClient returns a
+// non-nil error when cfg.Endpoint is empty, enforcing fail-fast behavior
+// instead of silently defaulting to a founder-specific host.
+func TestNewOllaClient_RequiresEndpoint(t *testing.T) {
+	_, err := llmclient.NewOllaClient(llmclient.Config{})
+	if err == nil {
+		t.Fatal("NewOllaClient(Config{}) returned nil error, want non-nil error for empty Endpoint")
+	}
+}
+


### PR DESCRIPTION
Closes #1207

## Problem
Several defaults pointed at the founder's private infrastructure. An operator who omits the override silently hits founder infra, gets confusing errors, or misconfigures their deployment.

## Changes
- **`internal/llmclient/olla.go`**: `defaultOllaHost` removed; `NewOllaClient` returns error if `Endpoint` is empty (fail-fast)
- **`cmd/engram-setup/main.go`**: `defaultServerURL` changed from `https://engram.petersimmons.com` to `http://localhost:8788`
- **`cmd/starter/main.go`**: `INFISICAL_DOMAIN` no longer defaults to founder's Infisical; requires explicit env var with clear error
- **`cmd/longmemeval/main.go`**: `--fleet-url` / `--olla-url` default to `""` (already fail-fast in `discoverRoute`)
- **`docker-compose.yml`**: `trunas.petersimmons.com:5434` replaced with `${POSTGRES_HOST:?}:${POSTGRES_PORT:-5432}`
- **`hooks/engram/engram-session-recall.sh`**: `MEMORY_FILE` path derived from `$HOME` dynamically instead of hardcoded `-home-psimmons`

## Tests
- `TestNewOllaClient_RequiresEndpoint`: fails on empty `Endpoint`
- `TestDefaultEndpointIsLocalhost` / `TestDryRunExplainsEffectiveTargets` updated
- `starter/main_test.go` updated for new INFISICAL_DOMAIN behavior