### PR TITLE
fix(mcp): declare real input schemas for every registered tool (#1281)

### DIFF
--- a/internal/mcp/query_document.go
+++ b/internal/mcp/query_document.go
@@ -131,7 +131,7 @@ func handleMemoryQueryDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 	if rawFilter, ok := args["filter"]; ok {
 		if fmap, ok := rawFilter.(map[string]any); ok {
 			filterRegex = getString(fmap, "regex", "")
-			filterSubs, _ = toStringSlice(fmap["substrings"]) // ignore control-char error in optional filter
+			filterSubs, _ = toStringSlice(fmap, "substrings") // ignore control-char error in optional filter
 		}
 	}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1173,7 +1173,11 @@ func degradedToolMessage(toolName, reason string) string {
 // and Prometheus instrumentation. timeout=0 uses defaultToolTimeout. readOnly
 // sets the MCP ReadOnlyHint annotation: clients (notably Claude Code's plan
 // mode) use that hint to decide whether to invoke a tool without prompting.
-func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeout time.Duration, readOnly bool) {
+// schema declares the tool's JSON input schema (WithString/WithNumber/
+// WithArray/WithBoolean/WithObject + Required()) — see #1281: every tool must
+// carry a real schema so MCP clients type-coerce arguments correctly instead
+// of stringifying array/number params, which handlers then silently drop.
+func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeout time.Duration, readOnly bool, schema ...mcpgo.ToolOption) {
 	if timeout == 0 {
 		timeout = defaultToolTimeout
 	}
@@ -1193,9 +1197,10 @@ func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeo
 		s.toolDescriptions = make(map[string]string)
 	}
 	s.toolDescriptions[name] = desc
-	s.mcp.AddTool(mcpgo.NewTool(name,
-		mcpgo.WithDescription(desc),
-		mcpgo.WithToolAnnotation(annotation)),
+	opts := make([]mcpgo.ToolOption, 0, len(schema)+2)
+	opts = append(opts, mcpgo.WithDescription(desc), mcpgo.WithToolAnnotation(annotation))
+	opts = append(opts, schema...)
+	s.mcp.AddTool(mcpgo.NewTool(name, opts...),
 		func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 			ctx, cancel := context.WithTimeout(ctx, toolTimeout)
 			defer cancel()
@@ -1227,9 +1232,10 @@ func (s *Server) registerToolWithTimeout(name, desc string, h toolHandler, timeo
 }
 
 // registerTool adds a tool with the default dispatch timeout. The readOnly hint
-// is sourced from readOnlyToolNames() — single source of truth.
-func (s *Server) registerTool(name, desc string, h toolHandler) {
-	s.registerToolWithTimeout(name, desc, h, 0, readOnlyToolNames()[name])
+// is sourced from readOnlyToolNames() — single source of truth. schema declares
+// the tool's JSON input schema (see registerToolWithTimeout).
+func (s *Server) registerTool(name, desc string, h toolHandler, schema ...mcpgo.ToolOption) {
+	s.registerToolWithTimeout(name, desc, h, 0, readOnlyToolNames()[name], schema...)
 }
 
 func (s *Server) registerTools() {
@@ -1245,89 +1251,267 @@ func (s *Server) registerTools() {
 		name    string
 		desc    string
 		handler toolHandler
+		schema  []mcpgo.ToolOption
 	}
 	tools := []toolDef{
 		// Core store operations
 		{"memory_store", "Store a focused memory (<=10k chars). Optional: pattern_confidence (float 0.0–1.0) for caller-provided confidence that a detected pattern is genuine." + embedSuffix,
-			handleMemoryStore},
+			handleMemoryStore, []mcpgo.ToolOption{
+				requiredStrProp("content", "The memory content to store (<=10,000 chars)."),
+				projectProp(),
+				enumStrProp("memory_type", "Type of memory. Defaults to \"context\" (auto-upgraded to \"preference\" when the content reads as a stated preference and memory_type was not explicitly supplied).",
+					"decision", "pattern", "error", "context", "architecture", "preference"),
+				numberProp("importance", "Retention priority 0–4 (0=Critical .. 4=Low). Defaults to 2."),
+				tagsProp("Freeform tags. A tag of the form \"date:YYYY-MM-DD\" sets valid_from."),
+				boolProp("immutable", "When true, the memory can never be edited or soft-deleted."),
+				numberProp("pattern_confidence", "Caller-provided confidence (0.0–1.0) that a detected pattern is genuine."),
+				strProp("episode_id", "Episode to attach this memory to. Falls back to the session's auto-started episode when omitted."),
+			}},
 		{"memory_store_document", "Store a large document (auto-tiered up to 50 MB via synopsis + raw blob storage)",
-			handleMemoryStoreDocument},
+			handleMemoryStoreDocument, []mcpgo.ToolOption{
+				requiredStrProp("content", "The document content to store."),
+				projectProp(),
+				enumStrProp("memory_type", "Type of memory. Defaults to \"context\".",
+					"decision", "pattern", "error", "context", "architecture", "preference"),
+				numberProp("importance", "Retention priority 0–4 (0=Critical .. 4=Low). Defaults to 2."),
+				tagsProp("Freeform tags. A tag of the form \"date:YYYY-MM-DD\" sets valid_from."),
+				boolProp("immutable", "When true, the memory can never be edited or soft-deleted."),
+				strProp("episode_id", "Episode to attach this memory to."),
+			}},
 		{"memory_ingest_document_stream", "Ingest a very large document via server-local path or chunked base64 upload (auto-tiered, up to 50 MB)",
 			func(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
 				return handleMemoryIngestDocumentStream(ctx, s, pool, req, cfg)
+			}, []mcpgo.ToolOption{
+				projectProp(),
+				strProp("path", "Server-local file path to ingest directly (mutually exclusive with the chunked-upload action flow)."),
+				enumStrProp("action", "Chunked-upload action, used when path is not set.", "start", "append", "finish"),
+				strProp("upload_id", "Identifier for the chunked-upload session (required for append/finish; letters, digits, hyphens, underscores, dots only)."),
+				numberProp("part", "0-indexed part number for action=append."),
+				numberProp("part_index", "Legacy alias for part."),
+				strProp("data", "Base64-encoded chunk payload for action=append."),
 			}},
 		{"memory_store_batch", "Store multiple memories in one call. Each item supports the same optional fields as memory_store, including pattern_confidence (float 0.0–1.0) for per-item caller-provided confidence. If any item fails validation the entire batch is rejected." + embedSuffix,
-			handleMemoryStoreBatch},
+			handleMemoryStoreBatch, []mcpgo.ToolOption{
+				projectProp(),
+				mcpgo.WithArray("memories", mcpgo.Required(),
+					mcpgo.Description("Array of memory objects to store (max 100). Each item accepts the same fields as memory_store: content (required), memory_type, importance, tags, immutable, pattern_confidence, episode_id."),
+					mcpgo.Items(map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"content":            map[string]any{"type": "string", "description": "The memory content (required)."},
+							"memory_type":        map[string]any{"type": "string", "enum": []string{"decision", "pattern", "error", "context", "architecture", "preference"}},
+							"importance":         map[string]any{"type": "number", "description": "0-4, defaults to 2."},
+							"tags":               map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+							"immutable":          map[string]any{"type": "boolean"},
+							"pattern_confidence": map[string]any{"type": "number"},
+							"episode_id":         map[string]any{"type": "string"},
+						},
+						"required": []string{"content"},
+					}),
+				),
+			}},
 		// Recall and retrieval
 		{"memory_recall", "Recall memories by semantic + full-text query. Accepts top_k or limit; mode=handle returns lightweight handles. Pass record_event=true to receive an event_id in the response for use with memory_feedback (off by default so recall stays side-effect free)." + embedSuffix,
-			withWarnLog("memory_recall", handleMemoryRecall)},
+			withWarnLog("memory_recall", handleMemoryRecall), []mcpgo.ToolOption{
+				requiredStrProp("query", "The search query."),
+				projectProp(),
+				numberProp("top_k", "Maximum number of results to return. Defaults to a server-configured value."),
+				numberProp("limit", "Alias for top_k; top_k wins if both are supplied."),
+				enumStrProp("detail", "Result verbosity.", "summary", "full", "chunk"),
+				boolProp("include_conflicts", "Include conflicting_results enrichment in the response."),
+				boolProp("record_event", "Return an event_id usable with memory_feedback. Off by default so recall stays side-effect free. Not supported for federated (projects) recall."),
+				enumStrProp("mode", "Response shape.", "handle", "full", "summary", "id_only"),
+				strProp("since", "RFC3339 or YYYY-MM-DD lower bound on memory recency (single-project recall only)."),
+				strProp("before", "RFC3339 or YYYY-MM-DD upper bound on memory recency (single-project recall only)."),
+				boolProp("temporal_window_recall", "Enable server-side date-windowed temporal recall using question_text/question_date."),
+				strProp("question_text", "Free text used to parse a temporal anchor for temporal_window_recall."),
+				strProp("question_date", "Reference date (RFC3339 or YYYY-MM-DD) used to resolve relative temporal anchors."),
+				strProp("atom_recall_as_of", "RFC3339 or YYYY-MM-DD point-in-time bound for atom_recall."),
+				boolProp("atom_recall", "Enable atom-level recall."),
+				stringArrayProp("projects", "Federated recall: search across these project names instead of the single project arg. Pass [\"*\"] to expand to all known projects."),
+				boolProp("rerank", "Opt in to Claude-based reranking (single-project only; requires the server to have reranking enabled)."),
+				boolProp("exact_fact_boost", "Boost results containing verbatim identifier matches (URLs, phone numbers, quoted phrases)."),
+				boolProp("topic_anchor_boost", "Boost topic-anchor matches for preference-shaped queries."),
+				numberProp("session_diversity_n", "Per-session chunk cap on returned results."),
+				boolProp("paraphrase_union", "Enable paraphrase-union retrieval for this call."),
+				boolProp("rrf_fusion", "Enable reciprocal-rank-fusion for this call."),
+				boolProp("evidence_first_pack", "Reorder results so verbatim-identifier matches come first."),
+			}},
 		{"memory_fetch", "Fetch a single memory by ID; detail=summary|chunk|full",
-			handleMemoryFetch},
+			handleMemoryFetch, []mcpgo.ToolOption{
+				requiredStrProp("id", "ID of the memory to fetch."),
+				projectProp(),
+				enumStrProp("detail", "Response verbosity. Defaults to \"summary\".", "summary", "full", "chunk"),
+				stringArrayProp("chunk_ids", "When detail=chunk, restrict the response to these chunk IDs."),
+			}},
 		{"memory_list", "List memories with optional filters",
-			noConfig(handleMemoryList)},
+			noConfig(handleMemoryList), []mcpgo.ToolOption{
+				projectProp(),
+				numberProp("limit", "Maximum number of memories to return (1–500). Defaults to 50; out-of-range values fall back to 50."),
+				numberProp("offset", "Number of memories to skip for pagination. Defaults to 0."),
+				strProp("memory_type", "Filter to a single memory type."),
+				tagsProp("Filter to memories matching any of these tags."),
+			}},
 		{"memory_history", "Return the full version chain for a memory",
-			noConfig(handleMemoryHistory)},
+			noConfig(handleMemoryHistory), []mcpgo.ToolOption{
+				projectProp(),
+				memoryIDProp(""),
+			}},
 		{"memory_timeline", "Recall memories that were active at a given point in time (as_of param, RFC3339)",
-			noConfig(handleMemoryTimeline)},
+			noConfig(handleMemoryTimeline), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("as_of", "RFC3339 timestamp — return memories active at this point in time."),
+				numberProp("limit", "Maximum number of memories to return. Defaults to 20."),
+			}},
 		// Graph operations
 		{"memory_connect", "Create a directed relationship between two memories. relation_type values: caused_by, relates_to, depends_on, supersedes, used_in, resolved_by, contradicts, supports, derived_from, part_of, follows",
-			noConfig(handleMemoryConnect)},
+			noConfig(handleMemoryConnect), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("source_id", "ID of the source memory."),
+				requiredStrProp("target_id", "ID of the target memory."),
+				strProp("relation_type", "Relationship type. Defaults to \"relates_to\"."),
+				numberProp("strength", "Relationship strength, 0.0–1.0. Defaults to 1.0."),
+			}},
 		{"memory_expand", "Explore the relationship graph neighbourhood of a known memory.",
-			noConfig(handleMemoryExpand)},
+			noConfig(handleMemoryExpand), []mcpgo.ToolOption{
+				projectProp(),
+				memoryIDProp(""),
+				numberProp("depth", "Number of relationship hops to traverse. Defaults to 2."),
+			}},
 		// Mutations
 		{"memory_correct", "Update content, tags, importance, or pattern_confidence (float 0.0–1.0) on an existing memory. Omit pattern_confidence to leave it unchanged. Only-promote-never-nullify rule: omit 'tags' entirely to preserve the existing valid_from; sending tags=[...] recalculates valid_from from date: tags; sending tags=[] clears valid_from to null. See docs/tools.md#memory_correct and issue #765.",
-			noConfig(handleMemoryCorrect)},
+			noConfig(handleMemoryCorrect), []mcpgo.ToolOption{
+				projectProp(),
+				memoryIDProp(""),
+				strProp("content", "New content. Omit to leave content unchanged."),
+				tagsProp("New tags. Omit entirely to preserve the existing tags/valid_from; pass [] to clear tags and valid_from."),
+				numberProp("importance", "New importance, 0–4. Omit to leave unchanged."),
+				numberProp("pattern_confidence", "New pattern confidence, 0.0–1.0. Omit to leave unchanged."),
+			}},
 		{"memory_forget", "Soft-delete a memory (sets valid_to, preserves history, respects immutability)",
-			noConfig(handleMemoryForget)},
+			noConfig(handleMemoryForget), []mcpgo.ToolOption{
+				projectProp(),
+				memoryIDProp(""),
+				strProp("reason", "Optional human-readable reason for the deletion."),
+			}},
 		// Maintenance
 		{"memory_summarize", "Immediately summarize a memory",
-			handleMemorySummarize},
+			handleMemorySummarize, []mcpgo.ToolOption{
+				projectProp(),
+				memoryIDProp(""),
+			}},
 		{"memory_resummarize", "Clear all summaries for a project — they regenerate automatically within 60s",
-			noConfig(handleMemoryResummarize)},
+			noConfig(handleMemoryResummarize), []mcpgo.ToolOption{
+				projectProp(),
+			}},
 		{"memory_status", "Return project statistics",
-			noConfig(handleMemoryStatus)},
+			noConfig(handleMemoryStatus), []mcpgo.ToolOption{
+				projectProp(),
+			}},
 		{"memory_status_ping", "Lightweight liveness probe — no DB writes, 2s internal timeout. Used by the Claude Code Stop hook to detect MCP disconnection.",
-			noConfig(handleMemoryStatusPing)},
+			noConfig(handleMemoryStatusPing), nil},
 		{"memory_verify", "Integrity check -- hash coverage and corrupt count",
-			noConfig(handleMemoryVerify)},
+			noConfig(handleMemoryVerify), []mcpgo.ToolOption{
+				projectProp(),
+			}},
 		// Feedback and aggregation
 		{"memory_feedback", "Record retrieval feedback. event_id: the id returned by memory_recall's response when called with record_event=true (required when failure_class is set). failure_class values (for misses): vocabulary_mismatch, aggregation_failure, stale_ranking, missing_content, scope_mismatch, other",
-			noConfig(handleMemoryFeedback)},
+			noConfig(handleMemoryFeedback), []mcpgo.ToolOption{
+				projectProp(),
+				stringArrayProp("memory_ids", "IDs of memories to reinforce (max 100)."),
+				strProp("event_id", "UUID from a prior memory_recall(record_event=true) call. Required when failure_class is set."),
+				enumStrProp("failure_class", "Classify a retrieval miss instead of reinforcing.",
+					"vocabulary_mismatch", "aggregation_failure", "stale_ranking", "missing_content", "scope_mismatch", "other"),
+			}},
 		{"memory_aggregate", "Group and count memories. by=tag|type|failure_class. filter: optional ILIKE substring — tag mode only, error for failure_class.",
-			noConfig(handleMemoryAggregate)},
+			noConfig(handleMemoryAggregate), []mcpgo.ToolOption{
+				projectProp(),
+				requiredEnumStrProp("by", "Dimension to group by.", "tag", "type", "failure_class"),
+				strProp("filter", "Optional ILIKE substring filter — tag mode only."),
+				numberProp("limit", "Maximum number of groups to return (1–1000). Defaults to 20."),
+			}},
 		// Consolidation
 		{"memory_consolidate", "Prune stale memories, decay edges, merge near-duplicates",
-			handleMemoryConsolidate},
+			handleMemoryConsolidate, []mcpgo.ToolOption{
+				projectProp(),
+			}},
 		{"memory_sleep", "Run full sleep-consolidation cycle: infer relationships between semantically related memories",
-			handleMemorySleep},
+			handleMemorySleep, []mcpgo.ToolOption{
+				projectProp(),
+				numberProp("min_similarity", "Minimum cosine similarity to infer a relationship. Defaults to 0.7."),
+				numberProp("limit", "Maximum memories to scan for relationship inference (1–5000). Defaults to 500."),
+				boolProp("llm_contradiction_detection", "Enable LLM-based contradiction detection (opt-in, default off)."),
+				strProp("llm_model", "Ollama model to use for contradiction detection. Defaults to \"llama3.2:3b\"."),
+				numberProp("llm_max_calls", "Cap on LLM calls for contradiction detection. Defaults to 10."),
+				boolProp("auto_supersede", "Automatically mark detected contradictions as superseded."),
+				numberProp("contradiction_limit", "Memories to scan for contradiction detection. Defaults to the value of limit when 0."),
+			}},
 		{"memory_delete_project", "Delete all memories and project data for a project. IRREVERSIBLE. Requires server started with ENGRAM_ALLOW_PROJECT_DELETE=1 AND a confirm argument exactly matching the project argument (#689). Not for normal use.",
-			noConfig(handleMemoryDeleteProject)},
+			noConfig(handleMemoryDeleteProject), []mcpgo.ToolOption{
+				requiredStrProp("project", "Project to permanently delete."),
+				requiredStrProp("confirm", "Must exactly match project — typo guard for this irreversible operation."),
+			}},
 		// Episodes
 		{"memory_episode_start", "Start a named episode to group memories from this session",
-			withWarnLog("memory_episode_start", noConfig(handleMemoryEpisodeStart))},
+			withWarnLog("memory_episode_start", noConfig(handleMemoryEpisodeStart)), []mcpgo.ToolOption{
+				projectProp(),
+				strProp("description", "Human-readable description of the episode."),
+			}},
 		{"memory_episode_end", "End an episode with an optional summary",
-			noConfig(handleMemoryEpisodeEnd)},
+			noConfig(handleMemoryEpisodeEnd), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("episode_id", "ID of the episode to end."),
+				strProp("summary", "Optional summary of what happened in this episode."),
+			}},
 		{"memory_episode_list", "List recent episodes for a project",
-			noConfig(handleMemoryEpisodeList)},
+			noConfig(handleMemoryEpisodeList), []mcpgo.ToolOption{
+				projectProp(),
+				numberProp("limit", "Maximum number of episodes to return. Defaults to 20."),
+			}},
 		{"memory_episode_recall", "Return all memories from a specific episode in chronological order",
-			noConfig(handleMemoryEpisodeRecall)},
+			noConfig(handleMemoryEpisodeRecall), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("episode_id", "ID of the episode to recall."),
+			}},
 		// Embedder management
 		{"memory_migrate_embedder", "Switch embedding model; triggers background re-embedding. Also resets any learned adaptive weights for the project to compile-time defaults.",
-			handleMemoryMigrateEmbedder},
+			handleMemoryMigrateEmbedder, []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("new_model", "Name of the new embedding model."),
+				strProp("ollama_url", "Override the server-configured embedder endpoint for this call."),
+				boolProp("force", "Bypass the same-model no-op guard."),
+				boolProp("dry_run", "Report what would happen without nulling any embeddings."),
+				boolProp("confirm", "Explicit confirmation required by some migration guards."),
+			}},
 		{"memory_models", "List installed and suggested Ollama embedding models. Shows which suggested models are installed, which is current, and flags the recommended upgrade.",
-			handleMemoryModels},
+			handleMemoryModels, nil},
 		{"memory_embedding_eval", "Compare two Ollama embedding models using probe sentences. model_a defaults to the configured embedding model; model_b defaults to the recommended registry entry. Use this to validate a 1024-dim compatible replacement before migrating. Auto-pulls missing models. Read-only — does not migrate stored embeddings.",
-			handleMemoryEmbeddingEval},
+			handleMemoryEmbeddingEval, []mcpgo.ToolOption{
+				strProp("model_a", "First model to compare. Defaults to the server's configured embedding model."),
+				strProp("model_b", "Second model to compare. Defaults to the recommended registry entry."),
+			}},
 		// Import / export
 		{"memory_export_all", "Export all memories to markdown files",
-			handleMemoryExportAll},
+			handleMemoryExportAll, []mcpgo.ToolOption{
+				projectProp(),
+				strProp("output_path", "Destination directory, relative to the server's data directory. Defaults to \"./memory-export\"."),
+			}},
 		{"memory_import_claudemd", "Import a CLAUDE.md file as structured memories",
-			handleMemoryImportClaudeMD},
+			handleMemoryImportClaudeMD, []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("path", "Path to the CLAUDE.md file, relative to the server's data directory."),
+			}},
 		{"memory_ingest", "Ingest a file or directory as document memories",
-			handleMemoryIngest},
+			handleMemoryIngest, []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("path", "File or directory to ingest, relative to the server's data directory."),
+			}},
 		{"memory_ingest_export",
 			"Ingest a server-local AI conversation export file (Slack workspace .zip, Claude.ai conversations.json, or ChatGPT conversations.json). Parses the file, auto-detects format, and stores one memory per conversation or channel.",
-			handleMemoryIngestExport},
+			handleMemoryIngestExport, []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("path", "Path to the export file, relative to the server's data directory."),
+			}},
 		{"memory_ingest_status",
 			"Check the status of an async ingestion job queued by memory_ingest_export, memory_ingest, or memory_ingest_document_stream.",
 			func(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest, cfg Config) (*mcpgo.CallToolResult, error) {
@@ -1355,62 +1539,144 @@ func (s *Server) registerTools() {
 					out["duration_ms"] = r.DoneAt.Sub(r.StartedAt).Milliseconds()
 				}
 				return toolResult(out)
+			}, []mcpgo.ToolOption{
+				requiredStrProp("job_id", "Job ID returned by the queuing call."),
 			}},
 		// Cross-project federation
 		{"memory_projects", "List all projects with memory counts",
-			noConfig(handleMemoryProjects)},
+			noConfig(handleMemoryProjects), []mcpgo.ToolOption{
+				projectProp(),
+			}},
 		{"memory_adopt", "Create a cross-project reference relationship",
-			noConfig(handleMemoryAdopt)},
+			noConfig(handleMemoryAdopt), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("source_id", "ID of the memory in the calling project."),
+				requiredStrProp("target_id", "ID of the memory in the other project."),
+				strProp("relation_type", "Relationship type. Defaults to \"relates_to\"."),
+				numberProp("strength", "Relationship strength, 0.0–1.0. Defaults to 1.0."),
+			}},
 		// Simplified front-door tools
 		{"memory_quick_store", "Store a memory and automatically extract entities. Simplified front door for memory_store.",
-			withWarnLog("memory_quick_store", handleMemoryQuickStore)},
+			withWarnLog("memory_quick_store", handleMemoryQuickStore), []mcpgo.ToolOption{
+				requiredStrProp("content", "The memory content to store."),
+				projectProp(),
+				enumStrProp("memory_type", "Type of memory. Defaults to \"context\".",
+					"decision", "pattern", "error", "context", "architecture", "preference"),
+				numberProp("importance", "Retention priority 0–4. Defaults to 2."),
+				tagsProp("Freeform tags."),
+				boolProp("immutable", "When true, the memory can never be edited or soft-deleted."),
+			}},
 		{"memory_query", "Simplified front door for memory_recall. Accepts a 'limit' param instead of top_k; sensible defaults applied." + embedSuffix,
-			handleMemoryQuery},
+			handleMemoryQuery, []mcpgo.ToolOption{
+				requiredStrProp("query", "The search query."),
+				projectProp(),
+				numberProp("limit", "Maximum number of results to return. Defaults to 5. Mapped to top_k internally."),
+				numberProp("top_k", "Alias for limit; wins if both are supplied."),
+				enumStrProp("detail", "Result verbosity.", "summary", "full", "chunk"),
+				boolProp("include_conflicts", "Include conflicting_results enrichment in the response."),
+				enumStrProp("mode", "Response shape.", "handle", "full", "summary", "id_only"),
+			}},
 		// Safety constraint verification
 		{"get_constraints", "List constraint and policy memories relevant to an optional query",
-			noConfig(handleGetConstraints)},
+			noConfig(handleGetConstraints), []mcpgo.ToolOption{
+				projectProp(),
+				strProp("query", "Optional free-text query to scope the constraint search."),
+				numberProp("limit", "Maximum number of constraints to return (1–50). Defaults to 10."),
+				numberProp("stale_after_days", "Days after which a matched constraint is flagged stale (1–3650). Defaults to 180."),
+			}},
 		{"check_constraints", "Classify a proposed action and return matching constraints with a verification decision",
-			noConfig(handleCheckConstraints)},
+			noConfig(handleCheckConstraints), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("proposed_action", "Description of the action to classify."),
+				numberProp("limit", "Maximum number of constraints to return (1–50). Defaults to 10."),
+				numberProp("stale_after_days", "Days after which a matched constraint is flagged stale (1–3650). Defaults to 180."),
+			}},
 		{"verify_before_acting", "Run the full constraint verification pipeline and return a proceed/warn/require_approval/block decision",
-			noConfig(handleVerifyBeforeActing)},
+			noConfig(handleVerifyBeforeActing), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("proposed_action", "Description of the action to verify."),
+				numberProp("limit", "Maximum number of constraints to return (1–50). Defaults to 10."),
+				numberProp("stale_after_days", "Days after which a matched constraint is flagged stale (1–3650). Defaults to 180."),
+			}},
 		// Audit and weight tuning
 		{"memory_audit_add_query", "Register a canonical query for retrieval drift monitoring",
-			handleMemoryAuditAddQuery},
+			handleMemoryAuditAddQuery, []mcpgo.ToolOption{
+				requiredProjectProp(),
+				requiredStrProp("query", "The canonical query text to monitor."),
+				strProp("description", "Optional human-readable description of this canonical query."),
+			}},
 		{"memory_audit_list_queries", "List canonical queries registered for drift monitoring in a project",
-			handleMemoryAuditListQueries},
+			handleMemoryAuditListQueries, []mcpgo.ToolOption{
+				requiredProjectProp(),
+			}},
 		{"memory_audit_deactivate_query", "Deactivate a canonical query (stops future drift snapshots)",
-			handleMemoryAuditDeactivateQuery},
+			handleMemoryAuditDeactivateQuery, []mcpgo.ToolOption{
+				requiredStrProp("query_id", "ID of the canonical query to deactivate."),
+			}},
 		{"memory_audit_run", "Run a decay audit pass for a project immediately and return snapshot summaries",
-			handleMemoryAuditRun},
+			handleMemoryAuditRun, []mcpgo.ToolOption{
+				requiredProjectProp(),
+			}},
 		{"memory_audit_compare", "Compare retrieval snapshots for a canonical query to detect ranking drift",
-			handleMemoryAuditCompare},
+			handleMemoryAuditCompare, []mcpgo.ToolOption{
+				requiredStrProp("query_id", "ID of the canonical query."),
+				numberProp("limit", "Maximum number of snapshots to return. Defaults to 10."),
+			}},
 		{"memory_weight_history", "Return current retrieval weights and tuning history for a project",
-			handleMemoryWeightHistory},
+			handleMemoryWeightHistory, []mcpgo.ToolOption{
+				requiredProjectProp(),
+			}},
 		// Diagnose (always available — no Claude required)
 		{"memory_diagnose", "Return evidence map for recalled memories: conflicts, confidence, invalidated sources — no synthesis",
-			noConfig(handleMemoryDiagnose)},
+			noConfig(handleMemoryDiagnose), []mcpgo.ToolOption{
+				projectProp(),
+				requiredStrProp("question", "Query used to recall the memories to diagnose."),
+				numberProp("top_k", "Maximum number of memories to recall for diagnosis. Defaults to 10."),
+				enumStrProp("detail", "Recall detail level passed through to the underlying recall.", "summary", "full", "chunk"),
+			}},
 	}
 	for _, t := range tools {
-		s.registerTool(t.name, t.desc, t.handler)
+		s.registerTool(t.name, t.desc, t.handler, t.schema...)
 	}
 
 	// Claude-required tools: registered only when a client is available.
 	if s.cfg.ClaudeEnabled {
 		s.registerTool("memory_reason",
 			"Recall memories and synthesize a grounded answer using Claude",
-			handleMemoryReason)
+			handleMemoryReason,
+			projectProp(),
+			requiredStrProp("question", "The question to answer."),
+			numberProp("top_k", "Maximum number of memories to recall (1–100). Defaults to 10."),
+			enumStrProp("detail", "Recall detail level.", "summary", "full", "chunk"))
 		s.registerTool("memory_explore",
 			"Iterative recall+score+synthesis loop — returns a single grounded answer (A3)",
-			handleMemoryExplore)
+			handleMemoryExplore,
+			projectProp(),
+			requiredStrProp("question", "The question to answer."),
+			numberProp("max_iterations", "Cap on recall+score+synthesis loop iterations (1–10)."),
+			numberProp("confidence_threshold", "Stop iterating once this confidence (0.0–1.0) is reached. Defaults to 0.75."),
+			numberProp("token_budget", "Cumulative scoring-call token budget. Defaults to a server-configured value."),
+			boolProp("include_trace", "Include the full iteration trace in the response."),
+			exploreScopeProp())
 		// memory_query_document (A5): query a single large document by regex/substring
 		// or semantic recall and synthesize an answer with Claude.
 		s.registerTool("memory_query_document",
 			"Query a large document stored in memory using regex/substring matching or semantic search. Returns relevant spans and an AI-synthesized answer.",
-			handleMemoryQueryDocument)
+			handleMemoryQueryDocument,
+			requiredProjectProp(),
+			requiredStrProp("memory_id", "ID of the document memory to query."),
+			requiredStrProp("question", "The question to answer against the document."),
+			queryDocumentFilterProp(),
+			numberProp("window_chars", "Characters of context to include around each match. Defaults to 4000."),
+			boolProp("semantic", "Use semantic recall instead of regex/substring matching."),
+			numberProp("token_budget", "Token budget for the synthesis call. Defaults to 6000."))
 		// memory_ask (P2): retrieval-augmented question answering with numbered citations.
 		s.registerTool("memory_ask",
 			"Answer a question using stored memories as context. Returns answer + numbered citations.",
-			handleMemoryAsk)
+			handleMemoryAsk,
+			requiredProjectProp(),
+			requiredStrProp("question", "The question to answer."),
+			numberProp("top_k", "Maximum number of memories to use as context (0–100). 0 or omitted uses the default (10)."))
 	}
 
 	// Hide maintenance/operational tools from tools/list. They remain callable

