### PR TITLE
feat(lme): per-type ss-pref context-topk + session-diversity override (#1176, #1180 assessed)

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -64,8 +64,26 @@ type Config struct {
 	ChronoSort          bool // sort context blocks by Session date ascending before prompt assembly
 	DisableQueryRewrite bool // use raw question as recall query; skip temporal/preference rewriting
 	MaxBlockChars       int  // truncate each context block to this many chars before prompt assembly; 0 = no truncation
-	BlockOverlapChars   int  // ingest-time pre-chunk overlap in chars; 0 = disabled
-	RepairPreset        string
+
+	// Issue #1176: per-type retrieval hygiene for single-session-preference
+	// (ss-pref). Both default to 0 = off (baseline-identity, no behavior
+	// change unless explicitly set). Scoped to single-session-preference only
+	// — question_type is an eval-only artifact (FM-77; see
+	// internal/search/session_diversity.go), so this gating lives entirely in
+	// the eval harness client, never in internal/search/engine.go.
+	//
+	// SSPrefContextTopK overrides ContextTopKForTypeWithBump's per-type
+	// default (15) for single-session-preference questions only; other types
+	// are unaffected. Lower priority than the existing global
+	// --context-topk/ContextTopKOverride flag.
+	SSPrefContextTopK int
+	// SSPrefSessionDiversityN caps chunks-per-session (via the MCP
+	// session_diversity_n arg) for single-session-preference recall calls
+	// only, independent of the server-wide ENGRAM_SESSION_DIVERSITY_N
+	// default used by --session-diversity-n/SessionDiversityN.
+	SSPrefSessionDiversityN int
+	BlockOverlapChars       int // ingest-time pre-chunk overlap in chars; 0 = disabled
+	RepairPreset            string
 
 	// H16: question_date injection
 	InjectQuestionDate bool // prepend "Today's date is: {question_date}" to temporal-reasoning prompts (default off)
@@ -297,6 +315,14 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	fs.IntVar(&cfg.SessionDiversityN, "session-diversity-n", defaultDiversityN, "LEVER-9: expected per-session chunk cap on the server (0 = off; reads ENGRAM_SESSION_DIVERSITY_N as default)")
+	// Issue #1176: per-type retrieval hygiene, scoped to single-session-preference
+	// only. Both default to 0 (off) — no behavior change unless explicitly set.
+	// Unlike --session-diversity-n (which only documents the server-wide env-var
+	// default), --ss-pref-session-diversity-n is actually sent as an explicit
+	// per-call session_diversity_n override for ss-pref questions, via
+	// Client.RecallScoredWithDiversityOverride.
+	fs.IntVar(&cfg.SSPrefSessionDiversityN, "ss-pref-session-diversity-n", 0, "issue #1176: per-session chunk cap applied ONLY to single-session-preference recall calls (0 = off; independent of --session-diversity-n)")
+	fs.IntVar(&cfg.SSPrefContextTopK, "ss-pref-context-topk", 0, "issue #1176: context topK applied ONLY to single-session-preference questions (0 = use the per-type default of 15; overridden by --context-topk if set)")
 	// #749: contention guard. --no-exclusive-backend is the negation flag.
 	// Default is exclusive=true; --no-exclusive-backend sets it false.
 	var noExclusiveBackend bool

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -527,6 +527,12 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		}
 	}
 
+	// Issue #1176: per-type session-diversity override for single-session-preference
+	// only. Computed once per item and threaded into the plain (non-atom,
+	// non-exact-signal-boost) recall closures below, which cover the default LME
+	// run configuration. Zero (the common case) preserves exact baseline behavior.
+	ssPrefDiversityOverride := resolveSessionDiversityOverride(cfg, item.QuestionType)
+
 	recall := func(query string, topK int, callSince, callBefore *time.Time) (longmemeval.RecallResult, error) {
 		if cfg.AtomMode {
 			return mcpClient.RecallWithAtomRecall(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost, cfg.ExactSignalBoost, atomRecallAsOf)
@@ -535,14 +541,14 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			ids, err := mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, callSince, callBefore)
 			return longmemeval.RecallResult{IDs: ids}, err
 		}
