### PR TITLE
fix: fail loudly on load-bearing optional params

### DIFF
--- a/internal/mcp/migrate_guards_test.go
+++ b/internal/mcp/migrate_guards_test.go
@@ -142,6 +142,17 @@ func TestMCPMigrateDryRunArgPassedToEngine(t *testing.T) {
 	require.True(t, dryRunSeen, "dry_run=true must reach migrateFunc as DryRun=true")
 }
 
+func TestMCPMigrateDryRunWrongTypeReturnsLoudError(t *testing.T) {
+	pool := newDimPool(t, "", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-768", map[string]any{
+		"dry_run": []any{"not-bool"},
+	})
+
+	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, Config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dry_run")
+}
+
 // TestMCPMigrateLargeVolumeRefusalPassedThrough: large volume refusal from
 // the engine is surfaced as a tool error.
 func TestMCPMigrateLargeVolumeRefusalPassedThrough(t *testing.T) {
@@ -203,6 +214,17 @@ func TestMCPMigrateConfirmArgPassedToEngine(t *testing.T) {
 	require.True(t, confirmSeen, "confirm=true must reach migrateFunc as Confirm=true")
 }
 
+func TestMCPMigrateConfirmWrongTypeReturnsLoudError(t *testing.T) {
+	pool := newDimPool(t, "", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-different", map[string]any{
+		"confirm": []any{"not-bool"},
+	})
+
+	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, Config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "confirm")
+}
+
 // ── G4: force arg passthrough ─────────────────────────────────────────────────
 
 // TestMCPMigrateForceArgPassedToEngine verifies force=true is forwarded.
@@ -234,4 +256,15 @@ func TestMCPMigrateForceArgPassedToEngine(t *testing.T) {
 	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, cfg)
 	require.NoError(t, err)
 	require.True(t, forceSeen, "force=true must reach migrateFunc as Force=true")
