### PR TITLE
feat(wp05): wire H8 exhaustive aggregation into retrofit harness

### DIFF
--- a/cmd/wp05-layerb-gate-trace/main.go
+++ b/cmd/wp05-layerb-gate-trace/main.go
@@ -1,0 +1,194 @@
+// Command wp05-layerb-gate-trace diagnoses which Layer B v4 gate blocks
+// BuildSummary for recalled candidate sets. Diagnostic only.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/wp05retrofit"
+)
+
+type gateTrace struct {
+	QuestionID       string            `json:"question_id"`
+	Question         string            `json:"question"`
+	Project          string            `json:"project"`
+	GreenfieldProject string           `json:"greenfield_project,omitempty"`
+	SessionsIngested int              `json:"sessions_ingested"`
+	RecallCount      int              `json:"recall_count"`
+	GreenfieldMemoryCount int         `json:"greenfield_memory_count,omitempty"`
+	Exhaustive       bool             `json:"exhaustive_aggregation"`
+	BaselineGate     layerb.Diagnosis `json:"baseline_gate"`
+	ExhaustiveGate   *layerb.Diagnosis `json:"exhaustive_gate,omitempty"`
+	GreenfieldGate   *layerb.Diagnosis `json:"greenfield_gate,omitempty"`
+	RetrofitDBGate   *layerb.Diagnosis `json:"retrofit_db_gate,omitempty"`
+	RetrofitDBMemoryCount int         `json:"retrofit_db_memory_count,omitempty"`
+	LayerBFired      bool             `json:"layer_b_fired"`
+	GreenfieldWouldFire bool          `json:"greenfield_would_fire,omitempty"`
+	RetrofitDBWouldFire bool          `json:"retrofit_db_would_fire,omitempty"`
+}
+
+func main() {
+	var (
+		fixturePath   = flag.String("fixture", "/tmp/lme_s_multisession_133.json", "LME-S multi-session fixture")
+		idsCSV        = flag.String("ids", "", "comma-separated question_ids (required)")
+		projectPrefix = flag.String("project-prefix", "wp05-retrofit-2026-07-04c", "ingested project prefix")
+		serverURL     = flag.String("url", "http://127.0.0.1:8790", "Engram MCP server URL")
+		apiKey        = flag.String("api-key", "", "Engram API key")
+		limit         = flag.Int("limit", 200, "recall limit for baseline path")
+		exhaustive        = flag.Bool("exhaustive-aggregation", true, "also run exhaustive recall path and diagnose")
+		greenfieldDSN     = flag.String("greenfield-dsn", "", "optional Postgres DSN to diagnose greenfield raw_memories (e.g. engram_ng)")
+		greenfieldPrefix  = flag.String("greenfield-prefix", "wp05b-refire2-2026-07-04", "greenfield project prefix")
+		retrofitDSN       = flag.String("retrofit-dsn", "", "optional Postgres DSN to diagnose retrofit memories directly (e.g. engram_go_retrofit)")
+		outPath           = flag.String("out", "-", "output JSON path (- for stdout)")
+	)
+	flag.Parse()
+	if strings.TrimSpace(*idsCSV) == "" {
+		fmt.Fprintln(os.Stderr, "wp05-layerb-gate-trace: -ids is required")
+		os.Exit(2)
+	}
+	if strings.TrimSpace(*apiKey) == "" {
+		*apiKey = strings.TrimSpace(os.Getenv("ENGRAM_API_KEY"))
+	}
+	if *apiKey == "" {
+		*apiKey = "wp05-local"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	items, err := wp05retrofit.LoadFixture(*fixturePath)
+	if err != nil {
+		fatal("load fixture: %v", err)
+	}
+	byID := make(map[string]wp05retrofit.Item, len(items))
+	for _, it := range items {
+		byID[it.QuestionID] = it
+	}
+
+	client, err := longmemeval.Connect(ctx, *serverURL, *apiKey)
+	if err != nil {
+		fatal("connect MCP: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	traces := make([]gateTrace, 0)
+	for _, id := range splitCSV(*idsCSV) {
+		it, ok := byID[id]
+		if !ok {
+			fatal("question_id %q not in fixture", id)
+		}
+		project := fmt.Sprintf("%s-%s", strings.TrimSuffix(*projectPrefix, "-"), id)
+
+		baseline, err := wp05retrofit.RecallItem(ctx, client, project, it, wp05retrofit.Config{Limit: *limit})
+		if err != nil {
+			fatal("baseline recall %s: %v", id, err)
+		}
+		baseDiag := layerb.DiagnoseBuildSummary(it.Question, baseline.Results)
+
+		trace := gateTrace{
+			QuestionID:       id,
+			Question:         it.Question,
+			Project:          project,
+			SessionsIngested: len(it.HaystackSessions),
+			RecallCount:      len(baseline.Results),
+			Exhaustive:       *exhaustive,
+			BaselineGate:     baseDiag,
+			LayerBFired:      baseline.LayerB != nil,
+		}
+
+		if *exhaustive {
+			exh, err := wp05retrofit.RecallItem(ctx, client, project, it, wp05retrofit.Config{
+				Limit:                 *limit,
+				ExhaustiveAggregation: true,
+			})
+			if err != nil {
+				fatal("exhaustive recall %s: %v", id, err)
+			}
+			exhDiag := layerb.DiagnoseBuildSummary(it.Question, exh.Results)
+			trace.ExhaustiveGate = &exhDiag
+			trace.RecallCount = len(exh.Results)
+			trace.LayerBFired = exh.LayerB != nil
+		}
+
+		if strings.TrimSpace(*greenfieldDSN) != "" {
+			gfProject := fmt.Sprintf("%s-%s", strings.TrimSuffix(*greenfieldPrefix, "-"), id)
+			trace.GreenfieldProject = gfProject
+			gfMemories, err := wp05retrofit.LoadGreenfieldMemories(ctx, *greenfieldDSN, gfProject)
+			if err != nil {
+				fatal("greenfield load %s: %v", id, err)
+			}
+			trace.GreenfieldMemoryCount = len(gfMemories)
+			gfDiag := layerb.DiagnoseBuildSummary(it.Question, gfMemories)
+			trace.GreenfieldGate = &gfDiag
+			trace.GreenfieldWouldFire = gfDiag.WouldFire
+		}
+
+		if strings.TrimSpace(*retrofitDSN) != "" {
+			rfMemories, err := wp05retrofit.LoadRetrofitMemories(ctx, *retrofitDSN, project)
+			if err != nil {
+				fatal("retrofit db load %s: %v", id, err)
+			}
+			trace.RetrofitDBMemoryCount = len(rfMemories)
+			rfDiag := layerb.DiagnoseBuildSummary(it.Question, rfMemories)
+			trace.RetrofitDBGate = &rfDiag
+			trace.RetrofitDBWouldFire = rfDiag.WouldFire
+		}
+
+		traces = append(traces, trace)
+	}
+
+	payload, err := json.MarshalIndent(map[string]any{
+		"system":            "engram-go-retrofit",
+		"project_prefix":    *projectPrefix,
+		"greenfield_prefix":   strings.TrimSpace(*greenfieldPrefix),
+		"greenfield_dsn_set": strings.TrimSpace(*greenfieldDSN) != "",
+		"retrofit_dsn_set":   strings.TrimSpace(*retrofitDSN) != "",
+		"exhaustive":        *exhaustive,
+		"traces":            traces,
+	}, "", "  ")
+	if err != nil {
+		fatal("marshal: %v", err)
+	}
+	if *outPath == "-" {
+		fmt.Println(string(payload))
+		return
+	}
+	if err := os.MkdirAll(dirOf(*outPath), 0o755); err != nil {
+		fatal("mkdir: %v", err)
+	}
+	if err := os.WriteFile(*outPath, payload, 0o644); err != nil {
+		fatal("write %s: %v", *outPath, err)
+	}
+}
+
+func dirOf(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[:i]
+	}
+	return "."
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "wp05-layerb-gate-trace: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/wp05-retrofit-runner/main.go
+++ b/cmd/wp05-retrofit-runner/main.go
@@ -23,19 +23,20 @@ func main() {
 		serverURL     = flag.String("url", "", "Engram server URL (env: ENGRAM_URL)")
 		apiKey        = flag.String("api-key", "", "Engram API key (env: ENGRAM_API_KEY)")
 		projectPrefix = flag.String("project-prefix", "wp05-retrofit", "project namespace prefix; each fixture item gets its own <prefix>-<question_id> project")
-		limit         = flag.Int("limit", 200, "recall limit; must exceed the max haystack session count per item")
-		outPath       = flag.String("out", "results/wp05-retrofit/retrofit-bundle.json", "output path for the retrofit bundle JSON")
+		limit                 = flag.Int("limit", 200, "recall limit; must exceed the max haystack session count per item")
+		exhaustiveAggregation = flag.Bool("exhaustive-aggregation", false, "H8: for aggregation questions, union topK=500 primary+anchor recall with a project-wide memory_list sweep and build Layer B client-side")
+		outPath               = flag.String("out", "results/wp05-retrofit/retrofit-bundle.json", "output path for the retrofit bundle JSON")
 	)
 	flag.Parse()
 	applySharedDefaults(flag.CommandLine, serverURL, apiKey)
 
-	if err := run(*dataPath, *serverURL, *apiKey, *projectPrefix, *limit, *outPath); err != nil {
+	if err := run(*dataPath, *serverURL, *apiKey, *projectPrefix, *limit, *exhaustiveAggregation, *outPath); err != nil {
 		fmt.Fprintf(os.Stderr, "wp05-retrofit-runner: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, outPath string) error {
+func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiveAggregation bool, outPath string) error {
 	items, err := wp05retrofit.LoadFixture(dataPath)
 	if err != nil {
 		return fmt.Errorf("load fixture: %w", err)
@@ -56,23 +57,28 @@ func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, outPath s
 	}
 	runID := "wp05-retrofit-" + time.Now().UTC().Format("20060102T150405Z")
 	itemSet := fmt.Sprintf("%s-develop-n%d", strings.TrimSuffix(filepath.Base(dataPath), filepath.Ext(dataPath)), len(items))
+	featureFlags := []string{"layer_b_retrofit"}
+	if exhaustiveAggregation {
+		featureFlags = append(featureFlags, "exhaustive_aggregation")
+	}
 	provenance := wp05retrofit.Provenance{
 		GoldVersion:   filepath.Base(dataPath),
 		ScorerVersion: "wp05-retrofit-v1",
-		FeatureFlags:  []string{"layer_b_retrofit"},
+		FeatureFlags:  featureFlags,
 		System:        wp05retrofit.SystemName,
 		ItemSet:       itemSet,
 		RunID:         runID,
 		HarnessSHA:    harnessSHA,
 	}
 
-	log.Printf("wp05-retrofit-runner: starting %d fixture item(s), project-prefix=%s limit=%d url=%s",
-		len(items), projectPrefix, limit, serverURL)
+	log.Printf("wp05-retrofit-runner: starting %d fixture item(s), project-prefix=%s limit=%d exhaustive=%t url=%s",
+		len(items), projectPrefix, limit, exhaustiveAggregation, serverURL)
 
 	bundle, err := wp05retrofit.Run(ctx, client, items, wp05retrofit.Config{
-		ProjectPrefix:      projectPrefix,
-		Limit:              limit,
-		ProvenanceTemplate: provenance,
+		ProjectPrefix:         projectPrefix,
+		Limit:                 limit,
+		ExhaustiveAggregation: exhaustiveAggregation,
+		ProvenanceTemplate:    provenance,
 	}, log.Printf)
 	if err != nil {
 		return err

--- a/cmd/wp05-retrofit-runner/main.go
+++ b/cmd/wp05-retrofit-runner/main.go
@@ -25,18 +25,19 @@ func main() {
 		projectPrefix = flag.String("project-prefix", "wp05-retrofit", "project namespace prefix; each fixture item gets its own <prefix>-<question_id> project")
 		limit                 = flag.Int("limit", 200, "recall limit; must exceed the max haystack session count per item")
 		exhaustiveAggregation = flag.Bool("exhaustive-aggregation", false, "H8: for aggregation questions, union topK=500 primary+anchor recall with a project-wide memory_list sweep and build Layer B client-side")
+		skipIngest            = flag.Bool("skip-ingest", false, "recall/score only — assumes memories already ingested under project-prefix")
 		outPath               = flag.String("out", "results/wp05-retrofit/retrofit-bundle.json", "output path for the retrofit bundle JSON")
 	)
 	flag.Parse()
 	applySharedDefaults(flag.CommandLine, serverURL, apiKey)
 
-	if err := run(*dataPath, *serverURL, *apiKey, *projectPrefix, *limit, *exhaustiveAggregation, *outPath); err != nil {
+	if err := run(*dataPath, *serverURL, *apiKey, *projectPrefix, *limit, *exhaustiveAggregation, *skipIngest, *outPath); err != nil {
 		fmt.Fprintf(os.Stderr, "wp05-retrofit-runner: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiveAggregation bool, outPath string) error {
+func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiveAggregation, skipIngest bool, outPath string) error {
 	items, err := wp05retrofit.LoadFixture(dataPath)
 	if err != nil {
 		return fmt.Errorf("load fixture: %w", err)
@@ -71,13 +72,14 @@ func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiv
 		HarnessSHA:    harnessSHA,
 	}
 
-	log.Printf("wp05-retrofit-runner: starting %d fixture item(s), project-prefix=%s limit=%d exhaustive=%t url=%s",
-		len(items), projectPrefix, limit, exhaustiveAggregation, serverURL)
+	log.Printf("wp05-retrofit-runner: starting %d fixture item(s), project-prefix=%s limit=%d exhaustive=%t skip-ingest=%t url=%s",
+		len(items), projectPrefix, limit, exhaustiveAggregation, skipIngest, serverURL)
 
 	bundle, err := wp05retrofit.Run(ctx, client, items, wp05retrofit.Config{
 		ProjectPrefix:         projectPrefix,
 		Limit:                 limit,
 		ExhaustiveAggregation: exhaustiveAggregation,
+		SkipIngest:            skipIngest,
 		ProvenanceTemplate:    provenance,
 	}, log.Printf)
 	if err != nil {

--- a/cmd/wp05-trace/main.go
+++ b/cmd/wp05-trace/main.go
@@ -46,8 +46,9 @@ func main() {
 		projectPrefix = flag.String("project-prefix", "wp05-retrofit-2026-07-04c", "ingested project prefix")
 		serverURL     = flag.String("url", "http://127.0.0.1:8790", "Engram MCP server URL")
 		apiKey        = flag.String("api-key", "", "Engram API key (env ENGRAM_API_KEY)")
-		limit         = flag.Int("limit", 200, "recall limit")
-		outPath       = flag.String("out", "-", "output JSON path (- for stdout)")
+		limit                 = flag.Int("limit", 200, "recall limit")
+		exhaustiveAggregation = flag.Bool("exhaustive-aggregation", false, "H8 exhaustive recall path")
+		outPath               = flag.String("out", "-", "output JSON path (- for stdout)")
 	)
 	flag.Parse()
 
@@ -88,7 +89,10 @@ func main() {
 			fatal("question_id %q not found in fixture", id)
 		}
 		project := fmt.Sprintf("%s-%s", strings.TrimSuffix(*projectPrefix, "-"), id)
-		res, err := wp05retrofit.RecallItem(ctx, client, project, it, wp05retrofit.Config{Limit: *limit})
+		res, err := wp05retrofit.RecallItem(ctx, client, project, it, wp05retrofit.Config{
+			Limit:                 *limit,
+			ExhaustiveAggregation: *exhaustiveAggregation,
+		})
 		if err != nil {
 			fatal("recall %s: %v", id, err)
 		}
@@ -141,7 +145,8 @@ func main() {
 	payload, err := json.MarshalIndent(map[string]any{
 		"system":         "engram-go-retrofit",
 		"project_prefix": *projectPrefix,
-		"limit":          *limit,
+		"limit":                   *limit,
+		"exhaustive_aggregation":  *exhaustiveAggregation,
 		"server_url":     *serverURL,
 		"traces":         traces,
 	}, "", "  ")

--- a/cmd/wp05-trace/main.go
+++ b/cmd/wp05-trace/main.go
@@ -1,0 +1,191 @@
+// Command wp05-trace compares retrofit recall + Layer B behavior for selected
+// LME-S multi-session items against data already ingested via wp05-retrofit-runner.
+// Diagnostic only — not part of the scored A/B.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/aggq"
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/wp05retrofit"
+)
+
+type recallHit struct {
+	ID      string  `json:"id"`
+	Score   float64 `json:"score"`
+	Preview string  `json:"preview"`
+}
+
+type itemTrace struct {
+	QuestionID       string      `json:"question_id"`
+	Question         string      `json:"question"`
+	GoldAnswer       string      `json:"gold_answer"`
+	Project          string      `json:"project"`
+	SessionsIngested int         `json:"sessions_ingested"`
+	Anchor           string      `json:"anchor"`
+	AggregationQ     bool        `json:"aggregation_expected"`
+	RecallCount      int         `json:"recall_count"`
+	TopHits          []recallHit `json:"top_hits"`
+	LayerBFired      bool        `json:"layer_b_fired"`
+	LayerBCount      int         `json:"layer_b_count"`
+	LayerBEvidence   int         `json:"layer_b_evidence"`
+	GoldInTopK       bool        `json:"gold_literal_in_topk"`
+}
+
+func main() {
+	var (
+		fixturePath   = flag.String("fixture", "/tmp/lme_s_multisession_133.json", "LME-S multi-session fixture")
+		idsCSV        = flag.String("ids", "", "comma-separated question_ids to trace (required)")
+		projectPrefix = flag.String("project-prefix", "wp05-retrofit-2026-07-04c", "ingested project prefix")
+		serverURL     = flag.String("url", "http://127.0.0.1:8790", "Engram MCP server URL")
+		apiKey        = flag.String("api-key", "", "Engram API key (env ENGRAM_API_KEY)")
+		limit         = flag.Int("limit", 200, "recall limit")
+		outPath       = flag.String("out", "-", "output JSON path (- for stdout)")
+	)
+	flag.Parse()
+
+	if strings.TrimSpace(*idsCSV) == "" {
+		fmt.Fprintln(os.Stderr, "wp05-trace: -ids is required")
+		os.Exit(2)
+	}
+	if strings.TrimSpace(*apiKey) == "" {
+		*apiKey = strings.TrimSpace(os.Getenv("ENGRAM_API_KEY"))
+	}
+	if *apiKey == "" {
+		*apiKey = "wp05-trace-local"
+	}
+
+	targets := splitCSV(*idsCSV)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	items, err := wp05retrofit.LoadFixture(*fixturePath)
+	if err != nil {
+		fatal("load fixture: %v", err)
+	}
+	byID := make(map[string]wp05retrofit.Item, len(items))
+	for _, it := range items {
+		byID[it.QuestionID] = it
+	}
+
+	client, err := longmemeval.Connect(ctx, *serverURL, *apiKey)
+	if err != nil {
+		fatal("connect MCP: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	traces := make([]itemTrace, 0, len(targets))
+	for _, id := range targets {
+		it, ok := byID[id]
+		if !ok {
+			fatal("question_id %q not found in fixture", id)
+		}
+		project := fmt.Sprintf("%s-%s", strings.TrimSuffix(*projectPrefix, "-"), id)
+		res, err := wp05retrofit.RecallItem(ctx, client, project, it, *limit)
+		if err != nil {
+			fatal("recall %s: %v", id, err)
+		}
+
+		hits := make([]recallHit, 0, len(res.Results))
+		goldInTop := false
+		gold := goldString(it.Answer)
+		for i, r := range res.Results {
+			if r.Memory == nil {
+				continue
+			}
+			preview := strings.ReplaceAll(r.Memory.Content, "\n", " ")
+			if len(preview) > 160 {
+				preview = preview[:160] + "..."
+			}
+			hits = append(hits, recallHit{ID: r.Memory.ID, Score: r.Score, Preview: preview})
+			if gold != "" && strings.Contains(r.Memory.Content, gold) {
+				goldInTop = true
+			}
+			if i >= 9 {
+				continue
+			}
+		}
+
+		lbCount := 0
+		lbEvidence := 0
+		lbFired := res.LayerB != nil
+		if res.LayerB != nil {
+			lbCount = res.LayerB.Count
+			lbEvidence = len(res.LayerB.Evidence)
+		}
+
+		traces = append(traces, itemTrace{
+			QuestionID:       id,
+			Question:         it.Question,
+			GoldAnswer:       gold,
+			Project:          project,
+			SessionsIngested: len(it.HaystackSessions),
+			Anchor:           aggq.ExtractAggregationAnchor(it.Question),
+			AggregationQ:     aggq.IsAggregationQuestion(it.Question),
+			RecallCount:      len(res.Results),
+			TopHits:          hits,
+			LayerBFired:      lbFired,
+			LayerBCount:      lbCount,
+			LayerBEvidence:   lbEvidence,
+			GoldInTopK:       goldInTop,
+		})
+	}
+
+	payload, err := json.MarshalIndent(map[string]any{
+		"system":         "engram-go-retrofit",
+		"project_prefix": *projectPrefix,
+		"limit":          *limit,
+		"server_url":     *serverURL,
+		"traces":         traces,
+	}, "", "  ")
+	if err != nil {
+		fatal("marshal: %v", err)
+	}
+	if *outPath == "-" {
+		fmt.Println(string(payload))
+		return
+	}
+	if err := os.WriteFile(*outPath, payload, 0o644); err != nil {
+		fatal("write %s: %v", *outPath, err)
+	}
+}
+
+func goldString(answer interface{}) string {
+	switch v := answer.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%v", v)
+	case json.Number:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "wp05-trace: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/wp05-trace/main.go
+++ b/cmd/wp05-trace/main.go
@@ -88,7 +88,7 @@ func main() {
 			fatal("question_id %q not found in fixture", id)
 		}
 		project := fmt.Sprintf("%s-%s", strings.TrimSuffix(*projectPrefix, "-"), id)
-		res, err := wp05retrofit.RecallItem(ctx, client, project, it, *limit)
+		res, err := wp05retrofit.RecallItem(ctx, client, project, it, wp05retrofit.Config{Limit: *limit})
 		if err != nil {
 			fatal("recall %s: %v", id, err)
 		}

--- a/internal/layerb/diagnose.go
+++ b/internal/layerb/diagnose.go
@@ -1,0 +1,126 @@
+package layerb
+
+import (
+	"strings"
+
+	"github.com/petersimmons1972/engram/internal/aggq"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// Diagnosis records which BuildSummary gate failed for a candidate recall set.
+type Diagnosis struct {
+	Anchor                string   `json:"anchor"`
+	AnchorTerms           []string `json:"anchor_terms"`
+	AnchorTermCount       int      `json:"anchor_term_count"`
+	UnionRequired         int      `json:"union_required"`
+	RecallCount           int      `json:"recall_count"`
+	ContributingMemories  int      `json:"contributing_memories"`
+	UnionMatchedTerms     []string `json:"union_matched_terms"`
+	UnionMatchedCount     int      `json:"union_matched_count"`
+	Connected             bool     `json:"connected"`
+	ConnectedComponents   int      `json:"connected_components"`
+	FailedGate            string   `json:"failed_gate"`
+	WouldFire             bool     `json:"would_fire"`
+}
+
+// DiagnoseBuildSummary reports which v4 gate would block BuildSummary for the
+// given recall results without persisting atoms or events.
+func DiagnoseBuildSummary(q string, results []types.SearchResult) Diagnosis {
+	d := Diagnosis{
+		RecallCount: len(results),
+		FailedGate:  "none",
+		WouldFire:   false,
+		Connected:   true,
+	}
+	if !aggq.IsAggregationQuestion(q) {
+		d.FailedGate = "not_aggregation"
+		return d
+	}
+	anchor := strings.TrimSpace(aggq.ExtractAggregationAnchor(q))
+	d.Anchor = anchor
+	anchorTerms := normalizeTerms(anchor)
+	d.AnchorTerms = anchorTerms
+	d.AnchorTermCount = len(anchorTerms)
+	d.UnionRequired = minimumAnchorTermMatches(len(anchorTerms))
+	if len(anchorTerms) == 0 {
+		d.FailedGate = "empty_anchor"
+		return d
+	}
+
+	var contributions []memberContribution
+	for _, result := range results {
+		if result.Memory == nil || strings.TrimSpace(result.Memory.Content) == "" {
+			continue
+		}
+		matches, memMatchedTerms := extractMatchingAtoms(result.Memory, anchorTerms)
+		if len(matches) == 0 {
+			continue
+		}
+		contributions = append(contributions, memberContribution{atoms: matches, terms: dedupe(memMatchedTerms)})
+	}
+	d.ContributingMemories = len(contributions)
+	if d.ContributingMemories == 0 {
+		d.ConnectedComponents = 0
+		d.FailedGate = "no_contributions"
+		return d
+	}
+
+	var unionTerms []string
+	for _, c := range contributions {
+		unionTerms = append(unionTerms, c.terms...)
+	}
+	unionMatched := dedupe(unionTerms)
+	d.UnionMatchedTerms = unionMatched
+	d.UnionMatchedCount = len(unionMatched)
+	if d.UnionMatchedCount < d.UnionRequired {
+		d.ConnectedComponents = connectedComponents(contributions)
+		d.FailedGate = "collective_coverage"
+		return d
+	}
+
+	d.ConnectedComponents = connectedComponents(contributions)
+	d.Connected = d.ConnectedComponents <= 1
+	if !d.Connected {
+		d.FailedGate = "connectivity"
+		return d
+	}
+
+	d.FailedGate = "none"
+	d.WouldFire = true
+	return d
+}
+
+func connectedComponents(contributions []memberContribution) int {
+	if len(contributions) <= 1 {
+		return len(contributions)
+	}
+	parent := make([]int, len(contributions))
+	for i := range parent {
+		parent[i] = i
+	}
+	find := func(i int) int {
+		for parent[i] != i {
+			parent[i] = parent[parent[i]]
+			i = parent[i]
+		}
+		return i
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+	for i := 0; i < len(contributions); i++ {
+		for j := i + 1; j < len(contributions); j++ {
+			if sharesTerm(contributions[i].terms, contributions[j].terms) {
+				union(i, j)
+			}
+		}
+	}
+	roots := make(map[int]bool)
+	for i := range contributions {
+		roots[find(i)] = true
+	}
+	return len(roots)
+}

--- a/internal/layerb/diagnose_test.go
+++ b/internal/layerb/diagnose_test.go
@@ -1,0 +1,46 @@
+package layerb_test
+
+import (
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+func memory(content string) types.SearchResult {
+	return types.SearchResult{
+		Memory: &types.Memory{ID: "m1", Content: content, Project: "p"},
+	}
+}
+
+func TestDiagnoseBuildSummary_NotAggregation(t *testing.T) {
+	d := layerb.DiagnoseBuildSummary("What is Alex's favorite color?", nil)
+	if d.FailedGate != "not_aggregation" || d.WouldFire {
+		t.Fatalf("Diagnosis = %+v, want not_aggregation", d)
+	}
+}
+
+func TestDiagnoseBuildSummary_NoContributions(t *testing.T) {
+	d := layerb.DiagnoseBuildSummary("How many times did I visit the doctor?", []types.SearchResult{
+		memory("unrelated budget planning for March"),
+	})
+	if d.FailedGate != "no_contributions" {
+		t.Fatalf("FailedGate = %q, want no_contributions", d.FailedGate)
+	}
+}
+
+func TestDiagnoseBuildSummary_ConnectivityFailure(t *testing.T) {
+	d := layerb.DiagnoseBuildSummary(
+		"How many bikes did I service or plan to service in March?",
+		[]types.SearchResult{
+			memory("I serviced the bike rack in January."),
+			memory("I plan the March budget next week."),
+		},
+	)
+	if d.FailedGate != "connectivity" {
+		t.Fatalf("FailedGate = %q, want connectivity; diag=%+v", d.FailedGate, d)
+	}
+	if d.ConnectedComponents < 2 {
+		t.Fatalf("ConnectedComponents = %d, want >= 2", d.ConnectedComponents)
+	}
+}

--- a/internal/longmemeval/client_test.go
+++ b/internal/longmemeval/client_test.go
@@ -393,6 +393,50 @@ func TestRecallFullResult_HappyPathIncludesLayerB(t *testing.T) {
 	}
 }
 
+func TestListProjectMemories_HappyPath(t *testing.T) {
+	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
+		"memory_list": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			args := req.GetArguments()
+			if got := args["project"]; got != "proj" {
+				t.Fatalf("project = %#v, want proj", got)
+			}
+			if got := args["limit"]; got != float64(500) {
+				t.Fatalf("limit = %#v, want 500", got)
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"memories": []map[string]any{
+					{"id": "mem-1", "content": "first"},
+					{"id": "mem-2", "content": "second"},
+				},
+				"count": 2,
+			})
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: string(resp)}},
+			}, nil
+		},
+	})
+	ctx := context.Background()
+	c, err := longmemeval.Connect(ctx, url, "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	results, err := c.ListProjectMemories(ctx, "proj", 500)
+	if err != nil {
+		t.Fatalf("ListProjectMemories: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Memory == nil || results[0].Memory.ID != "mem-1" {
+		t.Fatalf("first result = %+v, want mem-1", results[0])
+	}
+	if results[0].Score != 0 {
+		t.Fatalf("score = %v, want 0 for listed memories", results[0].Score)
+	}
+}
+
 func TestRecallFullResult_OlderResponseWithoutLayerB(t *testing.T) {
 	url := newTestMCPServer(t, map[string]func(mcp.CallToolRequest) (*mcp.CallToolResult, error){
 		"memory_recall": func(req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -754,6 +754,54 @@ func (c *Client) FetchContent(ctx context.Context, project, id string) (string, 
 	return resp.Content, nil
 }
 
+// ListProjectMemories returns project memories via the memory_list MCP tool.
+// Results are shaped as SearchResult values with score 0 so harness code can
+// union them with recall hits. limit is clamped to [1, 500] per server policy.
+func (c *Client) ListProjectMemories(ctx context.Context, project string, limit int) ([]types.SearchResult, error) {
+	if limit < 1 || limit > 500 {
+		limit = 500
+	}
+	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "memory_list",
+			Arguments: map[string]any{
+				"project": project,
+				"limit":   limit,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, toolErrorMsg(result, "memory_list")
+	}
+	if len(result.Content) == 0 {
+		return nil, fmt.Errorf("memory_list returned no content")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return nil, fmt.Errorf("unexpected content type from memory_list: %T", result.Content[0])
+	}
+	var resp struct {
+		Memories []*types.Memory `json:"memories"`
+	}
+	if err := json.Unmarshal([]byte(tc.Text), &resp); err != nil {
+		return nil, fmt.Errorf("parse memory_list response: %w", err)
+	}
+	out := make([]types.SearchResult, 0, len(resp.Memories))
+	for _, mem := range resp.Memories {
+		if mem == nil || strings.TrimSpace(mem.ID) == "" {
+			continue
+		}
+		if strings.TrimSpace(mem.Project) == "" {
+			mem.Project = project
+		}
+		out = append(out, types.SearchResult{Memory: mem, Score: 0})
+	}
+	return out, nil
+}
+
 // DeleteProject calls memory_delete_project to clean up an isolation project.
 func (c *Client) DeleteProject(ctx context.Context, project string) error {
 	result, err := c.mcp.CallTool(ctx, mcp.CallToolRequest{

--- a/internal/wp05retrofit/greenfield_load.go
+++ b/internal/wp05retrofit/greenfield_load.go
@@ -1,0 +1,45 @@
+package wp05retrofit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// LoadGreenfieldMemories returns all raw_memories for a greenfield project as
+// SearchResult values (score 0) for offline Layer B diagnosis.
+func LoadGreenfieldMemories(ctx context.Context, dsn, project string) ([]types.SearchResult, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open greenfield pool: %w", err)
+	}
+	defer pool.Close()
+
+	rows, err := pool.Query(ctx, `
+		SELECT id, content, project
+		FROM raw_memories
+		WHERE project = $1
+		ORDER BY created_at ASC`, project)
+	if err != nil {
+		return nil, fmt.Errorf("query raw_memories: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]types.SearchResult, 0)
+	for rows.Next() {
+		var id, content, proj string
+		if err := rows.Scan(&id, &content, &proj); err != nil {
+			return nil, fmt.Errorf("scan raw_memory: %w", err)
+		}
+		out = append(out, types.SearchResult{
+			Memory: &types.Memory{ID: id, Content: content, Project: proj},
+			Score:  0,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/wp05retrofit/recall_exhaustive.go
+++ b/internal/wp05retrofit/recall_exhaustive.go
@@ -84,8 +84,12 @@ func mergeSearchResults(batches ...[]types.SearchResult) []types.SearchResult {
 			}
 			if hit.Score > current.result.Score {
 				current.result.Score = hit.Score
-				merged[id] = current
 			}
+			// Recall uses detail=summary (500-char cap); memory_list carries full
+			// session text. Keep the longer content so client-side Layer B sees
+			// the same evidence the server uses when building layer_b in full mode.
+			preferLongerMemoryContent(&current.result, hit)
+			merged[id] = current
 		}
 	}
 	out := make([]mergedHit, 0, len(merged))
@@ -106,6 +110,21 @@ func mergeSearchResults(batches ...[]types.SearchResult) []types.SearchResult {
 		results = append(results, hit.result)
 	}
 	return results
+}
+
+func preferLongerMemoryContent(dst *types.SearchResult, src types.SearchResult) {
+	if dst.Memory == nil {
+		if src.Memory != nil {
+			dst.Memory = src.Memory
+		}
+		return
+	}
+	if src.Memory == nil {
+		return
+	}
+	if len(src.Memory.Content) > len(dst.Memory.Content) {
+		dst.Memory.Content = src.Memory.Content
+	}
 }
 
 func idsFromSearchResults(results []types.SearchResult) []string {

--- a/internal/wp05retrofit/recall_exhaustive.go
+++ b/internal/wp05retrofit/recall_exhaustive.go
@@ -1,0 +1,158 @@
+package wp05retrofit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+const projectSweepLimit = 500
+
+type recallCall struct {
+	query string
+	topK  int
+}
+
+// layerbStubStore is an in-memory Layer B store for client-side BuildSummary.
+type layerbStubStore struct {
+	atoms  map[string]layerb.Atom
+	events map[string]layerb.Event
+}
+
+func (s *layerbStubStore) UpsertLayerBAtom(_ context.Context, atom layerb.Atom) error {
+	if s.atoms == nil {
+		s.atoms = map[string]layerb.Atom{}
+	}
+	s.atoms[atom.MemoryID+"|"+atom.ProvenanceSpan+"|"+atom.NormalizedText] = atom
+	return nil
+}
+
+func (s *layerbStubStore) UpsertLayerBEvent(_ context.Context, event layerb.Event) error {
+	if s.events == nil {
+		s.events = map[string]layerb.Event{}
+	}
+	s.events[event.MemoryID+"|"+event.ProvenanceSpan+"|"+event.Anchor] = event
+	return nil
+}
+
+func (s *layerbStubStore) ListLayerBEvents(_ context.Context, _ string, memoryIDs []string) ([]layerb.EventRecord, error) {
+	allow := make(map[string]bool, len(memoryIDs))
+	for _, id := range memoryIDs {
+		allow[id] = true
+	}
+	out := make([]layerb.EventRecord, 0, len(s.events))
+	for _, event := range s.events {
+		if !allow[event.MemoryID] {
+			continue
+		}
+		out = append(out, layerb.EventRecord{
+			MemoryID:       event.MemoryID,
+			ProvenanceSpan: event.ProvenanceSpan,
+			SpanText:       event.SpanText,
+			Anchor:         event.Anchor,
+			NormalizedText: event.NormalizedText,
+			EventTime:      event.EventTime,
+		})
+	}
+	return out, nil
+}
+
+// mergeSearchResults unions recall hits by memory ID, keeps the maximum score per
+// ID, and preserves first-seen order across the input batches.
+func mergeSearchResults(batches ...[]types.SearchResult) []types.SearchResult {
+	type mergedHit struct {
+		result types.SearchResult
+		order  int
+	}
+	merged := make(map[string]mergedHit)
+	order := 0
+	for _, batch := range batches {
+		for _, hit := range batch {
+			if hit.Memory == nil || strings.TrimSpace(hit.Memory.ID) == "" {
+				continue
+			}
+			id := hit.Memory.ID
+			current, ok := merged[id]
+			if !ok {
+				merged[id] = mergedHit{result: hit, order: order}
+				order++
+				continue
+			}
+			if hit.Score > current.result.Score {
+				current.result.Score = hit.Score
+				merged[id] = current
+			}
+		}
+	}
+	out := make([]mergedHit, 0, len(merged))
+	for _, hit := range merged {
+		out = append(out, hit)
+	}
+	// Stable sort by original discovery order; recall-ranked items stay ahead of
+	// zero-score project-list entries when scores tie.
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if out[j].order < out[i].order {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	results := make([]types.SearchResult, 0, len(out))
+	for _, hit := range out {
+		results = append(results, hit.result)
+	}
+	return results
+}
+
+func idsFromSearchResults(results []types.SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, r := range results {
+		if r.Memory != nil && r.Memory.ID != "" {
+			ids = append(ids, r.Memory.ID)
+		}
+	}
+	return ids
+}
+
+func recallItemExhaustive(ctx context.Context, client Client, project string, item Item, limit int) (longmemeval.RecallResult, error) {
+	runOpts := longmemeval.RunOpts{ExhaustiveAggregation: true}
+	effectiveTopK := runOpts.EffectiveRecallTopK(item.Question, limit)
+
+	primary, err := client.RecallFullResult(ctx, project, item.Question, effectiveTopK)
+	if err != nil {
+		return longmemeval.RecallResult{}, err
+	}
+
+	batches := [][]types.SearchResult{primary.Results}
+	anchor := strings.TrimSpace(longmemeval.ExtractAggregationAnchor(item.Question))
+	if anchor != "" && !strings.EqualFold(anchor, strings.TrimSpace(item.Question)) {
+		anchorResult, anchorErr := client.RecallFullResult(ctx, project, anchor, effectiveTopK)
+		if anchorErr != nil {
+			return longmemeval.RecallResult{}, fmt.Errorf("anchor recall: %w", anchorErr)
+		}
+		batches = append(batches, anchorResult.Results)
+	}
+
+	listed, listErr := client.ListProjectMemories(ctx, project, projectSweepLimit)
+	if listErr != nil {
+		return longmemeval.RecallResult{}, fmt.Errorf("project sweep: %w", listErr)
+	}
+	batches = append(batches, listed)
+
+	merged := mergeSearchResults(batches...)
+	store := &layerbStubStore{}
+	layerBSummary, err := layerb.BuildSummary(ctx, store, item.Question, merged)
+	if err != nil {
+		return longmemeval.RecallResult{}, fmt.Errorf("client layer_b build: %w", err)
+	}
+
+	return longmemeval.RecallResult{
+		IDs:     idsFromSearchResults(merged),
+		Results: merged,
+		LayerB:  layerBSummary,
+	}, nil
+}

--- a/internal/wp05retrofit/recall_exhaustive_test.go
+++ b/internal/wp05retrofit/recall_exhaustive_test.go
@@ -1,0 +1,142 @@
+package wp05retrofit
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/layerb"
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+func memoryResult(id, content string, score float64) types.SearchResult {
+	return types.SearchResult{
+		Memory: &types.Memory{ID: id, Content: content, Project: "proj"},
+		Score:  score,
+	}
+}
+
+func TestMergeSearchResults_UnionsByIDAndKeepsMaxScore(t *testing.T) {
+	primary := []types.SearchResult{
+		memoryResult("a", "alpha", 0.9),
+		memoryResult("b", "beta", 0.5),
+	}
+	secondary := []types.SearchResult{
+		memoryResult("b", "beta", 0.8),
+		memoryResult("c", "gamma", 0.1),
+	}
+	got := mergeSearchResults(primary, secondary)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3; got %#v", len(got), got)
+	}
+	if got[0].Memory.ID != "a" || got[1].Memory.ID != "b" || got[2].Memory.ID != "c" {
+		t.Fatalf("order = [%s %s %s], want [a b c]", got[0].Memory.ID, got[1].Memory.ID, got[2].Memory.ID)
+	}
+	if got[1].Score != 0.8 {
+		t.Fatalf("merged score for b = %v, want 0.8", got[1].Score)
+	}
+}
+
+func TestRecallItem_BaselineUsesSingleRecall(t *testing.T) {
+	client := &fakeClient{
+		recallResult: longmemeval.RecallResult{
+			LayerB: &layerb.Summary{Count: 1},
+		},
+	}
+	item := Item{QuestionID: "q1", Question: "How many times did I bake bread?"}
+	got, err := RecallItem(context.Background(), client, "proj-q1", item, Config{Limit: 200})
+	if err != nil {
+		t.Fatalf("RecallItem: %v", err)
+	}
+	if len(client.recallCalls) != 1 {
+		t.Fatalf("recallCalls = %d, want 1", len(client.recallCalls))
+	}
+	if client.recallCalls[0].topK != 200 {
+		t.Fatalf("topK = %d, want 200", client.recallCalls[0].topK)
+	}
+	if len(client.listCalls) != 0 {
+		t.Fatalf("listCalls = %d, want 0", len(client.listCalls))
+	}
+	if got.LayerB == nil || got.LayerB.Count != 1 {
+		t.Fatalf("LayerB = %+v, want server summary", got.LayerB)
+	}
+}
+
+func TestRecallItem_ExhaustiveAggregationUnionsPasses(t *testing.T) {
+	question := "How many times did I visit the doctor?"
+	anchor := longmemeval.ExtractAggregationAnchor(question)
+	client := &fakeClient{
+		recallByQuery: map[string]longmemeval.RecallResult{
+			question: {
+				Results: []types.SearchResult{memoryResult("primary", "visited doctor once", 0.9)},
+			},
+			anchor: {
+				Results: []types.SearchResult{memoryResult("anchor", "doctor appointment follow-up", 0.7)},
+			},
+		},
+		listResult: []types.SearchResult{
+			memoryResult("listed", "Session date: 2024-01-01\nuser: saw doctor again", 0),
+		},
+	}
+	item := Item{QuestionID: "q1", Question: question}
+	got, err := RecallItem(context.Background(), client, "proj-q1", item, Config{
+		Limit:                 200,
+		ExhaustiveAggregation: true,
+	})
+	if err != nil {
+		t.Fatalf("RecallItem: %v", err)
+	}
+	if len(client.recallCalls) != 2 {
+		t.Fatalf("recallCalls = %d, want 2 (primary + anchor)", len(client.recallCalls))
+	}
+	if client.recallCalls[0].topK != 500 || client.recallCalls[1].topK != 500 {
+		t.Fatalf("recall topK = [%d %d], want [500 500]", client.recallCalls[0].topK, client.recallCalls[1].topK)
+	}
+	if len(client.listCalls) != 1 || client.listCalls[0] != projectSweepLimit {
+		t.Fatalf("listCalls = %v, want [%d]", client.listCalls, projectSweepLimit)
+	}
+	if len(got.Results) != 3 {
+		t.Fatalf("len(Results) = %d, want 3", len(got.Results))
+	}
+	if got.LayerB == nil {
+		t.Fatal("LayerB = nil, want client-side summary over merged set")
+	}
+}
+
+func TestRecallItem_ExhaustiveSkipsNonAggregation(t *testing.T) {
+	client := &fakeClient{
+		recallResult: longmemeval.RecallResult{},
+	}
+	item := Item{QuestionID: "q1", Question: "What is Alex's favorite color?"}
+	_, err := RecallItem(context.Background(), client, "proj-q1", item, Config{
+		Limit:                 200,
+		ExhaustiveAggregation: true,
+	})
+	if err != nil {
+		t.Fatalf("RecallItem: %v", err)
+	}
+	if len(client.recallCalls) != 1 || client.recallCalls[0].topK != 200 {
+		t.Fatalf("recallCalls = %+v, want single baseline recall at 200", client.recallCalls)
+	}
+	if len(client.listCalls) != 0 {
+		t.Fatalf("listCalls = %d, want 0", len(client.listCalls))
+	}
+}
+
+func TestRecallItem_ExhaustivePropagatesListError(t *testing.T) {
+	client := &fakeClient{
+		recallByQuery: map[string]longmemeval.RecallResult{
+			"How many times did I visit the doctor?": {Results: nil},
+		},
+		listErr: context.Canceled,
+	}
+	item := Item{QuestionID: "q1", Question: "How many times did I visit the doctor?"}
+	_, err := RecallItem(context.Background(), client, "proj-q1", item, Config{
+		Limit:                 200,
+		ExhaustiveAggregation: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "project sweep") {
+		t.Fatalf("err = %v, want project sweep failure", err)
+	}
+}

--- a/internal/wp05retrofit/recall_exhaustive_test.go
+++ b/internal/wp05retrofit/recall_exhaustive_test.go
@@ -17,6 +17,27 @@ func memoryResult(id, content string, score float64) types.SearchResult {
 	}
 }
 
+func TestMergeSearchResults_PrefersLongerContentOnIDCollision(t *testing.T) {
+	truncated := strings.Repeat("a", 500) + "…"
+	full := strings.Repeat("a", 2000) + " spent playing games"
+	primary := []types.SearchResult{
+		memoryResult("a", truncated, 0.9),
+	}
+	secondary := []types.SearchResult{
+		memoryResult("a", full, 0),
+	}
+	got := mergeSearchResults(primary, secondary)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Score != 0.9 {
+		t.Fatalf("score = %v, want 0.9", got[0].Score)
+	}
+	if got[0].Memory.Content != full {
+		t.Fatalf("content len = %d, want full session len %d", len(got[0].Memory.Content), len(full))
+	}
+}
+
 func TestMergeSearchResults_UnionsByIDAndKeepsMaxScore(t *testing.T) {
 	primary := []types.SearchResult{
 		memoryResult("a", "alpha", 0.9),

--- a/internal/wp05retrofit/retrofit_load.go
+++ b/internal/wp05retrofit/retrofit_load.go
@@ -1,0 +1,45 @@
+package wp05retrofit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/petersimmons1972/engram/internal/types"
+)
+
+// LoadRetrofitMemories returns all memories for a retrofit project as SearchResult
+// values for offline Layer B diagnosis.
+func LoadRetrofitMemories(ctx context.Context, dsn, project string) ([]types.SearchResult, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open retrofit pool: %w", err)
+	}
+	defer pool.Close()
+
+	rows, err := pool.Query(ctx, `
+		SELECT id, content, project
+		FROM memories
+		WHERE project = $1
+		ORDER BY created_at ASC`, project)
+	if err != nil {
+		return nil, fmt.Errorf("query memories: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]types.SearchResult, 0)
+	for rows.Next() {
+		var id, content, proj string
+		if err := rows.Scan(&id, &content, &proj); err != nil {
+			return nil, fmt.Errorf("scan memory: %w", err)
+		}
+		out = append(out, types.SearchResult{
+			Memory: &types.Memory{ID: id, Content: content, Project: proj},
+			Score:  0,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/wp05retrofit/runner.go
+++ b/internal/wp05retrofit/runner.go
@@ -82,6 +82,7 @@ type Config struct {
 	ProjectPrefix         string
 	Limit                 int
 	ExhaustiveAggregation bool
+	SkipIngest            bool
 	ProvenanceTemplate    Provenance
 }
 
@@ -122,8 +123,10 @@ func Run(ctx context.Context, client Client, items []Item, cfg Config, logf Logf
 	results := make([]ItemResult, 0, len(items))
 	for _, item := range items {
 		project := cfg.ProjectPrefix + "-" + item.QuestionID
-		if err := IngestItem(ctx, client, project, item); err != nil {
-			return Bundle{}, fmt.Errorf("ingest item %s: %w", item.QuestionID, err)
+		if !cfg.SkipIngest {
+			if err := IngestItem(ctx, client, project, item); err != nil {
+				return Bundle{}, fmt.Errorf("ingest item %s: %w", item.QuestionID, err)
+			}
 		}
 		recallResult, err := RecallItem(ctx, client, project, item, cfg)
 		if err != nil {

--- a/internal/wp05retrofit/runner.go
+++ b/internal/wp05retrofit/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/petersimmons1972/engram/internal/aggq"
 	"github.com/petersimmons1972/engram/internal/layerb"
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 const (
@@ -73,13 +74,15 @@ type Client interface {
 	Store(context.Context, string, string, []string) (string, error)
 	StoreBatch(context.Context, string, []longmemeval.BatchItem) ([]string, error)
 	RecallFullResult(context.Context, string, string, int) (longmemeval.RecallResult, error)
+	ListProjectMemories(context.Context, string, int) ([]types.SearchResult, error)
 }
 
 // Config controls one retrofit runner execution.
 type Config struct {
-	ProjectPrefix      string
-	Limit              int
-	ProvenanceTemplate Provenance
+	ProjectPrefix         string
+	Limit                 int
+	ExhaustiveAggregation bool
+	ProvenanceTemplate    Provenance
 }
 
 // Logf is the minimal logging seam shared by the runner and CLI.
@@ -122,7 +125,7 @@ func Run(ctx context.Context, client Client, items []Item, cfg Config, logf Logf
 		if err := IngestItem(ctx, client, project, item); err != nil {
 			return Bundle{}, fmt.Errorf("ingest item %s: %w", item.QuestionID, err)
 		}
-		recallResult, err := RecallItem(ctx, client, project, item, cfg.Limit)
+		recallResult, err := RecallItem(ctx, client, project, item, cfg)
 		if err != nil {
 			return Bundle{}, fmt.Errorf("recall item %s: %w", item.QuestionID, err)
 		}
@@ -197,8 +200,14 @@ func sessionTags(item Item, idx int) []string {
 }
 
 // RecallItem runs the full-mode recall path so additive layer_b data survives transport.
-func RecallItem(ctx context.Context, client Client, project string, item Item, limit int) (longmemeval.RecallResult, error) {
-	return client.RecallFullResult(ctx, project, item.Question, limit)
+// When cfg.ExhaustiveAggregation is set and the question is aggregation-shaped, H8
+// deep recall plus anchor and project sweeps are unioned and Layer B is built
+// client-side over the merged candidate set.
+func RecallItem(ctx context.Context, client Client, project string, item Item, cfg Config) (longmemeval.RecallResult, error) {
+	if cfg.ExhaustiveAggregation && longmemeval.IsAggregationQuestion(item.Question) {
+		return recallItemExhaustive(ctx, client, project, item, cfg.Limit)
+	}
+	return client.RecallFullResult(ctx, project, item.Question, cfg.Limit)
 }
 
 // ScoreItem ports duramind's wp05b scorer semantics to the retrofit harness.

--- a/internal/wp05retrofit/runner_test.go
+++ b/internal/wp05retrofit/runner_test.go
@@ -303,6 +303,36 @@ func TestParseIntAnswer(t *testing.T) {
 	}
 }
 
+func TestRun_SkipIngestDoesNotStore(t *testing.T) {
+	items := []longmemeval.Item{
+		{
+			QuestionID:       "q1",
+			Question:         "How many times did I bake something?",
+			Answer:           "1",
+			HaystackSessions: [][]longmemeval.Turn{{{Role: "user", Content: "x"}}},
+		},
+	}
+	client := &fakeClient{
+		recallResult: longmemeval.RecallResult{
+			LayerB: &layerb.Summary{Count: 1, Evidence: []layerb.EventRecord{{ProvenanceSpan: "chars:0-1"}}},
+		},
+	}
+	_, err := Run(context.Background(), client, items, Config{
+		ProjectPrefix: "wp05",
+		Limit:         10,
+		SkipIngest:    true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(client.storeCalls) != 0 || len(client.storeBatchCalls) != 0 {
+		t.Fatalf("store calls = (%d, %d), want (0, 0) with skip-ingest", len(client.storeCalls), len(client.storeBatchCalls))
+	}
+	if len(client.recallCalls) != 1 {
+		t.Fatalf("recallCalls = %d, want 1", len(client.recallCalls))
+	}
+}
+
 func TestRun_PropagatesRecallError(t *testing.T) {
 	items := []longmemeval.Item{
 		{

--- a/internal/wp05retrofit/runner_test.go
+++ b/internal/wp05retrofit/runner_test.go
@@ -11,13 +11,19 @@ import (
 
 	"github.com/petersimmons1972/engram/internal/layerb"
 	"github.com/petersimmons1972/engram/internal/longmemeval"
+	"github.com/petersimmons1972/engram/internal/types"
 )
 
 type fakeClient struct {
 	storeCalls      []storeCall
 	storeBatchCalls []storeBatchCall
+	recallCalls     []recallCall
+	recallByQuery   map[string]longmemeval.RecallResult
+	listCalls       []int
+	listResult      []types.SearchResult
 	recallResult    longmemeval.RecallResult
 	recallErr       error
+	listErr         error
 }
 
 type storeCall struct {
@@ -43,7 +49,24 @@ func (f *fakeClient) StoreBatch(ctx context.Context, project string, items []lon
 }
 
 func (f *fakeClient) RecallFullResult(ctx context.Context, project, query string, topK int) (longmemeval.RecallResult, error) {
-	return f.recallResult, f.recallErr
+	f.recallCalls = append(f.recallCalls, recallCall{query: query, topK: topK})
+	if f.recallErr != nil {
+		return longmemeval.RecallResult{}, f.recallErr
+	}
+	if f.recallByQuery != nil {
+		if result, ok := f.recallByQuery[query]; ok {
+			return result, nil
+		}
+	}
+	return f.recallResult, nil
+}
+
+func (f *fakeClient) ListProjectMemories(ctx context.Context, project string, limit int) ([]types.SearchResult, error) {
+	f.listCalls = append(f.listCalls, limit)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listResult, nil
 }
 
 func TestScoreItem_HappyPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements founder Option A from `RECALL-POLICY-DECISION-BRIEF.md`:

- `--exhaustive-aggregation` on `wp05-retrofit-runner`: for aggregation questions, unions H8 topK=500 primary + anchor recall with `memory_list` project sweep (limit 500), then builds Layer B client-side over the merged candidate set
- `longmemeval.Client.ListProjectMemories` wraps `memory_list` MCP
- `--skip-ingest` for recall-only re-measurement on existing ingested projects
- `wp05-trace -exhaustive-aggregation` for diagnostic comparison

Provenance records `exhaustive_aggregation` in feature flags when enabled.

## Measurement (133-item, skip-ingest on `wp05-retrofit-2026-07-04c`)

| Metric | Baseline | Exhaustive | Delta |
|--------|----------|------------|-------|
| Fire rate (79-item apples-to-apples) | 18/79 (22.8%) | 18/79 (22.8%) | 0.0pp |
| vs greenfield | 86.1% | 86.1% | 63.3pp gap unchanged |

Recall breadth improves (e.g. `28dc39ac`: 32→39 sessions) but Layer B fire outcomes are identical. Residual gap is downstream Layer B gate failure, not recall breadth alone.

Artifacts: `duramind/results/wp05-retrofit-exhaustive-2026-07-05/`

## Test plan

- [x] `go test ./internal/wp05retrofit/... -race`
- [x] `go test ./internal/longmemeval/...` (ListProjectMemories)
- [x] 133-item local re-measurement with `--exhaustive-aggregation --skip-ingest`