### PR TITLE
docs: remove stale review-gate-relaxed verification comment (clean replacement for #1270)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- verify: review-gate-relaxed 2026-05-24 -->
 ![Go](https://img.shields.io/badge/Go-1.26.3-00ADD8?logo=go&logoColor=white) ![License](https://img.shields.io/badge/License-GPL%20v3-blue) ![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white) ![MCP](https://img.shields.io/badge/MCP-SSE-purple) ![Version](https://img.shields.io/badge/Version-3.1.0-green)
 
 <p align="center"><img src="docs/hero.svg" alt="Engram — Persistent Memory for AI Agents" width="100%"></p>


### PR DESCRIPTION
Clean replacement for #1270.

#1270's head branch (`chore/readme-remove-stale-review-gate-comment`) was contaminated by a concurrent-dispatch collision: a second session's branch switch on the shared clone caused two unrelated corpus-durability WIP commits (c51bc6f, 7297bbd — 2,144 added lines) to land on top of the intended one-line docs change (b6d4e4c).

This PR contains only the intended change, cherry-picked onto current main:
- b629afd (cherry-pick of b6d4e4c): remove the stale review-gate-relaxed verification comment from README.md (1 deletion)

The foreign WIP content has been properly homed, non-destructively:
- `wip/corpus-durability-20260702` — dedicated branch holding both WIP commits off main
- `fix/test-oom-gomaxprocs` — the pinned corpus branch, which was missing this content; both commits cherry-picked and pushed (fast-forward)

Recommendation: merge this PR and close #1270 (its branch is left untouched — no rewrite/force-push per collision-cleanup protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhnXhF3PJBo83XGj7yCd9p