+}
+
+func TestMCPMigrateForceWrongTypeReturnsLoudError(t *testing.T) {
+	pool := newDimPool(t, "", 1024)
+	req := makeMigrateRequestFull("proj", "new-model-different", map[string]any{
+		"force": []any{"not-bool"},
+	})
+
+	_, err := handleMemoryMigrateEmbedder(context.Background(), pool, req, Config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "force")
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -432,6 +432,20 @@ func requireOptionalInt(args map[string]any, key string) (value int, present boo
 	return 0, true, fmt.Errorf("%s must be a number, got %T", key, v)
 }
 
+// requireOptionalBool extracts an optional boolean arg. present=false means
+// the key is absent or null. A non-nil err means the key was present but could
+// not be interpreted as a boolean even via the string fallback.
+func requireOptionalBool(args map[string]any, key string) (value bool, present bool, err error) {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return false, false, nil
+	}
+	if b, ok := coerceToBool(v); ok {
+		return b, true, nil
+	}
+	return false, true, fmt.Errorf("%s must be a boolean, got %T", key, v)
+}
+
 // Per-tag and count limits to prevent tag injection attacks (#149).
 const (
 	maxTagCount  = 50

--- a/internal/mcp/tools_audit.go
+++ b/internal/mcp/tools_audit.go
@@ -191,10 +191,10 @@ func handleMemoryAuditCompare(ctx context.Context, pool *EnginePool, req mcpgo.C
 		return errResult, nil
 	}
 	limit := 10
-	if v, ok := args["limit"]; ok {
-		if n, ok := v.(float64); ok && n > 0 {
-			limit = int(n)
-		}
+	if n, present, err := requireOptionalInt(args, "limit"); err != nil {
+		return nil, err
+	} else if present && n > 0 {
+		limit = n
 	}
 
 	worker := newAuditWorker(pool, cfg)

--- a/internal/mcp/tools_audit_happy_test.go
+++ b/internal/mcp/tools_audit_happy_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -380,6 +381,43 @@ func TestHandleAuditCompare_HappyPath(t *testing.T) {
 	count, _ := m["count"].(float64)
 	if int(count) != 2 {
 		t.Errorf("expected count=2, got %v", m["count"])
+	}
+}
+
+func TestHandleAuditCompare_LimitStringCoerces(t *testing.T) {
+	var gotLimit any
+	db := &happyTestQuerier{
+		queryFn: func(_ string, args ...any) (pgx.Rows, error) {
+			if len(args) >= 2 {
+				gotLimit = args[1]
+			}
+			return newHappyRows(nil), nil
+		},
+	}
+	cfg := makeTestConfig(db)
+	pool := makeNilEnginePool()
+
+	_, err := handleMemoryAuditCompare(context.Background(), pool,
+		auditHandlerRequest(map[string]any{"query_id": "q1", "limit": "7"}), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotLimit != 7 {
+		t.Fatalf("expected coerced limit 7, got %#v", gotLimit)
+	}
+}
+
+func TestHandleAuditCompare_LimitWrongTypeReturnsLoudError(t *testing.T) {
+	cfg := makeTestConfig(&happyTestQuerier{})
+	pool := makeNilEnginePool()
+
+	_, err := handleMemoryAuditCompare(context.Background(), pool,
+		auditHandlerRequest(map[string]any{"query_id": "q1", "limit": []any{"oops"}}), cfg)
+	if err == nil {
+		t.Fatal("expected wrong-type limit to return error")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "limit") {
+		t.Fatalf("expected error to mention limit, got %q", got)
 	}
 }
 

--- a/internal/mcp/tools_consolidate.go
+++ b/internal/mcp/tools_consolidate.go
@@ -99,22 +99,47 @@ func handleMemorySleep(ctx context.Context, pool *EnginePool, req mcpgo.CallTool
 		return nil, err
 	}
 	minSim := getFloat(args, "min_similarity", 0.7)
-	limit := getInt(args, "limit", 500)
+	limit := 500
+	if v, present, err := requireOptionalInt(args, "limit"); err != nil {
+		return nil, err
+	} else if present {
+		limit = v
+	}
 	if limit < 1 || limit > 5000 {
 		limit = 500
+	}
+	// Optional LLM contradiction detection params (opt-in, default off).
+	// RouterURL comes from server config; model and call cap are per-request.
+	llmDetect := false
+	if v, present, err := requireOptionalBool(args, "llm_contradiction_detection"); err != nil {
+		return nil, err
+	} else if present {
+		llmDetect = v
+	}
+	llmModel := getString(args, "llm_model", "llama3.2:3b")
+	llmMaxCalls := 10
+	if v, present, err := requireOptionalInt(args, "llm_max_calls"); err != nil {
+		return nil, err
+	} else if present {
+		llmMaxCalls = v
+	}
+	autoSupersede := false
+	if v, present, err := requireOptionalBool(args, "auto_supersede"); err != nil {
+		return nil, err
+	} else if present {
+		autoSupersede = v
+	}
+
+	contradictionLimit := 0 // 0 → falls back to limit
+	if v, present, err := requireOptionalInt(args, "contradiction_limit"); err != nil {
+		return nil, err
+	} else if present {
+		contradictionLimit = v
 	}
 	h, err := pool.Get(ctx, project)
 	if err != nil {
 		return nil, err
 	}
-	// Optional LLM contradiction detection params (opt-in, default off).
-	// RouterURL comes from server config; model and call cap are per-request.
-	llmDetect := getBool(args, "llm_contradiction_detection", false)
-	llmModel := getString(args, "llm_model", "llama3.2:3b")
-	llmMaxCalls := getInt(args, "llm_max_calls", 10)
-	autoSupersede := getBool(args, "auto_supersede", false)
-
-	contradictionLimit := getInt(args, "contradiction_limit", 0) // 0 → falls back to limit
 
 	runner := consolidatepkg.NewRunner(h.Engine.Backend(), project, h.Engine.Embedder())
 	stats, err := runner.RunAll(ctx, consolidatepkg.RunOptions{

--- a/internal/mcp/tools_embedder.go
+++ b/internal/mcp/tools_embedder.go
@@ -49,9 +49,24 @@ func handleMemoryMigrateEmbedder(ctx context.Context, pool *EnginePool, req mcpg
 
 	// Extract new safety-guard args early — dry_run must bypass the dimension
 	// pre-flight since a dry_run only counts; it never nulls anything.
-	force := getBool(args, "force", false)
-	dryRun := getBool(args, "dry_run", false)
-	confirm := getBool(args, "confirm", false)
+	force := false
+	if v, present, err := requireOptionalBool(args, "force"); err != nil {
+		return nil, err
+	} else if present {
+		force = v
+	}
+	dryRun := false
+	if v, present, err := requireOptionalBool(args, "dry_run"); err != nil {
+		return nil, err
+	} else if present {
+		dryRun = v
+	}
+	confirm := false
+	if v, present, err := requireOptionalBool(args, "confirm"); err != nil {
+		return nil, err
+	} else if present {
+		confirm = v
+	}
 
 	// Dimension pre-flight (#251): compare stored dims against the new model's output.
 	// Avoids nulling all embeddings only to discover a dimension mismatch at INSERT.

--- a/internal/mcp/tools_sleep_validation_test.go
+++ b/internal/mcp/tools_sleep_validation_test.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemorySleepLoadBearingParamsWrongTypeReturnLoudError(t *testing.T) {
+	tests := []string{
+		"limit",
+		"llm_max_calls",
+		"contradiction_limit",
+		"llm_contradiction_detection",
+		"auto_supersede",
+	}
+
+	for _, key := range tests {
+		t.Run(key, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{
+				"project": "default",
+				key:       []any{"wrong-type"},
+			}
+
+			_, err := handleMemorySleep(context.Background(), nil, req, Config{})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), key)
+		})
+	}
+}

--- a/internal/mcp/tools_typed_args_test.go
+++ b/internal/mcp/tools_typed_args_test.go
@@ -94,6 +94,36 @@ func TestGetBool_AcceptsStringifiedBool(t *testing.T) {
 	require.True(t, getBool(args, "immutable", false))
 }
 
+// ── requireOptionalBool: loud-error path for load-bearing bool params ───────
+
+func TestRequireOptionalBool_AbsentKey(t *testing.T) {
+	b, present, err := requireOptionalBool(map[string]any{}, "confirm")
+	require.NoError(t, err)
+	require.False(t, present)
+	require.False(t, b)
+}
+
+func TestRequireOptionalBool_NullValue(t *testing.T) {
+	b, present, err := requireOptionalBool(map[string]any{"confirm": nil}, "confirm")
+	require.NoError(t, err)
+	require.False(t, present)
+	require.False(t, b)
+}
+
+func TestRequireOptionalBool_CoercibleString(t *testing.T) {
+	b, present, err := requireOptionalBool(map[string]any{"confirm": "true"}, "confirm")
+	require.NoError(t, err)
+	require.True(t, present)
+	require.True(t, b)
+}
+
+func TestRequireOptionalBool_UncoercibleValue_ReturnsLoudError(t *testing.T) {
+	_, present, err := requireOptionalBool(map[string]any{"confirm": []any{"oops"}}, "confirm")
+	require.True(t, present)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "confirm")
+}
+
 // ── requireOptionalInt: the loud-error path used by load-bearing params ────
 
 func TestRequireOptionalInt_AbsentKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1282.

This is a bounded first pass on load-bearing optional parameter validation. It changes parameters that can materially affect migration, audit scope, or sleep/consolidation cost from silent-default behavior to loud typed validation errors.

Covered params:
- `memory_migrate_embedder`: `force`, `dry_run`, `confirm`
- `memory_audit_compare`: `limit`
- `memory_sleep`: `limit`, `llm_max_calls`, `contradiction_limit`, `llm_contradiction_detection`, `auto_supersede`

Out of scope for this PR:
- Retrieval/tuning-only params that are not load-bearing for this issue.
- LME/WP05-adjacent work under the current stop boundary.
- Runtime/container changes.

## Verification

Red tests before implementation:
- `requireOptionalBool` helper test failed before the helper existed.
- `memory_migrate_embedder` wrong-type guard tests failed because bool args silently defaulted.
- `memory_audit_compare limit` tests failed because string/wrong-type input was not validated as intended.
- `memory_sleep` wrong-type tests reached pool access instead of returning validation errors.

Green tests after implementation:
- `go test ./internal/mcp -run 'TestRequireOptionalBool|TestMCPMigrate.*WrongTypeReturnsLoudError|TestMCPMigrate.*ArgPassedToEngine|TestHandleAuditCompare_Limit|TestMemorySleepLoadBearingParamsWrongTypeReturnLoudError' -count=1`
- `go test ./internal/mcp -count=1`
- `pkgs=$(go list ./... | grep -Ev '/(cmd/longmemeval|internal/longmemeval|internal/wp05retrofit|cmd/wp05-retrofit-runner)(/|$)') && go test $pkgs -count=1`
- `git diff --check`
- checkin-lint via commit hook

## Manifest First

No container, pod, service unit, manifest, or runtime behavior was changed by this PR.
