### PR TITLE
fix: validate relationship strength boundaries

### DIFF
--- a/internal/mcp/relationship_strength_test.go
+++ b/internal/mcp/relationship_strength_test.go
@@ -64,7 +64,62 @@ func TestMemoryRelationshipHandlers_CoerceNumericStringStrength(t *testing.T) {
 	}
 }
 
-func TestMemoryRelationshipHandlers_RejectNonFiniteStringStrength(t *testing.T) {
+func TestMemoryRelationshipHandlers_AcceptBoundaryStrength(t *testing.T) {
+	handlers := []struct {
+		name    string
+		handler func(context.Context, *EnginePool, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "memory_adopt", handler: handleMemoryAdopt},
+		{name: "memory_connect", handler: handleMemoryConnect},
+	}
+
+	for _, handlerTC := range handlers {
+		t.Run(handlerTC.name, func(t *testing.T) {
+			for _, strength := range []float64{0.0, 1.0} {
+				t.Run("strength_boundary", func(t *testing.T) {
+					backend := &relationshipCaptureBackend{}
+					pool := newRelationshipCapturePool(t, backend)
+
+					req := relationshipRequest(strength)
+
+					_, err := handlerTC.handler(context.Background(), pool, req)
+					require.NoError(t, err)
+					require.Len(t, backend.relationships, 1)
+					require.InDelta(t, strength, backend.relationships[0].Strength, 0.0001)
+				})
+			}
+		})
+	}
+}
+
+func TestMemoryRelationshipHandlers_RejectOutOfRangeFiniteStrength(t *testing.T) {
+	handlers := []struct {
+		name    string
+		handler func(context.Context, *EnginePool, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "memory_adopt", handler: handleMemoryAdopt},
+		{name: "memory_connect", handler: handleMemoryConnect},
+	}
+
+	badStrengths := []float64{1.5, -0.5, 1.0000001, -1e-9}
+	for _, handlerTC := range handlers {
+		t.Run(handlerTC.name, func(t *testing.T) {
+			for _, strength := range badStrengths {
+				t.Run("out_of_range", func(t *testing.T) {
+					backend := &relationshipCaptureBackend{}
+					pool := newRelationshipCapturePool(t, backend)
+
+					_, err := handlerTC.handler(context.Background(), pool, relationshipRequest(strength))
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "strength must be between 0 and 1")
+					require.Empty(t, backend.relationships)
+				})
+			}
+		})
+	}
+}
+
+func TestMemoryRelationshipHandlers_RejectNonFiniteNumericStrength(t *testing.T) {
 	handlers := []struct {
 		name    string
 		handler func(context.Context, *EnginePool, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
@@ -89,16 +144,7 @@ func TestMemoryRelationshipHandlers_RejectNonFiniteStringStrength(t *testing.T) 
 					backend := &relationshipCaptureBackend{}
 					pool := newRelationshipCapturePool(t, backend)
 
-					req := mcpgo.CallToolRequest{}
-					req.Params.Arguments = map[string]any{
-						"project":       "test",
-						"source_id":     "src-001",
-						"target_id":     "dst-001",
-						"relation_type": types.RelTypeRelatesTo,
-						"strength":      strength.val,
-					}
-
-					_, err := handlerTC.handler(context.Background(), pool, req)
+					_, err := handlerTC.handler(context.Background(), pool, relationshipRequest(strength.val))
 					require.Error(t, err)
 					require.Contains(t, err.Error(), "strength must be between 0 and 1")
 					require.Empty(t, backend.relationships)
@@ -106,4 +152,42 @@ func TestMemoryRelationshipHandlers_RejectNonFiniteStringStrength(t *testing.T) 
 			}
 		})
 	}