--- a/internal/mcp/tool_schemas.go
+++ b/internal/mcp/tool_schemas.go
@@ -1,0 +1,117 @@
+package mcp
+
+// Small helper builders for the MCP tool input schemas declared in
+// registerTools() (server.go). Extracted so the (long) per-tool schema list
+// stays readable — every helper here is a thin wrapper over the mcpgo
+// WithString/WithNumber/WithArray/WithBoolean/WithObject builders.
+//
+// #1281: prior to this file, every tool was registered with an empty input
+// schema ({"properties":{}}), so MCP clients that type-coerce arguments based
+// on the advertised schema had no way to know a parameter was an array or a
+// number and sent it JSON-encoded as a string. Handlers then silently
+// dropped it (see toStringSlice / getInt in tools.go, pre-fix). Every
+// property declared below was derived by reading the corresponding handler's
+// arg-extraction code, not guessed from docs.
+
+import (
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// projectProp declares the near-universal optional "project" string param.
+func projectProp() mcpgo.ToolOption {
+	return mcpgo.WithString("project",
+		mcpgo.Description(`Project namespace to scope this call to. Defaults to "default" when omitted.`))
+}
+
+// requiredProjectProp is projectProp for the handful of tools that reject an
+// empty/absent project (audit + weight tools call getProject(args, "") and
+// then explicitly error when the result is empty).
+func requiredProjectProp() mcpgo.ToolOption {
+	return mcpgo.WithString("project",
+		mcpgo.Required(),
+		mcpgo.Description("Project namespace."))
+}
+
+// tagsProp declares an optional array-of-strings "tags" param.
+func tagsProp(desc string) mcpgo.ToolOption {
+	return mcpgo.WithArray("tags", mcpgo.WithStringItems(), mcpgo.Description(desc))
+}
+
+// stringArrayProp declares an optional array-of-strings param under an
+// arbitrary name.
+func stringArrayProp(name, desc string) mcpgo.ToolOption {
+	return mcpgo.WithArray(name, mcpgo.WithStringItems(), mcpgo.Description(desc))
+}
+
+// numberProp declares an optional number param.
+func numberProp(name, desc string) mcpgo.ToolOption {
+	return mcpgo.WithNumber(name, mcpgo.Description(desc))
+}
+
+// requiredNumberProp declares a required number param.
+func requiredNumberProp(name, desc string) mcpgo.ToolOption {
+	return mcpgo.WithNumber(name, mcpgo.Required(), mcpgo.Description(desc))
+}
+
+// boolProp declares an optional boolean param.
+func boolProp(name, desc string) mcpgo.ToolOption {
+	return mcpgo.WithBoolean(name, mcpgo.Description(desc))
+}
+
+// strProp declares an optional string param.
+func strProp(name, desc string) mcpgo.ToolOption {
+	return mcpgo.WithString(name, mcpgo.Description(desc))
+}
+
+// requiredStrProp declares a required string param.
+func requiredStrProp(name, desc string) mcpgo.ToolOption {
+	return mcpgo.WithString(name, mcpgo.Required(), mcpgo.Description(desc))
+}
+
+// enumStrProp declares an optional string param constrained to an enum.
+func enumStrProp(name, desc string, values ...string) mcpgo.ToolOption {
+	return mcpgo.WithString(name, mcpgo.Description(desc), mcpgo.Enum(values...))
+}
+
+// requiredEnumStrProp declares a required string param constrained to an enum.
+func requiredEnumStrProp(name, desc string, values ...string) mcpgo.ToolOption {
+	return mcpgo.WithString(name, mcpgo.Required(), mcpgo.Description(desc), mcpgo.Enum(values...))
+}
+
+// memoryIDProp declares the near-universal required "memory_id" string param.
+func memoryIDProp(desc string) mcpgo.ToolOption {
+	if desc == "" {
+		desc = "ID of the target memory."
+	}
+	return mcpgo.WithString("memory_id", mcpgo.Required(), mcpgo.Description(desc))
+}
+
+// exploreScopeProp declares memory_explore's optional "scope" object param.
+// Extracted to a helper (rather than inlined at the call site) so the
+// braces of its nested map[string]any literal don't sit inside the
+// `if s.cfg.ClaudeEnabled { ... }` block in registerTools() — the doc-count
+// regression guard (tool_count_doc_test.go) locates that block with a
+// non-greedy brace match and would otherwise stop at the first inner `}`.
+func exploreScopeProp() mcpgo.ToolOption {
+	return mcpgo.WithObject("scope",
+		mcpgo.Description("Restrict recall to memories matching all of these constraints."),
+		mcpgo.Properties(map[string]any{
+			"tags":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Memory must contain all of these tags."},
+			"episode_id": map[string]any{"type": "string"},
+			"since":      map[string]any{"type": "string", "description": "RFC3339 lower bound on created_at."},
+			"until":      map[string]any{"type": "string", "description": "RFC3339 upper bound on created_at."},
+		}),
+	)
+}
+
+// queryDocumentFilterProp declares memory_query_document's optional "filter"
+// object param. See exploreScopeProp for why this is a helper function.
+func queryDocumentFilterProp() mcpgo.ToolOption {
+	return mcpgo.WithObject("filter",
+		mcpgo.Description("Optional pre-filter narrowing which spans are considered."),
+		mcpgo.Properties(map[string]any{
+			"regex":      map[string]any{"type": "string", "description": "Regex applied to document spans."},
+			"substrings": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Spans must contain at least one of these substrings."},
+		}),
+	)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -322,37 +322,114 @@ func validateContent(s string) error {
 	return nil
 }
 
-// getInt extracts an int arg (JSON numbers arrive as float64) with a fallback.
+// coerceToFloat converts v to float64. It accepts a native JSON number
+// (float64/int) or a JSON-encoded numeric string (e.g. "250") as a
+// defense-in-depth fallback for MCP clients that stringify arguments despite
+// the tool's declared schema (#1281). Returns ok=false when v is present but
+// cannot be interpreted as a number by either path.
+func coerceToFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case string:
+		s := strings.TrimSpace(n)
+		if s == "" {
+			return 0, false
+		}
+		var f float64
+		if err := json.Unmarshal([]byte(s), &f); err == nil {
+			return f, true
+		}
+		return 0, false
+	}
+	return 0, false
+}
+
+// coerceToInt is coerceToFloat rounded to the nearest int.
+func coerceToInt(v any) (int, bool) {
+	f, ok := coerceToFloat(v)
+	if !ok {
+		return 0, false
+	}
+	return int(math.Round(f)), true
+}
+
+// coerceToBool converts v to bool. It accepts a native JSON boolean or the
+// exact strings "true"/"false" (case-insensitive) as a defense-in-depth
+// fallback (#1281). No truthy/falsy guessing on other strings.
+func coerceToBool(v any) (bool, bool) {
+	switch b := v.(type) {
+	case bool:
+		return b, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(b)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+		return false, false
+	}
+	return false, false
+}
+
+// getInt extracts an int arg (JSON numbers arrive as float64) with a
+// fallback. Accepts a JSON-encoded numeric string as a coercion fallback
+// (#1281); a present-but-uncoercible value silently returns def — callers on
+// load-bearing params should use requireOptionalInt instead so a genuinely
+// bad value produces a loud error rather than a silent default.
 func getInt(args map[string]any, key string, def int) int {
 	if v, ok := args[key]; ok {
-		switch n := v.(type) {
-		case float64:
-			return int(math.Round(n))
-		case int:
+		if n, ok := coerceToInt(v); ok {
 			return n
 		}
 	}
 	return def
 }
 
-// getFloat extracts a float64 arg with a fallback.
+// getFloat extracts a float64 arg with a fallback. Accepts a JSON-encoded
+// numeric string as a coercion fallback (#1281).
 func getFloat(args map[string]any, key string, def float64) float64 {
 	if v, ok := args[key]; ok {
-		if f, ok := v.(float64); ok {
+		if f, ok := coerceToFloat(v); ok {
 			return f
 		}
 	}
 	return def
 }
 
-// getBool extracts a bool arg with a fallback default.
+// getBool extracts a bool arg with a fallback default. Accepts the strings
+// "true"/"false" as a coercion fallback (#1281).
 func getBool(args map[string]any, key string, def bool) bool {
 	if v, ok := args[key]; ok {
-		if b, ok := v.(bool); ok {
+		if b, ok := coerceToBool(v); ok {
 			return b
 		}
 	}
 	return def
+}
+
+// requireOptionalInt extracts an optional numeric arg. present=false means
+// the key is absent or null — the caller should apply its own default. A
+// non-nil err means the key was present but the value could not be
+// interpreted as a number even via the coerceToInt string fallback.
+//
+// This is the loud-error counterpart to getInt: load-bearing numeric params
+// (memory_list's limit/offset, memory_store's importance, etc.) must use this
+// instead of getInt so a present-but-wrongly-typed value surfaces a tool
+// error rather than silently falling back to a default that looks
+// indistinguishable from a legitimate response (#1279, #1280, #1281).
+func requireOptionalInt(args map[string]any, key string) (value int, present bool, err error) {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return 0, false, nil
+	}
+	if n, ok := coerceToInt(v); ok {
+		return n, true, nil
+	}
+	return 0, true, fmt.Errorf("%s must be a number, got %T", key, v)
 }
 
 // Per-tag and count limits to prevent tag injection attacks (#149).
@@ -361,13 +438,34 @@ const (
 	maxTagLength = 256
 )
 
-// toStringSlice converts []any to []string, applying per-tag/count limits (#149).
+// toStringSlice extracts args[key] as a []string, applying per-tag/count
+// limits (#149). present semantics: an absent or null key returns (nil, nil)
+// — "no items", the same as an omitted optional array param always meant.
+//
+// A present-but-wrongly-typed value is a loud error naming the key (#1279,
+// #1281) — it is never silently dropped. As a defense-in-depth fallback for
+// clients that still JSON-encode the array as a string despite the tool's
+// declared schema, a string value is first attempted as JSON before being
+// rejected.
+//
 // Returns an error if any tag contains NUL or C0 control characters
 // (except tab/newline/carriage-return) or DEL (#252).
-func toStringSlice(v any) ([]string, error) {
+func toStringSlice(args map[string]any, key string) ([]string, error) {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return nil, nil
+	}
 	arr, ok := v.([]any)
 	if !ok {
-		return nil, nil
+		s, isStr := v.(string)
+		if !isStr {
+			return nil, fmt.Errorf("%s must be an array of strings, got %T", key, v)
+		}
+		var decoded []any
+		if err := json.Unmarshal([]byte(s), &decoded); err != nil {
+			return nil, fmt.Errorf("%s must be an array of strings, got a string that is not valid JSON: %w", key, err)
+		}
+		arr = decoded
 	}
 	result := make([]string, 0, len(arr))
 	for _, item := range arr {

--- a/internal/mcp/tools_admin.go
+++ b/internal/mcp/tools_admin.go
@@ -133,7 +133,7 @@ func handleMemoryFeedback(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 	if err != nil {
 		return nil, err
 	}
-	ids, err := toStringSlice(args["memory_ids"])
+	ids, err := toStringSlice(args, "memory_ids")
 	if err != nil {
 		return nil, fmt.Errorf("memory_ids: %w", err)
 	}

--- a/internal/mcp/tools_list_test.go
+++ b/internal/mcp/tools_list_test.go
@@ -1,0 +1,207 @@
+package mcp
+
+// Regression tests for #1280: memory_list ignored limit/offset because the
+// empty MCP input schema (#1281) let schema-driven clients stringify numeric
+// args, and getInt's typed cast then silently fell back to its default.
+//
+// listCapturingBackend captures both the stored memories (for a genuine
+// store→list round trip) and the db.ListOptions passed to ListMemories, so
+// these tests prove the values reach the backend call — not just that no Go
+// error occurred.
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// listCapturingBackend records StoreMemoryTx writes and ListMemories calls,
+// returning the stored memories (most-recent-first) from ListMemories so a
+// store→list round trip can be verified without a real Postgres instance.
+type listCapturingBackend struct {
+	storeCapableBackend
+	mu           sync.Mutex
+	stored       []*types.Memory
+	lastListOpts db.ListOptions
+	listCalls    int
+}
+
+func (b *listCapturingBackend) StoreMemoryTx(_ context.Context, _ db.Tx, m *types.Memory) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.stored = append(b.stored, m)
+	return nil
+}
+
+func (b *listCapturingBackend) ListMemories(_ context.Context, _ string, opts db.ListOptions) ([]*types.Memory, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.lastListOpts = opts
+	b.listCalls++
+	// Return up to opts.Limit items starting at opts.Offset, mirroring a real
+	// paginated backend closely enough to prove limit/offset actually reached
+	// this call.
+	if opts.Offset >= len(b.stored) {
+		return []*types.Memory{}, nil
+	}
+	end := opts.Offset + opts.Limit
+	if end > len(b.stored) || opts.Limit <= 0 {
+		end = len(b.stored)
+	}
+	return b.stored[opts.Offset:end], nil
+}
+
+func newListCapturingPool(t *testing.T) (*EnginePool, *listCapturingBackend) {
+	t.Helper()
+	back := &listCapturingBackend{}
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, back, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory), back
+}
+
+// seedMemories stores n memories via handleMemoryStore so a real store→list
+// round trip can be exercised.
+func seedMemories(t *testing.T, pool *EnginePool, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		req := mcpgo.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"project": "test",
+			"content": "seed memory",
+		}
+		res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+		require.NoError(t, err)
+		require.False(t, res.IsError, "seed store %d failed: %+v", i, res.Content)
+	}
+}
+
+// TestMemoryList_LimitOffset_NativeNumbers_ReachBackend is the happy path a
+// schema-respecting client produces once #1281 lands: limit/offset arrive as
+// real JSON numbers and must reach db.ListOptions unchanged (#1280).
+func TestMemoryList_LimitOffset_NativeNumbers_ReachBackend(t *testing.T) {
+	pool, back := newListCapturingPool(t)
+	seedMemories(t, pool, 10)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"limit":   5.0,
+		"offset":  2.0,
+	}
+	res, err := handleMemoryList(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Equal(t, 1, back.listCalls)
+	require.Equal(t, 5, back.lastListOpts.Limit, "limit must reach ListMemories unchanged — see #1280")
+	require.Equal(t, 2, back.lastListOpts.Offset, "offset must reach ListMemories unchanged — see #1280")
+
+	out := parseSimpleResult(t, res)
+	require.Equal(t, float64(5), out["count"], "5 of the 10 seeded memories must be returned")
+}
+
+// TestMemoryList_LimitOffset_JSONEncodedStringFallback covers the
+// defense-in-depth coercion path: a stringified numeric limit/offset (what a
+// pre-#1281 schema-less client actually sent) must still reach the backend
+// correctly instead of silently falling back to the default (50/0).
+func TestMemoryList_LimitOffset_JSONEncodedStringFallback(t *testing.T) {
+	pool, back := newListCapturingPool(t)
+	seedMemories(t, pool, 10)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"limit":   "5",
+		"offset":  "2",
+	}
+	res, err := handleMemoryList(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Equal(t, 5, back.lastListOpts.Limit,
+		"stringified limit must be coerced, not silently fall back to the default 50 — this is the exact #1280 repro")
+	require.Equal(t, 2, back.lastListOpts.Offset,
+		"stringified offset must be coerced, not silently fall back to the default 0 — this is the exact #1280 repro")
+}
+
+// TestMemoryList_DefaultLimit_WhenOmitted verifies the documented default
+// (50) still applies when limit is genuinely absent.
+func TestMemoryList_DefaultLimit_WhenOmitted(t *testing.T) {
+	pool, back := newListCapturingPool(t)
+	seedMemories(t, pool, 3)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"project": "test"}
+	res, err := handleMemoryList(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Equal(t, 50, back.lastListOpts.Limit)
+	require.Equal(t, 0, back.lastListOpts.Offset)
+}
+
+// TestMemoryList_LimitWrongType_ReturnsLoudErrorNotSilentDefault is the
+// direct regression guard: a present-but-uncoercible limit must be a tool
+// error, never a silent fallback to 50 (the exact shape of #1280).
+func TestMemoryList_LimitWrongType_ReturnsLoudErrorNotSilentDefault(t *testing.T) {
+	pool, back := newListCapturingPool(t)
+	seedMemories(t, pool, 3)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"limit":   []any{"oops"},
+	}
+	res, err := handleMemoryList(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "wrongly-typed limit must produce a tool error, not silently default to 50")
+	require.Contains(t, res.Content[0].(mcpgo.TextContent).Text, "limit")
+	require.Equal(t, 0, back.listCalls, "the backend must not be queried on a rejected request")
+}
+
+// TestMemoryList_OffsetWrongType_ReturnsLoudErrorNotSilentDefault mirrors the
+// limit case for offset.
+func TestMemoryList_OffsetWrongType_ReturnsLoudErrorNotSilentDefault(t *testing.T) {
+	pool, back := newListCapturingPool(t)
+	seedMemories(t, pool, 3)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"offset":  []any{"oops"},
+	}
+	res, err := handleMemoryList(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "wrongly-typed offset must produce a tool error, not silently default to 0")
+	require.Contains(t, res.Content[0].(mcpgo.TextContent).Text, "offset")
+	require.Equal(t, 0, back.listCalls, "the backend must not be queried on a rejected request")
+}
+
+// TestMemoryList_LimitOutOfRange_StillClampsToDefault verifies the existing
+// range-clamp behavior (limit<1 or >500 → 50) is preserved by the new strict
+// parsing path — this is a boundary condition, not an error condition.
+func TestMemoryList_LimitOutOfRange_StillClampsToDefault(t *testing.T) {
+	pool, back := newListCapturingPool(t)
+	seedMemories(t, pool, 3)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"limit":   5000.0,
+	}
+	res, err := handleMemoryList(context.Background(), pool, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Equal(t, 50, back.lastListOpts.Limit, "out-of-range limit must still clamp to the default 50")
+}

