### PR TITLE
fix(embed): add ENGRAM_REEMBED_URL for live/reembed GPU role-separation (#1208)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -46,9 +46,19 @@ func reembedModelFromEnv() string {
 	return envOr("ENGRAM_REEMBED_MODEL", embedmodel.ReembedAlias)
 }
 
-func newEmbedClients(embedURL, liveModel, reembedModel, apiKey string, targetDims int, cbCfg embed.CircuitConfig) (embed.Client, embed.Client) {
+// reembedURLFromEnv resolves the endpoint for the batch/reembed embedding client.
+// It defaults to the live embed URL so single-endpoint deployments (dev, CI, and
+// any host without a dedicated reembed GPU) keep working unchanged, but can be
+// pointed at a physically separate host via ENGRAM_REEMBED_URL to enforce the
+// live/reembed GPU role-separation mandate — batch reembed traffic must not land
+// on the live-query GPU (#1208).
+func reembedURLFromEnv(embedURL string) string {
+	return envOr("ENGRAM_REEMBED_URL", embedURL)
+}
+
+func newEmbedClients(embedURL, reembedURL, liveModel, reembedModel, apiKey string, targetDims int, cbCfg embed.CircuitConfig) (embed.Client, embed.Client) {
 	return newLiteLLMEmbedClient(embedURL, liveModel, apiKey, targetDims, cbCfg),
-		newLiteLLMEmbedClient(embedURL, reembedModel, apiKey, targetDims, cbCfg)
+		newLiteLLMEmbedClient(reembedURL, reembedModel, apiKey, targetDims, cbCfg)
 }
 
 func main() {
@@ -295,7 +305,13 @@ func runServer(args []string) error {
 		BackoffMultiplier: *embedCircuitBackoffMultiplier,
 		BackoffCap:        *embedCircuitBackoffCap,
 	}
-	embedClient, reembedClient := newEmbedClients(embedURL, *embedModel, reembedModel, litellmAPIKey, *embedDims, cbCfg)
+	reembedURL := reembedURLFromEnv(embedURL)
+	if reembedURL == embedURL {
+		slog.Warn("embed live and reembed clients share one endpoint — GPU role-separation not enforced; set ENGRAM_REEMBED_URL to a distinct host so batch reembed traffic does not land on the live-query GPU (#1208)", "embed_url", embedURL)
+	} else {
+		slog.Info("embed live/reembed endpoints separated", "embed_url", embedURL, "reembed_url", reembedURL)
+	}
+	embedClient, reembedClient := newEmbedClients(embedURL, reembedURL, *embedModel, reembedModel, litellmAPIKey, *embedDims, cbCfg)
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	probeVec, probeModelID, probeErr := embedClient.EmbedWithModel(probeCtx, "startup probe")
 	probeCancel()

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -56,6 +56,36 @@ func reembedURLFromEnv(embedURL string) string {
 	return envOr("ENGRAM_REEMBED_URL", embedURL)
 }
 
+// normalizeEndpoint canonicalises an embed endpoint for the coincidence
+// diagnostic only (scheme/host lowercased, trailing slash trimmed). It is never
+// used for actual routing — the original URL strings are passed to the clients
+// verbatim — so this cannot alter where traffic is sent.
+func normalizeEndpoint(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return strings.TrimRight(strings.ToLower(raw), "/")
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + strings.TrimRight(u.Path, "/")
+}
+
+// embedEndpointsCoincide reports whether the live and reembed embed endpoints
+// resolve to the same host, tolerating trailing-slash / case differences so the
+// startup diagnostic does not report "separated" for URLs that hit one GPU.
+func embedEndpointsCoincide(embedURL, reembedURL string) bool {
+	return normalizeEndpoint(embedURL) == normalizeEndpoint(reembedURL)
+}
+
+// logEmbedEndpointSeparation emits the startup diagnostic for live/reembed GPU
+// role-separation (#1208): WARN when both clients share one endpoint (separation
+// not enforced), INFO when they are physically separated.
+func logEmbedEndpointSeparation(logger *slog.Logger, embedURL, reembedURL string) {
+	if embedEndpointsCoincide(embedURL, reembedURL) {
+		logger.Warn("embed live and reembed clients share one endpoint — GPU role-separation not enforced; set ENGRAM_REEMBED_URL to a distinct host so batch reembed traffic does not land on the live-query GPU (#1208)", "embed_url", embedURL, "reembed_url", reembedURL)
+		return
+	}
+	logger.Info("embed live/reembed endpoints separated", "embed_url", embedURL, "reembed_url", reembedURL)
+}
+
 func newEmbedClients(embedURL, reembedURL, liveModel, reembedModel, apiKey string, targetDims int, cbCfg embed.CircuitConfig) (embed.Client, embed.Client) {
 	return newLiteLLMEmbedClient(embedURL, liveModel, apiKey, targetDims, cbCfg),
 		newLiteLLMEmbedClient(reembedURL, reembedModel, apiKey, targetDims, cbCfg)
@@ -306,11 +336,7 @@ func runServer(args []string) error {
 		BackoffCap:        *embedCircuitBackoffCap,
 	}
 	reembedURL := reembedURLFromEnv(embedURL)
-	if reembedURL == embedURL {
-		slog.Warn("embed live and reembed clients share one endpoint — GPU role-separation not enforced; set ENGRAM_REEMBED_URL to a distinct host so batch reembed traffic does not land on the live-query GPU (#1208)", "embed_url", embedURL)
-	} else {
-		slog.Info("embed live/reembed endpoints separated", "embed_url", embedURL, "reembed_url", reembedURL)
-	}
+	logEmbedEndpointSeparation(slog.Default(), embedURL, reembedURL)
 	embedClient, reembedClient := newEmbedClients(embedURL, reembedURL, *embedModel, reembedModel, litellmAPIKey, *embedDims, cbCfg)
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	probeVec, probeModelID, probeErr := embedClient.EmbedWithModel(probeCtx, "startup probe")

--- a/cmd/engram/main_embed_routing_test.go
+++ b/cmd/engram/main_embed_routing_test.go
@@ -69,6 +69,32 @@ func TestReembedModelEnvDefaultAndOverride(t *testing.T) {
 	})
 }
 
+// TestEmbedEndpointsCoincide verifies the startup coincidence diagnostic that
+// drives the WARN-vs-INFO branch (#1208): it must treat trailing-slash / case
+// variants of the same host as coincident so a shared GPU is not mislabelled
+// "separated", while genuinely distinct hosts read as separated.
+func TestEmbedEndpointsCoincide(t *testing.T) {
+	cases := []struct {
+		name         string
+		embedURL     string
+		reembedURL   string
+		wantCoincide bool
+	}{
+		{"identical", "http://mi50:8007", "http://mi50:8007", true},
+		{"trailing slash", "http://mi50:8007", "http://mi50:8007/", true},
+		{"scheme case", "HTTP://MI50:8007", "http://mi50:8007", true},
+		{"distinct hosts", "http://mi50:8007", "http://w6800:8008", false},
+		{"distinct ports same host", "http://mi50:8007", "http://mi50:8008", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := embedEndpointsCoincide(tc.embedURL, tc.reembedURL); got != tc.wantCoincide {
+				t.Fatalf("embedEndpointsCoincide(%q, %q) = %v, want %v", tc.embedURL, tc.reembedURL, got, tc.wantCoincide)
+			}
+		})
+	}
+}
+
 // TestReembedURLRouting verifies live/reembed GPU role-separation is enforceable
 // from config (#1208): the live client is always constructed against the live
 // embed URL, while the reembed client honours ENGRAM_REEMBED_URL and falls back

