### PR TITLE
fix: run instinct service via installed go binary

### DIFF
--- a/ops/instinct-service.test.sh
+++ b/ops/instinct-service.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT="${ROOT}/ops/instinct.service"
+
+failures=0
+
+assert_contains() {
+  local description="$1"
+  local needle="$2"
+
+  if ! grep -qF "$needle" "$UNIT"; then
+    echo "not ok - ${description}: missing ${needle}"
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok - ${description}"
+}
+
+assert_not_contains() {
+  local description="$1"
+  local needle="$2"
+
+  if grep -qF "$needle" "$UNIT"; then
+    echo "not ok - ${description}: found ${needle}"
+    failures=$((failures + 1))
+    return
+  fi
+
+  echo "ok - ${description}"
+}
+
+assert_contains "service runs installed Go consolidator" "ExecStart=%h/bin/instinct-consolidate"
+assert_not_contains "service does not reference removed Python module" "python3 -m instinct.run"
+assert_not_contains "service does not set stale Python path" "PYTHONPATH="
+
+if (( failures > 0 )); then
+  echo "FAIL: ${failures} instinct.service contract assertion(s) failed"
+  exit 1
+fi
+
+echo "PASS: instinct.service contract"

--- a/ops/instinct.service
+++ b/ops/instinct.service
@@ -18,11 +18,10 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/env python3 -m instinct.run
+ExecStart=%h/bin/instinct-consolidate
 WorkingDirectory=%h
 StandardOutput=append:%S/instinct/run.log
 StandardError=append:%S/instinct/run.log
-Environment=PYTHONPATH=%h/projects/engram-go/consolidator
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

Closes #1333.

Updates the optional timer-mode `ops/instinct.service` to run the maintained Go consolidator installed by `make install-instinct` instead of the removed Python module path. Removes the stale `PYTHONPATH` from the unit and adds a focused service contract regression test.

## Verification

TDD red before implementation:
- `bash ops/instinct-service.test.sh` failed against the original unit because it still used `python3 -m instinct.run` and `PYTHONPATH`.

Green after implementation:
- `bash ops/instinct-service.test.sh`
- `systemd-analyze verify ops/instinct.service`
- `go test ./cmd/instinct ./cmd/audit -count=1`
- temporary-HOME install check: `HOME=$tmp_home GOPATH=/home/psimmons/go GOMODCACHE=/home/psimmons/go/pkg/mod make install-instinct` with `$tmp_home/sdk -> /home/psimmons/sdk` and disposable `$tmp_home/bin`
- `bash -n ops/instinct-service.test.sh`
- non-LME package pass: `go test $(go list ./... | grep -Ev '/(cmd/longmemeval|internal/longmemeval|cmd/wp05-retrofit-runner|internal/wp05retrofit)$') -count=1`\n- `git diff --check`\n- pre-commit checkin-lint passed\n\n## Runtime/Container Notes\n\nNo running service, pod, database, or container was modified. This is a manifest/config-only systemd unit fix. The install verification used a temporary HOME and removed the temporary output directory afterward; no Docker resources were created.\n