--- a/internal/mcp/tools_reason.go
+++ b/internal/mcp/tools_reason.go
@@ -183,7 +183,7 @@ func parseExploreScope(args map[string]any) claude.ExploreScope {
 		return claude.ExploreScope{}
 	}
 	var scope claude.ExploreScope
-	scope.Tags, _ = toStringSlice(scopeMap["tags"]) // ignore control-char error in optional scope
+	scope.Tags, _ = toStringSlice(scopeMap, "tags") // ignore control-char error in optional scope
 	scope.EpisodeID = getString(scopeMap, "episode_id", "")
 	if since := getString(scopeMap, "since", ""); since != "" {
 		if t, err := time.Parse(time.RFC3339, since); err == nil {

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -222,7 +222,7 @@ func handleMemoryFetch(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		return errResult, nil
 	}
 	detail := getString(args, "detail", "summary")
-	chunkIDs, err := toStringSlice(args["chunk_ids"])
+	chunkIDs, err := toStringSlice(args, "chunk_ids")
 	if err != nil {
 		return nil, fmt.Errorf("chunk_ids: %w", err)
 	}
@@ -350,7 +350,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	opts.AtomRecallAsOf = atomRecallAsOf
 
 	// Federated path: "projects" overrides the single-project recall.
-	projectNames, err := toStringSlice(args["projects"])
+	projectNames, err := toStringSlice(args, "projects")
 	if err != nil {
 		return nil, fmt.Errorf("projects: %w", err)
 	}
@@ -705,16 +705,28 @@ func handleMemoryList(ctx context.Context, pool *EnginePool, req mcpgo.CallToolR
 	if err != nil {
 		return nil, err
 	}
-	limit := getInt(args, "limit", 50)
+	limit, limitPresent, limitErr := requireOptionalInt(args, "limit")
+	if limitErr != nil {
+		return mcpgo.NewToolResultError(fmt.Sprintf("limit: %v", limitErr)), nil
+	}
+	if !limitPresent {
+		limit = 50
+	}
 	if limit < 1 || limit > 500 {
 		limit = 50
 	}
-	offset := getInt(args, "offset", 0)
+	offset, offsetPresent, offsetErr := requireOptionalInt(args, "offset")
+	if offsetErr != nil {
+		return mcpgo.NewToolResultError(fmt.Sprintf("offset: %v", offsetErr)), nil
+	}
+	if !offsetPresent {
+		offset = 0
+	}
 	var memType *string
 	if s := getString(args, "memory_type", ""); s != "" {
 		memType = &s
 	}
-	listTags, err := toStringSlice(args["tags"])
+	listTags, err := toStringSlice(args, "tags")
 	if err != nil {
 		return nil, fmt.Errorf("tags: %w", err)
 	}

--- a/internal/mcp/tools_schema_test.go
+++ b/internal/mcp/tools_schema_test.go
@@ -1,0 +1,278 @@
+package mcp
+
+// Regression tests for #1281: every MCP tool must advertise a real JSON input
+// schema (types, required fields) instead of the empty {"properties":{}}
+// schema that let clients silently stringify array/number params.
+//
+// These tests inspect the *mcpgo.Tool* registered on the real mcp-go server
+// (srv.mcp.GetTool(name).Tool.InputSchema) rather than re-deriving expected
+// values from the handler source, so they catch drift between the schema and
+// what registerTools() actually declares.
+
+import (
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// newSchemaTestServer builds a Server with all tools registered (including
+// the Claude-gated ones, since ClaudeEnabled is set) so schema assertions can
+// cover the full tool surface.
+func newSchemaTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv := &Server{
+		cfg:             Config{ClaudeEnabled: true},
+		uploads:         make(map[string]*uploadSession),
+		toolAnnotations: make(map[string]mcpgo.ToolAnnotation),
+	}
+	srv.mcp = server.NewMCPServer("engram-test", "0.0.0",
+		server.WithToolCapabilities(true),
+		server.WithHooks(&server.Hooks{}),
+	)
+	srv.registerTools()
+	return srv
+}
+
+// schemaProps is a small helper that fetches a registered tool's input schema
+// properties map, failing the test if the tool was not registered.
+func schemaProps(t *testing.T, srv *Server, tool string) map[string]any {
+	t.Helper()
+	st := srv.mcp.GetTool(tool)
+	require.NotNil(t, st, "tool %q must be registered", tool)
+	return st.Tool.InputSchema.Properties
+}
+
+func schemaRequired(t *testing.T, srv *Server, tool string) []string {
+	t.Helper()
+	st := srv.mcp.GetTool(tool)
+	require.NotNil(t, st, "tool %q must be registered", tool)
+	return st.Tool.InputSchema.Required
+}
+
+func propType(t *testing.T, props map[string]any, name string) string {
+	t.Helper()
+	raw, ok := props[name]
+	require.True(t, ok, "property %q must be declared", name)
+	m, ok := raw.(map[string]any)
+	require.True(t, ok, "property %q schema must be a map, got %T", name, raw)
+	typ, _ := m["type"].(string)
+	return typ
+}
+
+func propItemsType(t *testing.T, props map[string]any, name string) string {
+	t.Helper()
+	raw, ok := props[name]
+	require.True(t, ok, "property %q must be declared", name)
+	m, ok := raw.(map[string]any)
+	require.True(t, ok)
+	items, ok := m["items"].(map[string]any)
+	require.True(t, ok, "property %q must declare array items", name)
+	typ, _ := items["type"].(string)
+	return typ
+}
+
+func requireContains(t *testing.T, haystack []string, want string) {
+	t.Helper()
+	for _, s := range haystack {
+		if s == want {
+			return
+		}
+	}
+	t.Errorf("expected %q in required list %v", want, haystack)
+}
+
+// ── #1279 direct regression guard: memory_store "tags" must be a declared array ──
+
+func TestSchema_MemoryStore_TagsIsArrayOfStrings(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_store")
+	require.Equal(t, "array", propType(t, props, "tags"))
+	require.Equal(t, "string", propItemsType(t, props, "tags"))
+	require.Equal(t, "number", propType(t, props, "importance"))
+	require.Equal(t, "string", propType(t, props, "content"))
+	requireContains(t, schemaRequired(t, srv, "memory_store"), "content")
+}
+
+func TestSchema_MemoryStoreBatch_MemoriesIsArrayOfObjects(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_store_batch")
+	require.Equal(t, "array", propType(t, props, "memories"))
+	requireContains(t, schemaRequired(t, srv, "memory_store_batch"), "memories")
+}
+
+// ── #1280 direct regression guard: memory_list "limit"/"offset" must be numbers ──
+
+func TestSchema_MemoryList_LimitOffsetAreNumbers(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_list")
+	require.Equal(t, "number", propType(t, props, "limit"))
+	require.Equal(t, "number", propType(t, props, "offset"))
+	require.Equal(t, "array", propType(t, props, "tags"))
+	require.Equal(t, "string", propItemsType(t, props, "tags"))
+}
+
+// ── Representative coverage across the rest of the tool surface ────────────
+
+func TestSchema_MemoryRecall_TypesAndRequired(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_recall")
+	require.Equal(t, "string", propType(t, props, "query"))
+	require.Equal(t, "number", propType(t, props, "top_k"))
+	require.Equal(t, "number", propType(t, props, "limit"))
+	require.Equal(t, "boolean", propType(t, props, "include_conflicts"))
+	require.Equal(t, "array", propType(t, props, "projects"))
+	requireContains(t, schemaRequired(t, srv, "memory_recall"), "query")
+}
+
+func TestSchema_MemoryCorrect_TagsImportancePatternConfidence(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_correct")
+	require.Equal(t, "array", propType(t, props, "tags"))
+	require.Equal(t, "number", propType(t, props, "importance"))
+	require.Equal(t, "number", propType(t, props, "pattern_confidence"))
+	requireContains(t, schemaRequired(t, srv, "memory_correct"), "memory_id")
+}
+
+func TestSchema_MemoryConnect_StrengthIsNumber(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_connect")
+	require.Equal(t, "number", propType(t, props, "strength"))
+	req := schemaRequired(t, srv, "memory_connect")
+	requireContains(t, req, "source_id")
+	requireContains(t, req, "target_id")
+}
+
+func TestSchema_MemoryFeedback_MemoryIDsIsArray(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_feedback")
+	require.Equal(t, "array", propType(t, props, "memory_ids"))
+	require.Equal(t, "string", propItemsType(t, props, "memory_ids"))
+}
+
+func TestSchema_MemoryAggregate_LimitIsNumberAndByRequired(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_aggregate")
+	require.Equal(t, "number", propType(t, props, "limit"))
+	requireContains(t, schemaRequired(t, srv, "memory_aggregate"), "by")
+}
+
+func TestSchema_MemorySleep_NumericAndBooleanParams(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_sleep")
+	require.Equal(t, "number", propType(t, props, "min_similarity"))
+	require.Equal(t, "number", propType(t, props, "limit"))
+	require.Equal(t, "boolean", propType(t, props, "llm_contradiction_detection"))
+	require.Equal(t, "number", propType(t, props, "llm_max_calls"))
+	require.Equal(t, "boolean", propType(t, props, "auto_supersede"))
+}
+
+func TestSchema_MemoryMigrateEmbedder_BooleanGuards(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_migrate_embedder")
+	require.Equal(t, "boolean", propType(t, props, "force"))
+	require.Equal(t, "boolean", propType(t, props, "dry_run"))
+	require.Equal(t, "boolean", propType(t, props, "confirm"))
+	requireContains(t, schemaRequired(t, srv, "memory_migrate_embedder"), "new_model")
+}
+
+func TestSchema_GetConstraints_LimitIsNumber(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "get_constraints")
+	require.Equal(t, "number", propType(t, props, "limit"))
+	require.Equal(t, "number", propType(t, props, "stale_after_days"))
+}
+
+func TestSchema_VerifyBeforeActing_ProposedActionRequired(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	requireContains(t, schemaRequired(t, srv, "verify_before_acting"), "proposed_action")
+}
+
+func TestSchema_MemoryEpisodeEnd_RequiresEpisodeID(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	requireContains(t, schemaRequired(t, srv, "memory_episode_end"), "episode_id")
+}
+
+func TestSchema_MemoryDeleteProject_ConfirmAndProjectRequired(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	req := schemaRequired(t, srv, "memory_delete_project")
+	requireContains(t, req, "project")
+	requireContains(t, req, "confirm")
+}
+
+func TestSchema_MemoryExplore_ScopeIsObject(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_explore")
+	require.Equal(t, "object", propType(t, props, "scope"))
+	require.Equal(t, "number", propType(t, props, "max_iterations"))
+	require.Equal(t, "number", propType(t, props, "confidence_threshold"))
+}
+
+func TestSchema_MemoryQueryDocument_FilterIsObject(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_query_document")
+	require.Equal(t, "object", propType(t, props, "filter"))
+	requireContains(t, schemaRequired(t, srv, "memory_query_document"), "question")
+}
+
+func TestSchema_MemoryIngestDocumentStream_ActionEnumAndPart(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	props := schemaProps(t, srv, "memory_ingest_document_stream")
+	require.Equal(t, "number", propType(t, props, "part"))
+	require.Equal(t, "string", propType(t, props, "action"))
+}
+
+// ── Blanket coverage: no tool ships with an empty schema unless documented ──
+
+// noArgTools lists tools whose handlers genuinely read no MCP arguments (or
+// only cfg). Any registered tool NOT in this list must declare at least one
+// property — an empty schema for anything else means a new tool was added
+// without its parameters being declared, exactly the #1281 failure mode.
+func noArgTools() map[string]bool {
+	return map[string]bool{
+		"memory_status_ping": true,
+		"memory_models":      true,
+	}
+}
+
+func TestSchema_NoToolShipsWithEmptySchemaUnlessDocumented(t *testing.T) {
+	srv := newSchemaTestServer(t)
+	allow := noArgTools()
+
+	// Union of every name we know should be registered: the main tool slice
+	// plus the Claude-gated ones. readOnlyToolNames/hiddenToolNames double as
+	// a convenient enumeration of "tools that exist" for this sweep, unioned
+	// with a few mutating tools not in either set.
+	names := map[string]bool{}
+	for n := range readOnlyToolNames() {
+		names[n] = true
+	}
+	for n := range hiddenToolNames() {
+		names[n] = true
+	}
+	extra := []string{
+		"memory_store", "memory_store_document", "memory_store_batch",
+		"memory_recall", "memory_fetch", "memory_list", "memory_history",
+		"memory_connect", "memory_correct", "memory_forget", "memory_feedback",
+		"memory_adopt", "memory_quick_store", "memory_query",
+		"get_constraints", "check_constraints", "verify_before_acting",
+		"memory_reason", "memory_explore", "memory_query_document", "memory_ask",
+		"memory_ingest_document_stream", "memory_episode_start", "memory_episode_end",
+		"memory_audit_add_query", "memory_audit_deactivate_query", "memory_audit_run",
+		"memory_projects", "memory_status",
+	}
+	for _, n := range extra {
+		names[n] = true
+	}
+
+	for name := range names {
+		if allow[name] {
+			continue
+		}
+		st := srv.mcp.GetTool(name)
+		require.NotNilf(t, st, "tool %q must be registered", name)
+		require.NotEmptyf(t, st.Tool.InputSchema.Properties,
+			"tool %q was registered with an empty input schema — this is the exact #1281 bug shape", name)
+	}
+}

--- a/internal/mcp/tools_store.go
+++ b/internal/mcp/tools_store.go
@@ -61,11 +61,17 @@ func handleMemoryStore(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 			memType = types.MemoryTypePreference
 		}
 	}
-	importance := getInt(args, "importance", 2)
+	importance, importancePresent, importanceErr := requireOptionalInt(args, "importance")
+	if importanceErr != nil {
+		return mcpgo.NewToolResultError(fmt.Sprintf("importance: %v", importanceErr)), nil
+	}
+	if !importancePresent {
+		importance = 2
+	}
 	if importance < 0 || importance > 4 {
 		return mcpgo.NewToolResultError(fmt.Sprintf("importance must be 0–4, got %d", importance)), nil
 	}
-	tags, err := toStringSlice(args["tags"])
+	tags, err := toStringSlice(args, "tags")
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("tags: %v", err)), nil
 	}
