### PR TITLE
fix: make instinct healthcheck timestamp parsing portable

### DIFF
--- a/ops/healthcheck.sh
+++ b/ops/healthcheck.sh
@@ -15,7 +15,7 @@ fi
 
 # Extract the most recent ISO-8601 timestamp from log lines of the form:
 #   instinct: ... [2026-04-22T10:00:00Z]
-last_ts=$(grep -oP '\[\K\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z(?=\])' "$LOG" 2>/dev/null | tail -1 || :)
+last_ts=$(sed -n 's/.*\[\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z\)\].*/\1/p' "$LOG" | tail -1 || :)
 
 if [[ -z "$last_ts" ]]; then
     echo "WARN: no timestamped instinct runs found in $LOG"
@@ -34,4 +34,3 @@ fi
 
 echo "OK: instinct last ran ${gap}s ago"
 echo "Last: $last_ts"
-exit 0

--- a/ops/healthcheck.test.sh
+++ b/ops/healthcheck.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Test suite for ops/healthcheck.sh
+# Usage: bash ops/healthcheck.test.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/healthcheck.sh"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" -eq "$actual" ]; then
+    echo "PASS: $desc (exit=$actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected=$expected got=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (missing '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/state/instinct"
+
+cat >"$tmp/bin/grep" <<'FAKE_GREP'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *P*) echo "fake grep: -P is unavailable" >&2; exit 2 ;;
+  esac
+done
+exec /usr/bin/grep "$@"
+FAKE_GREP
+chmod +x "$tmp/bin/grep"
+
+now_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+printf 'instinct: ok [%s]\n' "$now_ts" >"$tmp/state/instinct/run.log"
+
+out=$(PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" INSTINCT_MAX_GAP=7200 bash "$SCRIPT" 2>&1)
+rc=$?
+assert_exit "healthcheck works without grep -P" 0 "$rc"
+assert_contains "reports healthy status" "OK: instinct last ran" "$out"
+assert_contains "reports extracted timestamp" "Last: $now_ts" "$out"
+
+echo
+echo "--- ${PASS} passed, ${FAIL} failed ---"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- replaces GNU-only `grep -P` timestamp extraction in `ops/healthcheck.sh` with portable `sed`
- adds a shell regression test with fake grep rejecting `-P`
- removes the script's final unconditional success `exit 0` while preserving successful fallthrough

Closes #1335.

## Verification
- `bash ops/healthcheck.test.sh`
- `bash -n ops/healthcheck.sh ops/healthcheck.test.sh`
- `git diff --check`
- pre-commit `checkin-lint` passed during commit
