### PR TITLE
fix(setup-token): wire AllowRFC1918SetupToken; correct /mcp endpoint docs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -56,7 +56,7 @@ curl http://localhost:8788/health
 curl http://localhost:8788/ready
 ```
 
-**`GET /setup-token`** — returns the current bearer token, SSE endpoint URL, and server name as JSON. Requires `Authorization: Bearer <ENGRAM_API_KEY>`. Localhost-only (accepts loopback `127.0.0.1` / `::1` and RFC1918 Docker bridge addresses; rejects all others). Used by `make setup` to configure MCP clients without manual copy-paste.
+**`GET /setup-token`** — returns the current bearer token, MCP endpoint path, and server name as JSON. Requires `Authorization: Bearer <ENGRAM_API_KEY>`. Localhost-only (accepts loopback `127.0.0.1` / `::1` and RFC1918 Docker bridge addresses; rejects all others). Used by `make setup` to configure MCP clients without manual copy-paste.
 
 **Request:**
 ```bash
@@ -69,7 +69,7 @@ curl \
 ```json
 {
   "token": "64-char-hex-bearer-token",
-  "endpoint": "http://127.0.0.1:8788/sse",
+  "endpoint": "/mcp",
   "name": "engram"
 }
 ```

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -527,9 +527,11 @@ const (
 )
 
 // NewRestClient constructs a RestClient pointed at baseURL with Bearer auth.