@@ -181,12 +187,18 @@ func handleMemoryStoreDocument(ctx context.Context, pool *EnginePool, req mcpgo.
 	if !types.ValidateMemoryType(memType) {
 		return mcpgo.NewToolResultError(fmt.Sprintf("invalid memory_type %q; valid values: decision, pattern, error, context, architecture, preference", memType)), nil
 	}
-	importance := getInt(args, "importance", 2)
+	importance, importancePresent, importanceErr := requireOptionalInt(args, "importance")
+	if importanceErr != nil {
+		return mcpgo.NewToolResultError(fmt.Sprintf("importance: %v", importanceErr)), nil
+	}
+	if !importancePresent {
+		importance = 2
+	}
 	if importance < 0 || importance > 4 {
 		return mcpgo.NewToolResultError(fmt.Sprintf("importance must be 0–4, got %d", importance)), nil
 	}
 	maxDoc, rawMax := configOrDefaults(cfg)
-	docTags, err := toStringSlice(args["tags"])
+	docTags, err := toStringSlice(args, "tags")
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("tags: %v", err)), nil
 	}
@@ -240,7 +252,27 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 		return nil, err
 	}
 	const maxBatchItems = 100 // guard against CPU/DB overload (#144)
-	items, _ := args["memories"].([]any)
+	rawMemories, memoriesPresent := args["memories"]
+	if !memoriesPresent || rawMemories == nil {
+		return toolResult(map[string]any{"ids": []string{}, "count": 0, "warning": "no memories provided"})
+	}
+	items, ok := rawMemories.([]any)
+	if !ok {
+		// Defense-in-depth (#1281): tolerate a client that still JSON-encodes the
+		// array as a string despite the declared schema, but never silently treat
+		// a wrongly-typed value as "no memories provided" — that shape (a
+		// success response reporting count:0) is the worst variant of the
+		// #1281 bug: a bulk write that looks done but wrote nothing.
+		s, isStr := rawMemories.(string)
+		if !isStr {
+			return mcpgo.NewToolResultError(fmt.Sprintf("memories must be an array of objects, got %T", rawMemories)), nil
+		}
+		var decoded []any
+		if jsonErr := json.Unmarshal([]byte(s), &decoded); jsonErr != nil {
+			return mcpgo.NewToolResultError(fmt.Sprintf("memories must be an array of objects, got a string that is not valid JSON: %v", jsonErr)), nil
+		}
+		items = decoded
+	}
 	if len(items) == 0 {
 		return toolResult(map[string]any{"ids": []string{}, "count": 0, "warning": "no memories provided"})
 	}
