### PR TITLE
docs(embed): correct computeBackoff comment

### DIFF
--- a/internal/embed/litellm.go
+++ b/internal/embed/litellm.go
@@ -205,9 +205,9 @@ func isRetryableError(err error, statusCode int) bool {
 
 // computeBackoff returns the backoff duration for the given attempt (0-indexed).
 // Formula: base * 2^attempt + jitter, where base=100ms.
-// Attempt 0: 100ms → 200ms ± 25% = 75–125ms (no jitter needed, it's the first retry)
-// Attempt 1: 200ms → 400ms ± 25% = 300–500ms
-// Attempt 2: 400ms → 1600ms ± 25% = 1.2–2.0s.
+// Attempt 0: 100ms ± 25% = 75-125ms
+// Attempt 1: 200ms ± 25% = 150-250ms
+// Attempt 2: 400ms ± 25% = 300-500ms.
 func computeBackoff(attempt int) time.Duration {
 	base := 100 * time.Millisecond
 	// base * 2^attempt gives us the exponential part


### PR DESCRIPTION
Correct the `computeBackoff` doc comment so its attempt examples and jitter wording match the implementation (`100ms * 2^attempt` with unconditional `±25%` jitter). Testing: `/usr/local/go/bin/go test ./... -count=1 -race`; `/usr/local/go/bin/go vet ./...`; `/usr/local/go/bin/gofmt -l internal/embed/litellm.go`.