### PR TITLE
fix(mcp): CI fix-forward for #1283 — accept Go-native []string in toStringSlice, drop dead requiredNumberProp

### DIFF
--- a/internal/mcp/tool_schemas.go
+++ b/internal/mcp/tool_schemas.go
@@ -48,11 +48,6 @@ func numberProp(name, desc string) mcpgo.ToolOption {
 	return mcpgo.WithNumber(name, mcpgo.Description(desc))
 }
 
-// requiredNumberProp declares a required number param.
-func requiredNumberProp(name, desc string) mcpgo.ToolOption {
-	return mcpgo.WithNumber(name, mcpgo.Required(), mcpgo.Description(desc))
-}
-
 // boolProp declares an optional boolean param.
 func boolProp(name, desc string) mcpgo.ToolOption {
 	return mcpgo.WithBoolean(name, mcpgo.Description(desc))

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -457,15 +457,28 @@ func toStringSlice(args map[string]any, key string) ([]string, error) {
 	}
 	arr, ok := v.([]any)
 	if !ok {
-		s, isStr := v.(string)
-		if !isStr {
+		switch typed := v.(type) {
+		case []string:
+			// Go-native callers (test helpers, REST bridges, internal
+			// handler-to-handler calls) build args maps directly with
+			// []string rather than the []any JSON decoding produces. It IS
+			// an array of strings — route it through the same per-item
+			// validation below rather than rejecting the type. (Post-#1283
+			// CI regression: the tags-only memory_correct integration test's
+			// helper passes []string.)
+			arr = make([]any, len(typed))
+			for i, s := range typed {
+				arr[i] = s
+			}
+		case string:
+			var decoded []any
+			if err := json.Unmarshal([]byte(typed), &decoded); err != nil {
+				return nil, fmt.Errorf("%s must be an array of strings, got a string that is not valid JSON: %w", key, err)
+			}
+			arr = decoded
+		default:
 			return nil, fmt.Errorf("%s must be an array of strings, got %T", key, v)
 		}
-		var decoded []any
-		if err := json.Unmarshal([]byte(s), &decoded); err != nil {
-			return nil, fmt.Errorf("%s must be an array of strings, got a string that is not valid JSON: %w", key, err)
-		}
-		arr = decoded
 	}
 	result := make([]string, 0, len(arr))
 	for _, item := range arr {

--- a/internal/mcp/tools_typed_args_test.go
+++ b/internal/mcp/tools_typed_args_test.go
@@ -154,6 +154,36 @@ func TestToStringSlice_NativeArray_HappyPath(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, tags)
 }
 
+func TestToStringSlice_GoStringSlice_Accepted(t *testing.T) {
+	// Go-native callers (test helpers, REST bridges, internal handler-to-handler
+	// calls) construct args maps directly with []string rather than the []any
+	// that JSON decoding produces. A []string IS an array of strings — it must
+	// be accepted, not rejected as a wrong type. Regression guard for the
+	// post-#1283 CI failure in TestHandleMemoryCorrect_PreservesSummaryOnTagOnlyChange,
+	// whose helper passes tags as []string.
+	tags, err := toStringSlice(map[string]any{"tags": []string{"go", "style"}}, "tags")
+	require.NoError(t, err)
+	require.Equal(t, []string{"go", "style"}, tags)
+}
+
+func TestToStringSlice_GoStringSlice_StillValidatesControlChars(t *testing.T) {
+	// The []string path must go through the same control-character validation
+	// as the []any path — acceptance of the type must not bypass #252 checks.
+	_, err := toStringSlice(map[string]any{"tags": []string{"bad\x00tag"}}, "tags")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "disallowed control character")
+}
+
+func TestToStringSlice_GoStringSlice_Empty_ReturnsEmptyNotNil(t *testing.T) {
+	// tags=[] has distinct semantics from tags omitted (memory_correct: []
+	// clears valid_from, omitted preserves it). A Go-native empty []string
+	// must behave like an empty []any: non-nil empty result, no error.
+	tags, err := toStringSlice(map[string]any{"tags": []string{}}, "tags")
+	require.NoError(t, err)
+	require.NotNil(t, tags)
+	require.Empty(t, tags)
+}
+
 func TestToStringSlice_JSONEncodedStringArray_Coerces(t *testing.T) {
 	// Defense-in-depth: a client that still JSON-encodes the array as a string
 	// despite the declared schema must not silently lose the tags (#1279).


### PR DESCRIPTION
## Summary

Fix-forward for the two CI failures on main introduced by #1283 (merged without gating on the PR's CI).

### 1. `TestHandleMemoryCorrect_PreservesSummaryOnTagOnlyChange` (live-Postgres, `TEST_DATABASE_URL`-gated)

**Why it was missed:** the test skips without a live DB, and neither the #1283 test run nor the review ran with one.

**Root cause:** the #1283 `toStringSlice` rewrite rejects any present value that is neither `[]any` nor a JSON-string. The test's helper (`CallHandleMemoryCorrectTagsOnly` in `export_test.go`) builds the args map in-process with a Go-native `[]string` — which never passes through JSON decoding, so it isn't `[]any`. Result: `handleMemoryCorrect` returned `tags: tags must be an array of strings, got []string` and the test fataled.

**Fix:** `toStringSlice` now accepts `[]string` (it IS an array of strings), converting it into the same per-item validation loop as the `[]any` path — control-character checks (#252), tag count/length limits (#149) all still apply. Genuinely wrong types (numbers, objects, garbage strings) still produce the loud error #1283 introduced.

**Behavior-contract note (relevant for review):** under pre-#1283 code, this test only passed because `[]string` failed the `[]any` cast and `toStringSlice` **silently returned `(nil, nil)`** — the tags were never applied at all, which is precisely the #1279 silent-drop bug. With this fix the test finally exercises its stated intent: tags actually applied, content untouched, summary preserved. The summary-preservation contract holds because `UpdateMemory` (internal/db/postgres_memory.go) clears the summary only on the `content != nil` branch (`sqlUpdateMemoryWithContent`); tag-only updates take `sqlUpdateMemoryNoContent`. Verified against a live DB, not just reasoned about.

### 2. golangci-lint: `requiredNumberProp` unused

Declared in #1283's `internal/mcp/tool_schemas.go` but never referenced — deleted per the reviewer's dead-code finding. All other schema helpers verified in use (1–40 call sites each in `server.go`).

## Repro + verification (WITH live DB this time)

Provisioned an ephemeral `pgvector/pgvector:pg16` container mirroring CI's service definition (user `engram`, db `engram_test`) — the repo's canonical `test-postgres` compose service's host port (5433) is occupied locally by `engram-ng-postgres`, so it ran on 127.0.0.1:15433 and was removed after.

- **Repro on origin/main (pre-fix):** `--- FAIL: TestHandleMemoryCorrect_PreservesSummaryOnTagOnlyChange` with `handleMemoryCorrect (tags-only): tags: tags must be an array of strings, got []string` — exact CI failure.
- **Post-fix:** that test + its two siblings (`TestHandleMemoryResummarize_ClearsSummaries`, `TestHandleMemoryCorrect_ClearsSummaryOnContentChange`) pass with the live DB.
- **New unit regression guards (TDD — written and confirmed failing before the fix):** `TestToStringSlice_GoStringSlice_Accepted`, `_StillValidatesControlChars` (acceptance must not bypass #252 checks), `_Empty_ReturnsEmptyNotNil` (`tags=[]` clears valid_from vs. omitted preserves it — the distinction must survive the []string path).
- **Full suite:** `TEST_DATABASE_URL=... go test ./... -count=1 -race` green across all 50 packages except `cmd/benchmark`'s two pre-existing worktree-VCS-stamping failures (`error obtaining VCS status` from the test's `go build` subprocess inside a git worktree — unrelated to this diff, passes in CI's normal checkout).
- **Lint:** `golangci-lint run ./internal/mcp/...` → 0 issues. `gofmt -l` clean on all touched files.
- Audited the other in-repo callers that pass `[]string` tags (`cmd/instinct`, `internal/hookdaemon`, quick-store/quick-recall REST tests) — all go through JSON marshal + HTTP transport, so they arrive server-side as `[]any` and were never affected; the `[]string` path matters only for in-process handler invocation.

Labeled `ai-generated` per repo policy. Not merging — gate on CI green first.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
https://claude.ai/code/session_01CL7bkT4CcyGvmKP4gjbWGf