### PR TITLE
fix: reject caller atom ids on rest store

### DIFF
--- a/internal/mcp/atoms_handler.go
+++ b/internal/mcp/atoms_handler.go
@@ -79,6 +79,10 @@ func (s *Server) handleAtomStore(w http.ResponseWriter, r *http.Request, pg *db.
 		writeJSONError(w, http.StatusBadRequest, "atom is required for action=store")
 		return
 	}
+	if req.Atom.ID != "" {
+		writeJSONError(w, http.StatusBadRequest, "atom.id must be omitted for action=store")
+		return
+	}
 	req.Atom.Project = req.Project
 
 	if insErr := pg.InsertAtom(r.Context(), req.Atom); insErr != nil {

--- a/internal/mcp/atoms_handler_test.go
+++ b/internal/mcp/atoms_handler_test.go
@@ -65,6 +65,44 @@ func atomEmbeddingText(t *testing.T, ctx context.Context, pool *pgxpool.Pool, at
 	return got
 }
 
+func atomRowCount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, atomID, project string) int {
+	t.Helper()
+	var got int
+	err := pool.QueryRow(ctx, `SELECT count(*) FROM atoms WHERE id = $1 AND project = $2`, atomID, project).Scan(&got)
+	require.NoError(t, err)
+	return got
+}
+
+func atomEmbeddingRowCount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, atomID string) int {
+	t.Helper()
+	var got int
+	err := pool.QueryRow(ctx, `SELECT count(*) FROM atom_embeddings WHERE atom_id = $1`, atomID).Scan(&got)
+	require.NoError(t, err)
+	return got
+}
+
+func TestAtomsStoreRejectsCallerSuppliedIDBeforeSideEffects(t *testing.T) {
+	ctx := context.Background()
+	dsn := testAtomsDSN(t)
+	project := uniqueAtomsProject("atoms-id")
+
+	pool := NewTestPoolWithDSN(t, ctx, dsn, project)
+	s := &Server{pool: pool, cfg: testConfig()}
+
+	queryPool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(queryPool.Close)
+
+	callerID := "caller-controlled-id-" + project
+	at := testAtom("mallory", "coffee")
+	at.ID = callerID
+	resp := postAtomsStore(t, s, project, at, make([]float32, 1024))
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Zero(t, atomRowCount(t, ctx, queryPool, callerID, project), "rejected caller ID must not insert an atom row")
+	require.Zero(t, atomEmbeddingRowCount(t, ctx, queryPool, callerID), "rejected caller ID must not insert an embedding row")
+}
+
 func TestAtomsStoreRejectsCrossProjectCallerSuppliedID(t *testing.T) {
 	ctx := context.Background()
 	dsn := testAtomsDSN(t)
@@ -104,4 +142,5 @@ func TestAtomsStoreRejectsCrossProjectCallerSuppliedID(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, attackResp.Code)
 	after := atomEmbeddingText(t, ctx, queryPool, created.ID)
 	require.Equal(t, before, after, "cross-project atom ID reuse must not mutate the existing embedding")
+	require.Zero(t, atomRowCount(t, ctx, queryPool, created.ID, projectB), "rejected cross-project request must not insert an atom row")
 }

