### PR TITLE
feat(lme): add KU recency generation prompt (H-KUR, #1178)

### DIFF
--- a/cmd/longmemeval/ku_recency_test.go
+++ b/cmd/longmemeval/ku_recency_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestKURecencyPrompt_FlagRegistered verifies that the --ku-recency-prompt
+// flag is registered in the dispatch function and backed by a Config field.
+// H-KUR, issue #1178.
+func TestKURecencyPrompt_FlagRegistered(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "ku-recency-prompt") {
+		t.Error("main.go missing 'ku-recency-prompt' flag registration — H-KUR harness wiring broken")
+	}
+	if !strings.Contains(text, "KURecencyPrompt") {
+		t.Error("main.go missing KURecencyPrompt config field — H-KUR harness wiring broken")
+	}
+}
+
+// TestKURecencyPrompt_RunGoWiresPromptSelection verifies that run.go contains
+// the ku-recency-prompt prompt selection path.
+func TestKURecencyPrompt_RunGoWiresPromptSelection(t *testing.T) {
+	src, err := os.ReadFile("run.go")
+	if err != nil {
+		t.Fatalf("read run.go: %v", err)
+	}
+	text := string(src)
+	if !strings.Contains(text, "cfg.KURecencyPrompt") {
+		t.Error("run.go missing cfg.KURecencyPrompt check — H-KUR flag not applied during prompt selection")
+	}
+	if !strings.Contains(text, "GenerationPromptForTypeKURecency") {
+		t.Error("run.go missing GenerationPromptForTypeKURecency call — H-KUR prompt variant not wired")
+	}
+}

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -95,6 +95,9 @@ type Config struct {
 
 	// H-PG: grounded preference generation for ss-preference.
 	PreferenceGround bool // forbid unsupported specific additions in preference answers (default off)
+
+	// H-KUR: knowledge-update recency generation prompt (issue #1178).
+	KURecencyPrompt bool // instruct the model to answer with the most-recent-session value when multiple values for the same attribute appear across sessions (default off)
 	// Retrieval-fusion flags for issue #938.
 	RetrievalFusion     bool // union multiple query variants (primary/raw/identifier queries)
 	ExactSignalBoost    bool // re-rank candidate IDs by exact identifier/entity overlap
@@ -278,6 +281,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.PreferenceEnumerate, "preference-enumerate", false, "H-PE: inject exhaustive named-item enumeration instruction for single-session-preference questions; lists every specific item/brand/attribute from context rather than abstractly summarising (default off)")
 	// H-PG: grounded preference generation (issue #1183)
 	fs.BoolVar(&cfg.PreferenceGround, "preference-ground", false, "H-PG: for single-session-preference answers, forbid specific brands/titles/cuisines/ingredients/genres unless they appear explicitly in retrieved context; prefer a short grounded answer over padded specifics (default off)")
+	// H-KUR: knowledge-update recency generation prompt (issue #1178)
+	fs.BoolVar(&cfg.KURecencyPrompt, "ku-recency-prompt", false, "H-KUR: for knowledge-update answers, instruct the model to answer with the value from the most recent session (latest date) when multiple values for the same attribute appear across sessions in context (default off)")
 	fs.BoolVar(&cfg.RetrievalFusion, "retrieval-fusion", false, "issue #938: fuse retrieval candidates from primary/raw/identifier query variants")
 	fs.BoolVar(&cfg.ExactSignalBoost, "exact-signal-boost", false, "issue #938: boost candidates that contain exact identifiers/entities from the question")
 	fs.BoolVar(&cfg.EvidenceFirstPacked, "evidence-first-pack", false, "issue #938: pack context in evidence-first order using exact overlap signals")

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -756,6 +756,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// instead of replacing it.
 	// H-PE (--preference-enumerate) is orthogonal — it only fires for
 	// single-session-preference questions and is independent of the other flags.