@@ -280,12 +312,19 @@ func handleMemoryStoreBatch(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 			validErrs = append(validErrs, fmt.Sprintf("item %d: invalid memory_type %q", idx, memType))
 			continue
 		}
-		importance := getInt(mmap, "importance", 2)
+		importance, importancePresent, importanceErr := requireOptionalInt(mmap, "importance")
+		if importanceErr != nil {
+			validErrs = append(validErrs, fmt.Sprintf("item %d: importance: %v", idx, importanceErr))
+			continue
+		}
+		if !importancePresent {
+			importance = 2
+		}
 		if importance < 0 || importance > 4 {
 			validErrs = append(validErrs, fmt.Sprintf("item %d: importance must be 0–4, got %d", idx, importance))
 			continue
 		}
-		itemTags, tagErr := toStringSlice(mmap["tags"])
+		itemTags, tagErr := toStringSlice(mmap, "tags")
 		if tagErr != nil {
 			validErrs = append(validErrs, fmt.Sprintf("item %d: tags: %v", idx, tagErr))
 			continue
@@ -385,8 +424,18 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		content = &c
 	}
 	var importance *int
-	if v, ok := args["importance"].(float64); ok {
-		n := int(v)
+	if raw, exists := args["importance"]; exists && raw != nil {
+		f, coerceOK := coerceToFloat(raw)
+		if !coerceOK {
+			// A present-but-wrongly-typed importance must be a loud error, not
+			// silently treated as "omitted" (which would leave the field
+			// unchanged and mask the caller's intent) — see #1279, #1281.
+			return mcpgo.NewToolResultError(fmt.Sprintf("importance must be a number, got %T", raw)), nil
+		}
+		// int(f) truncates rather than rounds — this is the pre-existing,
+		// intentionally-unchanged behavior for memory_correct (unlike
+		// memory_store's getInt, which rounds). See TestImportanceFieldUnchangedBehavior.
+		n := int(f)
 		if n < highestImportanceLevel || n > lowestImportanceLevel {
 			return mcpgo.NewToolResultError(fmt.Sprintf("importance must be %d–%d, got %d", highestImportanceLevel, lowestImportanceLevel, n)), nil
 		}
@@ -405,7 +454,7 @@ func handleMemoryCorrect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		}
 		patternConfidence = &validated
 	}
