### PR TITLE
feat(longmemeval): add full-timeline context mode

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -216,6 +216,7 @@ go run ./cmd/benchmark/main.go \
 go run ./cmd/longmemeval help
 go run ./cmd/longmemeval ingest --data questions.json --out results/lme-run --cleanup-policy=never
 go run ./cmd/longmemeval run --data questions.json --out results/lme-run --recall-topk 100 --context-topk 8
+go run ./cmd/longmemeval run --data questions.json --out results/lme-run --full-timeline-context
 go run ./cmd/longmemeval score-efficient --data questions.json --out results/lme-run
 go run ./cmd/longmemeval analyze --results results/lme-run
 ```
@@ -224,6 +225,7 @@ go run ./cmd/longmemeval analyze --results results/lme-run
 
 - `ingest` — load the dataset into per-question Engram projects.
 - `run` — recall context and generate hypotheses.
+- `run --full-timeline-context` — benchmark-only generation-context ablation that bypasses retrieval and injects the full dated haystack timeline directly into the prompt.
 - `score` — score hypotheses against gold answers.
 - `all` — run ingest, run, and score in one invocation.
 - `score-efficient` — score with an Olla/OpenAI-compatible backend while preserving already-correct rows by default.

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -61,6 +61,7 @@ type Config struct {
 	RecallTopK          int  // memories recalled before context trim (default 100)
 	ContextTopKOverride int  // explicit context topK; 0 = per-type default
 	ChronoSort          bool // sort context blocks by Session date ascending before prompt assembly
+	FullTimelineContext bool // bypass retrieval and inject the full dated haystack timeline directly into the generation prompt
 	DisableQueryRewrite bool // use raw question as recall query; skip temporal/preference rewriting
 	MaxBlockChars       int  // truncate each context block to this many chars before prompt assembly; 0 = no truncation
 	RepairPreset        string
@@ -163,6 +164,7 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  --out <dir>             Output directory for checkpoints (default .)")
 	_, _ = fmt.Fprintln(w, "  --run-id <hex>          Run identifier (auto-generated if empty)")
 	_, _ = fmt.Fprintln(w, "  --retries <n>           Retry count for generation + Engram calls (default 1)")
+	_, _ = fmt.Fprintln(w, "  --full-timeline-context Bypass recall and inject the full dated haystack timeline directly into the prompt")
 	_, _ = fmt.Fprintln(w, "  --cleanup-policy <val>  Project cleanup after run: auto (default), always, never")
 	_, _ = fmt.Fprintln(w, "                          auto: delete only projects created by this run invocation")
 	_, _ = fmt.Fprintln(w, "                          always: unconditional deletion (pre-v0 behavior)")
@@ -230,6 +232,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.IntVar(&cfg.RecallTopK, "recall-topk", 100, "memories to recall before context trim (1–500)")
 	fs.IntVar(&cfg.ContextTopKOverride, "context-topk", 0, "explicit context topK; 0 = per-type default")
 	fs.BoolVar(&cfg.ChronoSort, "chrono-sort", false, "sort context blocks by Session date ascending before prompt assembly")
+	fs.BoolVar(&cfg.FullTimelineContext, "full-timeline-context", false, "benchmark-only: bypass memory_recall and inject the full dated haystack timeline directly into the generation prompt")
 	fs.BoolVar(&cfg.DisableQueryRewrite, "disable-query-rewrite", false, "use raw question as recall query; skip temporal/preference rewriting")
 	fs.IntVar(&cfg.MaxBlockChars, "max-block-chars", 0, "truncate each context block to this many chars before prompt assembly; 0 = no limit (use with large --context-topk to stay within vLLM max_model_len)")
 	fs.StringVar(&cfg.RepairPreset, "repair-preset", "", "named LongMemEval repair preset to enable known repair switches: recall-repair")
@@ -546,6 +549,10 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 
 	// Phase 2A (#1079): validate oracle flags when set.
 	if cfg.AtomOracle {
+		if cfg.FullTimelineContext {
+			_, _ = fmt.Fprintln(stderr, "--full-timeline-context cannot be combined with --atom-oracle")
+			return 1
+		}
 		if cfg.LLMBaseURL == "" {
 			_, _ = fmt.Fprintln(stderr, "--atom-oracle requires --llm-url (local LLM endpoint for atom extraction)")
 			return 1

--- a/cmd/longmemeval/manifest.go
+++ b/cmd/longmemeval/manifest.go
@@ -41,6 +41,17 @@ type questionProjectProvenance struct {
 	Warning            string `json:"warning,omitempty"`
 }
 
+func generationContextMode(cfg *Config) string {
+	switch {
+	case cfg.AtomOracle:
+		return "atom-oracle"
+	case cfg.FullTimelineContext:
+		return "full-timeline"
+	default:
+		return "retrieval"
+	}
+}
+
 func scoreCompletenessFromScores(scores []longmemeval.ScoreEntry) scoreCompleteness {
 	scoreDone, scoreErrors := scoreOutcomeCounts(scores)
 	total := scoreDone + scoreErrors
@@ -124,6 +135,7 @@ func writeRunManifest(
 		"complete":              completeness.Complete,
 		"question_projects":     questionProjects,
 		"project_warning_total": projectWarningTotal,
+		"generation_context":    generationContextMode(cfg),
 		"binary_path":           exe,
 		"command_line":          os.Args,
 		"git_sha":               bestEffortGit("rev-parse", "HEAD"),
@@ -172,6 +184,7 @@ func writeRunStatus(cfg *Config, stage string, startedAt, endedAt time.Time, exi
 		"score_row_total":       snapshot.ScoreRowTotal,
 		"question_projects":     snapshot.QuestionProjects,
 		"project_warning_total": snapshot.ProjectWarningTotal,
+		"generation_context":    generationContextMode(cfg),
 		"binary_path":           exe,
 		"command_line":          commandLine,
 		"git_sha":               bestEffortGit("rev-parse", "HEAD"),

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -463,6 +463,17 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	if cfg.AtomOracle {
 		return runOneOracle(ctx, cfg, item, ingest)
 	}
+	if cfg.FullTimelineContext {
+		contextBlocks := buildFullTimelineContextBlocks(item, cfg.MaxBlockChars)
+		if len(contextBlocks) == 0 {
+			return longmemeval.RunEntry{
+				QuestionID: item.QuestionID,
+				Status:     "error",
+				Error:      "full-timeline context: no non-empty sessions found in haystack",
+			}
+		}
+		return generateRunEntry(ctx, cfg, item, nil, contextBlocks, "")
+	}
 
 	// Strip leading interrogative phrases for temporal questions so the recall
 	// query matches event noun-phrases rather than "how many weeks ago did...".
@@ -671,10 +682,28 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	if cfg.AtomMode {
 		atomContextBlock = fetchAtomContextBlock(ctx, mcpClient, ingest.Project, item.QuestionID, cfg.AtomCacheDir)
 	}
-	// Exp-14: --temporal-prompt-aug takes priority over --inject-question-date;
-	// the two are mutually exclusive. When both are set, aug wins.
-	// H12 (--enumerate-first) is orthogonal — it only fires for aggregation
-	// questions, which the temporal/preference branches above never match.
+	return generateRunEntry(ctx, cfg, item, retrievedIDs, contextBlocks, atomContextBlock)
+}
+
+func buildFullTimelineContextBlocks(item longmemeval.Item, maxBlockChars int) []string {
+	blocks := make([]string, 0, len(item.HaystackSessions))
+	for i, session := range item.HaystackSessions {
+		content := longmemeval.SessionContent(session)
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		if i < len(item.HaystackDates) && item.HaystackDates[i] != "" {
+			content = "Session date: " + item.HaystackDates[i] + "\n" + content
+		}
+		if maxBlockChars > 0 && len(content) > maxBlockChars {
+			content = content[:maxBlockChars]
+		}
+		blocks = append(blocks, content)
+	}
+	return sortBlocksChronologically(blocks)
+}
+
+func generateRunEntry(ctx context.Context, cfg *Config, item longmemeval.Item, retrievedIDs []string, contextBlocks []string, atomContextBlock string) longmemeval.RunEntry {
 	var prompt string
 	switch {
 	case cfg.TemporalPromptAug:
@@ -686,12 +715,11 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	default:
 		prompt = longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, contextBlocks)
 	}
-
-	// #938: prepend atom context block before the memory context when --atom-mode is set.
 	if atomContextBlock != "" {
 		prompt = atomContextBlock + "\n" + prompt
 	}
 	var hypothesis string
+	var err error
 	if cfg.LLMBaseURL != "" {
 		maxTok := cfg.LLMMaxTokens
 		if maxTok == 0 && cfg.EnableThinking {

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"reflect"
@@ -9,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/petersimmons1972/engram/internal/longmemeval"
 )
@@ -148,6 +154,107 @@ func TestSortBlocksChronologically_DoesNotMutateInput(t *testing.T) {
 		if input[i] != orig[i] {
 			t.Errorf("input slice was mutated at index %d", i)
 		}
+	}
+}
+
+func TestBuildFullTimelineContextBlocks_Chronological(t *testing.T) {
+	item := longmemeval.Item{
+		HaystackDates: []string{"2024-06-01", "2024-05-20", "2024-06-03"},
+		HaystackSessions: [][]longmemeval.Turn{
+			{{Role: "user", Content: "latest session"}},
+			{{Role: "assistant", Content: "earliest session"}},
+			{{Role: "user", Content: ""}}, // empty session should be skipped
+		},
+	}
+
+	got := buildFullTimelineContextBlocks(item, 0)
+	want := []string{
+		"Session date: 2024-05-20\nassistant: earliest session",
+		"Session date: 2024-06-01\nuser: latest session",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildFullTimelineContextBlocks() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunOne_FullTimelineContext_BypassesRecallAndFetch(t *testing.T) {
+	url := newTestEngram(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			t.Fatal("memory_recall should not be called in full-timeline mode")
+			return nil, nil
+		},
+		"memory_fetch": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			t.Fatal("memory_fetch should not be called in full-timeline mode")
+			return nil, nil
+		},
+	})
+
+	var prompt string
+	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var body struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode llm request: %v", err)
+		}
+		for _, msg := range body.Messages {
+			if msg.Role == "user" {
+				prompt = msg.Content
+				break
+			}
+		}
+		fmt.Fprint(w, `{"choices":[{"message":{"content":"Alice"}}]}`)
+	}))
+	defer llmSrv.Close()
+
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	item := longmemeval.Item{
+		QuestionID:   "q-full-timeline",
+		QuestionType: "single-session-user",
+		Question:     "Who attended the planning session?",
+		QuestionDate: "2024-06-05",
+		HaystackDates: []string{
+			"2024-06-03",
+			"2024-06-01",
+		},
+		HaystackSessions: [][]longmemeval.Turn{
+			{{Role: "user", Content: "Bob attended the planning session."}},
+			{{Role: "user", Content: "Alice attended the planning session."}},
+		},
+	}
+	ingest := longmemeval.IngestEntry{QuestionID: item.QuestionID, Project: "lme-r-q-full-timeline"}
+	cfg := &Config{
+		FullTimelineContext: true,
+		LLMBaseURL:          llmSrv.URL,
+		LLMModel:            "test",
+		Retries:             0,
+	}
+
+	entry := runOne(ctx, cfg, c, item, ingest)
+	if entry.Status != "done" {
+		t.Fatalf("runOne status = %q error=%q, want done", entry.Status, entry.Error)
+	}
+	if len(entry.RetrievedIDs) != 0 {
+		t.Fatalf("RetrievedIDs = %#v, want empty in full-timeline mode", entry.RetrievedIDs)
+	}
+	if !strings.Contains(prompt, "Session date: 2024-06-01\nuser: Alice attended the planning session.") {
+		t.Fatalf("prompt missing earliest dated session:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Session date: 2024-06-03\nuser: Bob attended the planning session.") {
+		t.Fatalf("prompt missing later dated session:\n%s", prompt)
+	}
+	if strings.Index(prompt, "2024-06-01") > strings.Index(prompt, "2024-06-03") {
+		t.Fatalf("prompt sessions not in chronological order:\n%s", prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- add a benchmark-only `--full-timeline-context` mode to `longmemeval run` that bypasses `memory_recall`/`memory_fetch` and injects the full dated haystack timeline directly into generation prompts\n- record the selected generation context in run manifest/status artifacts for A/B attribution\n- document the new flag and lock it with focused TDD coverage\n\n## Testing\n- `go test ./cmd/longmemeval`\n- `go test ./...`\n- `./bin/checkin-lint.sh`