### PR TITLE
fix: unify /setup-token handler — prod and tests share one implementation (#1214)

### DIFF
--- a/internal/mcp/health_test.go
+++ b/internal/mcp/health_test.go
@@ -378,3 +378,109 @@ func TestHealth_CircuitStateOpen(t *testing.T) {
 		t.Errorf("circuit_state: expected %q, got %q", "open", resp.CircuitState)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #1210 — /health topology gated behind Bearer auth
+// ---------------------------------------------------------------------------
+
+// TestHealth_UnauthenticatedReturnsMinimalStatus verifies that an unauthenticated
+// caller receives only {"status":"ok"|"degraded"} with no postgres/ollama/circuit
+// fields, while an authenticated caller receives the full topology (#1210).
+func TestHealth_UnauthenticatedReturnsMinimalStatus(t *testing.T) {
+	// Healthy fake Infinity server.
+	ollamaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"data": []map[string]any{{
+					"id": "BAAI/bge-m3",
+					"stats": map[string]any{
+						"queue_fraction":  0.10,
+						"queue_absolute":  6,
+						"results_pending": 2,
+						"batch_size":      64,
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ollamaServer.Close()
+
+	const testKey = "health-gate-test-key"
+	s := &Server{
+		cfg:       Config{RouterURL: ollamaServer.URL},
+		embedDegraded: &atomic.Bool{},
+		apiKey:    testKey,
+	}
+
+	t.Run("unauthenticated_gets_minimal", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		// No Authorization header.
+		w := httptest.NewRecorder()
+		s.handleHealth(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["status"] != "ok" {
+			t.Errorf("status: expected ok, got %q", body["status"])
+		}
+		if _, hasPostgres := body["postgres"]; hasPostgres {
+			t.Error("unauthenticated response must not include postgres field")
+		}
+		if _, hasOllama := body["ollama"]; hasOllama {
+			t.Error("unauthenticated response must not include ollama field")
+		}
+		if _, hasCircuit := body["circuit_state"]; hasCircuit {
+			t.Error("unauthenticated response must not include circuit_state field")
+		}
+	})
+
+	t.Run("authenticated_gets_full_topology", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Authorization", "Bearer "+testKey)
+		w := httptest.NewRecorder()
+		s.handleHealth(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp healthResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Status != "ok" {
+			t.Errorf("status: expected ok, got %q", resp.Status)
+		}
+		if resp.Postgres != "ok" {
+			t.Errorf("postgres: expected ok, got %q", resp.Postgres)
+		}
+		if resp.Ollama != "ok" {
+			t.Errorf("ollama: expected ok, got %q", resp.Ollama)
+		}
+		if resp.CircuitState != "closed" {
+			t.Errorf("circuit_state: expected closed, got %q", resp.CircuitState)
+		}
+	})
+
+	t.Run("wrong_token_gets_minimal", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Authorization", "Bearer wrong-token")
+		w := httptest.NewRecorder()
+		s.handleHealth(w, req)
+
+		var body map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, hasPostgres := body["postgres"]; hasPostgres {
+			t.Error("wrong-token response must not include postgres field")
+		}
+	})
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -738,50 +738,9 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// the chicken-and-egg problem where engram-setup needs the token before it can authenticate.
 	//
 	// Rate limit: per IP (3 calls per 5-minute window).
-	mux.Handle("/setup-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Rate limit must use the physical TCP peer address, not the proxy-aware IP.
-		// Keying on s.clientIP(r) lets an attacker rotate X-Forwarded-For to mint new
-		// rate-limit buckets and exhaust unlimited /setup-token calls. The physical
-		// r.RemoteAddr cannot be forged via request headers. (#1209)
-		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
-		if !setupLimiter.allowSetupToken(rawPeer) {
-			slog.Warn("setup-token rate limited", "physical_remote", rawPeer)
-			w.Header().Set("Retry-After", "100")
-			http.Error(w, "rate limited", http.StatusTooManyRequests)
-			return
-		}
-
-		// TOFU: first unauthenticated request from loopback only.
-		// CRITICAL: use r.RemoteAddr (raw TCP peer), NOT s.clientIP(r),
-		// to prevent X-Forwarded-For spoofing when ENGRAM_TRUST_PROXY_HEADERS=1.
-		// rawPeer is already extracted above for the rate limit — reuse it here.
-		// Re-grant removed in #1187 — one grant per process lifetime.
-		if isLoopbackIP(rawPeer) && s.tofuGranted.CompareAndSwap(false, true) {
-			s.tofuGrantedAt.Store(time.Now().Unix())
-			slog.Warn("setup-token TOFU: one-time localhost bootstrap grant issued (#613)",
-				"remote_ip", rawPeer)
-			writeJSON(w, http.StatusOK, map[string]string{
-				"token":    apiKey,
-				"endpoint": advertised + "/mcp",
-				"name":     "engram",
-			})
-			return
-		}
-
-		// All other requests: require Bearer authentication (unchanged from #540).
-		s.applyMiddlewareWithRL(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				slog.Warn("setup-token accessed (authenticated)", "remote_ip", s.clientIP(r))
-				writeJSON(w, http.StatusOK, map[string]string{
-					"token":    apiKey,
-					"endpoint": advertised + "/mcp",
-					"name":     "engram",
-				})
-			}),
-			apiKey,
-			setupLimiter,
-		).ServeHTTP(w, r)
-	}))
+	// Route /setup-token through the shared TOFU handler so both production and
+	// tests exercise the same code path (#1214).
+	mux.Handle("/setup-token", s.setupTokenTOFUHandlerWithLimiter(apiKey, advertised, setupLimiter))
 
 	// GET /.well-known/oauth-authorization-server and /.well-known/oauth-protected-resource —
 	// Return 404 to tell Claude Code this server does not use MCP OAuth (spec 2025-03-26).
@@ -1001,13 +960,17 @@ func isLoopbackIP(ip string) bool {
 // First Use) logic. It creates an internal rate limiter whose eviction goroutine
 // is bound to ctx so it stops when the server shuts down (prevents goroutine leak).
 // Use setupTokenTOFUHandlerWithLimiter in tests to inject a pre-exhausted limiter.
-func (s *Server) setupTokenTOFUHandler(ctx context.Context, apiKey string) http.Handler {
-	return s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(ctx))
+// advertised is the base URL prefix for the "endpoint" field (e.g. https://engram.example.com).
+func (s *Server) setupTokenTOFUHandler(ctx context.Context, apiKey, advertised string) http.Handler {
+	return s.setupTokenTOFUHandlerWithLimiter(apiKey, advertised, newRateLimiter(ctx))
 }
 
 // setupTokenTOFUHandlerWithLimiter returns the /setup-token handler using the
-// provided rate limiter. This is the implementation; setupTokenTOFUHandler is
-// the production convenience wrapper.
+// provided rate limiter. This is the canonical implementation shared by the
+// production path (via Start → mux.Handle) and tests (#1214 unification).
+// advertised is the base URL prefix (e.g. "https://engram.example.com"); the
+// full endpoint is advertised+"/mcp". Pass "" in tests that do not care about
+// the advertised URL — the response will contain just "/mcp".
 //
 // Security contract:
 //  1. Rate limit is checked unconditionally — even TOFU requests are throttled.
@@ -1015,7 +978,8 @@ func (s *Server) setupTokenTOFUHandler(ctx context.Context, apiKey string) http.
 //     X-Forwarded-For spoofing when ENGRAM_TRUST_PROXY_HEADERS=1 (#540).
 //  3. Exactly one unauthenticated loopback request is granted via CompareAndSwap.
 //  4. All subsequent requests require Bearer authentication (unchanged from #540).
-func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey string, rl *rateLimiter) http.Handler {
+func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey, advertised string, rl *rateLimiter) http.Handler {
+	endpoint := advertised + "/mcp"
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Rate limit must use the physical TCP peer address, not the proxy-aware IP.
 		// Keying on s.clientIP(r) lets an attacker rotate X-Forwarded-For to mint new
@@ -1040,7 +1004,7 @@ func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey string, rl *rateLimiter
 				"remote_ip", rawPeer)
 			writeJSON(w, http.StatusOK, map[string]string{
 				"token":    apiKey,
-				"endpoint": "/mcp",
+				"endpoint": endpoint,
 				"name":     "engram",
 			})
 			return
@@ -1052,7 +1016,7 @@ func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey string, rl *rateLimiter
 				slog.Warn("setup-token accessed (authenticated)", "remote_ip", s.clientIP(r))
 				writeJSON(w, http.StatusOK, map[string]string{
 					"token":    apiKey,
-					"endpoint": "/mcp",
+					"endpoint": endpoint,
 					"name":     "engram",
 				})
 			}),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -226,6 +226,11 @@ type Server struct {
 	// Tool handlers read these without locking to avoid contention.
 	runtimeCfg *RuntimeConfig
 
+	// apiKey is the Bearer token required to authenticate requests. Set once by
+	// Start() and never modified afterward. Used by handleHealth to gate the
+	// detailed topology response from unauthenticated callers (#1210).
+	apiKey string
+
 	// tofuGranted tracks whether the one-time localhost bootstrap grant for /setup-token
 	// has been issued (#613). Zero value (false) is the correct initial state — no allocation
 	// needed. CompareAndSwap ensures exactly one unauthenticated loopback request succeeds.
@@ -692,6 +697,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	sse := buildSSEServer(s.mcp, advertised)
 
 	s.registerSessionHooks(apiKey)
+	s.apiKey = apiKey
 
 	// setupTokenLimiter enforces 3 calls per 5-minute window per IP (#243).
 	// Uses a fixed budget regardless of RateLimitDisable — /setup-token is security-sensitive.
@@ -1555,6 +1561,22 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		// statusCode stays 200 — server is operational
 	}
 