-	correctTags, err := toStringSlice(args["tags"])
+	correctTags, err := toStringSlice(args, "tags")
 	if err != nil {
 		return nil, fmt.Errorf("tags: %w", err)
 	}

--- a/internal/mcp/tools_store_test.go
+++ b/internal/mcp/tools_store_test.go
@@ -842,3 +842,206 @@ func TestMemoryCorrect_ImportanceOutOfRange(t *testing.T) {
 		})
 	}
 }
+
+// ── #1281/#1279: tags and importance must round-trip through handleMemoryStore ──
+//
+// Before the #1281 fix, tools were registered with empty MCP input schemas, so
+// schema-driven clients (Claude Code among them) had no way to know "tags" was
+// an array or "importance" a number and sent them JSON-encoded as strings.
+// toStringSlice(v) silently returned (nil, nil) for any non-[]any value and
+// getInt silently fell back to its default — so a caller who did everything
+// the (empty) schema allowed lost their tags/importance with no error at all.
+//
+// These tests exercise handleMemoryStore end-to-end (through the real
+// search.SearchEngine, captured at the StoreMemoryTx boundary) to prove the
+// values that reach the DB layer, not just the absence of a Go error.
+
+// TestMemoryStore_TagsRoundTrip_NativeArray is the "happy path" a
+// schema-respecting client produces once #1281 lands: tags arrive as a real
+// JSON array. It must persist all the way to the stored Memory (#1279).
+func TestMemoryStore_TagsRoundTrip_NativeArray(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"content": "tagged memory",
+		"tags":    []any{"example-tag-probe", "another-tag"},
+	}
+
+	res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Len(t, cap.stored, 1)
+	require.Equal(t, []string{"example-tag-probe", "another-tag"}, cap.stored[0].Tags,
+		"tags must reach the DB layer unchanged — see #1279")
+}
+
+// TestMemoryStore_TagsRoundTrip_JSONEncodedStringFallback covers the
+// defense-in-depth coercion path: a client that (despite the now-declared
+// schema) still sends tags as a JSON-encoded string must not silently lose
+// them either.
+func TestMemoryStore_TagsRoundTrip_JSONEncodedStringFallback(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"content": "tagged memory via stringified array",
+		"tags":    `["example-tag-probe"]`,
+	}
+
+	res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Len(t, cap.stored, 1)
+	require.Equal(t, []string{"example-tag-probe"}, cap.stored[0].Tags)
+}
+
+// TestMemoryStore_TagsWrongType_ReturnsLoudErrorNotSilentDrop is the direct
+// regression guard for #1279: a wrongly-typed (and non-coercible) tags value
+// must produce a tool-level error, never a silent "stored" response with the
+// tags dropped.
+func TestMemoryStore_TagsWrongType_ReturnsLoudErrorNotSilentDrop(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"content": "should not be stored",
+		"tags":    12345.0, // neither an array nor a JSON-array-encoded string
+	}
+
+	res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "wrongly-typed tags must produce a tool error")
+	require.Contains(t, res.Content[0].(mcpgo.TextContent).Text, "tags")
+	require.Empty(t, cap.stored, "nothing must be written to the DB layer on a rejected store")
+}
+
+// TestMemoryStore_ImportanceRoundTrip_NativeNumber verifies a native JSON
+// number for importance reaches the DB layer unchanged.
+func TestMemoryStore_ImportanceRoundTrip_NativeNumber(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":    "test",
+		"content":    "importance test",
+		"importance": 1.0,
+	}
+
+	res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.False(t, res.IsError, "expected non-error result, got: %+v", res.Content)
+
+	require.Len(t, cap.stored, 1)
+	require.Equal(t, 1, cap.stored[0].Importance,
+		"importance=1 must reach the DB layer as 1, not silently default to 2 — see #1279 secondary observation")
+}
+
+// TestMemoryStore_ImportanceWrongType_ReturnsLoudErrorNotSilentDefault is the
+// regression guard for the #1279 secondary observation: importance:1 coming
+// back as 2 (the default) because the typed cast failed silently.
+func TestMemoryStore_ImportanceWrongType_ReturnsLoudErrorNotSilentDefault(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":    "test",
+		"content":    "should not be stored",
+		"importance": []any{"oops"}, // not a number and not JSON-coercible to one
+	}
+
+	res, err := handleMemoryStore(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "wrongly-typed importance must produce a tool error, not silently default to 2")
+	require.Contains(t, res.Content[0].(mcpgo.TextContent).Text, "importance")
+	require.Empty(t, cap.stored, "nothing must be written to the DB layer on a rejected store")
+}
+
+// ── #1281: memory_store_batch "memories" no-op-success bug ─────────────────
+//
+// Before the fix, `items, _ := args["memories"].([]any)` silently discarded
+// the ok flag: a wrongly-typed "memories" value (e.g. a JSON-encoded string,
+// which is exactly what a schema-less client would send for an array param)
+// produced items=nil, which the handler then reported as a *success-shaped*
+// response: {"count":0,"warning":"no memories provided"}. This is the
+// "worst variant" of the silent-discard bug called out in #1281 — a bulk
+// write that reports "ok, 0 written" and gets treated as done.
+
+// TestMemoryStoreBatch_MemoriesWrongType_ReturnsLoudErrorNotFakeSuccess is the
+// direct regression guard.
+func TestMemoryStoreBatch_MemoriesWrongType_ReturnsLoudErrorNotFakeSuccess(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":  "test",
+		"memories": `[{"content":"test 1"},{"content":"test 2"}]`, // stringified array
+	}
+
+	res, err := handleMemoryStoreBatch(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Two acceptable outcomes at this layer: either the string-coercion
+	// fallback decodes it and stores both items, or — if coercion is not
+	// implemented for this call site — it must be a loud tool error, never
+	// the old fake-success "no memories provided" shape.
+	if res.IsError {
+		require.Empty(t, cap.stored)
+		return
+	}
+	out := parseSimpleResult(t, res)
+	if warning, ok := out["warning"]; ok {
+		t.Fatalf("memory_store_batch must not report a fake success for a wrongly-typed 'memories' param; got warning=%v", warning)
+	}
+	require.Len(t, cap.stored, 2, "the stringified batch must be decoded and both items stored")
+}
+
+// TestMemoryStoreBatch_MemoriesAbsent_StillReturnsFriendlyNoOp verifies the
+// boundary: genuinely absent/empty "memories" is NOT an error — it is the
+// documented empty-batch no-op. Only a present-but-wrongly-typed value is an
+// error.
+func TestMemoryStoreBatch_MemoriesAbsent_StillReturnsFriendlyNoOp(t *testing.T) {
+	pool, _ := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+	}
+
+	res, err := handleMemoryStoreBatch(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError)
+	out := parseSimpleResult(t, res)
+	require.Equal(t, "no memories provided", out["warning"])
+	require.Equal(t, float64(0), out["count"])
+}
+
+// TestMemoryStoreBatch_MemoriesWrongScalarType_ReturnsLoudError covers a
+// non-coercible scalar (a number, not even a string) — must always be a
+// loud error since there is no fallback decoding path.
+func TestMemoryStoreBatch_MemoriesWrongScalarType_ReturnsLoudError(t *testing.T) {
+	pool, cap := newCapturingPool(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":  "test",
+		"memories": 42.0,
+	}
+
+	res, err := handleMemoryStoreBatch(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "a non-array, non-string 'memories' value must be a loud tool error")
+	require.Empty(t, cap.stored)
+}