-		ids, err := mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost)
+		ids, err := mcpClient.RecallWithDiversityOverride(ctx, ingest.Project, query, topK, callSince, callBefore, cfg.TopicAnchorBoost, ssPrefDiversityOverride)
 		return longmemeval.RecallResult{IDs: ids}, err
 	}
 	recallScoredDefault := func(query string, topK int) ([]longmemeval.ScoredMemoryID, error) {
 		if cfg.ExactSignalBoost {
 			return mcpClient.RecallScoredWithExactBoost(ctx, ingest.Project, query, topK, since, before)
 		}
-		return mcpClient.RecallScoredWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
+		return mcpClient.RecallScoredWithDiversityOverride(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost, ssPrefDiversityOverride)
 	}
 	recallDefault := func(query string, topK int) (longmemeval.RecallResult, error) {
 		if cfg.AtomMode {
@@ -552,7 +558,7 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 			ids, err := mcpClient.RecallWithExactBoost(ctx, ingest.Project, query, topK, since, before)
 			return longmemeval.RecallResult{IDs: ids}, err
 		}
-		ids, err := mcpClient.RecallWithOpts(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost)
+		ids, err := mcpClient.RecallWithDiversityOverride(ctx, ingest.Project, query, topK, since, before, cfg.TopicAnchorBoost, ssPrefDiversityOverride)
 		return longmemeval.RecallResult{IDs: ids}, err
 	}
 
@@ -673,17 +679,9 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 
 	// Fetch content for top contextLimit memories.
 	// --context-topk overrides per-type default; 0 means use per-type default.
-	var contextLimit int
-	if cfg.ContextTopKOverride > 0 {
-		contextLimit = cfg.ContextTopKOverride
-	} else if runOpts.UseFullAggregationContext(item.Question) {
-		contextLimit = len(retrievedIDs)
-	} else {
-		contextLimit = longmemeval.ContextTopKForTypeWithBump(item.QuestionType, cfg.ContextTopKBump)
-	}
-	if contextLimit > len(retrievedIDs) {
-		contextLimit = len(retrievedIDs)
-	}
+	// See resolveContextTopK for the full priority chain, including the
+	// issue #1176 --ss-pref-context-topk knob.
+	contextLimit := resolveContextTopK(cfg, item.QuestionType, runOpts.UseFullAggregationContext(item.Question), len(retrievedIDs))
 	contextIDs := selectContextIDs(retrievedIDs, secondaryContextIDs, contextLimit)
 	sessionDateByID := haystackDateBySessionID(item)
 	contextBlocks := make([]string, 0, contextLimit)
@@ -869,6 +867,54 @@ func orderContextEvidenceFirst(blocks []string, question string) []string {
 		return scoreExactSignals(stripContextMetadataHeader(out[i]), question) > scoreExactSignals(stripContextMetadataHeader(out[j]), question)
 	})
 	return out
