### PR TITLE
fix(layerb): port duramind PR#10 v4 matcher fix (issue #1298)

### DIFF
--- a/internal/layerb/layerb.go
+++ b/internal/layerb/layerb.go
@@ -286,8 +286,7 @@ func contributionsAreConnected(contributions []memberContribution) bool {
 	for i := range parent {
 		parent[i] = i
 	}
-	var find func(int) int
-	find = func(i int) int {
+	find := func(i int) int {
 		for parent[i] != i {
 			parent[i] = parent[parent[i]]
 			i = parent[i]
@@ -490,6 +489,8 @@ func endsWithSibilant(s string) bool {
 // in silent-e before a bare "o" syllable (e.g. "shoe"/"shoes") will still
 // mis-stem under this rule; this is an accepted tradeoff, not a regression
 // target, since no test in this package currently depends on that case.
+//
+//nolint:misspell
 func endsWithSibilantOrIrregularO(s string) bool {
 	if endsWithSibilant(s) {
 		return true

--- a/internal/layerb/layerb.go
+++ b/internal/layerb/layerb.go
@@ -7,12 +7,14 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/petersimmons1972/engram/internal/aggq"
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
-// Atom is one deterministic evidence span extracted from a recalled memory.
+// Atom is one deterministic evidence span extracted from a recalled raw memory.
 type Atom struct {
 	Project        string     `json:"project"`
 	MemoryID       string     `json:"memory_id"`
@@ -71,12 +73,12 @@ var stopWords = map[string]bool{
 // BuildSummary deterministically indexes matching evidence spans from recalled
 // memories and returns a count-style aggregation payload when the query is
 // aggregation-shaped. Non-aggregation queries return (nil, nil).
-func BuildSummary(ctx context.Context, store Store, query string, results []types.SearchResult) (*Summary, error) {
-	if !aggq.IsAggregationQuestion(query) {
+func BuildSummary(ctx context.Context, store Store, q string, results []types.SearchResult) (*Summary, error) {
+	if !aggq.IsAggregationQuestion(q) {
 		return nil, nil
 	}
 
-	anchor := strings.TrimSpace(aggq.ExtractAggregationAnchor(query))
+	anchor := strings.TrimSpace(aggq.ExtractAggregationAnchor(q))
 	anchorTerms := normalizeTerms(anchor)
 	if len(anchorTerms) == 0 {
 		return nil, nil
@@ -84,6 +86,7 @@ func BuildSummary(ctx context.Context, store Store, query string, results []type
 
 	project := ""
 	memoryIDs := make([]string, 0, len(results))
+	var contributions []memberContribution
 	for _, result := range results {
 		if result.Memory == nil || strings.TrimSpace(result.Memory.Content) == "" {
 			continue
@@ -91,29 +94,72 @@ func BuildSummary(ctx context.Context, store Store, query string, results []type
 		if project == "" {
 			project = result.Memory.Project
 		}
-		memoryIDs = append(memoryIDs, result.Memory.ID)
-		matches := extractMatchingAtoms(result.Memory, anchorTerms)
-		for _, atom := range matches {
-			if err := store.UpsertLayerBAtom(ctx, atom); err != nil {
-				return nil, fmt.Errorf("layerb upsert atom: %w", err)
-			}
-			event := Event{
-				Project:        atom.Project,
-				MemoryID:       atom.MemoryID,
-				ProvenanceSpan: atom.ProvenanceSpan,
-				SpanText:       atom.SpanText,
-				Anchor:         strings.Join(anchorTerms, " "),
-				NormalizedText: atom.NormalizedText,
-				EventTime:      atom.EventTime,
-			}
-			if err := store.UpsertLayerBEvent(ctx, event); err != nil {
-				return nil, fmt.Errorf("layerb upsert event: %w", err)
-			}
+		matches, memMatchedTerms := extractMatchingAtoms(result.Memory, anchorTerms)
+		if len(matches) == 0 {
+			continue
 		}
+		memoryIDs = append(memoryIDs, result.Memory.ID)
+		contributions = append(contributions, memberContribution{atoms: matches, terms: dedupe(memMatchedTerms)})
 	}
 
 	if len(memoryIDs) == 0 || project == "" {
 		return nil, nil
+	}
+
+	var unionTerms []string
+	for _, c := range contributions {
+		unionTerms = append(unionTerms, c.terms...)
+	}
+
+	// Collective near-complete gate: the ASSEMBLED evidence across every
+	// contributing memory must cover the anchor near-completely, even though
+	// each individual memory only needed to supply a fragment
+	// (minimumAnchorTermMatchesForAggregation in extractMatchingAtoms). This
+	// is where the strict v1 near-complete threshold now lives for the
+	// multi-memory case — a single low-coverage memory cannot pass this gate
+	// alone, and true scattered multi-session evidence collectively can.
+	if len(dedupe(unionTerms)) < minimumAnchorTermMatches(len(anchorTerms)) {
+		return nil, nil
+	}
+
+	// Connectivity gate (v4, issue #9 round-1 review finding): the lexical
+	// union gate above only checks total term coverage — it does not check
+	// that the contributing memories are actually RELATED to each other. Two
+	// memories that share zero matched anchor terms can each supply a
+	// fragment whose union still clears the near-complete bar, despite
+	// describing wholly unrelated facts (e.g. "I serviced the bike rack in
+	// January" + "I plan the March budget next week" — union covers all 4
+	// anchor terms, but neither memory has anything to do with the other).
+	// Require every contributing memory to be reachable from every other one
+	// via a chain of shared matched terms (single connected component). This
+	// preserves genuine scattered-evidence cases (each memory need only
+	// share one term with SOME other contributor, not all of them directly)
+	// while rejecting coincidental disjoint-fragment unions.
+	if !contributionsAreConnected(contributions) {
+		return nil, nil
+	}
+
+	var pendingAtoms []Atom
+	for _, c := range contributions {
+		pendingAtoms = append(pendingAtoms, c.atoms...)
+	}
+
+	for _, atom := range pendingAtoms {
+		if err := store.UpsertLayerBAtom(ctx, atom); err != nil {
+			return nil, fmt.Errorf("layerb upsert atom: %w", err)
+		}
+		event := Event{
+			Project:        atom.Project,
+			MemoryID:       atom.MemoryID,
+			ProvenanceSpan: atom.ProvenanceSpan,
+			SpanText:       atom.SpanText,
+			Anchor:         strings.Join(anchorTerms, " "),
+			NormalizedText: atom.NormalizedText,
+			EventTime:      atom.EventTime,
+		}
+		if err := store.UpsertLayerBEvent(ctx, event); err != nil {
+			return nil, fmt.Errorf("layerb upsert event: %w", err)
+		}
 	}
 
 	records, err := store.ListLayerBEvents(ctx, project, dedupe(memoryIDs))
@@ -160,19 +206,27 @@ func BuildSummary(ctx context.Context, store Store, query string, results []type
 	}, nil
 }
 
-func extractMatchingAtoms(mem *types.Memory, anchorTerms []string) []Atom {
+func extractMatchingAtoms(mem *types.Memory, anchorTerms []string) ([]Atom, []string) {
 	if mem == nil {
-		return nil
+		return nil, nil
 	}
+	// Coverage is always computed from the whole memory's content. The
+	// per-sentence-vs-fallback distinction below governs only which atoms
+	// (evidence spans) get extracted for persistence — never how much anchor
+	// coverage this memory contributes to BuildSummary's collective gate.
+	wholeMemoryMatched := dedupe(matchedAnchorTerms(normalizeText(mem.Content), anchorTerms))
+
+	aggregationMin := minimumAnchorTermMatchesForAggregation(len(anchorTerms))
 	spans := sentenceSpans(mem.Content)
 	matches := make([]Atom, 0, len(spans))
 	for _, span := range spans {
-		sentence := strings.TrimSpace(mem.Content[span.start:span.end])
+		sentence := mem.Content[span.start:span.end]
 		if sentence == "" {
 			continue
 		}
 		normalized := normalizeText(sentence)
-		if !containsAllTerms(normalized, anchorTerms) {
+		sentenceMatched := matchedAnchorTerms(normalized, anchorTerms)
+		if len(sentenceMatched) < aggregationMin {
 			continue
 		}
 		matches = append(matches, Atom{
@@ -185,7 +239,95 @@ func extractMatchingAtoms(mem *types.Memory, anchorTerms []string) []Atom {
 			EventTime:      memoryEventTime(mem),
 		})
 	}
-	return matches
+	if len(matches) > 0 {
+		return matches, wholeMemoryMatched
+	}
+	// Whole-memory fallback ATOM (extraction only — no sentence individually
+	// qualified). Still gated by the strict v1 near-complete threshold: this is
+	// where the arbitrary-unrelated-text false-positive risk lives, and it is
+	// unchanged from v1/v2.
+	if len(wholeMemoryMatched) < minimumAnchorTermMatches(len(anchorTerms)) {
+		return nil, nil
+	}
+	if trimmed, ok := trimSpanBounds(mem.Content, 0, len(mem.Content)); ok {
+		matches = append(matches, Atom{
+			Project:        mem.Project,
+			MemoryID:       mem.ID,
+			ProvenanceSpan: fmt.Sprintf("chars:%d-%d", trimmed.start, trimmed.end),
+			SpanText:       mem.Content[trimmed.start:trimmed.end],
+			Statement:      mem.Content[trimmed.start:trimmed.end],
+			NormalizedText: normalizeText(mem.Content[trimmed.start:trimmed.end]),
+			EventTime:      memoryEventTime(mem),
+		})
+	}
+	return matches, wholeMemoryMatched
+}
+
+// memberContribution is one contributing memory's atoms and matched anchor
+// terms, kept together so BuildSummary's connectivity gate (v4) can check
+// term-overlap between contributors before committing to persist anything.
+type memberContribution struct {
+	atoms []Atom
+	terms []string
+}
+
+// contributionsAreConnected reports whether every contributing memory is
+// reachable from every other one via a chain of shared matched anchor terms
+// — the discriminator between genuine scattered evidence about the same
+// underlying fact (each fragment overlaps on at least one term with some
+// other fragment, even if not directly with all of them) and a coincidental
+// union of wholly disjoint fragments that only look complete when combined
+// (see PR #10 round-1 review, hermes + grok, both independently found this).
+func contributionsAreConnected(contributions []memberContribution) bool {
+	if len(contributions) <= 1 {
+		return true
+	}
+	parent := make([]int, len(contributions))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(i int) int {
+		for parent[i] != i {
+			parent[i] = parent[parent[i]]
+			i = parent[i]
+		}
+		return i
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+	for i := 0; i < len(contributions); i++ {
+		for j := i + 1; j < len(contributions); j++ {
+			if sharesTerm(contributions[i].terms, contributions[j].terms) {
+				union(i, j)
+			}
+		}
+	}
+	root := find(0)
+	for i := 1; i < len(contributions); i++ {
+		if find(i) != root {
+			return false
+		}
+	}
+	return true
+}
+
+// sharesTerm reports whether a and b have at least one element in common.
+func sharesTerm(a, b []string) bool {
+	set := make(map[string]bool, len(a))
+	for _, t := range a {
+		set[t] = true
+	}
+	for _, t := range b {
+		if set[t] {
+			return true
+		}
+	}
+	return false
 }
 
 type span struct {
@@ -194,8 +336,7 @@ type span struct {
 }
 
 func sentenceSpans(text string) []span {
-	text = strings.TrimSpace(text)
-	if text == "" {
+	if strings.TrimSpace(text) == "" {
 		return nil
 	}
 	var spans []span
@@ -204,32 +345,78 @@ func sentenceSpans(text string) []span {
 		switch r {
 		case '.', '!', '?', '\n':
 			end := i + 1
-			if start < end {
-				spans = append(spans, span{start: start, end: end})
+			if trimmed, ok := trimSpanBounds(text, start, end); ok {
+				spans = append(spans, trimmed)
 			}
 			start = end
 		}
 	}
-	if start < len(text) {
-		spans = append(spans, span{start: start, end: len(text)})
+	if trimmed, ok := trimSpanBounds(text, start, len(text)); ok {
+		spans = append(spans, trimmed)
 	}
 	return spans
 }
 
-func containsAllTerms(normalized string, terms []string) bool {
-	if len(terms) == 0 {
-		return false
+func trimSpanBounds(text string, start, end int) (span, bool) {
+	for start < end {
+		r, size := utf8.DecodeRuneInString(text[start:end])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		start += size
 	}
+	for start < end {
+		r, size := utf8.DecodeLastRuneInString(text[start:end])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		end -= size
+	}
+	if start >= end {
+		return span{}, false
+	}
+	return span{start: start, end: end}, true
+}
+
+// matchedAnchorTerms returns the subset of terms present in normalized,
+// preserving terms' input order and without duplicates within the result.
+func matchedAnchorTerms(normalized string, terms []string) []string {
 	have := make(map[string]bool, len(terms))
 	for _, term := range normalizeTerms(normalized) {
 		have[term] = true
 	}
+	matched := make([]string, 0, len(terms))
 	for _, term := range terms {
-		if !have[term] {
-			return false
+		if have[term] {
+			matched = append(matched, term)
 		}
 	}
-	return true
+	return matched
+}
+
+func minimumAnchorTermMatches(termCount int) int {
+	switch {
+	case termCount <= 0:
+		return 0
+	case termCount <= 2:
+		return termCount
+	default:
+		return termCount - 1
+	}
+}
+
+// minimumAnchorTermMatchesForAggregation is the per-memory bar used when a
+// memory is one of potentially several contributing to a cross-memory
+// aggregation: a memory only needs to supply a genuine fragment of the
+// anchor, not near-complete coverage on its own — the near-complete
+// requirement is enforced collectively, across the whole evidence set, by
+// the caller (see BuildSummary). A single common word should not qualify a
+// memory, so the floor is min(2, termCount).
+func minimumAnchorTermMatchesForAggregation(termCount int) int {
+	if termCount < 2 {
+		return termCount
+	}
+	return 2
 }
 
 func normalizeTerms(text string) []string {
@@ -257,15 +444,128 @@ func stem(token string) string {
 	case len(token) > 4 && strings.HasSuffix(token, "ied"):
 		return token[:len(token)-3] + "y"
 	case len(token) > 4 && strings.HasSuffix(token, "ing"):
-		return token[:len(token)-3]
+		return stemAfterSuffix(token[:len(token)-3])
 	case len(token) > 3 && strings.HasSuffix(token, "ed"):
-		return token[:len(token)-2]
+		return stemAfterSuffix(token[:len(token)-2])
 	case len(token) > 3 && strings.HasSuffix(token, "es"):
-		return token[:len(token)-2]
-	case len(token) > 2 && strings.HasSuffix(token, "s"):
+		candidate := token[:len(token)-2]
+		if endsWithSibilantOrIrregularO(candidate) {
+			return candidate
+		}
+		return token[:len(token)-1]
+	case len(token) > 2 && strings.HasSuffix(token, "s") && !strings.HasSuffix(token, "ss"):
 		return token[:len(token)-1]
 	default:
 		return token
+	}
+}
+
+// endsWithSibilant reports whether s ends in a sibilant sound (s, x, z, ch,
+// sh) — the class of endings where English pluralizes with "-es" rather than
+// a bare "-s" (wish->wishes, box->boxes, class->classes), as distinct from
+// endings like "bike" where the "-es" in "bikes" is really just "-s" plus the
+// word's own trailing "e" (bike->bikes, not "bik"+"es").
+func endsWithSibilant(s string) bool {
+	if strings.HasSuffix(s, "ch") || strings.HasSuffix(s, "sh") {
+		return true
+	}
+	if len(s) == 0 {
+		return false
+	}
+	switch s[len(s)-1] {
+	case 's', 'x', 'z':
+		return true
+	default:
+		return false
+	}
+}
+
+// endsWithSibilantOrIrregularO reports whether s ends in a sibilant (see
+// endsWithSibilant) OR in a bare "o" — the second case covers a common
+// irregular English "-oes" plural class (go->goes, do->does, hero->heroes,
+// tomato->tomatoes, echo->echoes) that would otherwise mis-stem to "goe",
+// "doe", "heroe", "tomatoe", "echoe" if only the sibilant check applied.
+// Known residual imprecision (inherent to a lookup-free heuristic stemmer,
+// not fixable without a dictionary): a handful of real words already ending
+// in silent-e before a bare "o" syllable (e.g. "shoe"/"shoes") will still
+// mis-stem under this rule; this is an accepted tradeoff, not a regression
+// target, since no test in this package currently depends on that case.
+func endsWithSibilantOrIrregularO(s string) bool {
+	if endsWithSibilant(s) {
+		return true
+	}
+	if len(s) == 0 {
+		return false
+	}
+	return s[len(s)-1] == 'o'
+}
+
+func stemAfterSuffix(base string) string {
+	switch {
+	case strings.HasSuffix(base, "ic"):
+		return base + "e"
+	case strings.HasSuffix(base, "at"), strings.HasSuffix(base, "bl"), strings.HasSuffix(base, "iz"):
+		return base + "e"
+	case endsWithDoubleConsonant(base) && !strings.HasSuffix(base, "l") && !strings.HasSuffix(base, "s") && !strings.HasSuffix(base, "z"):
+		return base[:len(base)-1]
+	case isShortStem(base):
+		return base + "e"
+	default:
+		return base
+	}
+}
+
+func endsWithDoubleConsonant(token string) bool {
+	if len(token) < 2 {
+		return false
+	}
+	last := token[len(token)-1]
+	prev := token[len(token)-2]
+	return last == prev && isConsonant(token, len(token)-1)
+}
+
+func isShortStem(token string) bool {
+	if len(token) < 3 {
+		return false
+	}
+	last := len(token) - 1
+	return measure(token) == 1 &&
+		isConsonant(token, last) &&
+		!isConsonant(token, last-1) &&
+		isConsonant(token, last-2) &&
+		!strings.ContainsRune("wxy", rune(token[last]))
+}
+
+func measure(token string) int {
+	count := 0
+	inVowelRun := false
+	for i := 0; i < len(token); i++ {
+		if isConsonant(token, i) {
+			if inVowelRun {
+				count++
+				inVowelRun = false
+			}
+			continue
+		}
+		inVowelRun = true
+	}
+	return count
+}
+
+func isConsonant(token string, index int) bool {
+	if index < 0 || index >= len(token) {
+		return false
+	}
+	switch token[index] {
+	case 'a', 'e', 'i', 'o', 'u':
+		return false
+	case 'y':
+		if index == 0 {
+			return true
+		}
+		return !isConsonant(token, index-1)
+	default:
+		return true
 	}
 }
 

--- a/internal/layerb/layerb_internal_test.go
+++ b/internal/layerb/layerb_internal_test.go
@@ -1,0 +1,44 @@
+package layerb
+
+import "testing"
+
+func TestStem_PreservesTerminalEOnPluralS(t *testing.T) {
+	if got := stem("bikes"); got != "bike" {
+		t.Fatalf("stem(\"bikes\") = %q, want %q", got, "bike")
+	}
+}
+
+func TestStem_NormalizesBakeAndBakedToSameRoot(t *testing.T) {
+	if got := stem("bake"); got != "bake" {
+		t.Fatalf("stem(\"bake\") = %q, want %q", got, "bake")
+	}
+	if got := stem("baked"); got != "bake" {
+		t.Fatalf("stem(\"baked\") = %q, want %q", got, "bake")
+	}
+}
+
+func TestStemVariants(t *testing.T) {
+	cases := map[string]string{
+		"wishes":   "wish",
+		"boxes":    "box",
+		"classes":  "class",
+		"bikes":    "bike",
+		"bake":     "bake",
+		"baked":    "bake",
+		"tried":    "try",
+		"walking":  "walk",
+		"visited":  "visit",
+		"cats":     "cat",
+		"go":       "go",
+		"goes":     "go",
+		"does":     "do",
+		"heroes":   "hero",
+		"tomatoes": "tomato",
+		"echoes":   "echo",
+	}
+	for input, want := range cases {
+		if got := stem(input); got != want {
+			t.Fatalf("stem(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/layerb/layerb_test.go
+++ b/internal/layerb/layerb_test.go
@@ -2,17 +2,23 @@ package layerb_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/petersimmons1972/engram/internal/layerb"
 	"github.com/petersimmons1972/engram/internal/types"
-	"github.com/stretchr/testify/require"
 )
 
 type stubStore struct {
 	atoms  map[string]layerb.Atom
 	events map[string]layerb.Event
+}
+
+type listErrorStore struct {
+	stubStore
+	err error
 }
 
 func (s *stubStore) UpsertLayerBAtom(_ context.Context, atom layerb.Atom) error {
@@ -53,6 +59,10 @@ func (s *stubStore) ListLayerBEvents(_ context.Context, _ string, memoryIDs []st
 	return out, nil
 }
 
+func (s *listErrorStore) ListLayerBEvents(_ context.Context, _ string, _ []string) ([]layerb.EventRecord, error) {
+	return nil, s.err
+}
+
 func TestBuildSummary_UsesValidFromForTemporalInversion(t *testing.T) {
 	store := &stubStore{}
 	validFrom := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
@@ -69,12 +79,24 @@ func TestBuildSummary_UsesValidFromForTemporalInversion(t *testing.T) {
 	}}
 
 	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
-	require.NoError(t, err)
-	require.NotNil(t, summary)
-	require.Equal(t, "visit doctor", summary.Anchor)
-	require.Len(t, summary.Evidence, 1)
-	require.NotNil(t, summary.Evidence[0].EventTime)
-	require.True(t, summary.Evidence[0].EventTime.Equal(validFrom), "valid_from must win over created_at for temporal inversion replay")
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("BuildSummary returned nil summary")
+	}
+	if summary.Anchor != "visit doctor" {
+		t.Fatalf("anchor = %q, want %q", summary.Anchor, "visit doctor")
+	}
+	if len(summary.Evidence) != 1 {
+		t.Fatalf("evidence len = %d, want 1", len(summary.Evidence))
+	}
+	if summary.Evidence[0].EventTime == nil {
+		t.Fatal("event_time is nil")
+	}
+	if !summary.Evidence[0].EventTime.Equal(validFrom) {
+		t.Fatalf("event_time = %v, want %v", summary.Evidence[0].EventTime, validFrom)
+	}
 }
 
 func TestBuildSummary_NonAggregationQuestionIsNoOp(t *testing.T) {
@@ -90,8 +112,311 @@ func TestBuildSummary_NonAggregationQuestionIsNoOp(t *testing.T) {
 	}}
 
 	summary, err := layerb.BuildSummary(context.Background(), store, "When did I visit the doctor?", results)
-	require.NoError(t, err)
-	require.Nil(t, summary)
-	require.Empty(t, store.atoms)
-	require.Empty(t, store.events)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("summary = %#v, want nil", summary)
+	}
+	if len(store.atoms) != 0 {
+		t.Fatalf("atoms len = %d, want 0", len(store.atoms))
+	}
+	if len(store.events) != 0 {
+		t.Fatalf("events len = %d, want 0", len(store.events))
+	}
+}
+
+func TestBuildSummary_PreservesProvenanceSpanAgainstSourceWhitespace(t *testing.T) {
+	store := &stubStore{}
+	content := "\n  I visited the doctor on Tuesday.  \n"
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   content,
+			CreatedAt: time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC),
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("BuildSummary returned nil summary")
+	}
+	if len(summary.Evidence) != 1 {
+		t.Fatalf("evidence len = %d, want 1", len(summary.Evidence))
+	}
+
+	start, end := mustParseSpan(t, summary.Evidence[0].ProvenanceSpan)
+	if got := content[start:end]; got != "I visited the doctor on Tuesday." {
+		t.Fatalf("content[%d:%d] = %q, want exact sentence", start, end, got)
+	}
+	if got := summary.Evidence[0].SpanText; got != "I visited the doctor on Tuesday." {
+		t.Fatalf("span_text = %q, want exact sentence", got)
+	}
+}
+
+func TestBuildSummary_EmptyAnchorTermsReturnNil(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   "I did it yesterday.",
+			CreatedAt: time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC),
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I do?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("summary = %#v, want nil", summary)
+	}
+	if len(store.atoms) != 0 || len(store.events) != 0 {
+		t.Fatalf("store writes = atoms:%d events:%d, want none", len(store.atoms), len(store.events))
+	}
+}
+
+func TestBuildSummary_IgnoresNilAndBlankMemories(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{
+		{Memory: nil},
+		{Memory: &types.Memory{ID: "mem-blank", Project: "proj", Content: " \n\t "}},
+	}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("summary = %#v, want nil", summary)
+	}
+}
+
+func TestBuildSummary_ReturnsNilWhenNoEvidenceMatchesAnchor(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   "I cooked dinner at home.",
+			CreatedAt: time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC),
+		},
+		Score: 1,
+	}}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("summary = %#v, want nil", summary)
+	}
+}
+
+func TestBuildSummary_SortsEvidenceWithNilEventTimesLast(t *testing.T) {
+	store := &stubStore{}
+	validFrom := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:        "mem-no-time",
+				Project:   "proj",
+				Content:   "I visited the doctor during intake.",
+				CreatedAt: time.Time{},
+			},
+			Score: 1,
+		},
+		{
+			Memory: &types.Memory{
+				ID:        "mem-with-time",
+				Project:   "proj",
+				Content:   "I visited the doctor during follow-up.",
+				ValidFrom: &validFrom,
+				CreatedAt: time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+	}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("BuildSummary returned nil summary")
+	}
+	if len(summary.Evidence) != 2 {
+		t.Fatalf("evidence len = %d, want 2", len(summary.Evidence))
+	}
+	if got := summary.Evidence[0].MemoryID; got != "mem-with-time" {
+		t.Fatalf("first evidence memory_id = %q, want timed record first", got)
+	}
+	if got := summary.Evidence[1].MemoryID; got != "mem-no-time" {
+		t.Fatalf("second evidence memory_id = %q, want nil-time record last", got)
+	}
+}
+
+func TestBuildSummary_PropagatesListErrors(t *testing.T) {
+	store := &listErrorStore{err: fmt.Errorf("boom")}
+	results := []types.SearchResult{{
+		Memory: &types.Memory{
+			ID:        "mem-1",
+			Project:   "proj",
+			Content:   "I visited the doctor on Tuesday.",
+			CreatedAt: time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC),
+		},
+		Score: 1,
+	}}
+
+	_, err := layerb.BuildSummary(context.Background(), store, "How many times did I visit the doctor?", results)
+	if err == nil {
+		t.Fatal("BuildSummary error = nil, want wrapped list failure")
+	}
+	if !strings.Contains(err.Error(), "layerb list events: boom") {
+		t.Fatalf("error = %v, want wrapped list failure", err)
+	}
+}
+
+func TestBuildSummary_MatchesScatteredAggregationEvidenceAcrossSessions(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:        "mem-1",
+				Project:   "proj",
+				Content:   "I serviced my neighbor's mountain bike as a favor.",
+				CreatedAt: time.Date(2026, 3, 3, 18, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+		{
+			Memory: &types.Memory{
+				ID:        "mem-2",
+				Project:   "proj",
+				Content:   "I still plan to service my own work queue.",
+				CreatedAt: time.Date(2026, 3, 10, 18, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+		{
+			Memory: &types.Memory{
+				ID:        "mem-3",
+				Project:   "proj",
+				Content:   "Later in March I inspected my sister's bike.",
+				CreatedAt: time.Date(2026, 3, 20, 18, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+	}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many bikes did I service or plan to service in March?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("BuildSummary returned nil summary")
+	}
+	if summary.Anchor != "bike service plan march" {
+		t.Fatalf("anchor = %q, want %q", summary.Anchor, "bike service plan march")
+	}
+	if summary.Count != 3 {
+		t.Fatalf("count = %d, want 3", summary.Count)
+	}
+}
+
+func mustParseSpan(t *testing.T, provenance string) (int, int) {
+	t.Helper()
+	var start, end int
+	if _, err := fmt.Sscanf(strings.TrimSpace(provenance), "chars:%d-%d", &start, &end); err != nil {
+		t.Fatalf("parse provenance span %q: %v", provenance, err)
+	}
+	return start, end
+}
+
+func TestBuildSummary_WholeMemoryFallbackFiresWhenNoSingleSentenceMatches(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:        "mem-scattered-1",
+				Project:   "proj",
+				Content:   "I have a bike. I need to service it. I plan to do that.",
+				CreatedAt: time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+	}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many bikes did I service or plan to service in March?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("BuildSummary returned nil summary — expected the whole-memory fallback to fire")
+	}
+	if summary.Count != 1 {
+		t.Fatalf("count = %d, want 1 (whole-memory fallback should produce exactly one Atom for this memory)", summary.Count)
+	}
+}
+
+func TestBuildSummary_LoneMemoryWithPartialAnchorOverlapDoesNotFire(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:        "mem-unrelated",
+				Project:   "proj",
+				Content:   "I rode my bike to plan a surprise party for my coworker.",
+				CreatedAt: time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+	}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many bikes did I service or plan to service in March?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("BuildSummary returned a summary (count=%d) for a single memory covering only 2 of 4 anchor terms in unrelated content — expected nil (collective near-complete gate should reject this)", summary.Count)
+	}
+}
+
+func TestBuildSummary_DisjointFragmentUnionAcrossUnrelatedMemoriesDoesNotFire(t *testing.T) {
+	store := &stubStore{}
+	results := []types.SearchResult{
+		{
+			Memory: &types.Memory{
+				ID:        "mem-unrelated-a",
+				Project:   "proj",
+				Content:   "I serviced the bike rack in January.",
+				CreatedAt: time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+		{
+			Memory: &types.Memory{
+				ID:        "mem-unrelated-b",
+				Project:   "proj",
+				Content:   "I plan the March budget next week.",
+				CreatedAt: time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC),
+			},
+			Score: 1,
+		},
+	}
+
+	summary, err := layerb.BuildSummary(context.Background(), store, "How many bikes did I service or plan to service in March?", results)
+	if err != nil {
+		t.Fatalf("BuildSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("BuildSummary returned a summary (count=%d) for two memories with disjoint matched-term sets (bike/service vs plan/march, zero shared terms) — expected nil (connectivity gate should reject a coincidental disjoint-fragment union)", summary.Count)
+	}
 }


### PR DESCRIPTION
Mechanical port of duramind PR #10's v4 Layer B matcher fix (per-fragment aggregation + collective near-complete gate + connectivity gate + stemmer -oes/sibilant fixes) onto engram-go's structurally-identical retrofit copy. Fixes #1298. Four prior codex attempts on this port failed (wrong file / stale-base restoration, see claude-codex#400) - codex is banned from this issue going forward. Coordinator pre-verified the ported content (build/vet/gofmt/full test suite) before dispatch; this PR re-verifies independently as part of the dispatch. Requires the standard engram-go 3-round adversarial review before merge - mechanical origin does not exempt it.