### PR TITLE
fix(mcp): record recall events on empty recall hits

### DIFF
--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -50,6 +50,7 @@ func (s *recallStubFetcher) GetChunksForMemory(_ context.Context, _ string) ([]*
 
 type recallTrackingBackend struct {
 	noopBackend
+	ftsResults   []db.FTSResult
 	storedEvents atomic.Int64
 	increments   atomic.Int64
 	// lastEventID is the ID of the most recent event passed to
@@ -62,6 +63,9 @@ type recallTrackingBackend struct {
 }
 
 func (b *recallTrackingBackend) FTSSearch(_ context.Context, project, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	if b.ftsResults != nil {
+		return b.ftsResults, nil
+	}
 	return []db.FTSResult{{
 		Memory: &types.Memory{
 			ID:        "mem-1",
@@ -467,6 +471,53 @@ func TestHandleMemoryRecall_HandleModeRecordEventReturnsFeedbackEvent(t *testing
 	require.NotEmpty(t, out["event_id"], "handle mode record_event=true should return a feedback event")
 	require.Equal(t, int64(1), backend.storedEvents.Load())
 	require.Equal(t, int64(1), backend.increments.Load())
+}
+
+func TestHandleMemoryRecall_EmptyResultsRecordEventReturnsFeedbackEvent(t *testing.T) {
+	backend := &recallTrackingBackend{
+		ftsResults: make([]db.FTSResult, 0),
+	}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":      "test",
+		"query":        "record recall telemetry miss",
+		"record_event": true,
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(0), out["count"])
+	require.NotEmpty(t, out["event_id"], "record_event=true should return a feedback event on zero results")
+	require.NotEmpty(t, out["feedback_hint"], "record_event=true should return a feedback_hint on zero results")
+	require.Equal(t, int64(1), backend.storedEvents.Load())
+}
+
+func TestHandleMemoryRecall_NilMemoryResultsRecordEventReturnsFeedbackEvent(t *testing.T) {
+	backend := &recallTrackingBackend{
+		ftsResults: []db.FTSResult{{
+			Memory: nil,
+			Score:  0.5,
+		}},
+	}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":      "test",
+		"query":        "record recall telemetry nil-mem",
+		"record_event": true,
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(1), out["count"])
+	require.NotEmpty(t, out["event_id"], "record_event=true should return a feedback event when only nil memories are returned")
+	require.NotEmpty(t, out["feedback_hint"], "record_event=true should return a feedback_hint when only nil memories are returned")
+	require.Equal(t, int64(1), backend.storedEvents.Load())
 }
 
 func TestHandleMemoryRecall_LimitAliasMapsToTopK(t *testing.T) {

--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -867,3 +867,33 @@ func TestHandleMemoryRecall_EmbedError_IncrementsDegradedCounter(t *testing.T) {
 	after := testutil.ToFloat64(metrics.RecallDegradedTotal.WithLabelValues("embed_error"))
 	require.Equal(t, before+1, after, "RecallDegradedTotal[embed_error] must increment once on hard embed error (engine-owned)")
 }
+
+// TestHandleMemoryRecall_NilMemoryResultSurfacesDroppedHitsInDegradedField verifies that
+// a nil-Memory FTS hit (dropped at engine layer) contributes to "count" and appears as
+// dropped_hits inside the "degraded" map, while the results payload remains empty.
+func TestHandleMemoryRecall_NilMemoryResultSurfacesDroppedHitsInDegradedField(t *testing.T) {
+	backend := &recallTrackingBackend{
+		ftsResults: []db.FTSResult{{
+			Memory: nil,
+			Score:  0.5,
+		}},
+	}
+	pool := newRecallTrackingPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "record recall telemetry nil-mem degraded field",
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	out := parseRecallResult(t, res)
+
+	require.Equal(t, float64(1), out["count"], "count must include the dropped nil-Memory hit")
+	degraded, ok := out["degraded"].(map[string]any)
+	require.True(t, ok, "degraded field must be a map")
+	require.Equal(t, float64(1), degraded["dropped_hits"], "degraded.dropped_hits must reflect the one dropped hit")
+	results, ok := out["results"].([]any)
+	require.True(t, ok, "results field must be a list")
+	require.Empty(t, results, "the memories payload must never include a nil-Memory entry")
+}

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -634,9 +634,6 @@ func recordRecallEvent(ctx context.Context, h *EngineHandle, project, query stri
 			resultIDs = append(resultIDs, r.Memory.ID)
 		}
 	}
-	if len(resultIDs) == 0 {
-		return ""
-	}
 	event := &types.RetrievalEvent{
 		ID:        types.NewMemoryID(),
 		Project:   project,

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -584,7 +584,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			"degraded":   degradedMap(embedDegraded, embedDegradeReason),
 		}
 		if droppedHits > 0 {
-			out["degraded"].(map[string]any)["dropped_hits"] = droppedHits
+			if dm, ok := out["degraded"].(map[string]any); ok {
+				dm["dropped_hits"] = droppedHits
+			}
 		}
 		if atomPreamble != "" {
 			out["atom_preamble"] = atomPreamble
@@ -625,7 +627,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	isDegraded := embedDegraded || !ok
 	out["degraded"] = degradedMap(isDegraded, reason)
 	if droppedHits > 0 {
-		out["degraded"].(map[string]any)["dropped_hits"] = droppedHits
+		if dm, ok := out["degraded"].(map[string]any); ok {
+			dm["dropped_hits"] = droppedHits
+		}
 	}
 	if isDegraded || droppedHits > 0 {
 		if reason == "" && embedDegraded {

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -524,6 +524,9 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	var embedDegradeReason string
 	opts.EmbedDegraded = &embedDegraded
 	opts.EmbedDegradedReason = &embedDegradeReason
+	// Capture dropped-hit count (nil-Memory recall candidates) — see RecallOpts.DroppedHits.
+	var droppedHits int
+	opts.DroppedHits = &droppedHits
 
 	var results []types.SearchResult
 	var eventID string
@@ -576,15 +579,19 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		sanitizeRecallResults(results)
 		out := map[string]any{
 			"handles":    search.ToHandles(results),
-			"count":      len(results),
+			"count":      len(results) + droppedHits,
 			"fetch_hint": "call memory_fetch with id and detail=summary|chunk|full",
 			"degraded":   degradedMap(embedDegraded, embedDegradeReason),
+		}
+		if droppedHits > 0 {
+			out["degraded"].(map[string]any)["dropped_hits"] = droppedHits
 		}
 		if atomPreamble != "" {
 			out["atom_preamble"] = atomPreamble
 		}
-		if embedDegraded {
-			addRecallDegradedWarning(out, cfg.RouterURL, embedDegradeReason)
+		if embedDegraded || droppedHits > 0 {
+			reason := embedDegradeReason
+			addRecallDegradedWarning(out, cfg.RouterURL, reason)
 		}
 		if eventID != "" {
 			out["event_id"] = eventID
@@ -593,7 +600,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		return toolResult(out)
 	}
 	sanitizeRecallResults(results)
-	out := map[string]any{"results": results, "count": len(results)}
+	out := map[string]any{"results": results, "count": len(results) + droppedHits}
 	if summary, err := buildLayerBSummary(ctx, h.Engine.Backend(), query, results); err != nil {
 		slog.Warn("layer_b recall post-pass failed", "project", project, "err", err)
 	} else if summary != nil {
@@ -617,7 +624,10 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	ok, reason := cfg.EmbedderHealth.Snapshot(ctx)
 	isDegraded := embedDegraded || !ok
 	out["degraded"] = degradedMap(isDegraded, reason)
-	if isDegraded {
+	if droppedHits > 0 {
+		out["degraded"].(map[string]any)["dropped_hits"] = droppedHits
+	}
+	if isDegraded || droppedHits > 0 {
 		if reason == "" && embedDegraded {
 			// Use the actual degradation reason surfaced by the engine (#989).
 			reason = embedDegradeReason

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -85,6 +85,16 @@ type RecallOpts struct {
 	// such as model crash or connection refused). Empty string when not degraded.
 	// Nil = do not populate. (#989)
 	EmbedDegradedReason *string
+	// DroppedHits receives the count of recall candidates the backend found
+	// but whose Memory failed to hydrate (nil Memory on an FTS/vector result),
+	// if the caller provides a non-nil pointer. These hits are never added to
+	// the returned result set (a contentless memory must never reach a
+	// caller) but they are real evidence of a retrieval-layer problem and
+	// must not silently vanish from the caller-visible count. Incremented
+	// (not overwritten) at every drop site, so a caller reusing the same
+	// pointer across multiple internal passes (e.g. recallTwoPassTemporal)
+	// sees the accumulated total. Nil = do not populate.
+	DroppedHits *int
 	// DateSince and DateBefore scope retrieval by memory valid_from timestamps.
 	// Nil bounds leave that side unbounded.
 	DateSince  *time.Time
@@ -946,6 +956,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 	maxBM25 := 0.0
 	for _, r := range ftsRes.results {
 		if r.Memory == nil {
+			if opts.DroppedHits != nil {
+				*opts.DroppedHits++
+			}
 			continue
 		}
 		ftsScores[r.Memory.ID] = r.Score
@@ -1007,6 +1020,9 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			if pFErr == nil {
 				for _, r := range pFTSResults {
 					if r.Memory == nil {
+						if opts.DroppedHits != nil {
+							*opts.DroppedHits++
+						}
 						continue
 					}
 					// Prefer higher BM25 score across passes.


### PR DESCRIPTION
### Summary