+}
+
+// resolveContextTopK computes the effective context window size (contextLimit)
+// for a single LME item (issue #1176). Priority chain, highest first:
+//
+//  1. cfg.ContextTopKOverride (--context-topk) — the existing global
+//     "kitchen sink" override; applies to every question type.
+//  2. useFullAggregation (H8 exhaustive-aggregation) — uses every retrieved ID.
+//  3. cfg.SSPrefContextTopK (--ss-pref-context-topk) — applies ONLY to
+//     single-session-preference questions; other types are unaffected.
+//  4. longmemeval.ContextTopKForTypeWithBump — the existing per-type default.
+//
+// The result is always clamped to retrievedCount, matching the previous
+// inline clamp in runOne. Default (SSPrefContextTopK == 0) is a no-op:
+// behavior is byte-identical to the pre-#1176 inline logic.
+func resolveContextTopK(cfg *Config, questionType string, useFullAggregation bool, retrievedCount int) int {
+	var limit int
+	switch {
+	case cfg.ContextTopKOverride > 0:
+		limit = cfg.ContextTopKOverride
+	case useFullAggregation:
+		limit = retrievedCount
+	case cfg.SSPrefContextTopK > 0 && questionType == "single-session-preference":
+		limit = cfg.SSPrefContextTopK
+	default:
+		limit = longmemeval.ContextTopKForTypeWithBump(questionType, cfg.ContextTopKBump)
+	}
+	if limit > retrievedCount {
+		limit = retrievedCount
+	}
+	return limit
+}
+
+// resolveSessionDiversityOverride returns the explicit per-call
+// session_diversity_n override to use for this item's recall calls, or 0 to
+// fall back to the server-wide ENGRAM_SESSION_DIVERSITY_N default (issue
+// #1176). Only single-session-preference questions ever receive a non-zero
+// override, and only when --ss-pref-session-diversity-n is set — default is a
+// no-op, preserving baseline-identity behavior for every other question type.
+//
+// Deliberately generator-agnostic (LME issue #1176 acceptance criterion): the
+// gate is keyed on question_type alone, with no dependency on which model
+// processes the item downstream.
+func resolveSessionDiversityOverride(cfg *Config, questionType string) int {
+	if cfg.SSPrefSessionDiversityN > 0 && questionType == "single-session-preference" {
+		return cfg.SSPrefSessionDiversityN
+	}
+	return 0
 }
 
 func selectContextIDs(retrievedIDs, secondaryIDs []string, limit int) []string {

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -13,6 +13,110 @@ import (
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
 
+// ---------------------------------------------------------------------------
+// resolveContextTopK / resolveSessionDiversityOverride (issue #1176:
+// per-session retrieval diversity cap + per-type context_topk override for
+// single-session-preference).
+// ---------------------------------------------------------------------------
+
+// TestResolveContextTopK_SSPrefOverrideAppliesOnlyToSSPref verifies that
+// --ss-pref-context-topk raises the window only for single-session-preference
+// questions; other types keep using ContextTopKForTypeWithBump.
+func TestResolveContextTopK_SSPrefOverrideAppliesOnlyToSSPref(t *testing.T) {
+	cfg := &Config{SSPrefContextTopK: 25}
+	cases := []struct {
+		questionType string
+		want         int
+	}{
+		{"single-session-preference", 25},
+		{"single-session-user", 15},
+		{"multi-session", 15},
+		{"knowledge-update", 8},
+	}
+	for _, c := range cases {
+		got := resolveContextTopK(cfg, c.questionType, false, 1000)
+		if got != c.want {
+			t.Errorf("resolveContextTopK(%q) = %d, want %d", c.questionType, got, c.want)
+		}
+	}
+}
+
+// TestResolveContextTopK_SSPrefOverrideOffIsNoOp verifies default (0) leaves
+// single-session-preference at the existing per-type default (15) — no
+// behavior change when the flag is unset (baseline-safe).
+func TestResolveContextTopK_SSPrefOverrideOffIsNoOp(t *testing.T) {
+	cfg := &Config{}
+	got := resolveContextTopK(cfg, "single-session-preference", false, 1000)
+	if got != 15 {
+		t.Errorf("resolveContextTopK() = %d, want 15 (unchanged baseline)", got)
+	}
+}
+
+// TestResolveContextTopK_GlobalOverrideWinsOverSSPref verifies --context-topk
+// (the existing global override) still takes priority over the new
+// --ss-pref-context-topk knob — the global "kitchen sink" flag must not be
+// silently shadowed by the narrower one.
+func TestResolveContextTopK_GlobalOverrideWinsOverSSPref(t *testing.T) {
+	cfg := &Config{ContextTopKOverride: 30, SSPrefContextTopK: 25}
+	got := resolveContextTopK(cfg, "single-session-preference", false, 1000)
+	if got != 30 {
+		t.Errorf("resolveContextTopK() = %d, want 30 (global override wins)", got)
+	}
+}
+
+// TestResolveContextTopK_FullAggregationWinsOverSSPref verifies the
+// full-aggregation-context path (H8) still takes priority over the new
+// ss-pref override.
+func TestResolveContextTopK_FullAggregationWinsOverSSPref(t *testing.T) {
+	cfg := &Config{SSPrefContextTopK: 25}
+	got := resolveContextTopK(cfg, "single-session-preference", true, 42)
+	if got != 42 {
+		t.Errorf("resolveContextTopK() = %d, want 42 (full-aggregation retrieved count)", got)
+	}
+}
+
+// TestResolveContextTopK_ClampsToRetrievedCount verifies the result never
+// exceeds how many IDs were actually retrieved, matching the existing
+// clamp behavior in runItem's inline contextLimit logic.
+func TestResolveContextTopK_ClampsToRetrievedCount(t *testing.T) {
+	cfg := &Config{SSPrefContextTopK: 25}
+	got := resolveContextTopK(cfg, "single-session-preference", false, 3)
+	if got != 3 {
+		t.Errorf("resolveContextTopK() = %d, want 3 (clamped to retrieved count)", got)
+	}
+}
+
+// TestResolveSessionDiversityOverride_SSPrefOnly verifies the override value
+// is returned only for single-session-preference questions.
+func TestResolveSessionDiversityOverride_SSPrefOnly(t *testing.T) {
+	cfg := &Config{SSPrefSessionDiversityN: 1}
+	cases := []struct {
+		questionType string
+		want         int
+	}{
+		{"single-session-preference", 1},
+		{"single-session-user", 0},
+		{"multi-session", 0},
+		{"", 0},
+	}
+	for _, c := range cases {
+		got := resolveSessionDiversityOverride(cfg, c.questionType)
+		if got != c.want {
+			t.Errorf("resolveSessionDiversityOverride(%q) = %d, want %d", c.questionType, got, c.want)
+		}
+	}
+}
+
+// TestResolveSessionDiversityOverride_OffByDefault verifies the flag is
+// baseline-safe: when SSPrefSessionDiversityN is 0 (unset), no override is
+// ever applied, regardless of question type.
+func TestResolveSessionDiversityOverride_OffByDefault(t *testing.T) {
+	cfg := &Config{}
+	if got := resolveSessionDiversityOverride(cfg, "single-session-preference"); got != 0 {
+		t.Errorf("resolveSessionDiversityOverride() = %d, want 0 (flag unset)", got)
+	}
+}
+
 // TestRunLogFormat_ErrorIncludesCause verifies that when runOne returns an
 // error entry, the log message format string produced by runWorker would
 // include the error cause — not just hypothesis_len=0.
@@ -380,6 +484,23 @@ func TestDualPreferenceRecallFlag_DefaultOff(t *testing.T) {
 	}
 	if !strings.Contains(string(src), `"dual-preference-recall", false`) {
 		t.Error("main.go: --dual-preference-recall must be opt-in (default false)")
+	}
+}
+
+// TestSSPrefFlags_DefaultOff verifies both issue #1176 flags are registered
+// as opt-in (default 0) so an unmodified `run` invocation is byte-identical
+// to pre-#1176 behavior.
+func TestSSPrefFlags_DefaultOff(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, `"ss-pref-session-diversity-n", 0`) {
+		t.Error("main.go: --ss-pref-session-diversity-n must be opt-in (default 0)")
+	}
+	if !strings.Contains(text, `"ss-pref-context-topk", 0`) {
+		t.Error("main.go: --ss-pref-context-topk must be opt-in (default 0)")
 	}
 }
 

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -388,6 +388,104 @@ func TestRecallWithOpts_SendsSessionDiversityN(t *testing.T) {
 	}
 }
 
