### PR TITLE
fix(ci): add -p 1 to serialize test packages (512Mi pod limit)

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go test ./... -count=1 -timeout 10m
+      - run: go test -p 1 ./... -count=1 -timeout 20m
         env:
           GOMAXPROCS: "2"
       - run: go vet ./...


### PR DESCRIPTION
## Summary
- GOMAXPROCS=2 alone was insufficient: test job died at 40m8s (OOM kill reported as runner lost communication)
- Root cause: go test runs packages concurrently by default (-p = nCPU), stacking multiple test binaries in 512Mi
- Fix: -p 1 serializes package execution, keeping peak memory to one package at a time
- Timeout raised 10m→20m to accommodate the longer wall-clock time of serial execution

## Test plan
- [ ] test job completes without external kill
- [ ] No test assertions changed — -p 1 only affects execution order, not results

Generated with Claude Code