+}
+
+func TestMemoryRelationshipHandlers_RejectNonFiniteStringStrength(t *testing.T) {
+	handlers := []struct {
+		name    string
+		handler func(context.Context, *EnginePool, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "memory_adopt", handler: handleMemoryAdopt},
+		{name: "memory_connect", handler: handleMemoryConnect},
+	}
+
+	for _, handlerTC := range handlers {
+		t.Run(handlerTC.name, func(t *testing.T) {
+			for _, strength := range []string{"NaN", "Inf", "+Inf", "-Inf"} {
+				t.Run(strength, func(t *testing.T) {
+					backend := &relationshipCaptureBackend{}
+					pool := newRelationshipCapturePool(t, backend)
+
+					_, err := handlerTC.handler(context.Background(), pool, relationshipRequest(strength))
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "strength must be between 0 and 1")
+					require.Empty(t, backend.relationships)
+				})
+			}
+		})
+	}
+}
+
+func relationshipRequest(strength any) mcpgo.CallToolRequest {
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":       "test",
+		"source_id":     "src-001",
+		"target_id":     "dst-001",
+		"relation_type": types.RelTypeRelatesTo,
+		"strength":      strength,
+	}
+	return req
 }

--- a/internal/mcp/tools_admin.go
+++ b/internal/mcp/tools_admin.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -44,6 +46,28 @@ func validateRelationshipStrength(strength float64) error {
 	return nil
 }
 
+func relationshipStrength(args map[string]any) (float64, error) {
+	raw, ok := args["strength"]
+	if !ok || raw == nil {
+		return 1.0, nil
+	}
+	if s, ok := raw.(string); ok {
+		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return 0, fmt.Errorf("strength must be numeric, got %v", s)
+		}
+		if err := validateRelationshipStrength(f); err != nil {
+			return 0, err
+		}
+		return f, nil
+	}
+	strength := getFloat(args, "strength", 1.0)
+	if err := validateRelationshipStrength(strength); err != nil {
+		return 0, err
+	}
+	return strength, nil
+}
+
 // handleMemoryAdopt creates a cross-project reference relationship from a memory in
 // the calling project to a memory in another project. The relationship is stored in
 // the calling project's edge table.
@@ -66,13 +90,8 @@ func handleMemoryAdopt(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		return errResult, nil
 	}
 	relType := getString(args, "relation_type", types.RelTypeRelatesTo)
