### PR TITLE
fix: bound rest json request bodies

### DIFF
--- a/internal/mcp/atoms_handler.go
+++ b/internal/mcp/atoms_handler.go
@@ -12,7 +12,6 @@ package mcp
 // are not yet in the db.Backend interface (Milestone 1 minimal footprint).
 
 import (
-	"encoding/json"
 	"log/slog"
 	"net/http"
 
@@ -38,13 +37,16 @@ func (s *Server) handleAtoms(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req atomsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+	if !decodeLimitedJSON(w, r, &req, atomsBodyLimitBytes) {
 		return
 	}
 
 	if req.Project == "" {
 		writeJSONError(w, http.StatusBadRequest, "project is required")
+		return
+	}
+	if req.Action == "store" && s.cfg.EmbedDimensions > 0 && len(req.Embedding) > s.cfg.EmbedDimensions {
+		writeJSONError(w, http.StatusBadRequest, "embedding dimension exceeds configured limit")
 		return
 	}
 

--- a/internal/mcp/atoms_handler_test.go
+++ b/internal/mcp/atoms_handler_test.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomsRequestBodyLimit(t *testing.T) {
+	s := &Server{}
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/atoms",
+		bytes.NewReader([]byte(fmt.Sprintf(
+			`{"action":"store","project":"global","padding":"%s"}`,
+			string(bytes.Repeat([]byte("x"), atomsBodyLimitBytes)),
+		))),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleAtoms(w, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestAtomsEmbeddingDimensionLimit(t *testing.T) {
+	s := &Server{cfg: Config{EmbedDimensions: 3}}
+	body, err := json.Marshal(map[string]any{
+		"action":    "store",
+		"project":   "global",
+		"atom":      map[string]any{"type": "preference", "subject": "editor", "predicate": "prefers", "object": "vim"},
+		"embedding": []float32{0.1, 0.2, 0.3, 0.4},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/atoms", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleAtoms(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "embedding dimension")
+}

--- a/internal/mcp/http_helpers.go
+++ b/internal/mcp/http_helpers.go
@@ -2,7 +2,14 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+)
+
+const (
+	quickStoreBodyLimitBytes  = 2 << 20
+	quickRecallBodyLimitBytes = 512 << 10
+	atomsBodyLimitBytes       = 2 << 20
 )
 
 // writeJSON sets Content-Type to application/json, writes status, and encodes v.
@@ -15,4 +22,18 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // writeJSONError writes a JSON {"error": msg} response with the given status.
 func writeJSONError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func decodeLimitedJSON(w http.ResponseWriter, r *http.Request, dst any, limit int64) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return false
+	}
+	return true
 }

--- a/internal/mcp/quick_recall_handler_test.go
+++ b/internal/mcp/quick_recall_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -107,6 +108,27 @@ func TestHandleQuickRecall_InvalidJSON(t *testing.T) {
 	s.handleQuickRecall(w, req)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestQuickRecallRequestBodyLimit verifies that the REST handler rejects request
+// bodies before decoding payloads large enough to allocate proportional memory.
+func TestQuickRecallRequestBodyLimit(t *testing.T) {
+	s := newQuickRecallServer(t)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/quick-recall",
+		bytes.NewReader([]byte(fmt.Sprintf(
+			`{"query":"hello","project":"global","padding":"%s"}`,
+			string(bytes.Repeat([]byte("x"), quickRecallBodyLimitBytes)),
+		))),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleQuickRecall(w, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 }
 
 // TestHandleQuickRecall_LimitClamped verifies that a limit > 20 is clamped to 20

--- a/internal/mcp/quick_store_handler_test.go
+++ b/internal/mcp/quick_store_handler_test.go
@@ -123,6 +123,27 @@ func TestQuickStoreHandler_InvalidJSON(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestQuickStoreRequestBodyLimit verifies that the REST handler rejects request
+// bodies before decoding payloads large enough to allocate proportional memory.
+func TestQuickStoreRequestBodyLimit(t *testing.T) {
+	s := newQuickStoreServer(t)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/quick-store",
+		bytes.NewReader([]byte(fmt.Sprintf(
+			`{"content":"ok","project":"global","padding":"%s"}`,
+			string(bytes.Repeat([]byte("x"), quickStoreBodyLimitBytes)),
+		))),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleQuickStore(w, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
 // TestQuickStoreHandler_OversizedContent verifies that content > 1 MiB is rejected with 400.
 func TestQuickStoreHandler_OversizedContent(t *testing.T) {
 	s := newQuickStoreServer(t)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1865,8 +1865,7 @@ func (s *Server) handleQuickStore(w http.ResponseWriter, r *http.Request) {
 		Importance int        `json:"importance"`
 		ExpiresAt  *time.Time `json:"expires_at"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+	if !decodeLimitedJSON(w, r, &body, quickStoreBodyLimitBytes) {
 		return
 	}
 	if strings.TrimSpace(body.Content) == "" {
@@ -1969,8 +1968,7 @@ func (s *Server) handleQuickRecall(w http.ResponseWriter, r *http.Request) {
 		Tags    []string `json:"tags"`
 		Limit   int      `json:"limit"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+	if !decodeLimitedJSON(w, r, &body, quickRecallBodyLimitBytes) {
 		return
 	}
 	if strings.TrimSpace(body.Project) == "" {


### PR DESCRIPTION
## Summary

Closes #1328.

Adds bounded JSON decoding to the authenticated REST JSON endpoints that previously decoded unbounded request bodies:
- `/quick-store` now rejects bodies over 2 MiB with `413`.
- `/quick-recall` now rejects bodies over 512 KiB with `413`.
- `/atoms` now rejects bodies over 2 MiB with `413`.
- `/atoms action=store` rejects embeddings larger than the configured `EmbedDimensions` before database access.

## Verification

TDD red before implementation:
- `go test ./internal/mcp -run 'TestQuickStoreRequestBodyLimit|TestQuickRecallRequestBodyLimit|TestAtomsRequestBodyLimit|TestAtomsEmbeddingDimensionLimit' -count=1` failed before the guards existed.\n\nGreen after implementation:\n- `go test ./internal/mcp -run 'TestQuickStoreRequestBodyLimit|TestQuickRecallRequestBodyLimit|TestAtomsRequestBodyLimit|TestAtomsEmbeddingDimensionLimit' -count=1`\n- `go test ./internal/mcp -count=1`\n- non-LME package pass: `go test $(go list ./... | grep -Ev '/(cmd/longmemeval|internal/longmemeval|cmd/wp05-retrofit-runner|internal/wp05retrofit)$') -count=1`\n- `git diff --check`\n- pre-commit checkin-lint passed\n\n## Runtime/Container Notes\n\nNo running service, pod, database, container, manifest, or deployment was modified. No Docker resources were created.\n\n## Integration Note\n\nThis PR touches `internal/mcp/atoms_handler.go`, which is also touched by PR #1348. If #1348 merges first, this branch may need a small rebase to combine the adjacent request-validation guards.\n