+// The URL is normalised with baseServerURL so callers may pass the server root,
+// an /mcp suffix, or an /sse suffix interchangeably.
 func NewRestClient(baseURL, token string) *RestClient {
 	return &RestClient{
-		baseURL: strings.TrimRight(baseURL, "/"),
+		baseURL: baseServerURL(baseURL),
 		token:   token,
 		http:    &http.Client{Timeout: 30 * time.Second},
 	}

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -520,6 +521,11 @@ type RestClient struct {
 	http    *http.Client
 }
 
+const (
+	restResponsePreviewBytes = 80
+	restBaseURLHint          = "is the base URL the server root rather than /mcp?"
+)
+
 // NewRestClient constructs a RestClient pointed at baseURL with Bearer auth.
 func NewRestClient(baseURL, token string) *RestClient {
 	return &RestClient{
@@ -575,23 +581,24 @@ func (r *RestClient) QuickStore(ctx context.Context, project, content string, ta
 			OK    bool   `json:"ok"`
 			ID    string `json:"id"`
 			Error string `json:"error"`
+			Hint  string `json:"hint"`
 		}
-		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
-		_ = resp.Body.Close()
-		if decodeErr != nil {
-			lastErr = fmt.Errorf("quick-store decode: %w", decodeErr)
-			continue
+		if err := decodeRESTJSONObjectResponse(resp, req.Method, req.URL.String(), &result); err != nil {
+			return "", fmt.Errorf("quick-store decode: %w", err)
 		}
 		if resp.StatusCode == 429 {
-			lastErr = fmt.Errorf("quick-store rate limited (status 429)")
+			lastErr = restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
 			continue
 		}
 		if resp.StatusCode >= 500 {
-			lastErr = fmt.Errorf("quick-store server error (status %d): %s", resp.StatusCode, result.Error)
+			lastErr = restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
 			continue
 		}
+		if resp.StatusCode >= 400 {
+			return "", restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
+		}
 		if !result.OK || result.ID == "" {
-			return "", fmt.Errorf("quick-store failed: %s (status %d)", result.Error, resp.StatusCode)
+			return "", restStatusError("quick-store", resp.StatusCode, result.Error, result.Hint)
 		}
 		return result.ID, nil
 	}
@@ -620,15 +627,59 @@ func (r *RestClient) QuickRecall(ctx context.Context, project, query string, lim
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
-		IDs []string `json:"ids"`
+		IDs   []string `json:"ids"`
+		Error string   `json:"error"`
+		Hint  string   `json:"hint"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := decodeRESTJSONObjectResponse(resp, req.Method, req.URL.String(), &result); err != nil {
 		return nil, fmt.Errorf("quick-recall decode: %w", err)
 	}
+	if resp.StatusCode >= 400 {
+		return nil, restStatusError("quick-recall", resp.StatusCode, result.Error, result.Hint)
+	}
 	return result.IDs, nil
+}
+
+func decodeRESTJSONObjectResponse(resp *http.Response, method, url string, dst any) error {
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("read response body from %s %s: %w", method, url, err)
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	preview := responseBodyPreview(trimmed)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return fmt.Errorf("unexpected non-object response from %s %s (status %d, first %d bytes: %q): %s",
+			method, url, resp.StatusCode, len(preview), preview, restBaseURLHint)
+	}
+	if err := json.Unmarshal(trimmed, dst); err != nil {
+		return fmt.Errorf("unexpected response object from %s %s (status %d, first %d bytes: %q): %v: %s",
+			method, url, resp.StatusCode, len(preview), preview, err, restBaseURLHint)
+	}
+	return nil
+}
+
+func responseBodyPreview(body []byte) string {
+	if len(body) > restResponsePreviewBytes {
+		body = body[:restResponsePreviewBytes]
+	}
+	return string(body)
+}
+
+func restStatusError(op string, status int, msg, hint string) error {
+	if msg == "" {
+		msg = http.StatusText(status)
+	}
+	if msg == "" {
+		msg = "request failed"
+	}
+	if hint != "" {
+		return fmt.Errorf("%s failed: %s (status %d): %s", op, msg, status, hint)
+	}
+	return fmt.Errorf("%s failed: %s (status %d)", op, msg, status)
 }
 
 // SessionContent concatenates all turns of a session into a single string,

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -64,6 +64,28 @@ func TestRestClient_QuickStore_HappyPath(t *testing.T) {
 	}
 }
 
+// TestNewRestClient_URLNormalization verifies that NewRestClient strips /mcp and /sse
+// suffixes so callers can pass any of the three common URL forms interchangeably.
+func TestNewRestClient_URLNormalization(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"http://host:8788", "http://host:8788"},
+		{"http://host:8788/", "http://host:8788"},
+		{"http://host:8788/mcp", "http://host:8788"},
+		{"http://host:8788/mcp/", "http://host:8788"},
+		{"http://host:8788/sse", "http://host:8788"},
+		{"http://host:8788/sse/", "http://host:8788"},
+	}
+	for _, tc := range cases {
+		rc := longmemeval.NewRestClient(tc.input, "tok")
+		if got := rc.BaseURL(); got != tc.want {
+			t.Errorf("NewRestClient(%q).BaseURL() = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
 // TestRestClient_QuickStore_RateLimitRetry verifies that 429 triggers retry
 // and that a subsequent success is returned.
 func TestRestClient_QuickStore_RateLimitRetry(t *testing.T) {
@@ -126,7 +148,7 @@ func TestRestClient_QuickStore_ServerError(t *testing.T) {
 // /mcp hint instead of the raw Go struct unmarshal error (#1192).
 func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/mcp/quick-store" {
+		if r.URL.Path != "/quick-store" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -135,7 +157,7 @@ func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	rc := longmemeval.NewRestClient(srv.URL, "")
 	_, err := rc.QuickStore(context.Background(), "proj-1", "content here", []string{"tag1"}, nil)
 	if err == nil {
 		t.Fatal("QuickStore error = nil, want non-object response error")
@@ -144,7 +166,7 @@ func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
 	if !strings.Contains(msg, "unexpected non-object response from POST") {
 		t.Fatalf("error = %q, want non-object response framing", msg)
 	}
-	if !strings.Contains(msg, "/mcp/quick-store") {
+	if !strings.Contains(msg, "/quick-store") {
 		t.Fatalf("error = %q, want called URL", msg)
 	}
 	if !strings.Contains(msg, "status 200") {
@@ -183,7 +205,7 @@ func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 // scalar or other non-object body (#1192).
 func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/mcp/quick-recall" {
+		if r.URL.Path != "/quick-recall" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -192,7 +214,7 @@ func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	rc := longmemeval.NewRestClient(srv.URL, "")
 	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
 	if err == nil {
 		t.Fatal("QuickRecall error = nil, want non-object response error")
@@ -201,7 +223,7 @@ func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 	if !strings.Contains(msg, "unexpected non-object response from POST") {
 		t.Fatalf("error = %q, want non-object response framing", msg)
 	}
-	if !strings.Contains(msg, "/mcp/quick-recall") {
+	if !strings.Contains(msg, "/quick-recall") {
 		t.Fatalf("error = %q, want called URL", msg)
 	}
 	if !strings.Contains(msg, "status 404") {
@@ -219,7 +241,7 @@ func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
 // JSON error response does not decode as a false success with empty IDs (#1192).
 func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/mcp/quick-recall" {
+		if r.URL.Path != "/quick-recall" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -231,7 +253,7 @@ func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	rc := longmemeval.NewRestClient(srv.URL, "")
 	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
 	if err == nil {
 		t.Fatal("QuickRecall error = nil, want structured 404 error")

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -67,22 +67,51 @@ func TestRestClient_QuickStore_HappyPath(t *testing.T) {
 // TestNewRestClient_URLNormalization verifies that NewRestClient strips /mcp and /sse
 // suffixes so callers can pass any of the three common URL forms interchangeably.
 func TestNewRestClient_URLNormalization(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
-		input string
-		want  string
+		name string
+		path string
 	}{
-		{"http://host:8788", "http://host:8788"},
-		{"http://host:8788/", "http://host:8788"},
-		{"http://host:8788/mcp", "http://host:8788"},
-		{"http://host:8788/mcp/", "http://host:8788"},
-		{"http://host:8788/sse", "http://host:8788"},
-		{"http://host:8788/sse/", "http://host:8788"},
+		{name: "bare base URL", path: ""},
+		{name: "trailing slash", path: "/"},
+		{name: "mcp suffix", path: "/mcp"},
+		{name: "sse suffix", path: "/sse"},
 	}
+
 	for _, tc := range cases {
-		rc := longmemeval.NewRestClient(tc.input, "tok")
-		if got := rc.BaseURL(); got != tc.want {
-			t.Errorf("NewRestClient(%q).BaseURL() = %q, want %q", tc.input, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			var sawQuickStore bool
+			mux := http.NewServeMux()
+			mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`1`))
+			})
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/quick-store" {
+					sawQuickStore = true
+					_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "mem-normalized"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`1`))
+			})
+
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			rc := longmemeval.NewRestClient(srv.URL+tc.path, "")
+			id, err := rc.QuickStore(context.Background(), "proj", "content", nil, nil)
+			if err != nil {
+				t.Fatalf("QuickStore(%q): %v", tc.path, err)
+			}
+			if !sawQuickStore {
+				t.Fatalf("QuickStore(%q) did not hit /quick-store", tc.path)
+			}
+			if id != "mem-normalized" {
+				t.Fatalf("id = %q, want mem-normalized", id)
+			}
+		})
 	}
 }
 

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -121,6 +121,43 @@ func TestRestClient_QuickStore_ServerError(t *testing.T) {
 	}
 }
 
+// TestRestClient_QuickStore_NonObjectResponseError verifies that decode
+// failures surface the called URL, HTTP status, body prefix, and the root-vs-
+// /mcp hint instead of the raw Go struct unmarshal error (#1192).
+func TestRestClient_QuickStore_NonObjectResponseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/quick-store" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("42"))
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	_, err := rc.QuickStore(context.Background(), "proj-1", "content here", []string{"tag1"}, nil)
+	if err == nil {
+		t.Fatal("QuickStore error = nil, want non-object response error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unexpected non-object response from POST") {
+		t.Fatalf("error = %q, want non-object response framing", msg)
+	}
+	if !strings.Contains(msg, "/mcp/quick-store") {
+		t.Fatalf("error = %q, want called URL", msg)
+	}
+	if !strings.Contains(msg, "status 200") {
+		t.Fatalf("error = %q, want status code", msg)
+	}
+	if !strings.Contains(msg, "\"42\"") {
+		t.Fatalf("error = %q, want body prefix", msg)
+	}
+	if !strings.Contains(msg, "server root rather than /mcp") {
+		t.Fatalf("error = %q, want base URL hint", msg)
+	}
+}
+
 // TestRestClient_QuickRecall_HappyPath verifies QuickRecall returns IDs.
 func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -138,6 +175,73 @@ func TestRestClient_QuickRecall_HappyPath(t *testing.T) {
 	}
 	if len(ids) != 2 || ids[0] != "id-1" {
 		t.Errorf("ids = %v, want [id-1, id-2]", ids)
+	}
+}
+
+// TestRestClient_QuickRecall_NonObjectResponseError verifies QuickRecall uses
+// the same wrapped decode error shape as QuickStore when the server returns a
+// scalar or other non-object body (#1192).
+func TestRestClient_QuickRecall_NonObjectResponseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/quick-recall" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("7"))
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
+	if err == nil {
+		t.Fatal("QuickRecall error = nil, want non-object response error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unexpected non-object response from POST") {
+		t.Fatalf("error = %q, want non-object response framing", msg)
+	}
+	if !strings.Contains(msg, "/mcp/quick-recall") {
+		t.Fatalf("error = %q, want called URL", msg)
+	}
+	if !strings.Contains(msg, "status 404") {
+		t.Fatalf("error = %q, want status code", msg)
+	}
+	if !strings.Contains(msg, "\"7\"") {
+		t.Fatalf("error = %q, want body prefix", msg)
+	}
+	if !strings.Contains(msg, "server root rather than /mcp") {
+		t.Fatalf("error = %q, want base URL hint", msg)
+	}
+}
+
+// TestRestClient_QuickRecall_ObjectErrorResponse verifies that a structured
+// JSON error response does not decode as a false success with empty IDs (#1192).
+func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/quick-recall" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "not found",
+			"hint":  "REST endpoints (/quick-store,/atoms,/quick-recall) are at the server root, not under /mcp",
+		})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL+"/mcp", "")
+	_, err := rc.QuickRecall(context.Background(), "proj", "query", 5)
+	if err == nil {
+		t.Fatal("QuickRecall error = nil, want structured 404 error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "quick-recall failed: not found (status 404)") {
+		t.Fatalf("error = %q, want status error framing", msg)
+	}
+	if !strings.Contains(msg, "REST endpoints (/quick-store,/atoms,/quick-recall) are at the server root, not under /mcp") {
+		t.Fatalf("error = %q, want server hint", msg)
 	}
 }
 

--- a/internal/longmemeval/export_test.go
+++ b/internal/longmemeval/export_test.go
@@ -6,5 +6,3 @@ package longmemeval
 // accepts an injected TextGenerator instead of hard-coding GenerateHaiku.
 // Used by tests to inject a fake LLM without spawning a real claude process.
 var GenerateParaphrasesWith = generateParaphrasesWith
-// RestClientBaseURL exposes the normalised base URL of a RestClient for tests.
-func (r *RestClient) BaseURL() string { return r.baseURL }

--- a/internal/longmemeval/export_test.go
+++ b/internal/longmemeval/export_test.go
@@ -6,3 +6,5 @@ package longmemeval
 // accepts an injected TextGenerator instead of hard-coding GenerateHaiku.
 // Used by tests to inject a fake LLM without spawning a real claude process.
 var GenerateParaphrasesWith = generateParaphrasesWith
+// RestClientBaseURL exposes the normalised base URL of a RestClient for tests.
+func (r *RestClient) BaseURL() string { return r.baseURL }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -39,6 +39,8 @@ const (
 	phaseWarm     int32 = 2
 )
 
+const restEndpointRootHint = "REST endpoints (/quick-store,/atoms,/quick-recall) are at the server root, not under /mcp"
+
 // Exported aliases for use by main.go and other external callers that need to
 // advance the server phase without accessing unexported fields directly.
 const (
@@ -813,6 +815,7 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// Configure in mcp_servers.json: type:"http", url:"http://127.0.0.1:8788/mcp"
 	streamable := buildStreamableHTTPServer(s.mcp)
 	mux.Handle("/mcp", s.applyMiddleware(streamable, apiKey, rl))
+	mux.Handle("/mcp/", s.authenticatedNotFoundHandler(apiKey, rl))
 
 	// /quick-store — sessionless REST endpoint for hook scripts and CLI callers
 	// that cannot establish an SSE session (e.g. PreCompact hooks).
@@ -827,8 +830,10 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	// POST {"project":...,"atom_type":...,"top_k":N} → returns {"atoms":[...]} for --atom-mode recall.
 	mux.Handle("/atoms", s.applyMiddleware(http.HandlerFunc(s.handleAtoms), apiKey, rl))
 
-	// All other authenticated routes (including /sse) go through the standard middleware.
-	mux.Handle("/", s.applyMiddleware(sse, apiKey, rl))
+	// All other authenticated routes are either the legacy SSE endpoint or a
+	// structured JSON 404. Unknown paths must not fall through to the SSE
+	// transport, which can emit opaque non-object bodies (#1192).
+	mux.Handle("/", s.authenticatedFallbackHandler(sse, apiKey, rl))
 
 	// Background sweeper closes crash-orphaned open episodes on an hourly interval.
 	go s.sweepStaleEpisodes(ctx)
@@ -872,6 +877,29 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 	case err := <-errCh:
 		return err
 	}
+}
+
+func writeRESTEndpointNotFound(w http.ResponseWriter) {
+	writeJSON(w, http.StatusNotFound, map[string]string{
+		"error": "not found",
+		"hint":  restEndpointRootHint,
+	})
+}
+
+func (s *Server) authenticatedNotFoundHandler(apiKey string, rl *rateLimiter) http.Handler {
+	return s.applyMiddlewareWithRL(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeRESTEndpointNotFound(w)
+	}), apiKey, rl)
+}
+
+func (s *Server) authenticatedFallbackHandler(sse http.Handler, apiKey string, rl *rateLimiter) http.Handler {
+	return s.applyMiddlewareWithRL(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/sse" {
+			sse.ServeHTTP(w, r)
+			return
+		}
+		writeRESTEndpointNotFound(w)
+	}), apiKey, rl)
 }
 
 // applyMiddleware chains per-IP rate limiting (#140) and Bearer auth onto next.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -742,25 +742,31 @@ func (s *Server) Start(ctx context.Context, host string, port int, apiKey string
 			return
 		}
 
-		// TOFU: first unauthenticated request from loopback only.
+		// TOFU: first unauthenticated request from loopback (always) or RFC1918
+		// (when ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1) is granted exactly once.
 		// CRITICAL: use r.RemoteAddr (raw TCP peer), NOT s.clientIP(r),
 		// to prevent X-Forwarded-For spoofing when ENGRAM_TRUST_PROXY_HEADERS=1.
 		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
+		isTOFUEligible := isLoopbackIP(rawPeer) || (s.cfg.AllowRFC1918SetupToken && isRFC1918IP(rawPeer))
 		// #707: allow re-grant after 60s. If the prior grant succeeded but
 		// the client crashed/raced before receiving the response, the operator
 		// would otherwise have to restart the process. The time window keeps
 		// the "exactly once during bootstrap" semantics within a session.
-		if isLoopbackIP(rawPeer) {
+		if isTOFUEligible {
 			if s.tofuGranted.Load() {
 				if grantedAt := s.tofuGrantedAt.Load(); grantedAt != 0 && time.Now().Unix()-grantedAt > 60 {
 					s.tofuGranted.Store(false)
 				}
 			}
 		}
-		if isLoopbackIP(rawPeer) && s.tofuGranted.CompareAndSwap(false, true) {
+		if isTOFUEligible && s.tofuGranted.CompareAndSwap(false, true) {
 			s.tofuGrantedAt.Store(time.Now().Unix())
-			slog.Warn("setup-token TOFU: one-time localhost bootstrap grant issued (#613)",
-				"remote_ip", rawPeer)
+			via := "localhost"
+			if isRFC1918IP(rawPeer) && !isLoopbackIP(rawPeer) {
+				via = "RFC1918"
+			}
+			slog.Warn("setup-token TOFU: one-time bootstrap grant issued (#613, #1206)",
+				"remote_ip", rawPeer, "via", via)
 			writeJSON(w, http.StatusOK, map[string]string{
 				"token":    apiKey,
 				"endpoint": advertised + "/mcp",
@@ -992,6 +998,25 @@ func isLoopbackIP(ip string) bool {
 	return parsed != nil && parsed.IsLoopback()
 }
 
+// isRFC1918IP returns true when ip falls within any of the private address
+// ranges defined by RFC1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16.
+// IPv6 ULA addresses (fc00::/7) are intentionally excluded — Docker bridge
+// networks use IPv4 RFC1918, so the check is scoped to IPv4 only.
+func isRFC1918IP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	privateRanges := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+	for _, cidr := range privateRanges {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
 // setupTokenTOFUHandler returns the /setup-token handler with TOFU (Trust On
 // First Use) logic. It creates an internal rate limiter whose eviction goroutine
 // is bound to ctx so it stops when the server shuts down (prevents goroutine leak).
@@ -1021,25 +1046,31 @@ func (s *Server) setupTokenTOFUHandlerWithLimiter(apiKey string, rl *rateLimiter
 			return
 		}
 
-		// TOFU: first unauthenticated request from loopback only.
+		// TOFU: first unauthenticated request from loopback (always) or RFC1918
+		// (when ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1) is granted exactly once.
 		// CRITICAL: use r.RemoteAddr (raw TCP peer), NOT s.clientIP(r),
 		// to prevent X-Forwarded-For spoofing when ENGRAM_TRUST_PROXY_HEADERS=1.
 		rawPeer, _, _ := net.SplitHostPort(r.RemoteAddr)
+		isTOFUEligible := isLoopbackIP(rawPeer) || (s.cfg.AllowRFC1918SetupToken && isRFC1918IP(rawPeer))
 		// #707: allow re-grant after 60s. If the prior grant succeeded but
 		// the client crashed/raced before receiving the response, the operator
 		// would otherwise have to restart the process. The time window keeps
 		// the "exactly once during bootstrap" semantics within a session.
-		if isLoopbackIP(rawPeer) {
+		if isTOFUEligible {
 			if s.tofuGranted.Load() {
 				if grantedAt := s.tofuGrantedAt.Load(); grantedAt != 0 && time.Now().Unix()-grantedAt > 60 {
 					s.tofuGranted.Store(false)
 				}
 			}
 		}
-		if isLoopbackIP(rawPeer) && s.tofuGranted.CompareAndSwap(false, true) {
+		if isTOFUEligible && s.tofuGranted.CompareAndSwap(false, true) {
 			s.tofuGrantedAt.Store(time.Now().Unix())
-			slog.Warn("setup-token TOFU: one-time localhost bootstrap grant issued (#613)",
-				"remote_ip", rawPeer)
+			via := "localhost"
+			if isRFC1918IP(rawPeer) && !isLoopbackIP(rawPeer) {
+				via = "RFC1918"
+			}
+			slog.Warn("setup-token TOFU: one-time bootstrap grant issued (#613, #1206)",
+				"remote_ip", rawPeer, "via", via)
 			writeJSON(w, http.StatusOK, map[string]string{
 				"token":    apiKey,
 				"endpoint": "/mcp",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -172,6 +173,94 @@ func TestQuickStoreHandler_InvalidJSON_JSONErrorBody(t *testing.T) {
 	// Must not leak internal Go error messages like "invalid character".
 	if strings.Contains(body, "invalid character") || strings.Contains(body, "unexpected end") {
 		t.Fatalf("response body leaks raw Go error: %q", body)
+	}
+}
+
+// TestAuthenticatedWrongRESTPath_JSONNotFound verifies that authenticated
+// wrong-path REST requests under /mcp return a structured JSON 404 instead of
+// falling through to the legacy SSE catch-all (#1192).
+func TestAuthenticatedWrongRESTPath_JSONNotFound(t *testing.T) {
+	s := &Server{}
+	apiKey := "test-secret-key-123"
+	rl := newRateLimiter(context.Background())
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", s.applyMiddlewareWithRL(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}), apiKey, rl))
+	mux.Handle("/mcp/", s.authenticatedNotFoundHandler(apiKey, rl))
+	mux.Handle("/", s.authenticatedFallbackHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("42"))
+		}),
+		apiKey,
+		rl,
+	))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/quick-store", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for wrong-path REST request, got %d body=%q", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected JSON content-type, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal JSON body: %v", err)
+	}
+	if body["error"] != "not found" {
+		t.Fatalf("error = %q, want %q", body["error"], "not found")
+	}
+	if !strings.Contains(body["hint"], "/quick-store") || !strings.Contains(body["hint"], "not under /mcp") {
+		t.Fatalf("hint = %q, want REST root-path guidance", body["hint"])
+	}
+}
+
+// TestAuthenticatedUnknownPath_JSONNotFound verifies that unrouted
+// authenticated paths also return structured JSON 404s instead of whatever the
+// catch-all transport handler emits (#1192).
+func TestAuthenticatedUnknownPath_JSONNotFound(t *testing.T) {
+	s := &Server{}
+	apiKey := "test-secret-key-123"
+	rl := newRateLimiter(context.Background())
+
+	mux := http.NewServeMux()
+	mux.Handle("/", s.authenticatedFallbackHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("42"))
+		}),
+		apiKey,
+		rl,
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/definitely-not-a-route", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown path, got %d body=%q", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected JSON content-type, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal JSON body: %v", err)
+	}
+	if body["error"] != "not found" {
+		t.Fatalf("error = %q, want %q", body["error"], "not found")
+	}
+	if !strings.Contains(body["hint"], "/quick-store") || !strings.Contains(body["hint"], "not under /mcp") {
+		t.Fatalf("hint = %q, want REST root-path guidance", body["hint"])
 	}
 }
 

--- a/internal/mcp/setup_token_tofu_test.go
+++ b/internal/mcp/setup_token_tofu_test.go
@@ -6,6 +6,11 @@ package mcp
 // that engram-session-end.sh and fresh installations can self-configure without
 // a chicken-and-egg key problem (#613). All subsequent requests require Bearer
 // authentication (unchanged from #540).
+//
+// RFC1918 extension (#1206): when ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1, the
+// one-time TOFU grant is also issued to Docker bridge addresses (172.x RFC1918).
+// Without this flag, RFC1918 addresses are rejected identically to any other
+// non-loopback address.
 
 import (
 	"context"
@@ -175,4 +180,138 @@ func TestSetupToken_TOFURateLimitRunsFirst(t *testing.T) {
 
 	require.Equal(t, http.StatusTooManyRequests, w.Code,
 		"exhausted rate limiter must return 429 before TOFU logic runs")
+}
+
+// ── RFC1918 extension tests (#1206) ────────────────────────────────────────
+
+// newTOFUTestServerWithRFC1918 returns a Server with AllowRFC1918SetupToken set.
+func newTOFUTestServerWithRFC1918(t *testing.T, apiKey string, allow bool) *Server {
+	t.Helper()
+	pool := newTestNoopPool(t)
+	cfg := testConfig()
+	cfg.AllowRFC1918SetupToken = allow
+	s := NewServer(pool, cfg)
+	s.tofuGranted.Store(false)
+	return s
+}
+
+// TestSetupToken_RFC1918FlagOffRejectsDockerBridgeIP verifies that an
+// unauthenticated request from a Docker bridge IP (172.x, RFC1918) is rejected
+// when ENGRAM_SETUP_TOKEN_ALLOW_RFC1918 is false (the default).
+// This is the regression guard: before #1206 the flag existed but was never
+// read, so even "flag OFF" was silently granted.
+func TestSetupToken_RFC1918FlagOffRejectsDockerBridgeIP(t *testing.T) {
+	const apiKey = "test-api-key-rfc1918-off"
+	s := newTOFUTestServerWithRFC1918(t, apiKey, false /* flag OFF */)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(context.Background()))
+
+	req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+	req.RemoteAddr = "172.23.0.1:48000" // typical Docker bridge IP
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code,
+		"RFC1918 address must be rejected when AllowRFC1918SetupToken=false")
+	require.False(t, s.tofuGranted.Load(),
+		"tofuGranted must remain false after RFC1918 rejection with flag OFF")
+}
+
+// TestSetupToken_RFC1918FlagOnGrantsDockerBridgeIP verifies that an
+// unauthenticated request from a Docker bridge IP is granted the one-time TOFU
+// token when ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1. This is the main fix for #1206:
+// Docker TOFU bootstrap was silently broken because 172.x is RFC1918, not loopback.
+func TestSetupToken_RFC1918FlagOnGrantsDockerBridgeIP(t *testing.T) {
+	const apiKey = "test-api-key-rfc1918-on"
+	s := newTOFUTestServerWithRFC1918(t, apiKey, true /* flag ON */)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(context.Background()))
+
+	require.False(t, s.tofuGranted.Load(), "tofuGranted must start as false")
+
+	req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+	req.RemoteAddr = "172.23.0.1:48000" // typical Docker bridge IP
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"RFC1918 address must receive the one-time TOFU grant when AllowRFC1918SetupToken=true")
+	require.Contains(t, w.Body.String(), apiKey,
+		"response body must contain the API key on RFC1918 TOFU grant")
+	require.Contains(t, w.Body.String(), "/mcp",
+		"response body must advertise /mcp endpoint (not /sse)")
+	require.True(t, s.tofuGranted.Load(),
+		"tofuGranted must be true after RFC1918 TOFU grant")
+}
+
+// TestSetupToken_RFC1918FlagOnSecondRequestFails verifies that the RFC1918 TOFU
+// grant is still one-time-only: a second unauthenticated RFC1918 request after
+// the grant is consumed must return 401.
+func TestSetupToken_RFC1918FlagOnSecondRequestFails(t *testing.T) {
+	const apiKey = "test-api-key-rfc1918-second"
+	s := newTOFUTestServerWithRFC1918(t, apiKey, true)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(context.Background()))
+
+	// First RFC1918 request — TOFU grant.
+	req1 := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+	req1.RemoteAddr = "172.23.0.1:48001"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code, "first RFC1918 TOFU request must succeed")
+
+	// Second unauthenticated RFC1918 request — must be rejected.
+	req2 := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+	req2.RemoteAddr = "172.23.0.2:48002"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusUnauthorized, w2.Code,
+		"second unauthenticated RFC1918 request must return 401 (TOFU already consumed)")
+}
+
+// TestSetupToken_LoopbackResponseContainsMCPEndpoint verifies that the loopback
+// TOFU grant response advertises /mcp (not /sse) in the endpoint field (#1206).
+func TestSetupToken_LoopbackResponseContainsMCPEndpoint(t *testing.T) {
+	const apiKey = "test-api-key-endpoint-check"
+	s := newTOFUTestServer(t, apiKey)
+	handler := s.setupTokenTOFUHandlerWithLimiter(apiKey, newRateLimiter(context.Background()))
+
+	req := httptest.NewRequest(http.MethodGet, "/setup-token", nil)
+	req.RemoteAddr = "127.0.0.1:60001"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "loopback TOFU must return 200")
+	body := w.Body.String()
+	require.Contains(t, body, "/mcp",
+		"setup-token response must contain /mcp in endpoint field")
+	require.NotContains(t, body, `"endpoint":"/sse"`,
+		"setup-token response must not advertise /sse as the endpoint")
+}
+
+// TestSetupToken_RFC1918AllSubnets verifies isRFC1918IP across all three
+// private address ranges and confirms a public IP is not matched.
+func TestSetupToken_RFC1918AllSubnets(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+		desc string
+	}{
+		{"10.0.0.1", true, "10.x class-A private"},
+		{"10.255.255.255", true, "10.x upper bound"},
+		{"172.16.0.1", true, "172.16.x lower bound"},
+		{"172.23.0.1", true, "172.23.x Docker bridge typical"},
+		{"172.31.255.255", true, "172.31.x upper bound"},
+		{"172.15.0.1", false, "172.15.x just below 172.16/12"},
+		{"172.32.0.1", false, "172.32.x just above 172.31/12"},
+		{"192.168.0.1", true, "192.168.x private"},
+		{"192.168.255.255", true, "192.168.x upper bound"},
+		{"8.8.8.8", false, "public IP"},
+		{"127.0.0.1", false, "loopback is not RFC1918"},
+		{"::1", false, "IPv6 loopback is not RFC1918"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			got := isRFC1918IP(tc.ip)
+			require.Equal(t, tc.want, got, "isRFC1918IP(%q): %s", tc.ip, tc.desc)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- `ENGRAM_SETUP_TOKEN_ALLOW_RFC1918=1` was dead code: wired into Config but never read by the TOFU handler. Docker TOFU bootstrap was silently broken.
- Adds `isRFC1918IP` helper and extends the TOFU grant condition to include RFC1918 addresses when the flag is set.
- Adds regression tests: RFC1918-flag-off rejects unauthenticated RFC1918, RFC1918-flag-on grants TOFU, loopback still works.
- Fixes doc/README/env references: /setup-token response advertises /mcp, not /sse.

Fixes #1206