### PR TITLE
fix(longmemeval): sanitize control characters in LME-S ingest fixtures

### DIFF
--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -107,11 +107,17 @@ func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestCli
 			continue
 		}
 		// Prepend session date so the model can anchor relative-time questions.
-		tags := []string{"lme", "sid:" + sessionID}
-		if i < len(item.HaystackDates) && item.HaystackDates[i] != "" {
-			content = "Session date: " + item.HaystackDates[i] + "\n" + content
-			tags = append(tags, "date:"+item.HaystackDates[i])
+		tags := []string{"lme"}
+		if cleanSessionID := longmemeval.SanitizeStoreContent(sessionID); cleanSessionID != "" {
+			tags = append(tags, "sid:"+cleanSessionID)
 		}
+		if i < len(item.HaystackDates) && item.HaystackDates[i] != "" {
+			if cleanDate := longmemeval.SanitizeStoreContent(item.HaystackDates[i]); cleanDate != "" {
+				content = "Session date: " + cleanDate + "\n" + content
+				tags = append(tags, "date:"+cleanDate)
+			}
+		}
+		content = longmemeval.SanitizeStoreContent(content)
 		sessions = append(sessions, sessionEntry{
 			sessionID: sessionID,
 			item:      longmemeval.BatchItem{Content: content, Tags: tags},

--- a/cmd/longmemeval/ingest_test.go
+++ b/cmd/longmemeval/ingest_test.go
@@ -121,6 +121,53 @@ func TestIngestOne_EmptySessionsSkipped(t *testing.T) {
 	}
 }
 
+func TestIngestOne_SanitizesRenderedContentBeforeStore(t *testing.T) {
+	var gotBody struct {
+		Content string   `json:"content"`
+		Tags    []string `json:"tags"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": "m-sanitized"})
+	}))
+	defer srv.Close()
+
+	rc := longmemeval.NewRestClient(srv.URL, "")
+	cfg := &Config{RunID: "run-sanitize", Workers: 1}
+	item := longmemeval.Item{
+		QuestionID:         "e56a43b9",
+		HaystackSessionIDs: []string{"18"},
+		HaystackDates:      []string{"2024-01-0\x021"},
+		HaystackSessions: [][]longmemeval.Turn{
+			{{Role: "us\x02er", Content: "pre\x02dicting contextualized target represent"}},
+		},
+	}
+
+	entry := ingestOne(t.Context(), cfg, rc, item)
+	if entry.Status != "done" {
+		t.Fatalf("expected done, got %s: %s", entry.Status, entry.Error)
+	}
+	if strings.Contains(gotBody.Content, "\x02") {
+		t.Fatalf("stored content leaked control byte: %q", gotBody.Content)
+	}
+	if !strings.Contains(gotBody.Content, "Session date: 2024-01-01") {
+		t.Fatalf("stored content missing sanitized date prefix: %q", gotBody.Content)
+	}
+	if !strings.Contains(gotBody.Content, "user: predicting contextualized target represent") {
+		t.Fatalf("stored content missing sanitized role/content: %q", gotBody.Content)
+	}
+	for _, tag := range gotBody.Tags {
+		if strings.Contains(tag, "\x02") {
+			t.Fatalf("stored tag leaked control byte: %q (all tags: %v)", tag, gotBody.Tags)
+		}
+	}
+	if len(gotBody.Tags) < 3 || gotBody.Tags[1] != "sid:18" || gotBody.Tags[2] != "date:2024-01-01" {
+		t.Fatalf("stored tags missing sanitized sid/date tags: %v", gotBody.Tags)
+	}
+}
+
 // TestIngestOne_ScratchTTL_PassesExpiresAt verifies that when ScratchTTL > 0,
 // ingestOne passes a non-nil expires_at in the QuickStore request body.
 func TestIngestOne_ScratchTTL_PassesExpiresAt(t *testing.T) {

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -487,7 +487,6 @@ func (c *Client) RecallResultsWithOpts(ctx context.Context, project, query strin
 	return result.Results, nil
 }
 
-
 // recallParams carries the optional knobs for a single memory_recall call.
 type recallParams struct {
 	project           string
@@ -934,35 +933,32 @@ func restStatusError(op string, status int, msg, hint string) error {
 // preserving role labels so the retriever and generator can distinguish
 // user questions from assistant responses. Dropping assistant turns would
 // make single-session-assistant questions unanswerable (the gold content
-// lives in the assistant's reply).
-//
-// C0/C1 control characters (except \t, \n, \r) are stripped — the server's
-// validateContent rejects them and, because memory_store_batch is all-or-
-// nothing, one offender tanks an entire 100-item batch. See LongMemEval
-// session 158 of question 7e00a6cb for a real-world offender (\x0B).
+// lives in the assistant's reply). Control characters are stripped from both
+// role labels and content before the rendered session is returned.
 func SessionContent(turns []Turn) string {
 	var sb strings.Builder
 	for _, t := range turns {
-		if t.Content == "" {
+		content := SanitizeStoreContent(t.Content)
+		if content == "" {
 			continue
 		}
 		if sb.Len() > 0 {
 			sb.WriteByte('\n')
 		}
-		role := t.Role
+		role := SanitizeStoreContent(t.Role)
 		if role == "" {
 			role = "user"
 		}
 		sb.WriteString(role)
 		sb.WriteString(": ")
-		sb.WriteString(sanitizeControlChars(t.Content))
+		sb.WriteString(content)
 	}
 	return sb.String()
 }
 
-// sanitizeControlChars removes C0 (0x00-0x1F except \t \n \r) and C1 (0x7F-0x9F)
-// control characters from s.
-func sanitizeControlChars(s string) string {
+// SanitizeStoreContent removes C0/C1 control characters except tab, newline,
+// and carriage return before benchmark content reaches memory_store.
+func SanitizeStoreContent(s string) string {
 	var sb strings.Builder
 	sb.Grow(len(s))
 	for _, r := range s {

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -404,3 +404,17 @@ func TestSessionContent_SanitizesControlChars(t *testing.T) {
 		t.Errorf("content stripped too aggressively: %q", got)
 	}
 }
+
+func TestSessionContent_SanitizesRoleLabelsAndSkipsEmptyAfterSanitize(t *testing.T) {
+	turns := []longmemeval.Turn{
+		{Role: "us\x02er", Content: "pre\x02dicting contextualized target represent"},
+		{Role: "assistant", Content: "\x00\x02"},
+	}
+	got := longmemeval.SessionContent(turns)
+	if strings.Contains(got, "\x02") || strings.Contains(got, "\x00") {
+		t.Fatalf("control chars not stripped from %q", got)
+	}
+	if got != "user: predicting contextualized target represent" {
+		t.Fatalf("SessionContent() = %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #1321: the LME-S fixture contained raw control characters that memory_store_batch rejects. Sanitizes control characters during ingest and adds regression coverage in cmd/longmemeval/ingest_test.go and internal/longmemeval/engram_test.go. (Title/body repaired by coordinator — the impl agent rebased the branch onto current main but left the placeholder title.)