-	if s, ok := args["strength"].(string); ok {
-		if s == "NaN" || s == "Inf" || s == "-Inf" {
-			return nil, fmt.Errorf("strength must be between 0 and 1, got %v", s)
-		}
-	}
-	strength := getFloat(args, "strength", 1.0)
-	if err := validateRelationshipStrength(strength); err != nil {
+	strength, err := relationshipStrength(args)
+	if err != nil {
 		return nil, err
 	}
 	if err := h.Engine.Connect(ctx, srcID, dstID, relType, strength); err != nil {
@@ -106,13 +125,8 @@ func handleMemoryConnect(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		return errResult, nil
 	}
 	relType := getString(args, "relation_type", types.RelTypeRelatesTo)
-	if s, ok := args["strength"].(string); ok {
-		if s == "NaN" || s == "Inf" || s == "-Inf" {
-			return nil, fmt.Errorf("strength must be between 0 and 1, got %v", s)
-		}
-	}
-	strength := getFloat(args, "strength", 1.0)
-	if err := validateRelationshipStrength(strength); err != nil {
+	strength, err := relationshipStrength(args)
+	if err != nil {
 		return nil, err
 	}
 	if err := h.Engine.Connect(ctx, src, dst, relType, strength); err != nil {

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -2142,8 +2143,8 @@ func (e *SearchEngine) Connect(ctx context.Context, srcID, dstID, relType string
 	if !types.ValidateRelationType(relType) {
 		return fmt.Errorf("invalid relation type %q", relType)
 	}
-	if strength <= 0 {
-		strength = 1.0
+	if math.IsNaN(strength) || math.IsInf(strength, 0) || strength < 0 || strength > 1.0 {
+		return fmt.Errorf("strength must be between 0 and 1, got %v", strength)
 	}
 	rel := &types.Relationship{
 		ID:       types.NewMemoryID(),

--- a/internal/search/engine_test.go
+++ b/internal/search/engine_test.go
@@ -3,6 +3,8 @@ package search_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -181,6 +183,51 @@ func TestSearchEngine_Connect(t *testing.T) {
 
 	err := engine.Connect(ctx, m1.ID, m2.ID, types.RelTypeRelatesTo, 1.0)
 	require.NoError(t, err)
+}
+
+func TestSearchEngine_ConnectStrengthBoundaries(t *testing.T) {
+	for _, strength := range []float64{0.0, 1.0} {
+		t.Run(fmt.Sprintf("strength_%g", strength), func(t *testing.T) {
+			engine := newTestEngine(t, uniqueProject("test-connect-strength"))
+			t.Cleanup(func() { engine.Close() })
+			ctx := context.Background()
+
+			m1 := &types.Memory{ID: types.NewMemoryID(), Content: "source",
+				MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
+			m2 := &types.Memory{ID: types.NewMemoryID(), Content: "target",
+				MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
+			require.NoError(t, engine.Store(ctx, m1))
+			require.NoError(t, engine.Store(ctx, m2))
+
+			require.NoError(t, engine.Connect(ctx, m1.ID, m2.ID, types.RelTypeRelatesTo, strength))
+
+			rels, err := engine.Backend().GetRelationships(ctx, engine.Project(), m1.ID)
+			require.NoError(t, err)
+			require.Len(t, rels, 1)
+			require.InDelta(t, strength, rels[0].Strength, 0.0001)
+		})
+	}
+}
+
+func TestSearchEngine_ConnectRejectsInvalidStrength(t *testing.T) {
+	engine := newTestEngine(t, uniqueProject("test-connect-invalid-strength"))
+	t.Cleanup(func() { engine.Close() })
+	ctx := context.Background()
+
+	m1 := &types.Memory{ID: types.NewMemoryID(), Content: "source",
+		MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
+	m2 := &types.Memory{ID: types.NewMemoryID(), Content: "target",
+		MemoryType: types.MemoryTypeContext, StorageMode: "focused"}
+	require.NoError(t, engine.Store(ctx, m1))
+	require.NoError(t, engine.Store(ctx, m2))
+
+	for _, strength := range []float64{-0.5, -1e-9, 1.0000001, 1.5, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		t.Run(fmt.Sprintf("strength_%v", strength), func(t *testing.T) {
+			err := engine.Connect(ctx, m1.ID, m2.ID, types.RelTypeRelatesTo, strength)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "strength must be between 0 and 1")
+		})
+	}
 }
 
 func TestSearchEngine_Correct(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1311.

Adds the missing relationship-strength boundary coverage and fixes the behavior exposed by those tests:
- accepts and preserves exact boundary strengths `0.0` and `1.0`
- rejects finite out-of-range strengths (`1.5`, `-0.5`, `1.0000001`, `-1e-9`)
- rejects non-finite numeric strengths (`NaN`, `+Inf`, `-Inf`)
- rejects non-finite string strengths including Go-rendered `"+Inf"`
- consolidates duplicated adopt/connect strength parsing into `relationshipStrength`
- hardens `SearchEngine.Connect` so lower-level callers also cannot persist non-finite/out-of-range strengths, and explicit `0.0` is no longer rewritten to `1.0`

## Verification

TDD red before implementation:
- `go test ./internal/mcp -run 'TestMemoryRelationshipHandlers' -count=1` failed on `+Inf` strings and showed explicit `0.0` was stored as `1.0`.\n\nGreen after implementation:\n- `go test ./internal/mcp -run 'TestMemoryRelationshipHandlers' -count=1`\n- `go test ./internal/search -run TestSearchEngine_Connect -count=1`\n- `go test ./internal/mcp ./internal/search -count=1`\n- non-LME package pass: `go test $(go list ./... | grep -Ev '/(cmd/longmemeval|internal/longmemeval|cmd/wp05-retrofit-runner|internal/wp05retrofit)$') -count=1`\n- `git diff --check`\n- pre-commit checkin-lint passed\n\n## Runtime/Container Notes\n\nNo running service, pod, database, container, manifest, or deployment was modified. No Docker resources were created.\n