+// TestRecallScoredWithDiversityOverride_ExplicitValueWins verifies that an
+// explicit diversityNOverride is sent as session_diversity_n even when
+// ENGRAM_SESSION_DIVERSITY_N is unset — this is the mechanism issue #1176
+// uses to cap single-session-preference retrieval at N=1 without touching
+// the server-wide env-var default used by other question types.
+func TestRecallScoredWithDiversityOverride_ExplicitValueWins(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got, ok := args["session_diversity_n"].(float64); !ok || got != 1 {
+				t.Fatalf("session_diversity_n = %#v, want 1", args["session_diversity_n"])
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{{"id": "h-aaa", "score": 0.8}},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.RecallScoredWithDiversityOverride(ctx, "proj", "query", 5, nil, nil, false, 1); err != nil {
+		t.Fatalf("RecallScoredWithDiversityOverride: %v", err)
+	}
+}
+
+// TestRecallScoredWithDiversityOverride_ZeroFallsBackToEnv verifies that
+// passing diversityNOverride=0 preserves the existing RecallScoredWithOpts
+// behavior of reading ENGRAM_SESSION_DIVERSITY_N — non-ss-pref question
+// types must be byte-identical to baseline when no override is supplied.
+func TestRecallScoredWithDiversityOverride_ZeroFallsBackToEnv(t *testing.T) {
+	t.Setenv("ENGRAM_SESSION_DIVERSITY_N", "2")
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got, ok := args["session_diversity_n"].(float64); !ok || got != 2 {
+				t.Fatalf("session_diversity_n = %#v, want 2 (from env)", args["session_diversity_n"])
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{{"id": "h-aaa", "score": 0.8}},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	if _, err := c.RecallScoredWithDiversityOverride(ctx, "proj", "query", 5, nil, nil, false, 0); err != nil {
+		t.Fatalf("RecallScoredWithDiversityOverride: %v", err)
+	}
+}
+
+// TestRecallWithDiversityOverride_SendsExplicitValue is the []string-returning
+// sibling of RecallScoredWithDiversityOverride, used by the recall/recallDefault
+// closures in cmd/longmemeval/run.go.
+func TestRecallWithDiversityOverride_SendsExplicitValue(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got, ok := args["session_diversity_n"].(float64); !ok || got != 1 {
+				t.Fatalf("session_diversity_n = %#v, want 1", args["session_diversity_n"])
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"handles": []map[string]any{{"id": "h-aaa", "score": 0.8}},
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	ids, err := c.RecallWithDiversityOverride(ctx, "proj", "query", 5, nil, nil, false, 1)
+	if err != nil {
+		t.Fatalf("RecallWithDiversityOverride: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "h-aaa" {
+		t.Fatalf("ids = %v, want [h-aaa]", ids)
+	}
+}
+
 // TestFetchContent_HappyPath verifies content fetching.
 func TestFetchContent_HappyPath(t *testing.T) {
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -421,11 +421,41 @@ func (c *Client) RecallWithOptsResult(ctx context.Context, project, query string
 	})
 }
 
+// RecallScoredWithOpts reads ENGRAM_SESSION_DIVERSITY_N and sends it as
+// session_diversity_n on every call — a single server-wide value applied
+// uniformly to all question types. It delegates to
+// RecallScoredWithDiversityOverride with override=0 so its behavior is
+// unchanged (this preserves the LEVER-9 baseline contract).
 func (c *Client) RecallScoredWithOpts(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool) ([]ScoredMemoryID, error) {
-	diversityN := 0
-	if v := os.Getenv("ENGRAM_SESSION_DIVERSITY_N"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			diversityN = n
+	return c.RecallScoredWithDiversityOverride(ctx, project, query, topK, since, before, topicAnchorBoost, 0)
+}
+
+// RecallWithDiversityOverride is the []string-returning sibling of
+// RecallScoredWithDiversityOverride (issue #1176).
+func (c *Client) RecallWithDiversityOverride(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool, diversityNOverride int) ([]string, error) {
+	hits, err := c.RecallScoredWithDiversityOverride(ctx, project, query, topK, since, before, topicAnchorBoost, diversityNOverride)
+	if err != nil {
+		return nil, err
+	}
+	return IDsFromScoredRecall(hits), nil
+}
+
+// RecallScoredWithDiversityOverride is like RecallScoredWithOpts but lets the
+// caller force a specific session_diversity_n instead of always reading
+// ENGRAM_SESSION_DIVERSITY_N (issue #1176: per-type session-diversity gating
+// for single-session-preference, independent of the server-wide default used
+// by other question types).
+//
+// diversityNOverride == 0 falls back to the ENGRAM_SESSION_DIVERSITY_N
+// env-var default — byte-identical to RecallScoredWithOpts. A positive value
+// is sent as-is and takes priority over the env var for this call only.
+func (c *Client) RecallScoredWithDiversityOverride(ctx context.Context, project, query string, topK int, since, before *time.Time, topicAnchorBoost bool, diversityNOverride int) ([]ScoredMemoryID, error) {
+	diversityN := diversityNOverride
+	if diversityN == 0 {
+		if v := os.Getenv("ENGRAM_SESSION_DIVERSITY_N"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				diversityN = n
+			}
 		}
 	}
 	return c.recallScoredWithParams(ctx, recallParams{


### PR DESCRIPTION
## Summary

Implements the concrete code portion of **#1176** and documents the finding on **#1180** — this PR is a mechanism-only change; it does **not** run the LME benchmark gate that either issue's acceptance criteria ultimately depend on (see "What's NOT done" below — deferred per explicit compute-cost policy, not skipped silently).

### #1176 — per-type retrieval hygiene for single-session-preference

Adds two opt-in, baseline-safe CLI flags scoped to `single-session-preference` questions only:

- `--ss-pref-context-topk` (default 0=off): overrides the per-type context window (currently 15 for ss-pref) independent of the existing global `--context-topk`. New helper: `resolveContextTopK()` in `cmd/longmemeval/run.go:872-899`, wired in at `cmd/longmemeval/run.go:682` (replaces the old inline if/else chain 1:1, byte-identical when the flag is unset).
- `--ss-pref-session-diversity-n` (default 0=off): caps chunks-per-session for ss-pref recall calls only, independent of the server-wide `ENGRAM_SESSION_DIVERSITY_N` default. New helper: `resolveSessionDiversityOverride()` in `cmd/longmemeval/run.go:901-916`. Required two new `Client` methods in `internal/longmemeval/engram.go:407-459` — `RecallScoredWithDiversityOverride` / `RecallWithDiversityOverride` — since the existing `RecallScoredWithOpts` only ever read the env var (no per-call override existed). `RecallScoredWithOpts` now delegates to the new method with `override=0`, preserving exact prior behavior (existing `TestRecallWithOpts_SendsSessionDiversityN` still passes unmodified).
- Flags registered in `cmd/longmemeval/main.go:78-95` (Config fields) and `main.go:318-323` (flag registration).

**Why this scoping, not a global change:** the previous LEVER-9 experiment applied `ENGRAM_SESSION_DIVERSITY_N` globally at N=2 and got a mixed/NO-GO result (multi-session flat, temporal GoldInCtx -2.2pp; see `docs/lme-campaign/EXPERIMENT-REGISTRY.md` row 10 and `docs/lme-ledger.md:143-148`). The issue's own +14-item result came from an isolated ss-pref simulation (`EXPERIMENT-REGISTRY.md` row 19, "evidence-first-pack") that was explicitly marked **"not pursued — below ±3.3pp noise floor as isolated lever"** rather than shipped. This PR builds the mechanism to test the narrower, ss-pref-only hypothesis cleanly without repeating the global-flag mistake.

**Why client-side only, not `internal/search/engine.go`:** this codebase has an established discipline (FM-77, documented in `internal/search/session_diversity.go:14-19` and `internal/search/engine.go:180`) that production retrieval code must never gate on `question_type` — it's an eval-only artifact absent in prod. The existing `ContextTopKForType` per-type logic already lives client-side in `internal/longmemeval/claude_additions.go:257-265` for the same reason. This PR follows that precedent exactly; no production file (`internal/search/*`) was touched.

### #1180 — DenseReranker gating for ss-pref

**Finding: no code gap exists.** Everything the issue's "Task" section asks for is already built:
- The DenseReranker itself, its `ENGRAM_CROSS_ENCODER_RERANK` flag gate, and its documented A/B ablation-bench command already exist at `internal/search/cross_encoder_reranker.go:1-58` (comment block documents the exact `--recall-topk`/`--context-topk`/env-var invocation for a generator-free A/B).
- The generator-free retrieval-metrics scorer already reports GoldInCtx%, NDCG@5, and AvgRank **broken out per `question_type`** (including `single-session-preference` as its own row) — `cmd/longmemeval/retrieval_metrics.go:16-21, 138-161`.
- `docs/lme-ledger.md:150` already flags this exact gap: "cross-encoder reranker (PR #1111, flag-gated, TEI sidecar not yet deployed)".

So #1180 is **not a code-authoring task** — it's "stand up the TEI reranker sidecar and run the existing tooling twice (reranker off vs on) against the ss-pref subset." That is a live-infrastructure benchmark run (GPU-backed sidecar + real recall traffic against a live MCP server), which is explicitly out of scope for this PR per current policy (see below). No code changes were made for #1180.

## What's NOT done (explicit, not silent)

- **#1176's acceptance criteria** (GoldInCtx% 40%→≥60%, avg gold rank 63.5→≤20) require running the generator-free retrieval-metrics gate against a live server with the new flags enabled. **Not run.** This PR ships the mechanism only.
- **#1180 in its entirety** is the act of running that A/B experiment (requires the TEI cross-encoder sidecar). **Not run.**
- Both require separate authorization due to real compute/infra cost — this was a deliberate stop, not an oversight.

## Test plan

- [x] TDD: all new tests written first, confirmed failing (compile error) before implementation, then green after.
- [x] `go build ./...` — clean.
- [x] `go test ./... -count=1 -race` — **all packages pass**, no failures, no skips-as-failures. Full real output, e.g.: `ok github.com/petersimmons1972/engram/cmd/longmemeval 12.370s`, `ok github.com/petersimmons1972/engram/internal/longmemeval 57.253s`, `ok github.com/petersimmons1972/engram/internal/search 2.059s` (36 packages total, all `ok`).
- [x] New-code coverage: `resolveContextTopK` 100%, `resolveSessionDiversityOverride` 100%, `RecallScoredWithDiversityOverride` 100%, `RecallWithDiversityOverride` 75% (matches existing `RecallWithOpts` baseline coverage shape — untested branch is a pre-existing pattern, not new). `cmd/longmemeval` package coverage 61.8%, `internal/longmemeval` 77.5% — both above the 55% CI gate and the 60% aim.
- [x] `gofmt -l` clean on all 5 touched files (two files needed realignment after edits; the other three were already gofmt-dirty at `origin/main` baseline, unrelated to this change).
- [x] 11 new unit tests added: 4 in `internal/longmemeval/client_test.go` (explicit override wins, override=0 falls back to env unchanged, `[]string`-sibling method), 7 in `cmd/longmemeval/run_test.go` (ss-pref-only scoping, off-by-default no-op, global-override priority, full-aggregation priority, retrieved-count clamping, flag-registration structural guards ×1 covering both flags).

## Requires 3-round adversarial review per project policy before merge — not merge-ready.

Per `CLAUDE.md`: Correctness, Coverage, Structural review rounds, zero `severity/blocker` findings required before merge. **This PR has not been through that review and must not be merged as-is.**

Closes-partially #1176 (mechanism shipped; gate run deferred). Documents #1180 (no code gap; run deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ7gTYyj3WCgBNaujN1n5X