--- a/internal/mcp/atoms_handler_test.go
+++ b/internal/mcp/atoms_handler_test.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/stretchr/testify/require"
+)
+
+func testAtomsDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	return dsn
+}
+
+func uniqueAtomsProject(base string) string {
+	return fmt.Sprintf("%s-%d", base, time.Now().UnixNano())
+}
+
+func testAtom(subject, value string) *atom.Atom {
+	return &atom.Atom{
+		Type:       atom.TypePreference,
+		Subject:    subject,
+		Predicate:  "prefers",
+		Value:      value,
+		Statement:  fmt.Sprintf("%s prefers %s.", subject, value),
+		Scope:      atom.ScopeGlobal,
+		Confidence: 0.9,
+	}
+}
+
+func postAtomsStore(t *testing.T, s *Server, project string, at *atom.Atom, embedding []float32) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"action":    "store",
+		"project":   project,
+		"atom":      at,
+		"embedding": embedding,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/atoms", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handleAtoms(w, req)
+	return w
+}
+
+func atomEmbeddingText(t *testing.T, ctx context.Context, pool *pgxpool.Pool, atomID string) string {
+	t.Helper()
+	var got string
+	err := pool.QueryRow(ctx, `SELECT embedding::text FROM atom_embeddings WHERE atom_id = $1`, atomID).Scan(&got)
+	require.NoError(t, err)
+	return got
+}
+
+func TestAtomsStoreRejectsCrossProjectCallerSuppliedID(t *testing.T) {
+	ctx := context.Background()
+	dsn := testAtomsDSN(t)
+	projectA := uniqueAtomsProject("atoms-a")
+	projectB := uniqueAtomsProject("atoms-b")
+
+	pool := NewTestPoolWithDSN(t, ctx, dsn, projectA)
+	t.Cleanup(func() {
+		if h, err := pool.Get(ctx, projectB); err == nil && h != nil && h.Engine != nil {
+			h.Engine.Close()
+		}
+	})
+	s := &Server{pool: pool, cfg: testConfig()}
+
+	initial := make([]float32, 1024)
+	initial[0] = 0.25
+	createResp := postAtomsStore(t, s, projectA, testAtom("alice", "tea"), initial)
+	require.Equal(t, http.StatusCreated, createResp.Code)
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(createResp.Body.Bytes(), &created))
+	require.NotEmpty(t, created.ID)
+
+	queryPool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(queryPool.Close)
+	before := atomEmbeddingText(t, ctx, queryPool, created.ID)
+
+	attackerAtom := testAtom("mallory", "coffee")
+	attackerAtom.ID = created.ID
+	replacement := make([]float32, 1024)
+	replacement[0] = 0.99
+	attackResp := postAtomsStore(t, s, projectB, attackerAtom, replacement)
+
+	require.Equal(t, http.StatusBadRequest, attackResp.Code)
+	after := atomEmbeddingText(t, ctx, queryPool, created.ID)
+	require.Equal(t, before, after, "cross-project atom ID reuse must not mutate the existing embedding")
+}


### PR DESCRIPTION
## Summary

Closes #1327.

Prevents cross-project atom embedding mutation through `/atoms` REST storage:
- rejects caller-supplied `atom.id` for `action=store` before insert or embedding writes
- keeps server-side ID generation via `InsertAtom`
- adds a Postgres-backed handler regression proving project B cannot reuse project A's atom ID to mutate project A's embedding

## Verification

TDD red before implementation:
- `TEST_DATABASE_URL='postgresql://engram:ci-only-not-production@localhost:15432/engram_test?sslmode=disable' go test ./internal/mcp -run TestAtomsStoreRejectsCrossProjectCallerSuppliedID -count=1 -v` failed with expected 400, actual 201.

Green after implementation:
- `TEST_DATABASE_URL='postgresql://engram:ci-only-not-production@localhost:15432/engram_test?sslmode=disable' go test ./internal/mcp -run TestAtomsStoreRejectsCrossProjectCallerSuppliedID -count=1 -v`
- `TEST_DATABASE_URL='postgresql://engram:ci-only-not-production@localhost:15432/engram_test?sslmode=disable' go test ./internal/mcp ./internal/db -run 'TestAtoms|TestAtom' -count=1`
- `go test ./internal/mcp -run 'TestAtoms|TestAtom' -count=1` (skips DB integration when env absent)
- `go test ./internal/mcp ./internal/db -count=1`
- `go test ./... -count=1 -race`
- `git diff --check`

## Runtime/Container Notes

No production runtime or manifests were changed. I attempted to use the repo's existing test-postgres compose profile, but a stopped pre-existing `engram-test-postgres` name conflicted and port 5433 was already owned by an existing QA Postgres container. I used that existing QA container for integration verification and removed only the stray compose network created by the failed test-profile start. No containers or volumes were removed.
