### PR TITLE
fix: require explicit project ttl for quick store

### DIFF
--- a/cmd/longmemeval/ingest.go
+++ b/cmd/longmemeval/ingest.go
@@ -83,8 +83,8 @@ func ingestOne(ctx context.Context, cfg *Config, restClient *longmemeval.RestCli
 
 	project := projectName(cfg.RunID, item.QuestionID)
 
-	// #837: compute expiresAt once per question. Passed to every QuickStore call;
-	// SetProjectTTL is idempotent (ON CONFLICT DO UPDATE) so repeated upserts are safe.
+	// #837/#1329: compute project expiry once per question. Passed to every
+	// QuickStore call; SetProjectTTL is idempotent so repeated upserts are safe.
 	var expiresAt *time.Time
 	if cfg.ScratchTTL > 0 {
 		t := time.Now().UTC().Add(cfg.ScratchTTL)

--- a/cmd/longmemeval/ingest_test.go
+++ b/cmd/longmemeval/ingest_test.go
@@ -122,7 +122,7 @@ func TestIngestOne_EmptySessionsSkipped(t *testing.T) {
 }
 
 // TestIngestOne_ScratchTTL_PassesExpiresAt verifies that when ScratchTTL > 0,
-// ingestOne passes a non-nil expires_at in the QuickStore request body.
+// ingestOne requests explicit project-level TTL in the QuickStore request body.
 func TestIngestOne_ScratchTTL_PassesExpiresAt(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -149,24 +149,30 @@ func TestIngestOne_ScratchTTL_PassesExpiresAt(t *testing.T) {
 		t.Fatalf("expected done, got %s: %s", entry.Status, entry.Error)
 	}
 
-	raw, ok := gotBody["expires_at"]
+	raw, ok := gotBody["project_expires_at"]
 	if !ok {
-		t.Fatal("expires_at missing from QuickStore request body")
+		t.Fatal("project_expires_at missing from QuickStore request body")
+	}
+	if gotBody["set_project_ttl"] != true {
+		t.Fatal("set_project_ttl must be true when ScratchTTL is enabled")
+	}
+	if _, ok := gotBody["expires_at"]; ok {
+		t.Fatal("expires_at must not be sent for project TTL")
 	}
 	parsed, err := time.Parse(time.RFC3339, raw.(string))
 	if err != nil {
-		t.Fatalf("expires_at is not RFC3339: %v", err)
+		t.Fatalf("project_expires_at is not RFC3339: %v", err)
 	}
-	// expires_at is serialized as RFC3339 (second precision), so truncate to seconds for comparison.
+	// project_expires_at is serialized as RFC3339 (second precision), so truncate to seconds for comparison.
 	expectedMin := before.Add(168 * time.Hour).Truncate(time.Second)
 	expectedMax := after.Add(168 * time.Hour).Add(time.Second) // +1s to account for truncation
 	if parsed.Before(expectedMin) || parsed.After(expectedMax) {
-		t.Errorf("expires_at %v outside expected range [%v, %v]", parsed, expectedMin, expectedMax)
+		t.Errorf("project_expires_at %v outside expected range [%v, %v]", parsed, expectedMin, expectedMax)
 	}
 }
 
 // TestIngestOne_NoScratchTTL_OmitsExpiresAt verifies that when ScratchTTL == 0,
-// expires_at is absent from the QuickStore request body.
+// project TTL fields are absent from the QuickStore request body.
 func TestIngestOne_NoScratchTTL_OmitsExpiresAt(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -191,6 +197,12 @@ func TestIngestOne_NoScratchTTL_OmitsExpiresAt(t *testing.T) {
 	}
 	if _, ok := gotBody["expires_at"]; ok {
 		t.Error("expires_at must be absent from QuickStore body when ScratchTTL is 0")
+	}
+	if _, ok := gotBody["set_project_ttl"]; ok {
+		t.Error("set_project_ttl must be absent from QuickStore body when ScratchTTL is 0")
+	}
+	if _, ok := gotBody["project_expires_at"]; ok {
+		t.Error("project_expires_at must be absent from QuickStore body when ScratchTTL is 0")
 	}
 }
 

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -142,9 +142,9 @@ type Config struct {
 	ExclusiveBackend bool   // guard the vLLM endpoint with a PID-liveness lockfile (default true)
 	BackendLockDir   string // override lock file directory (default: $XDG_RUNTIME_DIR/lme or /tmp/lme)
 
-	// #754/#837: scratch TTL. Applied at ingest time via the /quick-store
-	// expires_at field so the `prune` subcommand can sweep expired lme-*
-	// projects later. Zero means durable (no expiry).
+	// #754/#837/#1329: scratch TTL. Applied at ingest time via explicit
+	// /quick-store project TTL fields so the `prune` subcommand can sweep
+	// expired lme-* projects later. Zero means durable (no expiry).
 	ScratchTTL time.Duration
 
 	// AtomMode: when true, fetch extracted preference atoms for the project

--- a/internal/longmemeval/engram.go
+++ b/internal/longmemeval/engram.go
@@ -806,8 +806,9 @@ func NewRestClient(baseURL, token string) *RestClient {
 }
 
 // QuickStore stores a single memory via POST /quick-store and returns its ID.
-// When expiresAt is non-nil, the server stamps project_ttl so the project can
-// be swept later by lme prune. Retries on 429 and 5xx with exponential backoff.
+// When expiresAt is non-nil, QuickStore explicitly requests project-level TTL
+// so the scratch project can be swept later by lme prune. Retries on 429 and
+// 5xx with exponential backoff.
 func (r *RestClient) QuickStore(ctx context.Context, project, content string, tags []string, expiresAt *time.Time) (string, error) {
 	body := map[string]any{
 		"content": content,
@@ -815,7 +816,8 @@ func (r *RestClient) QuickStore(ctx context.Context, project, content string, ta
 		"tags":    tags,
 	}
 	if expiresAt != nil {
-		body["expires_at"] = expiresAt.UTC().Format(time.RFC3339)
+		body["set_project_ttl"] = true
+		body["project_expires_at"] = expiresAt.UTC().Format(time.RFC3339)
 	}
 	data, err := json.Marshal(body)
 	if err != nil {

--- a/internal/longmemeval/engram_test.go
+++ b/internal/longmemeval/engram_test.go
@@ -295,7 +295,7 @@ func TestRestClient_QuickRecall_ObjectErrorResponse(t *testing.T) {
 }
 
 // TestRestClient_QuickStore_ExpiresAt_Set verifies that a non-nil expiresAt is
-// serialized as "expires_at" (RFC3339) in the POST body.
+// serialized as explicit project-level TTL intent in the POST body.
 func TestRestClient_QuickStore_ExpiresAt_Set(t *testing.T) {
 	future := time.Now().UTC().Add(72 * time.Hour)
 	var gotBody map[string]any
@@ -316,25 +316,31 @@ func TestRestClient_QuickStore_ExpiresAt_Set(t *testing.T) {
 	if id != "mem-ttl" {
 		t.Errorf("id = %q, want mem-ttl", id)
 	}
-	raw, ok := gotBody["expires_at"]
+	raw, ok := gotBody["project_expires_at"]
 	if !ok {
-		t.Fatal("expires_at field missing from request body")
+		t.Fatal("project_expires_at field missing from request body")
+	}
+	if gotBody["set_project_ttl"] != true {
+		t.Fatal("set_project_ttl must be true when project_expires_at is sent")
+	}
+	if _, ok := gotBody["expires_at"]; ok {
+		t.Fatal("expires_at must not be sent for project TTL")
 	}
 	parsed, err := time.Parse(time.RFC3339, raw.(string))
 	if err != nil {
-		t.Fatalf("expires_at is not RFC3339: %v", err)
+		t.Fatalf("project_expires_at is not RFC3339: %v", err)
 	}
 	delta := parsed.Sub(future)
 	if delta < 0 {
 		delta = -delta
 	}
 	if delta > 2*time.Second {
-		t.Errorf("expires_at delta = %v, want < 2s", delta)
+		t.Errorf("project_expires_at delta = %v, want < 2s", delta)
 	}
 }
 
 // TestRestClient_QuickStore_ExpiresAt_Nil verifies that a nil expiresAt does NOT
-// include an "expires_at" key in the POST body (not null — fully absent).
+// include any project TTL keys in the POST body (not null — fully absent).
 func TestRestClient_QuickStore_ExpiresAt_Nil(t *testing.T) {
 	var gotBody map[string]any
 
@@ -356,6 +362,12 @@ func TestRestClient_QuickStore_ExpiresAt_Nil(t *testing.T) {
 	}
 	if _, ok := gotBody["expires_at"]; ok {
 		t.Error("expires_at must be absent from request body when expiresAt is nil")
+	}
+	if _, ok := gotBody["set_project_ttl"]; ok {
+		t.Error("set_project_ttl must be absent from request body when expiresAt is nil")
+	}
+	if _, ok := gotBody["project_expires_at"]; ok {
+		t.Error("project_expires_at must be absent from request body when expiresAt is nil")
 	}
 }
 

--- a/internal/mcp/quick_store_handler_test.go
+++ b/internal/mcp/quick_store_handler_test.go
@@ -261,10 +261,18 @@ type ttlCaptureBackend struct {
 	mu              sync.Mutex
 	capturedProject string
 	capturedExpires *time.Time
+	beginCalls      int
 	returnErr       error
 }
 
 var _ db.Backend = (*ttlCaptureBackend)(nil)
+
+func (b *ttlCaptureBackend) Begin(_ context.Context) (db.Tx, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.beginCalls++
+	return noopTx{}, nil
+}
 
 func (b *ttlCaptureBackend) SetProjectTTL(_ context.Context, project string, _ time.Time, expiresAt *time.Time) error {
 	b.mu.Lock()
@@ -405,6 +413,60 @@ func TestQuickStoreHandler_ProjectTTL_RequiresExpiresAt(t *testing.T) {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called when project_expires_at is absent")
+	require.Zero(t, backend.beginCalls, "memory must not be stored when project_expires_at is absent")
+}
+
+// TestQuickStoreHandler_ProjectTTL_RequiresExplicitFlag verifies that a project
+// expiry timestamp without the explicit TTL flag is rejected before storing.
+func TestQuickStoreHandler_ProjectTTL_RequiresExplicitFlag(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	future := time.Now().UTC().Add(48 * time.Hour)
+	body, _ := json.Marshal(map[string]any{
+		"content":            "lme session content",
+		"project":            "lme-run1-q001",
+		"project_expires_at": future.Format(time.RFC3339),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called without set_project_ttl")
+	require.Zero(t, backend.beginCalls, "memory must not be stored without set_project_ttl")
+}
+
+// TestQuickStoreHandler_ProjectTTL_RequiresFutureTimestamp verifies that a past
+// project_expires_at is rejected before storing.
+func TestQuickStoreHandler_ProjectTTL_RequiresFutureTimestamp(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	body, _ := json.Marshal(map[string]any{
+		"content":            "lme session content",
+		"project":            "lme-run1-q001",
+		"set_project_ttl":    true,
+		"project_expires_at": past.Format(time.RFC3339),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called for past project_expires_at")
+	require.Zero(t, backend.beginCalls, "memory must not be stored for past project_expires_at")
 }
 
 // TestQuickStoreHandler_ExpiresAt_Absent verifies that omitting expires_at stores

--- a/internal/mcp/quick_store_handler_test.go
+++ b/internal/mcp/quick_store_handler_test.go
@@ -293,7 +293,9 @@ func newQuickStoreServerWithBackend(t *testing.T, backend db.Backend) *Server {
 }
 
 // TestQuickStoreHandler_ExpiresAt_FutureTimestamp verifies that a POST with a
-// future expires_at stores the memory and calls SetProjectTTL with the given time.
+// future expires_at stores the memory without mutating project-level TTL. The
+// field describes a memory write, not permission to make the whole project
+// prune-eligible.
 func TestQuickStoreHandler_ExpiresAt_FutureTimestamp(t *testing.T) {
 	backend := &ttlCaptureBackend{}
 	s := newQuickStoreServerWithBackend(t, backend)
@@ -319,13 +321,8 @@ func TestQuickStoreHandler_ExpiresAt_FutureTimestamp(t *testing.T) {
 
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	require.Equal(t, "lme-run1-q001", backend.capturedProject, "SetProjectTTL should be called with the correct project")
-	require.NotNil(t, backend.capturedExpires, "SetProjectTTL should receive a non-nil expiresAt")
-	delta := backend.capturedExpires.Sub(future)
-	if delta < 0 {
-		delta = -delta
-	}
-	require.Less(t, delta, 2*time.Second, "captured expiresAt should be within 2s of the requested value")
+	require.Empty(t, backend.capturedProject, "expires_at alone must not call SetProjectTTL")
+	require.Nil(t, backend.capturedExpires, "expires_at alone must not stamp project_ttl")
 }
 
 // TestQuickStoreHandler_ExpiresAt_PastTimestamp verifies that a past expires_at
@@ -353,6 +350,63 @@ func TestQuickStoreHandler_ExpiresAt_PastTimestamp(t *testing.T) {
 	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called when expires_at is in the past")
 }
 
+// TestQuickStoreHandler_ProjectTTL_ExplicitIntent verifies that project-level
+// TTL is only stamped when callers use the explicit project TTL fields.
+func TestQuickStoreHandler_ProjectTTL_ExplicitIntent(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	future := time.Now().UTC().Add(48 * time.Hour)
+	body, _ := json.Marshal(map[string]any{
+		"content":            "lme session content",
+		"project":            "lme-run1-q001",
+		"tags":               []string{"lme"},
+		"set_project_ttl":    true,
+		"project_expires_at": future.Format(time.RFC3339),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, "lme-run1-q001", backend.capturedProject, "SetProjectTTL should be called with the correct project")
+	require.NotNil(t, backend.capturedExpires, "SetProjectTTL should receive a non-nil project_expires_at")
+	delta := backend.capturedExpires.Sub(future)
+	if delta < 0 {
+		delta = -delta
+	}
+	require.Less(t, delta, 2*time.Second, "captured expiresAt should be within 2s of the requested value")
+}
+
+// TestQuickStoreHandler_ProjectTTL_RequiresExpiresAt verifies that setting the
+// project TTL flag without a timestamp is rejected before the memory is stored.
+func TestQuickStoreHandler_ProjectTTL_RequiresExpiresAt(t *testing.T) {
+	backend := &ttlCaptureBackend{}
+	s := newQuickStoreServerWithBackend(t, backend)
+
+	body, _ := json.Marshal(map[string]any{
+		"content":         "lme session content",
+		"project":         "lme-run1-q001",
+		"set_project_ttl": true,
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called when project_expires_at is absent")
+}
+
 // TestQuickStoreHandler_ExpiresAt_Absent verifies that omitting expires_at stores
 // the memory successfully without calling SetProjectTTL.
 func TestQuickStoreHandler_ExpiresAt_Absent(t *testing.T) {
@@ -376,17 +430,18 @@ func TestQuickStoreHandler_ExpiresAt_Absent(t *testing.T) {
 	require.Empty(t, backend.capturedProject, "SetProjectTTL must not be called when expires_at is absent")
 }
 
-// TestQuickStoreHandler_ExpiresAt_TTLError verifies that a SetProjectTTL error
-// does not fail the store — the response is still 200 (best-effort semantics).
-func TestQuickStoreHandler_ExpiresAt_TTLError(t *testing.T) {
+// TestQuickStoreHandler_ProjectTTL_TTLError verifies that a SetProjectTTL error
+// does not fail the store when project TTL was explicitly requested.
+func TestQuickStoreHandler_ProjectTTL_TTLError(t *testing.T) {
 	backend := &ttlCaptureBackend{returnErr: errors.New("simulated TTL write failure")}
 	s := newQuickStoreServerWithBackend(t, backend)
 
 	future := time.Now().UTC().Add(24 * time.Hour)
 	body, _ := json.Marshal(map[string]any{
-		"content":    "lme session content",
-		"project":    "lme-run1-q002",
-		"expires_at": future.Format(time.RFC3339),
+		"content":            "lme session content",
+		"project":            "lme-run1-q002",
+		"set_project_ttl":    true,
+		"project_expires_at": future.Format(time.RFC3339),
 	})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/quick-store", bytes.NewReader(body))

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1852,6 +1852,8 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 // POST /quick-store
 // Authorization: Bearer <token>
 // {"content":"...","project":"...","tags":[...],"importance":N}.
+// Project-level TTL for prune workflows requires explicit opt-in:
+// {"set_project_ttl":true,"project_expires_at":"..."}.
 func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1859,11 +1861,13 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Content    string     `json:"content"`
-		Project    string     `json:"project"`
-		Tags       []string   `json:"tags"`
-		Importance int        `json:"importance"`
-		ExpiresAt  *time.Time `json:"expires_at"`
+		Content          string     `json:"content"`
+		Project          string     `json:"project"`
+		Tags             []string   `json:"tags"`
+		Importance       int        `json:"importance"`
+		ExpiresAt        *time.Time `json:"expires_at"`
+		SetProjectTTL    bool       `json:"set_project_ttl"`
+		ProjectExpiresAt *time.Time `json:"project_expires_at"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body")
@@ -1885,6 +1889,18 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.ExpiresAt != nil && !body.ExpiresAt.After(time.Now()) {
 		writeJSONError(w, http.StatusBadRequest, "expires_at must be a future timestamp")
+		return
+	}
+	if body.SetProjectTTL && body.ProjectExpiresAt == nil {
+		writeJSONError(w, http.StatusBadRequest, "project_expires_at is required when set_project_ttl is true")
+		return
+	}
+	if !body.SetProjectTTL && body.ProjectExpiresAt != nil {
+		writeJSONError(w, http.StatusBadRequest, "set_project_ttl must be true when project_expires_at is provided")
+		return
+	}
+	if body.ProjectExpiresAt != nil && !body.ProjectExpiresAt.After(time.Now()) {
+		writeJSONError(w, http.StatusBadRequest, "project_expires_at must be a future timestamp")
 		return
 	}
 
@@ -1935,12 +1951,13 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": id})
 
-	// #837: if expires_at was provided, stamp project_ttl via the engine pool.
+	// Project TTL is a project-level deletion signal, so require explicit
+	// opt-in instead of deriving it from memory-level expires_at (#1329).
 	// Best-effort: failure is logged but does not affect the store response.
-	if body.ExpiresAt != nil {
+	if body.SetProjectTTL {
 		if h, poolErr := s.pool.Get(r.Context(), project); poolErr != nil {
 			slog.Warn("quick-store: pool.Get failed for SetProjectTTL", "project", project, "err", poolErr)
-		} else if ttlErr := h.Engine.Backend().SetProjectTTL(r.Context(), project, time.Now().UTC(), body.ExpiresAt); ttlErr != nil {
+		} else if ttlErr := h.Engine.Backend().SetProjectTTL(r.Context(), project, time.Now().UTC(), body.ProjectExpiresAt); ttlErr != nil {
 			slog.Warn("quick-store: SetProjectTTL failed", "project", project, "err", ttlErr)
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #1329.

Separates memory-level `expires_at` from project-level prune TTL in `/quick-store`:
- `expires_at` alone no longer writes `project_ttl`.
- project TTL writes require explicit `set_project_ttl: true` plus `project_expires_at`.
- LongMemEval scratch ingest now sends the explicit project TTL fields so `lme prune` behavior is preserved.

## Verification

TDD red before implementation:
- `go test ./internal/mcp -run 'TestQuickStoreHandler_ExpiresAt_FutureTimestamp|TestQuickStoreHandler_ProjectTTL' -count=1` failed because plain `expires_at` still called `SetProjectTTL` and explicit fields were unsupported.

Green after implementation:
- `go test ./internal/mcp -run 'TestQuickStoreHandler_ExpiresAt_FutureTimestamp|TestQuickStoreHandler_ProjectTTL' -count=1`
- `go test ./internal/mcp ./internal/longmemeval ./cmd/longmemeval -run 'TestQuickStoreHandler|TestRestClient_QuickStore_ExpiresAt|TestIngestOne_ScratchTTL|TestIngestOne_NoScratchTTL' -count=1`
- `go test ./internal/mcp ./internal/longmemeval ./cmd/longmemeval -count=1`
- `go test ./... -count=1 -race`
- `git diff --check`

## Notes

No containers or runtime pods were modified. Manifest First does not apply to this code-only API/client change.
