### PR TITLE
ci: raise coverage gate to 60%, close out stale #429/#694 justification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,19 @@ jobs:
           TEST_DATABASE_URL: postgres://engram:${{ secrets.CI_POSTGRES_PASSWORD || 'ci-only-not-production' }}@localhost:5432/engram_test?sslmode=disable
         run: go test -coverprofile=coverage.out ./...
 
-      - name: Coverage gate (55% minimum — see #694 for the path back to 60%)
-        # The campaign-level decision (#694): align ALL references — docs and
-        # CI — to the actually-enforced 55%. Raising the gate is a separate,
-        # planned operation that will follow once the t.Skip'd tests from #429
-        # are re-enabled (which will recover the missing ~4 points of coverage).
-        # The 60% target lives in #694 and is the next milestone for this gate.
+      - name: Coverage gate (60% minimum)
+        # #429 (the four t.Skip'd integration tests blocking this gate) is closed
+        # and fixed: TestHandleMemoryRecall_IncludeConflicts_Integration,
+        # TestFederatedRecall_IncludeConflicts_NotSilentlyDropped,
+        # TestEmbedDeadline_RecallWithinMemory, and TestRetrievalTracking_PrecisionUpdated
+        # all landed via PR #431 and PR #432 (#430 follow-up) and now only carry the
+        # ordinary TEST_DATABASE_URL skip guard. Measured coverage with
+        # TEST_DATABASE_URL set is 65.9%, confirmed clear of 60% before raising this
+        # gate from the temporary 55% floor (#694).
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "Total coverage: ${COVERAGE}%"
-          awk "BEGIN { if (${COVERAGE}+0 < 55) { print \"FAIL: coverage \" ${COVERAGE} \"% is below the 55% threshold (target: 60%, see #694)\"; exit 1 } else { print \"PASS: coverage \" ${COVERAGE} \"% meets the 55% threshold\" } }"
+          awk "BEGIN { if (${COVERAGE}+0 < 60) { print \"FAIL: coverage \" ${COVERAGE} \"% is below the 60% threshold\"; exit 1 } else { print \"PASS: coverage \" ${COVERAGE} \"% meets the 60% threshold\" } }"
 
       - name: Vet
         run: go vet ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ PRs submitted by any AI-assisted development (Claude Code, Cursor, GitHub Copilo
 
 ## Coverage Gate
 
-CI enforces a 55% minimum statement coverage on every PR (`.github/workflows/ci.yml`) — a temporary lower bound (#694) while four integration tests are `t.Skip`'d (#429). The target is 60%; re-enabling those tests should recover the missing ~4 points. New files should aim for 60%+ to keep the per-file bar above the global gate. The safety tools rewrite (safety.go) serves as the reference for what adequate coverage looks like.
+CI enforces a 60% minimum statement coverage on every PR (`.github/workflows/ci.yml`). The four integration tests previously blocked on #429 (`TestHandleMemoryRecall_IncludeConflicts_Integration`, `TestFederatedRecall_IncludeConflicts_NotSilentlyDropped`, `TestEmbedDeadline_RecallWithinMemory`, `TestRetrievalTracking_PrecisionUpdated`) are fixed and un-skipped; #429 is closed. Measured coverage with `TEST_DATABASE_URL` set is 65.9%. New files should aim for 60%+ to keep the per-file bar above the global gate. The safety tools rewrite (safety.go) serves as the reference for what adequate coverage looks like.
 
 ## Test Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ See `internal/mcp/tools_test.go` for examples of what adequate coverage looks li
 
 ## Coverage Gate
 
-CI enforces 55% minimum statement coverage on every PR — a temporary lower bound (#694) while four integration tests remain `t.Skip`'d (#429). The target is 60%; new files should aim for 60%+ to keep the per-file bar above the global gate.
+CI enforces 60% minimum statement coverage on every PR. The four integration tests previously blocked on #429 are fixed and un-skipped (#429 is closed); measured coverage with `TEST_DATABASE_URL` set is 65.9%. New files should aim for 60%+ to keep the per-file bar above the global gate.
 
 Check locally before pushing:
 


### PR DESCRIPTION
## Summary

The CI coverage gate has been sitting at a "temporary" 55% floor, justified by a comment in `.github/workflows/ci.yml` and matching language in `CLAUDE.md`/`CONTRIBUTING.md` claiming it was blocked on four `t.Skip`'d integration tests tracked in #429. A fresh triage found that justification stale:

- **#429 is closed**, and its fix genuinely landed (not just closed-without-action).
- All four named tests — `TestHandleMemoryRecall_IncludeConflicts_Integration`, `TestFederatedRecall_IncludeConflicts_NotSilentlyDropped`, `TestEmbedDeadline_RecallWithinMemory`, `TestRetrievalTracking_PrecisionUpdated` — no longer carry an algorithmic `t.Skip`. They only skip on the ordinary `TEST_DATABASE_URL not set` guard (`testutil.DSN(t)` / `testRecallDSN(t)`), same as every other integration test in the suite.
- Fix history: 3 of 4 landed in PR #431 (un-skip #429). The 4th (`TestFederatedRecall_IncludeConflicts_NotSilentlyDropped`) needed a product decision on cross-project relationship edges, spun off into #430, and landed in PR #432 (+ a later follow-up, PR #997).
- #694 (the issue that pinned CI to the "actually-enforced" 55% while flagging the doc/CI mismatch) is also closed.

## What changed

1. **`.github/workflows/ci.yml`** — coverage gate threshold raised from 55% to 60%; stale comment referencing #429/#694 as open blockers replaced with the closure/verification note.
2. **`CLAUDE.md`** / **`CONTRIBUTING.md`** — "temporary lower bound... while four integration tests remain t.Skip'd" language replaced with the current, verified state (#429 closed, gate at 60%, measured coverage recorded).

## Verification (before raising the gate)

Per the repo's own coverage-gate policy, I did not raise the threshold blind. Stood up a fresh `pgvector/pgvector:pg16` container matching CI's service config (`POSTGRES_DB=engram_test`), let migrations apply, and ran the full suite with `TEST_DATABASE_URL` set:

```
go test -coverprofile=coverage.out ./...
go tool cover -func=coverage.out | grep total
total: (statements) 65.9%
```

65.9% clears the 60% target comfortably. Aside: one unrelated test (`TestAdaptiveImportance_UsedInRecall`, internal/search) flaked once under heavy same-host parallel load (64 concurrent packages hitting a single local Postgres container) but passed 3/3 in isolation — a local sandbox contention artifact, not a real regression, and not one of the four tests in scope here. Left untouched; out of scope for this PR.

## Review scoping note

This is a config-threshold + doc-text change verified against real measured coverage (not new application logic) — flagging so reviewers can scope correctness/coverage/structural review appropriately per the repo's 3-round adversarial review policy. `ai-generated` label applied per repo policy.

## Test plan

- [x] Confirmed #429 closed with genuine fix (PR #431, #432/#430, #997) — not just closed-without-action
- [x] Confirmed all 4 named tests only carry the standard `TEST_DATABASE_URL` skip guard, no algorithmic skip
- [x] Ran full suite with real `TEST_DATABASE_URL` against a fresh `pgvector/pgvector:pg16` container
- [x] Measured coverage (65.9%) clears the 60% target before raising the gate
- [x] Updated `ci.yml`, `CLAUDE.md`, `CONTRIBUTING.md` to match verified current state
- [ ] Three rounds of adversarial review (correctness / coverage / structural) per repo policy — not self-merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ7gTYyj3WCgBNaujN1n5X