### PR TITLE
fix(ci): exclude .claude/worktrees from go test ./...

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: go test -p 1 ./... -count=1 -timeout 20m
+      - run: go test -p 1 $(go list ./... | grep -v '/.claude/') -count=1 -timeout 20m
         env:
           GOMAXPROCS: "2"
       - run: go vet ./...


### PR DESCRIPTION
## Summary
- `go test ./...` recurses into `.claude/worktrees/lme-preference-constraint/` — a live git worktree stored as a subdirectory of the repo root
- This doubles the test package count (53 real → 106) and more than doubles CI runtime (observed 2h+ instead of ~60-70m with `-p 1`)
- Fix: pipe through `grep -v /.claude/` to exclude current and future worktrees stored under `.claude/`
- No real packages are excluded — the filter only matches import paths containing `/.claude/`

## Test plan
- [ ] Test job completes in ~60-70 minutes instead of 2+ hours
- [ ] No real packages excluded (grep matches only `.claude/`-prefixed paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4oYJeZ2exSVCfUQKgN18A