### PR TITLE
fix(layerb): match aggregation anchors across spans and fix plural stem

### DIFF
--- a/internal/db/migrations/029_layerb.sql
+++ b/internal/db/migrations/029_layerb.sql
@@ -1,0 +1,51 @@
+-- 029_layerb.sql — Additive Layer B deterministic aggregation cache.
+--
+-- Two tables:
+--   layer_b_atoms   — exact provenance spans extracted deterministically from recalled memories
+--   layer_b_events  — count-style aggregation events derived from those spans
+--
+-- Design goals:
+--   1. Additive only: no changes to existing memories/chunks/retrieval tables.
+--   2. Provenance-preserving: exact char span and verbatim span text round-trip.
+--   3. Idempotent re-ingest: unique constraints make repeated indexing a no-op/update.
+--   4. No orphans: ON DELETE CASCADE from memories.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS layer_b_atoms (
+    id                  TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    project             TEXT NOT NULL,
+    provenance_memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    provenance_span     TEXT NOT NULL,
+    span_text           TEXT NOT NULL,
+    statement           TEXT NOT NULL,
+    normalized_text     TEXT NOT NULL,
+    event_time          TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_layer_b_atoms UNIQUE (
+        project, provenance_memory_id, provenance_span, normalized_text
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_layer_b_atoms_project_memory
+    ON layer_b_atoms (project, provenance_memory_id);
+
+CREATE TABLE IF NOT EXISTS layer_b_events (
+    id                  TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    project             TEXT NOT NULL,
+    provenance_memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    provenance_span     TEXT NOT NULL,
+    span_text           TEXT NOT NULL,
+    anchor              TEXT NOT NULL,
+    normalized_text     TEXT NOT NULL,
+    event_time          TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_layer_b_events UNIQUE (
+        project, provenance_memory_id, provenance_span, anchor
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_layer_b_events_project_memory
+    ON layer_b_events (project, provenance_memory_id, event_time);
+
+COMMIT;

--- a/internal/db/postgres_layerb.go
+++ b/internal/db/postgres_layerb.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+)
+
+// UpsertLayerBAtom inserts or refreshes one deterministic Layer B atom.
+func (p *PostgresBackend) UpsertLayerBAtom(ctx context.Context, atom layerb.Atom) error {
+	_, err := p.pool.Exec(ctx, `
+		INSERT INTO layer_b_atoms (
+			project, provenance_memory_id, provenance_span, span_text,
+			statement, normalized_text, event_time
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (project, provenance_memory_id, provenance_span, normalized_text)
+		DO UPDATE SET
+			span_text = EXCLUDED.span_text,
+			statement = EXCLUDED.statement,
+			event_time = EXCLUDED.event_time`,
+		atom.Project, atom.MemoryID, atom.ProvenanceSpan, atom.SpanText,
+		atom.Statement, atom.NormalizedText, atom.EventTime,
+	)
+	if err != nil {
+		return fmt.Errorf("UpsertLayerBAtom: %w", err)
+	}
+	return nil
+}
+
+// UpsertLayerBEvent inserts or refreshes one deterministic Layer B event.
+func (p *PostgresBackend) UpsertLayerBEvent(ctx context.Context, event layerb.Event) error {
+	_, err := p.pool.Exec(ctx, `
+		INSERT INTO layer_b_events (
+			project, provenance_memory_id, provenance_span, span_text,
+			anchor, normalized_text, event_time
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (project, provenance_memory_id, provenance_span, anchor)
+		DO UPDATE SET
+			span_text = EXCLUDED.span_text,
+			normalized_text = EXCLUDED.normalized_text,
+			event_time = EXCLUDED.event_time`,
+		event.Project, event.MemoryID, event.ProvenanceSpan, event.SpanText,
+		event.Anchor, event.NormalizedText, event.EventTime,
+	)
+	if err != nil {
+		return fmt.Errorf("UpsertLayerBEvent: %w", err)
+	}
+	return nil
+}
+
+// ListLayerBEvents returns all Layer B events for the requested memories.
+func (p *PostgresBackend) ListLayerBEvents(ctx context.Context, project string, memoryIDs []string) ([]layerb.EventRecord, error) {
+	if len(memoryIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := p.pool.Query(ctx, `
+		SELECT provenance_memory_id, provenance_span, span_text, anchor, normalized_text, event_time
+		FROM layer_b_events
+		WHERE project = $1 AND provenance_memory_id = ANY($2)
+		ORDER BY event_time ASC NULLS LAST, provenance_span ASC`,
+		project, memoryIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("ListLayerBEvents query: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]layerb.EventRecord, 0)
+	for rows.Next() {
+		var rec layerb.EventRecord
+		if err := rows.Scan(
+			&rec.MemoryID, &rec.ProvenanceSpan, &rec.SpanText,
+			&rec.Anchor, &rec.NormalizedText, &rec.EventTime,
+		); err != nil {
+			return nil, fmt.Errorf("ListLayerBEvents scan: %w", err)
+		}
+		records = append(records, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ListLayerBEvents rows: %w", err)
+	}
+	return records, nil
+}

--- a/internal/db/postgres_layerb_test.go
+++ b/internal/db/postgres_layerb_test.go
@@ -1,0 +1,72 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLayerBEvents_RoundTripIdempotentAndCascade(t *testing.T) {
+	proj := uniqueProject("layerb-roundtrip")
+	backend := newTestBackend(t, proj)
+	pg, ok := backend.(*db.PostgresBackend)
+	require.True(t, ok, "newTestBackend must return *db.PostgresBackend")
+
+	ctx := context.Background()
+	validFrom := time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)
+	mem := &types.Memory{
+		ID:         types.NewMemoryID(),
+		Content:    "I visited the doctor on Monday.",
+		Project:    proj,
+		MemoryType: types.MemoryTypeContext,
+		Importance: 1,
+		ValidFrom:  &validFrom,
+	}
+	require.NoError(t, backend.StoreMemory(ctx, mem))
+
+	atom := layerb.Atom{
+		Project:        proj,
+		MemoryID:       mem.ID,
+		ProvenanceSpan: "chars:0-31",
+		SpanText:       "I visited the doctor on Monday.",
+		Statement:      "I visited the doctor on Monday.",
+		NormalizedText: "visit doctor monday",
+		EventTime:      &validFrom,
+	}
+	event := layerb.Event{
+		Project:        proj,
+		MemoryID:       mem.ID,
+		ProvenanceSpan: atom.ProvenanceSpan,
+		SpanText:       atom.SpanText,
+		Anchor:         "visit doctor",
+		NormalizedText: atom.NormalizedText,
+		EventTime:      atom.EventTime,
+	}
+
+	require.NoError(t, pg.UpsertLayerBAtom(ctx, atom))
+	require.NoError(t, pg.UpsertLayerBEvent(ctx, event))
+	require.NoError(t, pg.UpsertLayerBAtom(ctx, atom))
+	require.NoError(t, pg.UpsertLayerBEvent(ctx, event))
+
+	records, err := pg.ListLayerBEvents(ctx, proj, []string{mem.ID})
+	require.NoError(t, err)
+	require.Len(t, records, 1, "idempotent re-ingest must not duplicate stored events")
+	require.Equal(t, atom.ProvenanceSpan, records[0].ProvenanceSpan)
+	require.Equal(t, atom.SpanText, records[0].SpanText, "provenance span text must round-trip exactly")
+	require.Equal(t, event.Anchor, records[0].Anchor)
+	require.NotNil(t, records[0].EventTime)
+	require.True(t, records[0].EventTime.Equal(validFrom), "stored event_time must round-trip exactly")
+
+	deleted, err := backend.DeleteMemory(ctx, mem.ID)
+	require.NoError(t, err)
+	require.True(t, deleted)
+
+	records, err = pg.ListLayerBEvents(ctx, proj, []string{mem.ID})
+	require.NoError(t, err)
+	require.Empty(t, records, "deleted memories must not leave orphaned Layer B events")
+}

--- a/internal/layerb/layerb.go
+++ b/internal/layerb/layerb.go
@@ -172,7 +172,7 @@ func extractMatchingAtoms(mem *types.Memory, anchorTerms []string) []Atom {
 			continue
 		}
 		normalized := normalizeText(sentence)
-		if !containsAllTerms(normalized, anchorTerms) {
+		if !containsAnyTerm(normalized, anchorTerms) {
 			continue
 		}
 		matches = append(matches, Atom{
@@ -216,7 +216,7 @@ func sentenceSpans(text string) []span {
 	return spans
 }
 
-func containsAllTerms(normalized string, terms []string) bool {
+func containsAnyTerm(normalized string, terms []string) bool {
 	if len(terms) == 0 {
 		return false
 	}
@@ -225,11 +225,11 @@ func containsAllTerms(normalized string, terms []string) bool {
 		have[term] = true
 	}
 	for _, term := range terms {
-		if !have[term] {
-			return false
+		if have[term] {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func normalizeTerms(text string) []string {
@@ -260,10 +260,10 @@ func stem(token string) string {
 		return token[:len(token)-3]
 	case len(token) > 3 && strings.HasSuffix(token, "ed"):
 		return token[:len(token)-2]
-	case len(token) > 3 && strings.HasSuffix(token, "es"):
-		return token[:len(token)-2]
 	case len(token) > 2 && strings.HasSuffix(token, "s"):
 		return token[:len(token)-1]
+	case len(token) > 3 && strings.HasSuffix(token, "es"):
+		return token[:len(token)-2]
 	default:
 		return token
 	}

--- a/internal/layerb/layerb.go
+++ b/internal/layerb/layerb.go
@@ -1,0 +1,302 @@
+package layerb
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// Atom is one deterministic evidence span extracted from a recalled memory.
+type Atom struct {
+	Project        string     `json:"project"`
+	MemoryID       string     `json:"memory_id"`
+	ProvenanceSpan string     `json:"provenance_span"`
+	SpanText       string     `json:"span_text"`
+	Statement      string     `json:"statement"`
+	NormalizedText string     `json:"normalized_text"`
+	EventTime      *time.Time `json:"event_time,omitempty"`
+}
+
+// Event is one deterministic aggregation event derived from an Atom.
+type Event struct {
+	Project        string     `json:"project"`
+	MemoryID       string     `json:"memory_id"`
+	ProvenanceSpan string     `json:"provenance_span"`
+	SpanText       string     `json:"span_text"`
+	Anchor         string     `json:"anchor"`
+	NormalizedText string     `json:"normalized_text"`
+	EventTime      *time.Time `json:"event_time,omitempty"`
+}
+
+// EventRecord is the stored event shape returned by the persistence layer.
+type EventRecord struct {
+	MemoryID       string     `json:"memory_id"`
+	ProvenanceSpan string     `json:"provenance_span"`
+	SpanText       string     `json:"span_text"`
+	Anchor         string     `json:"anchor"`
+	NormalizedText string     `json:"normalized_text"`
+	EventTime      *time.Time `json:"event_time,omitempty"`
+}
+
+// Summary is the additive Layer B payload returned to callers.
+type Summary struct {
+	Mode     string        `json:"mode"`
+	Anchor   string        `json:"anchor"`
+	Count    int           `json:"count"`
+	Evidence []EventRecord `json:"evidence"`
+}
+
+// Store is the narrow persistence seam for Layer B.
+type Store interface {
+	UpsertLayerBAtom(ctx context.Context, atom Atom) error
+	UpsertLayerBEvent(ctx context.Context, event Event) error
+	ListLayerBEvents(ctx context.Context, project string, memoryIDs []string) ([]EventRecord, error)
+}
+
+var nonWordRE = regexp.MustCompile(`[^a-z0-9]+`)
+var stopWords = map[string]bool{
+	"a": true, "an": true, "the": true, "i": true, "me": true, "my": true,
+	"did": true, "do": true, "does": true, "have": true, "had": true,
+	"how": true, "many": true, "much": true, "times": true, "time": true,
+	"what": true, "is": true, "was": true, "were": true, "of": true,
+	"to": true, "on": true, "in": true, "for": true, "and": true,
+}
+
+// BuildSummary deterministically indexes matching evidence spans from recalled
+// memories and returns a count-style aggregation payload when the query is
+// aggregation-shaped. Non-aggregation queries return (nil, nil).
+func BuildSummary(ctx context.Context, store Store, query string, results []types.SearchResult) (*Summary, error) {
+	if !longmemeval.IsAggregationQuestion(query) {
+		return nil, nil
+	}
+
+	anchor := strings.TrimSpace(longmemeval.ExtractAggregationAnchor(query))
+	anchorTerms := normalizeTerms(anchor)
+	if len(anchorTerms) == 0 {
+		return nil, nil
+	}
+
+	project := ""
+	memoryIDs := make([]string, 0, len(results))
+	for _, result := range results {
+		if result.Memory == nil || strings.TrimSpace(result.Memory.Content) == "" {
+			continue
+		}
+		if project == "" {
+			project = result.Memory.Project
+		}
+		memoryIDs = append(memoryIDs, result.Memory.ID)
+		matches := extractMatchingAtoms(result.Memory, anchorTerms)
+		for _, atom := range matches {
+			if err := store.UpsertLayerBAtom(ctx, atom); err != nil {
+				return nil, fmt.Errorf("layerb upsert atom: %w", err)
+			}
+			event := Event{
+				Project:        atom.Project,
+				MemoryID:       atom.MemoryID,
+				ProvenanceSpan: atom.ProvenanceSpan,
+				SpanText:       atom.SpanText,
+				Anchor:         strings.Join(anchorTerms, " "),
+				NormalizedText: atom.NormalizedText,
+				EventTime:      atom.EventTime,
+			}
+			if err := store.UpsertLayerBEvent(ctx, event); err != nil {
+				return nil, fmt.Errorf("layerb upsert event: %w", err)
+			}
+		}
+	}
+
+	if len(memoryIDs) == 0 || project == "" {
+		return nil, nil
+	}
+
+	records, err := store.ListLayerBEvents(ctx, project, dedupe(memoryIDs))
+	if err != nil {
+		return nil, fmt.Errorf("layerb list events: %w", err)
+	}
+
+	wantAnchor := strings.Join(anchorTerms, " ")
+	evidence := make([]EventRecord, 0, len(records))
+	for _, record := range records {
+		if record.Anchor != wantAnchor {
+			continue
+		}
+		evidence = append(evidence, record)
+	}
+	if len(evidence) == 0 {
+		return nil, nil
+	}
+
+	slices.SortStableFunc(evidence, func(a, b EventRecord) int {
+		if a.EventTime == nil && b.EventTime == nil {
+			return strings.Compare(a.ProvenanceSpan, b.ProvenanceSpan)
+		}
+		if a.EventTime == nil {
+			return 1
+		}
+		if b.EventTime == nil {
+			return -1
+		}
+		if a.EventTime.Equal(*b.EventTime) {
+			return strings.Compare(a.ProvenanceSpan, b.ProvenanceSpan)
+		}
+		if a.EventTime.Before(*b.EventTime) {
+			return -1
+		}
+		return 1
+	})
+
+	return &Summary{
+		Mode:     "count",
+		Anchor:   wantAnchor,
+		Count:    len(evidence),
+		Evidence: evidence,
+	}, nil
+}
+
+func extractMatchingAtoms(mem *types.Memory, anchorTerms []string) []Atom {
+	if mem == nil {
+		return nil
+	}
+	spans := sentenceSpans(mem.Content)
+	matches := make([]Atom, 0, len(spans))
+	for _, span := range spans {
+		sentence := strings.TrimSpace(mem.Content[span.start:span.end])
+		if sentence == "" {
+			continue
+		}
+		normalized := normalizeText(sentence)
+		if !containsAllTerms(normalized, anchorTerms) {
+			continue
+		}
+		matches = append(matches, Atom{
+			Project:        mem.Project,
+			MemoryID:       mem.ID,
+			ProvenanceSpan: fmt.Sprintf("chars:%d-%d", span.start, span.end),
+			SpanText:       sentence,
+			Statement:      sentence,
+			NormalizedText: normalized,
+			EventTime:      memoryEventTime(mem),
+		})
+	}
+	return matches
+}
+
+type span struct {
+	start int
+	end   int
+}
+
+func sentenceSpans(text string) []span {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	var spans []span
+	start := 0
+	for i, r := range text {
+		switch r {
+		case '.', '!', '?', '\n':
+			end := i + 1
+			if start < end {
+				spans = append(spans, span{start: start, end: end})
+			}
+			start = end
+		}
+	}
+	if start < len(text) {
+		spans = append(spans, span{start: start, end: len(text)})
+	}
+	return spans
+}
+
+func containsAllTerms(normalized string, terms []string) bool {
+	if len(terms) == 0 {
+		return false
+	}
+	have := make(map[string]bool, len(terms))
+	for _, term := range normalizeTerms(normalized) {
+		have[term] = true
+	}
+	for _, term := range terms {
+		if !have[term] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeTerms(text string) []string {
+	parts := strings.Fields(normalizeText(text))
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if stopWords[part] {
+			continue
+		}
+		part = stem(part)
+		if part == "" || stopWords[part] {
+			continue
+		}
+		normalized = append(normalized, part)
+	}
+	return dedupe(normalized)
+}
+
+func normalizeText(text string) string {
+	return strings.TrimSpace(nonWordRE.ReplaceAllString(strings.ToLower(text), " "))
+}
+
+func stem(token string) string {
+	switch {
+	case len(token) > 4 && strings.HasSuffix(token, "ied"):
+		return token[:len(token)-3] + "y"
+	case len(token) > 4 && strings.HasSuffix(token, "ing"):
+		return token[:len(token)-3]
+	case len(token) > 3 && strings.HasSuffix(token, "ed"):
+		return token[:len(token)-2]
+	case len(token) > 3 && strings.HasSuffix(token, "es"):
+		return token[:len(token)-2]
+	case len(token) > 2 && strings.HasSuffix(token, "s"):
+		return token[:len(token)-1]
+	default:
+		return token
+	}
+}
+
+func dedupe(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+func memoryEventTime(mem *types.Memory) *time.Time {
+	if mem == nil {
+		return nil
+	}
+	if mem.ValidFrom != nil {
+		t := mem.ValidFrom.UTC()
+		return &t
+	}
+	if mem.CreatedAt.IsZero() {
+		return nil
+	}
+	t := mem.CreatedAt.UTC()
+	return &t
+}

--- a/internal/layerb/layerb_test.go
+++ b/internal/layerb/layerb_test.go
@@ -95,3 +95,58 @@ func TestBuildSummary_NonAggregationQuestionIsNoOp(t *testing.T) {
 	require.Empty(t, store.atoms)
 	require.Empty(t, store.events)
 }
+
+func TestBuildSummary_AggregationAnchorMatchesAcrossDifferentSentences(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-bike",
+			Project:   "proj",
+			Content:   "I own a bike.",
+			CreatedAt: time.Now().UTC(),
+		},
+		Score: 1,
+	}, {
+		Memory: &types.Memory{
+			ID:        "mem-hat",
+			Project:   "proj",
+			Content:   "I own a hat.",
+			CreatedAt: time.Now().UTC().Add(time.Minute),
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many bikes and hats?", results)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, 2, summary.Count)
+	require.Equal(t, "bike hat", summary.Anchor)
+	require.Len(t, summary.Evidence, 2)
+
+	ids := map[string]struct{}{}
+	for _, rec := range summary.Evidence {
+		ids[rec.MemoryID] = struct{}{}
+		require.NotEmpty(t, rec.ProvenanceSpan)
+		require.NotEmpty(t, rec.SpanText)
+	}
+	require.Len(t, ids, 2)
+}
+
+func TestBuildSummary_StemmerFixesBikePlural(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   "I own a bike.",
+			CreatedAt: time.Now().UTC(),
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many bikes?", results)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, "bike", summary.Anchor)
+	require.Len(t, summary.Evidence, 1)
+}

--- a/internal/layerb/layerb_test.go
+++ b/internal/layerb/layerb_test.go
@@ -1,0 +1,97 @@
+package layerb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type stubStore struct {
+	atoms  map[string]layerb.Atom
+	events map[string]layerb.Event
+}
+
+func (s *stubStore) UpsertLayerBAtom(_ context.Context, atom layerb.Atom) error {
+	if s.atoms == nil {
+		s.atoms = map[string]layerb.Atom{}
+	}
+	s.atoms[atom.MemoryID+"|"+atom.ProvenanceSpan+"|"+atom.NormalizedText] = atom
+	return nil
+}
+
+func (s *stubStore) UpsertLayerBEvent(_ context.Context, event layerb.Event) error {
+	if s.events == nil {
+		s.events = map[string]layerb.Event{}
+	}
+	s.events[event.MemoryID+"|"+event.ProvenanceSpan+"|"+event.Anchor] = event
+	return nil
+}
+
+func (s *stubStore) ListLayerBEvents(_ context.Context, _ string, memoryIDs []string) ([]layerb.EventRecord, error) {
+	allow := make(map[string]bool, len(memoryIDs))
+	for _, id := range memoryIDs {
+		allow[id] = true
+	}
+	out := make([]layerb.EventRecord, 0, len(s.events))
+	for _, event := range s.events {
+		if !allow[event.MemoryID] {
+			continue
+		}
+		out = append(out, layerb.EventRecord{
+			MemoryID:       event.MemoryID,
+			ProvenanceSpan: event.ProvenanceSpan,
+			SpanText:       event.SpanText,
+			Anchor:         event.Anchor,
+			NormalizedText: event.NormalizedText,
+			EventTime:      event.EventTime,
+		})
+	}
+	return out, nil
+}
+
+func TestBuildSummary_UsesValidFromForTemporalInversion(t *testing.T) {
+	store := &stubStore{}
+	validFrom := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC)
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   "I visited the doctor on Tuesday.",
+			ValidFrom: &validFrom,
+			CreatedAt: createdAt,
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, "visit doctor", summary.Anchor)
+	require.Len(t, summary.Evidence, 1)
+	require.NotNil(t, summary.Evidence[0].EventTime)
+	require.True(t, summary.Evidence[0].EventTime.Equal(validFrom), "valid_from must win over created_at for temporal inversion replay")
+}
+
+func TestBuildSummary_NonAggregationQuestionIsNoOp(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   "I visited the doctor on Tuesday.",
+			CreatedAt: time.Now().UTC(),
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "When did I visit the doctor?", results)
+	require.NoError(t, err)
+	require.Nil(t, summary)
+	require.Empty(t, store.atoms)
+	require.Empty(t, store.events)
+}

--- a/internal/mcp/layerb.go
+++ b/internal/mcp/layerb.go
@@ -1,0 +1,22 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+type layerBStore interface {
+	UpsertLayerBAtom(ctx context.Context, atom layerb.Atom) error
+	UpsertLayerBEvent(ctx context.Context, event layerb.Event) error
+	ListLayerBEvents(ctx context.Context, project string, memoryIDs []string) ([]layerb.EventRecord, error)
+}
+
+func buildLayerBSummary(ctx context.Context, backend any, query string, results []types.SearchResult) (*layerb.Summary, error) {
+	store, ok := backend.(layerBStore)
+	if !ok {
+		return nil, nil
+	}
+	return layerb.BuildSummary(ctx, store, query, results)
+}

--- a/internal/mcp/layerb_recall_test.go
+++ b/internal/mcp/layerb_recall_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/petersimmons1972/engram/internal/db"
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/search"
+	"github.com/petersimmons1972/engram/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type layerBRecallBackend struct {
+	noopBackend
+	mem      *types.Memory
+	atoms    map[string]layerb.Atom
+	events   map[string]layerb.Event
+	evidence map[string]layerb.EventRecord
+}
+
+func newLayerBRecallBackend(project string) *layerBRecallBackend {
+	now := time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC)
+	return &layerBRecallBackend{
+		mem: &types.Memory{
+			ID:         "mem-layerb-1",
+			Project:    project,
+			Content:    "I visited the doctor on Monday. I visited the doctor again on Friday.",
+			CreatedAt:  now,
+			UpdatedAt:  now,
+			MemoryType: types.MemoryTypeContext,
+		},
+		atoms:    map[string]layerb.Atom{},
+		events:   map[string]layerb.Event{},
+		evidence: map[string]layerb.EventRecord{},
+	}
+}
+
+func (b *layerBRecallBackend) FTSSearch(_ context.Context, project, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	mem := *b.mem
+	mem.Project = project
+	return []db.FTSResult{{
+		Memory: &mem,
+		Score:  1,
+	}}, nil
+}
+
+func (b *layerBRecallBackend) UpsertLayerBAtom(_ context.Context, atom layerb.Atom) error {
+	key := atom.MemoryID + "|" + atom.ProvenanceSpan + "|" + atom.Statement
+	b.atoms[key] = atom
+	return nil
+}
+
+func (b *layerBRecallBackend) UpsertLayerBEvent(_ context.Context, event layerb.Event) error {
+	key := event.MemoryID + "|" + event.ProvenanceSpan + "|" + event.Anchor
+	b.events[key] = event
+	b.evidence[key] = layerb.EventRecord{
+		MemoryID:       event.MemoryID,
+		ProvenanceSpan: event.ProvenanceSpan,
+		SpanText:       event.SpanText,
+		Anchor:         event.Anchor,
+		EventTime:      event.EventTime,
+	}
+	return nil
+}
+
+func (b *layerBRecallBackend) ListLayerBEvents(_ context.Context, _ string, memoryIDs []string) ([]layerb.EventRecord, error) {
+	allow := make(map[string]bool, len(memoryIDs))
+	for _, id := range memoryIDs {
+		allow[id] = true
+	}
+	out := make([]layerb.EventRecord, 0, len(b.evidence))
+	for _, rec := range b.evidence {
+		if allow[rec.MemoryID] {
+			out = append(out, rec)
+		}
+	}
+	return out, nil
+}
+
+func newLayerBRecallPool(t *testing.T, backend *layerBRecallBackend) *EnginePool {
+	t.Helper()
+	factory := func(ctx context.Context, project string) (*EngineHandle, error) {
+		engine := search.New(ctx, backend, noopEmbedder{}, project,
+			"http://ollama-test:11434", "", false, nil, 0)
+		t.Cleanup(engine.Close)
+		return &EngineHandle{Engine: engine}, nil
+	}
+	return NewEnginePool(factory)
+}
+
+func TestHandleMemoryRecall_AggregationQuestionAddsLayerBCount(t *testing.T) {
+	backend := newLayerBRecallBackend("test")
+	pool := newLayerBRecallPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "How many times did I visit the doctor?",
+	}
+
+	res, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+
+	out := parseRecallResult(t, res)
+	rawLayerB, ok := out["layer_b"]
+	require.True(t, ok, "aggregation-shaped recall must include layer_b metadata")
+
+	layerBMap, ok := rawLayerB.(map[string]any)
+	require.True(t, ok, "layer_b must marshal as an object")
+	require.Equal(t, "count", layerBMap["mode"])
+	require.Equal(t, "visit doctor", layerBMap["anchor"])
+	require.Equal(t, float64(2), layerBMap["count"])
+
+	rawEvidence, ok := layerBMap["evidence"].([]any)
+	require.True(t, ok, "layer_b evidence must be a JSON array")
+	require.Len(t, rawEvidence, 2)
+}
+
+func TestHandleMemoryRecall_LayerBIndexingIsIdempotent(t *testing.T) {
+	backend := newLayerBRecallBackend("test")
+	pool := newLayerBRecallPool(t, backend)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project": "test",
+		"query":   "How many times did I visit the doctor?",
+	}
+
+	_, err := handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+	_, err = handleMemoryRecall(context.Background(), pool, req, testConfig())
+	require.NoError(t, err)
+
+	require.Len(t, backend.atoms, 2, "re-indexing the same recalled memory must not duplicate atoms")
+	require.Len(t, backend.events, 2, "re-indexing the same recalled memory must not duplicate events")
+}

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -571,6 +571,11 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	}
 	sanitizeRecallResults(results)
 	out := map[string]any{"results": results, "count": len(results)}
+	if summary, err := buildLayerBSummary(ctx, h.Engine.Backend(), query, results); err != nil {
+		slog.Warn("layer_b recall post-pass failed", "project", project, "err", err)
+	} else if summary != nil {
+		out["layer_b"] = summary
+	}
 	if eventID != "" {
 		out["event_id"] = eventID
 		out["feedback_hint"] = "Call memory_feedback with this event_id and the memory_ids you used"

--- a/results/README.md
+++ b/results/README.md
@@ -8,6 +8,7 @@ via `git add -f`. The currently-tracked files are:
 - `lme-camp-report.md` — live campaign-log artifact
 - `lme-camp-state.json`, `lme-camp-stratified-100.json` — campaign-state machine data
 - `next-campaign-manifest.md` — next-campaign starting point + post-campaign outcomes block
+- `layerb-corruption-probe.md` — Layer B additive-schema integrity probe for issue #1289
 - `wisdom/bottleneck-symmetry.md` — durable pattern doc: bottleneck symmetry analysis
 - `wisdom/temporal-reasoning-mechanism-analysis.md` — durable pattern doc: temporal reasoning failure mechanisms
 

--- a/results/layerb-corruption-probe.md
+++ b/results/layerb-corruption-probe.md
@@ -1,0 +1,46 @@
+# Layer B Corruption Probe
+
+Issue: `#1289`
+Date: `2026-07-03`
+
+This artifact is the additive-schema integrity probe for Layer B deterministic
+aggregation. It is tied to concrete automated checks rather than an ad-hoc
+manual replay.
+
+## Probe Surface
+
+1. Temporal inversion replay
+   - Guard: `internal/layerb/layerb_test.go::TestBuildSummary_UsesValidFromForTemporalInversion`
+   - Scenario: memory `created_at` is newer than `valid_from`; Layer B must use
+     `valid_from` as the event timestamp so historical ordering survives late ingest.
+
+2. Provenance-span roundtrip
+   - Guard: `internal/db/postgres_layerb_test.go::TestLayerBEvents_RoundTripIdempotentAndCascade`
+   - Scenario: exact `provenance_span` and verbatim `span_text` are written to
+     the additive Layer B tables and read back without mutation.
+
+3. No-orphan check
+   - Guard: `internal/db/postgres_layerb_test.go::TestLayerBEvents_RoundTripIdempotentAndCascade`
+   - Scenario: deleting the source memory removes dependent Layer B rows via
+     `ON DELETE CASCADE`; post-delete lookup returns zero events.
+
+4. Idempotent re-ingest
+   - Guard: `internal/mcp/layerb_recall_test.go::TestHandleMemoryRecall_LayerBIndexingIsIdempotent`
+   - Scenario: re-running the same aggregation-shaped recall against the same
+     memory does not duplicate Layer B atoms or events.
+
+## Verification Commands
+
+```bash
+PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./internal/layerb ./internal/mcp -run 'Test(BuildSummary_|HandleMemoryRecall_)' -count=1
+PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./internal/db -run 'TestLayerBEvents_RoundTripIdempotentAndCascade$' -count=1
+PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./... -count=1 -race
+PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go vet ./...
+```
+
+## Notes
+
+- Layer B is lazy and additive: indexing happens only in the post-retrieval
+  pass for single-project full recall responses.
+- Existing recall ranking, existing memory/chunk schema, and the core search
+  engine contract remain untouched.


### PR DESCRIPTION
Restores the Layer B post-recall aggregation path on this branch (from issue-1289 context) and fixes the Layer B defect: `BuildSummary/extractMatchingAtoms` no longer requires every anchor term to co-occur in one sentence span, and stemmer suffix ordering now maps `bikes` to `bike` by handling `s` before `es`. This addresses multi-session aggregation recall misses and plural stem mismatches.