### PR TITLE
deploy: capture live engram-go manifests into source

### DIFF
--- a/deploy/engram-embed-model.yaml
+++ b/deploy/engram-embed-model.yaml
@@ -1,0 +1,13 @@
+# engram-embed-model.yaml — ConfigMap for the embedding model name
+#
+# Captured from live cluster: 2026-06-27
+# BAAI/bge-m3 is a Hugging Face model identifier — not a secret, safe to commit.
+# The slash in the model name is intentional and verbatim from the live object.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: engram-embed-model
+  namespace: engram
+data:
+  ENGRAM_EMBED_MODEL: BAAI/bge-m3

--- a/deploy/engram-go-service.yaml
+++ b/deploy/engram-go-service.yaml
@@ -1,0 +1,18 @@
+# engram-go-service.yaml — Service manifest for the engram-go service
+#
+# Captured from live cluster: 2026-06-27
+# clusterIP is intentionally omitted — it is cluster-assigned and must not be
+# committed to source to avoid conflicts when applying to a different cluster.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: engram-go
+  namespace: engram
+spec:
+  ports:
+    - port: 8788
+      targetPort: 8788
+  selector:
+    app: engram-go
+  type: ClusterIP

--- a/deploy/engram-go.yaml
+++ b/deploy/engram-go.yaml
@@ -1,0 +1,141 @@
+# engram-go.yaml — Deployment manifest for the engram-go service
+#
+# Captured from live cluster: 2026-06-27
+# Image pinned to digest: main-ab5aff4@sha256:95778bfcd2a26d7291c02399b7fdeb4de5f5f81ad17f9d5aa0c9a47188f7797c
+#
+# The restartedAt annotation on the pod template is faithfully reproduced from
+# the live cluster for zero kubectl diff. It will diverge after future rollout
+# restarts — that is expected behavior and does not require updating this file
+# unless a permanent state change is being recorded.
+#
+# FOLLOW-UP NOTE (do not fix here): container securityContext is missing
+# allowPrivilegeEscalation:false, capabilities.drop:[ALL], and seccompProfile.
+# These are pre-existing PodSecurity warnings present on the live object and are
+# tracked for a separate hardening PR. Do not add them here — this manifest
+# captures live state verbatim; hardening is a separate intentional change.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engram-go
+  namespace: engram
+  labels:
+    app: engram-go
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: engram-go
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-06-19T08:45:20-04:00"
+      labels:
+        app: engram-go
+    spec:
+      containers:
+        - name: engram-go
+          image: registry.petersimmons.com/engram/engram-go:main-ab5aff4@sha256:95778bfcd2a26d7291c02399b7fdeb4de5f5f81ad17f9d5aa0c9a47188f7797c
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: engram-app-secret
+                  key: DATABASE_URL
+            - name: ENGRAM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: engram-app-secret
+                  key: ENGRAM_API_KEY
+            - name: ENGRAM_ROUTER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: engram-app-secret
+                  key: ENGRAM_ROUTER_URL
+            - name: ENGRAM_EMBED_URL
+              value: http://olla.ai-fleet.svc.cluster.local:80/olla/openai
+            - name: ENGRAM_EMBED_MODEL
+              valueFrom:
+                configMapKeyRef:
+                  name: engram-embed-model
+                  key: ENGRAM_EMBED_MODEL
+            - name: ENGRAM_EMBED_DIMENSIONS
+              value: "1024"
+            - name: ENGRAM_HOST
+              value: 0.0.0.0
+            - name: ENGRAM_BASE_URL
+              value: https://engram.petersimmons.com
+            - name: ENGRAM_SUMMARIZE_MODEL
+              value: qwen3-14b-awq
+            - name: ENGRAM_SUMMARIZE_ENABLED
+              value: "false"
+            - name: ENGRAM_REEMBED_BATCH_SIZE
+              value: "0"
+            - name: ENGRAM_SESSION_DIVERSITY_N
+              value: "0"
+            - name: ENGRAM_PREWARM_PROJECTS
+              value: "0"
+            - name: ENGRAM_RATE_LIMIT_RPS
+              value: "500"
+            - name: ENGRAM_RATE_LIMIT_BURST
+              value: "2000"
+            - name: ENGRAM_EMBED_RECALL_TIMEOUT_MS
+              value: "1500"
+          ports:
+            - containerPort: 8788
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8788
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8788
+              scheme: HTTP
+            failureThreshold: 12
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8788
+              scheme: HTTP
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary

- Closes the manifest-first gap: the engram-go Deployment was previously patched directly via `kubectl patch` with no corresponding source file in the repo
- Three Kubernetes objects captured verbatim from live cluster (2026-06-27) and verified zero-diff via `kubectl diff` before commit
- All three manifest files committed to `deploy/`

## Objects captured

| File | Kind | Notes |
|------|------|-------|
| `deploy/engram-go.yaml` | Deployment | Image pinned to digest `main-ab5aff4@sha256:95778bfc...`; restartedAt annotation faithfully reproduced |
| `deploy/engram-go-service.yaml` | Service | ClusterIP on port 8788; `clusterIP` intentionally omitted (cluster-assigned) |
| `deploy/engram-embed-model.yaml` | ConfigMap | `ENGRAM_EMBED_MODEL: BAAI/bge-m3` verbatim |

## kubectl diff results

All three objects produced **zero diff** (exit code 0) against the live cluster, confirming faithful capture:

```
kubectl diff -f deploy/engram-go.yaml         → exit 0 (zero diff, PodSecurity warning only — pre-existing)
kubectl diff -f deploy/engram-go-service.yaml → exit 0 (zero diff)
kubectl diff -f deploy/engram-embed-model.yaml → exit 0 (zero diff)
```

The PodSecurity warning on the Deployment (`allowPrivilegeEscalation != false`, missing `capabilities.drop`, missing `seccompProfile`) is **pre-existing** on the live object and is **not introduced by this PR**.

## Follow-up: securityContext hardening

Container securityContext is missing:
- `allowPrivilegeEscalation: false`
- `capabilities.drop: [ALL]`
- `seccompProfile` configuration

These are pre-existing PodSecurity warnings on the live Deployment. This PR captures live state verbatim. Hardening is tracked as a separate intentional change.

## Test plan

- [ ] `kubectl diff -f deploy/engram-go.yaml` returns exit 0 (zero diff) after merge
- [ ] `kubectl diff -f deploy/engram-go-service.yaml` returns exit 0
- [ ] `kubectl diff -f deploy/engram-embed-model.yaml` returns exit 0
- [ ] Confirm `BAAI/bge-m3` is present verbatim in `deploy/engram-embed-model.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A