### PR TITLE
fix(ci): cap test goroutines with GOMAXPROCS=2 (runner pod limit 512Mi)

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -40,6 +40,8 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: go test ./... -count=1 -timeout 10m
+        env:
+          GOMAXPROCS: "2"
       - run: go vet ./...
 
   build-push-deploy:


### PR DESCRIPTION
## Summary
- Runner pod memory limit is 512Mi; Go test parallelism can exceed this under concurrent package execution
- Setting GOMAXPROCS=2 caps the goroutine thread pool, reducing peak memory without changing test semantics
- OOM not confirmed by signal (exit code 2, not 137) but 512Mi < 2Gi threshold triggers this fix per runbook

## Test plan
- [ ] Pipeline test job completes without external kill
- [ ] go vet step still runs after test step
- [ ] No functional change to test coverage or assertions

Generated with Claude Code