--- a/cmd/engram/main_embed_routing_test.go
+++ b/cmd/engram/main_embed_routing_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 type constructedEmbedClient struct {
-	model string
+	baseURL string
+	model   string
 }
 
 func (c *constructedEmbedClient) Embed(_ context.Context, _ string) ([]float32, error) {
@@ -37,7 +38,7 @@ func TestReembedModelEnvDefaultAndOverride(t *testing.T) {
 		constructed = nil
 		t.Setenv("ENGRAM_REEMBED_MODEL", "")
 
-		live, reembed := newEmbedClients("http://litellm:4000", "bge-m3-live", reembedModelFromEnv(), "", 1024, embed.CircuitConfig{})
+		live, reembed := newEmbedClients("http://litellm:4000", "http://litellm:4000", "bge-m3-live", reembedModelFromEnv(), "", 1024, embed.CircuitConfig{})
 
 		if got := live.Name(); got != "bge-m3-live" {
 			t.Fatalf("live.Name() = %q, want %q", got, "bge-m3-live")
@@ -57,13 +58,65 @@ func TestReembedModelEnvDefaultAndOverride(t *testing.T) {
 		constructed = nil
 		t.Setenv("ENGRAM_REEMBED_MODEL", "custom-reembed")
 
-		_, reembed := newEmbedClients("http://litellm:4000", "bge-m3-live", reembedModelFromEnv(), "", 1024, embed.CircuitConfig{})
+		_, reembed := newEmbedClients("http://litellm:4000", "http://litellm:4000", "bge-m3-live", reembedModelFromEnv(), "", 1024, embed.CircuitConfig{})
 
 		if got := reembed.Name(); got != "custom-reembed" {
 			t.Fatalf("reembed.Name() = %q, want %q", got, "custom-reembed")
 		}
 		if len(constructed) != 2 {
 			t.Fatalf("constructed %d clients, want 2", len(constructed))
+		}
+	})
+}
+
+// TestReembedURLRouting verifies live/reembed GPU role-separation is enforceable
+// from config (#1208): the live client is always constructed against the live
+// embed URL, while the reembed client honours ENGRAM_REEMBED_URL and falls back
+// to the live URL only when that override is unset.
+func TestReembedURLRouting(t *testing.T) {
+	orig := newLiteLLMEmbedClient
+	t.Cleanup(func() { newLiteLLMEmbedClient = orig })
+
+	var urls []string
+	newLiteLLMEmbedClient = func(baseURL string, model string, _ string, _ int, _ embed.CircuitConfig) embed.Client {
+		urls = append(urls, baseURL)
+		return &constructedEmbedClient{baseURL: baseURL, model: model}
+	}
+
+	t.Run("reembed URL defaults to live URL when unset", func(t *testing.T) {
+		t.Setenv("ENGRAM_REEMBED_URL", "")
+		liveURL := "http://mi50:8007"
+		reembedURL := reembedURLFromEnv(liveURL)
+		if reembedURL != liveURL {
+			t.Fatalf("reembedURLFromEnv(unset) = %q, want fallback %q", reembedURL, liveURL)
+		}
+
+		urls = nil
+		live, reembed := newEmbedClients(liveURL, reembedURL, "bge-m3-live", "bge-m3-reembed", "", 1024, embed.CircuitConfig{})
+		if got := live.(*constructedEmbedClient).baseURL; got != liveURL {
+			t.Fatalf("live baseURL = %q, want %q", got, liveURL)
+		}
+		if got := reembed.(*constructedEmbedClient).baseURL; got != liveURL {
+			t.Fatalf("reembed baseURL = %q, want %q (fallback to live)", got, liveURL)
+		}
+	})
+
+	t.Run("reembed URL honours ENGRAM_REEMBED_URL override", func(t *testing.T) {
+		liveURL := "http://mi50:8007"
+		wantReembed := "http://w6800:8008"
+		t.Setenv("ENGRAM_REEMBED_URL", wantReembed)
+		reembedURL := reembedURLFromEnv(liveURL)
+		if reembedURL != wantReembed {
+			t.Fatalf("reembedURLFromEnv(override) = %q, want %q", reembedURL, wantReembed)
+		}
+
+		urls = nil
+		live, reembed := newEmbedClients(liveURL, reembedURL, "bge-m3-live", "bge-m3-reembed", "", 1024, embed.CircuitConfig{})
+		if got := live.(*constructedEmbedClient).baseURL; got != liveURL {
+			t.Fatalf("live baseURL = %q, want %q (live must stay on live endpoint)", got, liveURL)
+		}
+		if got := reembed.(*constructedEmbedClient).baseURL; got != wantReembed {
+			t.Fatalf("reembed baseURL = %q, want %q (reembed must route to override)", got, wantReembed)
 		}
 	})
 }


### PR DESCRIPTION
Closes #1208.

## Problem
`newEmbedClients` routed **both** the live and reembed embedding clients at a single `embedURL`. There was no `ENGRAM_REEMBED_URL`, so batch/reembed traffic could not be steered off the live-query GPU from config. If `ENGRAM_EMBED_URL` points at the MI-50 (`:8007`), reembed load also lands there — violating the physical live/reembed separation mandate (#1208, HIGH-CONFIDENCE 3-lens qa-finding).

## Fix
- Add `reembedURLFromEnv(embedURL)` → reads `ENGRAM_REEMBED_URL`, defaults to `embedURL`.
- Thread a distinct `reembedURL` param into `newEmbedClients`; route the reembed client to it (live client stays on `embedURL`).
- Startup logs **WARN** when the two URLs coincide (separation not enforced) and **INFO** when separated.

## Deliberately NOT changed
The `bge-m3-reembed` olla routing alias is **retained** — it is the live priority-routing mechanism (maps to canonical `BAAI/bge-m3`, priority-100 W6800+leviathan bulk embedder), not superseded dead code. Removing it would break olla routing.

## Compatibility
`reembedURL` defaults to `embedURL` when the new var is unset, so all existing single-endpoint deployments (dev, CI, hosts without a dedicated reembed GPU) are unaffected. WARN, not hard-fail, on coincident URLs.

## Tests (TDD, red→green)
- `TestReembedURLRouting` (new): asserts the live client always binds the live URL, and the reembed client falls back to live when `ENGRAM_REEMBED_URL` is unset / routes to the override when set.
- `TestReembedModelEnvDefaultAndOverride` updated for the new signature.
- `go test ./cmd/engram/ -count=1 -race` green; `go vet` clean; gofmt clean.

Per repo policy: `ai-generated`, awaiting 3-round adversarial review (correctness → coverage → structural).