--- a/internal/mcp/tools_typed_args_test.go
+++ b/internal/mcp/tools_typed_args_test.go
@@ -1,0 +1,179 @@
+package mcp
+
+// Unit tests for the typed-argument extraction helpers at the center of
+// issue #1281 (MCP tools registered with empty input schemas → array/number
+// params silently discarded when a schema-less client stringifies them).
+//
+// These tests exercise the helpers directly (no MCP transport involved) so
+// the coercion/error-surfacing contract is pinned independently of any
+// particular handler.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ── coerceToInt / coerceToFloat / coerceToBool ──────────────────────────────
+
+func TestCoerceToFloat_NativeNumber(t *testing.T) {
+	f, ok := coerceToFloat(5.0)
+	require.True(t, ok)
+	require.Equal(t, 5.0, f)
+}
+
+func TestCoerceToFloat_JSONEncodedString(t *testing.T) {
+	// Defense-in-depth: a client that ignores the (now-declared) schema and
+	// still stringifies a number must not silently lose the value.
+	f, ok := coerceToFloat("250")
+	require.True(t, ok)
+	require.Equal(t, 250.0, f)
+}
+
+func TestCoerceToFloat_GarbageString(t *testing.T) {
+	_, ok := coerceToFloat("not-a-number")
+	require.False(t, ok)
+}
+
+func TestCoerceToFloat_WrongType(t *testing.T) {
+	_, ok := coerceToFloat(true)
+	require.False(t, ok)
+}
+
+func TestCoerceToInt_RoundsFloat(t *testing.T) {
+	n, ok := coerceToInt(4.6)
+	require.True(t, ok)
+	require.Equal(t, 5, n)
+}
+
+func TestCoerceToInt_JSONEncodedString(t *testing.T) {
+	n, ok := coerceToInt("5")
+	require.True(t, ok)
+	require.Equal(t, 5, n)
+}
+
+func TestCoerceToBool_Native(t *testing.T) {
+	b, ok := coerceToBool(true)
+	require.True(t, ok)
+	require.True(t, b)
+}
+
+func TestCoerceToBool_StringFallback(t *testing.T) {
+	b, ok := coerceToBool("true")
+	require.True(t, ok)
+	require.True(t, b)
+
+	b, ok = coerceToBool("false")
+	require.True(t, ok)
+	require.False(t, b)
+}
+
+func TestCoerceToBool_GarbageString(t *testing.T) {
+	_, ok := coerceToBool("yes")
+	require.False(t, ok, "only exact true/false strings are coerced — no truthy guessing")
+}
+
+// ── getInt / getFloat / getBool: string-fallback coercion, still lenient ───
+
+func TestGetInt_AcceptsStringifiedNumber(t *testing.T) {
+	args := map[string]any{"limit": "250"}
+	require.Equal(t, 250, getInt(args, "limit", 50))
+}
+
+func TestGetInt_FallsBackToDefaultOnGarbage(t *testing.T) {
+	args := map[string]any{"limit": "not-a-number"}
+	require.Equal(t, 50, getInt(args, "limit", 50))
+}
+
+func TestGetInt_AbsentKeyUsesDefault(t *testing.T) {
+	require.Equal(t, 50, getInt(map[string]any{}, "limit", 50))
+}
+
+func TestGetBool_AcceptsStringifiedBool(t *testing.T) {
+	args := map[string]any{"immutable": "true"}
+	require.True(t, getBool(args, "immutable", false))
+}
+
+// ── requireOptionalInt: the loud-error path used by load-bearing params ────
+
+func TestRequireOptionalInt_AbsentKey(t *testing.T) {
+	n, present, err := requireOptionalInt(map[string]any{}, "importance")
+	require.NoError(t, err)
+	require.False(t, present)
+	require.Equal(t, 0, n)
+}
+
+func TestRequireOptionalInt_NullValue(t *testing.T) {
+	n, present, err := requireOptionalInt(map[string]any{"importance": nil}, "importance")
+	require.NoError(t, err)
+	require.False(t, present)
+	require.Equal(t, 0, n)
+}
+
+func TestRequireOptionalInt_NativeNumber(t *testing.T) {
+	n, present, err := requireOptionalInt(map[string]any{"importance": 1.0}, "importance")
+	require.NoError(t, err)
+	require.True(t, present)
+	require.Equal(t, 1, n)
+}
+
+func TestRequireOptionalInt_CoercibleString(t *testing.T) {
+	// Defense-in-depth fallback still applies before erroring.
+	n, present, err := requireOptionalInt(map[string]any{"limit": "5"}, "limit")
+	require.NoError(t, err)
+	require.True(t, present)
+	require.Equal(t, 5, n)
+}
+
+func TestRequireOptionalInt_UncoercibleValue_ReturnsLoudError(t *testing.T) {
+	// This is the exact shape of the #1279/#1280 bug: a present-but-wrong-typed
+	// value must produce an error, never a silent fallback to the default.
+	_, present, err := requireOptionalInt(map[string]any{"importance": []any{"oops"}}, "importance")
+	require.True(t, present, "the key was present — callers must not treat this as absent")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "importance")
+}
+
+// ── toStringSlice(args, key): presence vs. wrong-type vs. valid array ──────
+
+func TestToStringSlice_AbsentKey_ReturnsNilNil(t *testing.T) {
+	tags, err := toStringSlice(map[string]any{}, "tags")
+	require.NoError(t, err)
+	require.Nil(t, tags)
+}
+
+func TestToStringSlice_NullValue_ReturnsNilNil(t *testing.T) {
+	tags, err := toStringSlice(map[string]any{"tags": nil}, "tags")
+	require.NoError(t, err)
+	require.Nil(t, tags)
+}
+
+func TestToStringSlice_NativeArray_HappyPath(t *testing.T) {
+	tags, err := toStringSlice(map[string]any{"tags": []any{"a", "b"}}, "tags")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, tags)
+}
+
+func TestToStringSlice_JSONEncodedStringArray_Coerces(t *testing.T) {
+	// Defense-in-depth: a client that still JSON-encodes the array as a string
+	// despite the declared schema must not silently lose the tags (#1279).
+	tags, err := toStringSlice(map[string]any{"tags": `["a","b"]`}, "tags")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, tags)
+}
+
+func TestToStringSlice_WrongType_ReturnsLoudErrorNotSilentNil(t *testing.T) {
+	// The core #1279 regression: previously toStringSlice(v) returned (nil, nil)
+	// for any non-[]any value, silently dropping the caller's tags. It must now
+	// return an error naming the parameter.
+	tags, err := toStringSlice(map[string]any{"tags": 12345.0}, "tags")
+	require.Nil(t, tags)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tags")
+}
+
+func TestToStringSlice_GarbageString_ReturnsLoudError(t *testing.T) {
+	tags, err := toStringSlice(map[string]any{"tags": "not-json"}, "tags")
+	require.Nil(t, tags)
+	require.Error(t, err)
+}