+	// H-KUR (--ku-recency-prompt) is likewise orthogonal — it only fires for
+	// knowledge-update questions and is independent of the other flags.
 	var prompt string
 	switch {
 	case cfg.TemporalPromptAug:
@@ -766,6 +768,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		prompt = longmemeval.GenerationPromptForTypePreferenceEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.PreferenceGround:
 		prompt = longmemeval.GenerationPromptForTypePreferenceGround(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
+	case cfg.KURecencyPrompt:
+		prompt = longmemeval.GenerationPromptForTypeKURecency(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	default:
 		prompt = longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, contextBlocks)
 	}

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -606,7 +606,7 @@ Question (asked on %s): %s
 
 RECENCY RULE: When multiple values exist for the same attribute across sessions, answer with the value from the most recent session (latest date). Ignore earlier, superseded values — they are stale and must not be used in your answer.
 
-Answer in one sentence using only the facts directly required by the question. Do not restate the question. Do not add context the user did not ask for. If the answer is a number, date, name, or short phrase, return only that value with minimal framing.`, questionDate, ctx, questionDate, question)
+Answer in one sentence using only the facts directly required by the question. Do not restate the question. Do not add context the user did not ask for. If the answer is a number, date, name, or short phrase, return only that value with minimal framing. IMPORTANT: You MUST always provide a specific answer — never say "not mentioned", "not found in context", "cannot be determined", "not explicitly stated", or any similar refusal. If the answer is not directly stated, infer the most likely answer from the available context clues and state it directly. Output only the answer with no uncertainty hedging.`, questionDate, ctx, questionDate, question)
 }
 
 // GenerationPromptForTypeEnumerate (H12) is like GenerationPromptForType but

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -564,6 +564,50 @@ GROUNDING RULE:
 - Prefer a short grounded answer over a padded one.`, questionDate, ctx, questionDate, question)
 }
 
+// GenerationPromptForTypeKURecency (H-KUR, issue #1178) is like
+// GenerationPromptForType but, when kuRecencyPrompt is true for
+// "knowledge-update" questions, routes to GenerationPromptKnowledgeUpdate — a
+// dedicated prompt that instructs the model to answer with the most recent
+// session's value when multiple values for the same attribute appear across
+// sessions in the retrieved context. Targets the KU failure mode where ~18
+// items on LME-M pick the stale value when both old and new appear in
+// context, despite gold_visible ≈0.99 and avg_rank ≈2.0 (retrieval already
+// solved; this is purely a generation-time disambiguation problem).
+//
+// For all other question types, or when kuRecencyPrompt is false, the
+// standard GenerationPromptForType output is returned unchanged.
+// Activated by --ku-recency-prompt (Config.KURecencyPrompt). Off by default.
+func GenerationPromptForTypeKURecency(question, questionType, questionDate string, contextBlocks []string, kuRecencyPrompt bool) string {
+	if !kuRecencyPrompt || questionType != "knowledge-update" {
+		return GenerationPromptForType(question, questionType, questionDate, contextBlocks)
+	}
+	return GenerationPromptKnowledgeUpdate(question, questionDate, contextBlocks)
+}
+
+// GenerationPromptKnowledgeUpdate (H-KUR, issue #1178) returns a generation
+// prompt for knowledge-update questions that instructs the model to answer
+// using the value from the most recent session (by "Session date:" header)
+// when multiple values for the same attribute appear across sessions in the
+// retrieved context. Knowledge-update questions test whether the model
+// correctly tracks facts that change over time (e.g. a phone number or job
+// title updated in a later session); without an explicit recency rule the
+// model has no principled way to choose between a stale and a current value
+// when both are visible in context.
+func GenerationPromptKnowledgeUpdate(question, questionDate string, contextBlocks []string) string {
+	ctx := strings.Join(contextBlocks, "\n\n---\n\n")
+	return fmt.Sprintf(`You are answering a question about a person's conversation history, where facts may have changed over time across sessions.
+
+Each memory block may begin with a "Session date: YYYY-MM-DD" header. Use these dates to determine which session is most recent. The question was asked on %s.
+
+Relevant memory context:
+%s
+
+Question (asked on %s): %s
+
+RECENCY RULE: When multiple values exist for the same attribute across sessions, answer with the value from the most recent session (latest date). Ignore earlier, superseded values — they are stale and must not be used in your answer.
+
+Answer in one sentence using only the facts directly required by the question. Do not restate the question. Do not add context the user did not ask for. If the answer is a number, date, name, or short phrase, return only that value with minimal framing.`, questionDate, ctx, questionDate, question)
+}
 
 // GenerationPromptForTypeEnumerate (H12) is like GenerationPromptForType but
 // prepends an enumerate-first instruction when enumerateFirst is true and the

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -589,6 +589,13 @@ func TestGenerationPromptKnowledgeUpdate_ContainsRecencyInstructionAndContext(t 
 	if !strings.Contains(prompt, "What is the user's current phone number?") {
 		t.Errorf("KU recency prompt must include the question, got:\n%s", prompt)
 	}
+	// QA blocker on #1258: issue #1178's acceptance bar is the Strict metric,
+	// which credits only judge-label CORRECT (not PARTIALLY_CORRECT/hedged), so
+	// the KU prompt must carry the same anti-hedge instruction as every other
+	// direct-answer prompt in this file (see GenerationPrompt).
+	if !strings.Contains(prompt, `never say "not mentioned", "not found in context", "cannot be determined", "not explicitly stated", or any similar refusal`) {
+		t.Errorf("KU recency prompt must include the anti-hedge instruction, got:\n%s", prompt)
+	}
 }
 
 func TestGenerationPrompt_DefaultType_UsesGenericPrompt(t *testing.T) {

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -512,6 +512,85 @@ func TestGenerationPrompt_PreferenceGround_DefaultsToStandardPreferencePrompt(t 
 	}
 }
 
+// TestGenerationPrompt_KURecency_InstructsMostRecentValue verifies the H-KUR
+// (issue #1178) knowledge-update recency prompt tells the model to prefer the
+// most recent session's value when multiple values for the same attribute
+// appear across sessions in the retrieved context.
+func TestGenerationPrompt_KURecency_InstructsMostRecentValue(t *testing.T) {
+	prompt := longmemeval.GenerationPromptForTypeKURecency(
+		"What is the user's current phone number?",
+		"knowledge-update",
+		"2024-03-15",
+		[]string{
+			"Session date: 2024-01-05\nUser said their phone number is 555-1234.",
+			"Session date: 2024-02-20\nUser said their new phone number is 555-9876.",
+		},
+		true,
+	)
+	lower := strings.ToLower(prompt)
+	for _, want := range []string{
+		"most recent",
+		"latest date",
+	} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("KU recency prompt must contain %q, got:\n%s", want, prompt)
+		}
+	}
+}
+
+// TestGenerationPrompt_KURecency_FlagOffDefaultsToStandardPrompt verifies that
+// when kuRecencyPrompt is false, GenerationPromptForTypeKURecency is byte-identical
+// to the standard GenerationPromptForType output for knowledge-update questions.
+func TestGenerationPrompt_KURecency_FlagOffDefaultsToStandardPrompt(t *testing.T) {
+	question := "What is the user's current phone number?"
+	questionDate := "2024-03-15"
+	context := []string{
+		"Session date: 2024-01-05\nUser said their phone number is 555-1234.",
+		"Session date: 2024-02-20\nUser said their new phone number is 555-9876.",
+	}
+	got := longmemeval.GenerationPromptForTypeKURecency(question, "knowledge-update", questionDate, context, false)
+	want := longmemeval.GenerationPromptForType(question, "knowledge-update", questionDate, context)
+	if got != want {
+		t.Errorf("KU recency flag off should preserve standard knowledge-update prompt\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+// TestGenerationPrompt_KURecency_NonKUTypeUnaffected verifies the KU recency
+// flag is a no-op for non-knowledge-update question types even when true,
+// mirroring the type-gating pattern used by GenerationPromptForTypePreferenceGround.
+func TestGenerationPrompt_KURecency_NonKUTypeUnaffected(t *testing.T) {
+	question := "When did the user buy their camera?"
+	questionDate := "2024-03-15"
+	context := []string{"Session date: 2024-01-05\nUser mentioned they bought a Sony A7IV last week."}
+	got := longmemeval.GenerationPromptForTypeKURecency(question, "single-session-user", questionDate, context, true)
+	want := longmemeval.GenerationPromptForType(question, "single-session-user", questionDate, context)
+	if got != want {
+		t.Errorf("KU recency flag must not affect non-knowledge-update question types\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+// TestGenerationPromptKnowledgeUpdate_ContainsRecencyInstructionAndContext
+// verifies the underlying prompt builder (named per issue #1178's acceptance
+// criteria: GenerationPromptKnowledgeUpdate) embeds both the recency rule and
+// the supplied context/question so the model has both a rule and evidence.
+func TestGenerationPromptKnowledgeUpdate_ContainsRecencyInstructionAndContext(t *testing.T) {
+	prompt := longmemeval.GenerationPromptKnowledgeUpdate(
+		"What is the user's current phone number?",
+		"2024-03-15",
+		[]string{"Session date: 2024-02-20\nUser said their new phone number is 555-9876."},
+	)
+	lower := strings.ToLower(prompt)
+	if !strings.Contains(lower, "most recent session") {
+		t.Errorf("KU recency prompt must instruct use of the most recent session's value, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "555-9876") {
+		t.Errorf("KU recency prompt must include the supplied context, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "What is the user's current phone number?") {
+		t.Errorf("KU recency prompt must include the question, got:\n%s", prompt)
+	}
+}
+
 func TestGenerationPrompt_DefaultType_UsesGenericPrompt(t *testing.T) {
 	// Non-preference types must still use the original generic prompt.
 	prompt := longmemeval.GenerationPromptForType(


### PR DESCRIPTION
## Summary

Closes/addresses #1178 — knowledge-update is ~71-72% strict on both LME-M and LME-S, despite `gold_visible` ≈0.99 and `avg_rank` ≈2.0 (retrieval is already solved). ~18 items on LME-M pick the stale value when both an old and a new value for the same attribute appear in context. This PR adds a KU-specific generation prompt instructing the model to answer with the value from the *most recent* session, following the exact pattern PR #1172 (H-PE, `--preference-enumerate`) and #1183 (H-PG, `--preference-ground`) established for other opt-in generation-prompt variants.

## Changes

- `internal/longmemeval/claude.go:551-596` — two new functions:
  - `GenerationPromptKnowledgeUpdate` (claude.go:588) builds the recency-rule prompt itself — named to match the issue's acceptance-criteria wording exactly.
  - `GenerationPromptForTypeKURecency` (claude.go:565) gates it behind the `kuRecencyPrompt` bool + `questionType == "knowledge-update"`, mirroring `GenerationPromptForTypePreferenceGround` (claude.go:543).
- `cmd/longmemeval/main.go:97-99,278-279` — `Config.KURecencyPrompt` field + `--ku-recency-prompt` flag (default off).
- `cmd/longmemeval/run.go:759-773` — new `case cfg.KURecencyPrompt` in the per-item prompt-selection switch, orthogonal to the other flags (only fires for `knowledge-update` questions, same convention as `--preference-enumerate`/`--preference-ground`).

## Test plan (TDD — tests written before implementation, all failing red then green)

- `internal/longmemeval/claude_test.go` — 4 new tests:
  - `TestGenerationPrompt_KURecency_InstructsMostRecentValue` — prompt contains "most recent" / "latest date"
  - `TestGenerationPrompt_KURecency_FlagOffDefaultsToStandardPrompt` — flag off ⇒ byte-identical to `GenerationPromptForType`
  - `TestGenerationPrompt_KURecency_NonKUTypeUnaffected` — flag true but wrong question type ⇒ no-op
  - `TestGenerationPromptKnowledgeUpdate_ContainsRecencyInstructionAndContext` — recency rule + supplied context + question all present
  - 100% function coverage on both new functions (`go tool cover -func`)
- `cmd/longmemeval/ku_recency_test.go` — 2 new tests mirroring `preference_ground_test.go`:
  - `TestKURecencyPrompt_FlagRegistered` — flag + Config field present in main.go
  - `TestKURecencyPrompt_RunGoWiresPromptSelection` — dispatch wired in run.go

**Real results**, run tonight in an isolated worktree off `origin/main` (no interaction with in-progress uncommitted work on `fix/test-oom-gomaxprocs` in the primary checkout):

```
go test ./... -count=1 -race
```
→ **all packages pass, exit 0** (`internal/longmemeval` 58.9s, `cmd/longmemeval` 12.4s, full run ~150s). `go vet ./...` clean. `go build ./...` clean.

## Explicitly NOT done — requires separate authorization

The issue's acceptance criteria are benchmark outcomes:
- LME-M KU strict: 70.5% → ≥78%
- LME-S KU strict: 71.8% → ≥78%
- Full 500Q run confirms no regression on other categories

**None of these benchmark runs were executed.** I was operating under an explicit owner constraint tonight: no LME/retrieval benchmark runs. This PR implements the prompt/flag change and its unit tests only — it demonstrates the prompt text and wiring are correct and covered, but does **not** demonstrate the claimed score lift. Running `longmemeval run --ku-recency-prompt` (and the corresponding `score-efficient` pass) on LME-M and LME-S to validate the 72%→78%+ hypothesis, plus a full 500Q regression check, is the next step and needs separate authorization before it's run.

## Review gate (AI PR policy)

Per this repo's `CLAUDE.md`, this PR is labeled `ai-generated` and requires **three rounds of adversarial review before merge** (correctness, coverage, structural) with zero `severity/blocker` findings. **This PR is NOT merge-ready and should not be merged** until that review completes and, separately, the benchmark validation above is authorized and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ7gTYyj3WCgBNaujN1n5X