+	// Gate the detailed topology (postgres/ollama/circuit_state) behind Bearer
+	// authentication so unauthenticated callers (e.g. K8s readiness probes) only
+	// learn the overall ok/degraded status without internal topology details (#1210).
+	// When s.apiKey is empty (test environments that construct Server without a key),
+	// the full response is returned for backward compatibility.
+	if s.apiKey != "" {
+		got := hmac.New(sha256.New, []byte(s.apiKey))
+		got.Write([]byte(r.Header.Get("Authorization")))
+		want := hmac.New(sha256.New, []byte(s.apiKey))
+		want.Write([]byte("Bearer " + s.apiKey))
+		if subtle.ConstantTimeCompare(got.Sum(nil), want.Sum(nil)) != 1 {
+			// Unauthenticated: return minimal status without internal topology.
+			writeJSON(w, statusCode, map[string]string{"status": res.Status})
+			return
+		}
+	}
 	writeJSON(w, statusCode, res)
 }
 

--- a/internal/mcp/setup_token_tofu_test.go
+++ b/internal/mcp/setup_token_tofu_test.go
@@ -30,7 +30,8 @@ func newTOFUTestServer(t *testing.T, apiKey string) *Server {
 
 // buildSetupTokenTOFUHandler returns the TOFU-aware handler for /setup-token.
 func buildSetupTokenTOFUHandler(s *Server, apiKey string) http.Handler {
-	return s.setupTokenTOFUHandler(context.Background(), apiKey)
+	// Tests that use this helper don't check the endpoint URL, so advertised is "".
+	return s.setupTokenTOFUHandler(context.Background(), apiKey, "")
 }
 
 // TestSetupToken_TOFUFirstLocalhostSucceeds verifies that the very first
@@ -173,7 +174,7 @@ func TestSetupToken_XFFBypassBlocked(t *testing.T) {
 		t.Fatal("test setup: expected budget to be exhausted after 3 calls but still has tokens")
 	}
 
-	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, rl)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, "", rl)
 
 	// Attacker is physically at 10.0.0.1 but rotates X-Forwarded-For to "5.5.5.5".
 	// Pre-fix: clientIP(r)="5.5.5.5" → new bucket → not rate-limited → TOFU/auth logic runs.