--- a/internal/mcp/validation_test.go
+++ b/internal/mcp/validation_test.go
@@ -88,23 +88,23 @@ func TestValidateProjectName_RejectsBidiControlChars(t *testing.T) {
 // ── toStringSlice ────────────────────────────────────────────────────────────
 
 func TestToStringSlice_AcceptsNormal(t *testing.T) {
-	input := []any{"go", "tdd", "engram", "tag with spaces"}
-	got, err := toStringSlice(input)
+	args := map[string]any{"tags": []any{"go", "tdd", "engram", "tag with spaces"}}
+	got, err := toStringSlice(args, "tags")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"go", "tdd", "engram", "tag with spaces"}, got)
 }
 
 func TestToStringSlice_AcceptsTabLFCR(t *testing.T) {
 	// HT (0x09), LF (0x0A), CR (0x0D) are explicitly allowed.
-	input := []any{"tag\twith\ttabs", "tag\nwith\nnewline", "tag\rwith\rCR"}
-	got, err := toStringSlice(input)
+	args := map[string]any{"tags": []any{"tag\twith\ttabs", "tag\nwith\nnewline", "tag\rwith\rCR"}}
+	got, err := toStringSlice(args, "tags")
 	require.NoError(t, err)
 	assert.Len(t, got, 3)
 }
 
 func TestToStringSlice_RejectsNUL(t *testing.T) {
-	input := []any{"valid", "bad\x00tag"}
-	_, err := toStringSlice(input)
+	args := map[string]any{"tags": []any{"valid", "bad\x00tag"}}
+	_, err := toStringSlice(args, "tags")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "disallowed control character")
 }
@@ -113,21 +113,27 @@ func TestToStringSlice_RejectsC0ControlChars(t *testing.T) {
 	controlCases := []byte{0x01, 0x07, 0x08, 0x0B, 0x0C, 0x0E, 0x1F}
 	for _, b := range controlCases {
 		t.Run(string(rune(b)), func(t *testing.T) {
-			input := []any{"good", "bad" + string([]byte{b}) + "tag"}
-			_, err := toStringSlice(input)
+			args := map[string]any{"tags": []any{"good", "bad" + string([]byte{b}) + "tag"}}
+			_, err := toStringSlice(args, "tags")
 			require.Error(t, err, "expected error for byte 0x%02X", b)
 		})
 	}
 }
 
 func TestToStringSlice_RejectsDEL(t *testing.T) {
-	input := []any{"tag\x7fwith-del"}
-	_, err := toStringSlice(input)
+	args := map[string]any{"tags": []any{"tag\x7fwith-del"}}
+	_, err := toStringSlice(args, "tags")
 	require.Error(t, err)
 }
 
 func TestToStringSlice_NilInput(t *testing.T) {
-	got, err := toStringSlice(nil)
+	got, err := toStringSlice(map[string]any{"tags": nil}, "tags")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestToStringSlice_AbsentKey(t *testing.T) {
+	got, err := toStringSlice(map[string]any{}, "tags")
 	require.NoError(t, err)
 	assert.Nil(t, got)
 }
@@ -137,7 +143,8 @@ func TestToStringSlice_RespectsMaxTagCount(t *testing.T) {
 	for i := 0; i < maxTagCount+10; i++ {
 		input = append(input, "tag")
 	}
-	got, err := toStringSlice(input)
+	args := map[string]any{"tags": input}
+	got, err := toStringSlice(args, "tags")
 	require.NoError(t, err)
 	assert.Len(t, got, maxTagCount)
 }


### PR DESCRIPTION
## Summary

Closes #1281, #1279, #1280.

Root cause (#1281): `registerTools()` (internal/mcp/server.go) registered every MCP tool with an empty input schema (`"properties":{}`). Schema-driven clients (Claude Code among them) had no way to know a param was an array or a number, so they sent it JSON-encoded as a string. Handlers then did typed casts that failed silently:

- `toStringSlice(v)` returned `(nil, nil)` for any non-`[]any` value — tags silently dropped (#1279).
- `getInt` fell back to its default on a failed type assertion — `memory_list`'s `limit`/`offset` silently ignored (#1280), and `memory_store`'s `importance` silently defaulted.
- `memory_store_batch`'s `items, _ := args["memories"].([]any)` discarded the `ok` flag entirely, turning a wrongly-typed batch into a fake-success `{"count":0,"warning":"no memories provided"}`.

## What changed

**Primary fix — real schemas (#1281):** `registerTool`/`registerToolWithTimeout` now accept a variadic `schema ...mcpgo.ToolOption`. All 53 registered tools (including the 4 Claude-gated ones) declare real `WithString`/`WithNumber`/`WithArray`/`WithBoolean`/`WithObject` schemas with `Required()` flags, derived by reading each handler's actual `req.GetArguments()` usage — not guessed from docs. Shared property builders live in `internal/mcp/tool_schemas.go`.

**Handler-level fixes — loud errors instead of silent discard**, scoped to the params proven broken:

- `toStringSlice` now takes `(args, key)` instead of a bare value. Absent/null key still returns `(nil, nil)` — that's the legitimate "no items" case. A **present**-but-wrongly-typed value is now a loud error naming the param (with a JSON-string-decode fallback as defense-in-depth for clients that still stringify despite the schema). This is a single shared helper used at all 10 array-param call sites in the codebase, so it closes #1279 for every array param, not just `tags`.
- New `requireOptionalInt(args, key) (value int, present bool, err error)` distinguishes "absent" from "present but uncoercible." Wired into `memory_store`/`memory_store_document`/`memory_store_batch` (`importance`) and `memory_list` (`limit`/`offset`) — a wrongly-typed value is now a tool error, never a silent fallback to the default. Closes #1280 and the #1279 secondary "importance:1 comes back as 2" observation. `memory_correct`'s importance keeps its pre-existing truncate-not-round semantics unchanged (there's a dedicated regression test for that — `TestImportanceFieldUnchangedBehavior`).
- `memory_store_batch`'s top-level `memories` cast now distinguishes "absent" (the documented friendly no-op) from "present but wrong type" (loud tool error) — previously both collapsed into the same fake-success shape, which #1281 called "the worst variant" of this bug.
- `getInt`/`getFloat`/`getBool` gained a JSON-string coercion fallback (defense-in-depth for the ~50 lower-stakes call sites left lenient — tuning/threshold params where a silent default is comparatively low-risk). Filed **#1282** to triage those into "leave lenient" vs "upgrade to loud error" in a follow-up pass, per #1281's own "worth an audit pass" note — kept out of this PR to bound the diff.

## Verification

- `TestSchema_MemoryStore_TagsIsArrayOfStrings`, `TestSchema_MemoryStoreBatch_MemoriesIsArrayOfObjects`, `TestSchema_MemoryList_LimitOffsetAreNumbers`, and 15 more in `tools_schema_test.go` assert the real schema types/required-fields via `srv.mcp.GetTool(name).Tool.InputSchema` — plus a blanket `TestSchema_NoToolShipsWithEmptySchemaUnlessDocumented` sweep over the full tool surface.
- `tools_store_test.go`: `TestMemoryStore_TagsRoundTrip_NativeArray`/`_JSONEncodedStringFallback` prove tags reach the DB layer (captured at `StoreMemoryTx`) for both a native array and the string-coerced fallback; `TestMemoryStore_TagsWrongType_ReturnsLoudErrorNotSilentDrop` is the direct #1279 regression guard. Equivalent pairs for `importance`, plus `TestMemoryStoreBatch_MemoriesWrongType_ReturnsLoudErrorNotFakeSuccess` / `_MemoriesAbsent_StillReturnsFriendlyNoOp` / `_MemoriesWrongScalarType_ReturnsLoudError` for the batch no-op bug.
- `tools_list_test.go` (new): a `listCapturingBackend` spy captures `db.ListOptions` from `ListMemories`, proving `limit`/`offset` reach the backend unchanged for native numbers, the string-coerced fallback, and the wrong-type loud-error/boundary-clamp cases — direct #1280 regression guard.
- `tools_typed_args_test.go` (new): unit tests for `coerceToInt/Float/Bool`, `getInt/getFloat/getBool` coercion, `requireOptionalInt`, and `toStringSlice`.
- `go test ./... -count=1 -race`: all packages pass. (`cmd/benchmark`'s `TestQuietFlag_E2E`/`TestOutputJSONFlag_ImpliesQuiet` fail in this worktree with `error obtaining VCS status` — pre-existing, unrelated to this diff; zero files in `cmd/benchmark` touched, confirmed via `git diff --stat origin/main -- cmd/benchmark`.)
- `internal/mcp` coverage: 67.2% (above the 55% CI gate and the 60% target).
- `gofmt -l` clean on every file this PR touches.
- Existing regression suites (`TestReadOnlyToolAnnotations`, `TestHiddenToolsAbsentFromList`, `TestReadOnlyHiddenOverlapIsStable`, `TestToolCountsMatchDocs`) all still pass — `readOnlyToolNames()`/`hiddenToolNames()` were not touched.

## Test plan

- [x] `go test ./internal/mcp/... -count=1 -race`
- [x] `go test ./... -count=1 -race` (full repo; one pre-existing unrelated worktree-VCS failure in `cmd/benchmark`)
- [x] `gofmt -l` on all touched files
- [x] Schema assertions for all load-bearing tools + blanket empty-schema sweep
- [x] Handler-level round-trip tests via `StoreMemoryTx`/`ListMemories` spies (no live Postgres required)

Labeled `ai-generated` per repo policy — three rounds of adversarial review requested.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
https://claude.ai/code/session_01CL7bkT4CcyGvmKP4gjbWGf