@@ -202,8 +203,7 @@ func TestSetupToken_TOFURateLimitRunsFirst(t *testing.T) {
 	}
 
 	// Build the handler using the test-only variant that accepts an external limiter.
-	// setupTokenTOFUHandlerWithLimiter doesn't exist yet — COMPILE FAIL (red phase).
-	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, rl)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, "", rl)
 
 	req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
 	req.RemoteAddr = ip + ":55555"
@@ -212,4 +212,51 @@ func TestSetupToken_TOFURateLimitRunsFirst(t *testing.T) {
 
 	require.Equal(t, http.StatusTooManyRequests, w.Code,
 		"exhausted rate limiter must return 429 before TOFU logic runs")
+}
+
+// TestSetupToken_EndpointURLContainsAdvertisedBase verifies that /setup-token
+// returns the full advertised URL in the "endpoint" field, not a bare "/mcp"
+// path. This is the regression test for #1214: the production handler and the
+// test helper now share a single implementation that accepts advertised.
+func TestSetupToken_EndpointURLContainsAdvertisedBase(t *testing.T) {
+	const apiKey = "test-api-key-endpoint-url"
+	const advertised = "https://engram.example.com"
+	s := newTOFUTestServer(t, apiKey)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rl := newRateLimiter(ctx)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, advertised, rl)
+
+	t.Run("tofu_returns_full_endpoint", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+		req.RemoteAddr = "127.0.0.1:54399"
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "TOFU grant must return 200")
+		body := w.Body.String()
+		require.Contains(t, body, advertised+"/mcp",
+			"endpoint must be advertised+/mcp, not a bare /mcp path (#1214)")
+	})
+
+	t.Run("authed_returns_full_endpoint", func(t *testing.T) {
+		// Use a fresh server (tofuGranted was consumed above).
+		s2 := newTOFUTestServer(t, apiKey)
+		s2.tofuGranted.Store(true) // TOFU already consumed
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		defer cancel2()
+		h2 := s2.setupTokenTOFUHandlerWithLimiter(apiKey, advertised, newRateLimiter(ctx2))
+
+		req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+		req.RemoteAddr = "127.0.0.1:54400"
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		w := httptest.NewRecorder()
+		h2.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "authenticated request must return 200")
+		body := w.Body.String()
+		require.Contains(t, body, advertised+"/mcp",
+			"authenticated endpoint must be advertised+/mcp (#1214)")
+	})
 }


### PR DESCRIPTION
Closes #1214

## Problem
Two independent `/setup-token` implementations existed:
1. An inline anonymous handler registered in `Start()` (production path)
2. `setupTokenTOFUHandlerWithLimiter` used only in tests

The inline path returned `advertised+"/mcp"` while the test helper returned the bare `"/mcp"` path. Any change to one would ship unvalidated against the other.

## Fix
Remove the inline handler. Production route now calls `setupTokenTOFUHandlerWithLimiter(apiKey, advertised, setupLimiter)` directly. Added `advertised string` parameter so the response endpoint is the full URL in production and bare `/mcp` in tests (pass `""` to get bare path).

## Tests
- `TestSetupToken_EndpointURLContainsAdvertisedBase`: verifies both TOFU and authenticated paths return the full advertised URL, not a bare path

Note: this PR includes the #1210 health auth gate as its base (both touch `server.go`). Will merge after #1239 lands.