### PR TITLE
fix: label dropped recall hits accurately

### DIFF
--- a/internal/mcp/fetch_recall_test.go
+++ b/internal/mcp/fetch_recall_test.go
@@ -893,6 +893,12 @@ func TestHandleMemoryRecall_NilMemoryResultSurfacesDroppedHitsInDegradedField(t 
 	degraded, ok := out["degraded"].(map[string]any)
 	require.True(t, ok, "degraded field must be a map")
 	require.Equal(t, float64(1), degraded["dropped_hits"], "degraded.dropped_hits must reflect the one dropped hit")
+	warningsRaw, hasWarnings := out["warnings"]
+	require.True(t, hasWarnings, "warnings must be present when recall drops backend hits")
+	warnings, ok := warningsRaw.([]any)
+	require.True(t, ok, "warnings must be a list")
+	require.NotContains(t, warnings, recallEmbedDegradedWarning, "nil-Memory dropped hits are not an embed fallback")
+	require.Contains(t, warnings, recallDroppedHitsWarning)
 	results, ok := out["results"].([]any)
 	require.True(t, ok, "results field must be a list")
 	require.Empty(t, results, "the memories payload must never include a nil-Memory entry")

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -15,7 +15,10 @@ import (
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
-const recallEmbedDegradedWarning = "recall degraded: embed unavailable, using BM25 fallback"
+const (
+	recallEmbedDegradedWarning = "recall degraded: embed unavailable, using BM25 fallback"
+	recallDroppedHitsWarning   = "recall degraded: dropped backend hits with missing memory records"
+)
 
 // degradedMap builds the "degraded" response field.
 // When embed is true the reason string is included; when embed is false the
@@ -81,7 +84,21 @@ func addRecallDegradedWarning(out map[string]any, endpoint, reason string) {
 	slog.Warn("memory_recall degraded: embed unavailable, using BM25 fallback",
 		"embed_endpoint", endpoint,
 		"reason", reason)
-	out["warnings"] = []string{recallEmbedDegradedWarning}
+	appendRecallWarning(out, recallEmbedDegradedWarning)
+}
+
+func addRecallDroppedHitsWarning(out map[string]any, droppedHits int) {
+	slog.Warn("memory_recall degraded: dropped backend hits with missing memory records",
+		"dropped_hits", droppedHits)
+	appendRecallWarning(out, recallDroppedHitsWarning)
+}
+
+func appendRecallWarning(out map[string]any, warning string) {
+	if existing, ok := out["warnings"].([]string); ok {
+		out["warnings"] = append(existing, warning)
+		return
+	}
+	out["warnings"] = []string{warning}
 }
 
 func finiteOrZero(v float64) float64 {
@@ -591,9 +608,12 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		if atomPreamble != "" {
 			out["atom_preamble"] = atomPreamble
 		}
-		if embedDegraded || droppedHits > 0 {
+		if embedDegraded {
 			reason := embedDegradeReason
 			addRecallDegradedWarning(out, cfg.RouterURL, reason)
+		}
+		if droppedHits > 0 {
+			addRecallDroppedHitsWarning(out, droppedHits)
 		}
 		if eventID != "" {
 			out["event_id"] = eventID
@@ -631,12 +651,15 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			dm["dropped_hits"] = droppedHits
 		}
 	}
-	if isDegraded || droppedHits > 0 {
+	if isDegraded {
 		if reason == "" && embedDegraded {
 			// Use the actual degradation reason surfaced by the engine (#989).
 			reason = embedDegradeReason
 		}
 		addRecallDegradedWarning(out, cfg.RouterURL, reason)
+	}
+	if droppedHits > 0 {
+		addRecallDroppedHitsWarning(out, droppedHits)
 	}
 	return toolResult(out)
 }

--- a/internal/search/engine_pure_test.go
+++ b/internal/search/engine_pure_test.go
@@ -8,7 +8,9 @@ import (
 	"math"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/petersimmons1972/engram/internal/db"
 	"github.com/petersimmons1972/engram/internal/types"
 )
 
@@ -150,6 +152,59 @@ func TestSortResults_TiedScores(t *testing.T) {
 	}
 }
 
+type droppedHitsTemporalBackend struct {
+	noopBackend
+	calls atomic.Int64
+}
+
+func (b *droppedHitsTemporalBackend) FTSSearch(_ context.Context, _ string, _ string, _ int, _, _ *time.Time) ([]db.FTSResult, error) {
+	b.calls.Add(1)
+	return []db.FTSResult{{Memory: nil, Score: 1}}, nil
+}
+
+type pureTestEmbedder struct{}
+
+func (pureTestEmbedder) Embed(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (e pureTestEmbedder) EmbedWithModel(ctx context.Context, text string) ([]float32, string, error) {
+	vec, err := e.Embed(ctx, text)
+	return vec, "pure-test", err
+}
+
+func (pureTestEmbedder) Name() string { return "pure-test" }
+
+func (pureTestEmbedder) Dimensions() int { return 1 }
+
+func TestRecallTwoPassTemporal_AccumulatesDroppedHitsFromBothPasses(t *testing.T) {
+	backend := &droppedHitsTemporalBackend{}
+	engine := New(context.Background(), backend, pureTestEmbedder{}, "test-dropped-hits",
+		"http://ollama-test:11434", "", false, nil, 0)
+	t.Cleanup(engine.Close)
+
+	droppedHits := 0
+	results, err := engine.RecallWithOpts(context.Background(), "dentist appointment", 10, "summary", RecallOpts{
+		TemporalWindowRecall: true,
+		QuestionText:         "What did I schedule 3 days ago?",
+		QuestionDate:         "2023/06/09 (Fri)",
+		DroppedHits:          &droppedHits,
+	})
+	if err != nil {
+		t.Fatalf("RecallWithOpts returned error: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Fatalf("expected no materialized results for nil-Memory hits, got %d", len(results))
+	}
+	if calls := backend.calls.Load(); calls != 2 {
+		t.Fatalf("expected two temporal recall passes, got %d", calls)
+	}
+	if droppedHits != 2 {
+		t.Fatalf("expected dropped hits from both temporal passes, got %d", droppedHits)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // toConnectedMemories
 // ---------------------------------------------------------------------------
@@ -253,7 +308,6 @@ func TestToConnectedMemories_MixedDirections(t *testing.T) {
 		t.Errorf("in-source direction = %q, want 'incoming'", dirs["in-source"])
 	}
 }
-
 
 // ---------------------------------------------------------------------------
 // maybeRerank


### PR DESCRIPTION
## Summary

Closes #1312.

This PR separates recall degradation warning text for two distinct paths:
- Embed/health degradation still emits `recall degraded: embed unavailable, using BM25 fallback`.
- Nil-Memory backend hits now emit `recall degraded: dropped backend hits with missing memory records` instead of implying an embed fallback.

It also adds the missing regression test for temporal two-pass dropped-hit accumulation: one nil-Memory FTS result in each pass must produce `DroppedHits == 2`.

## Verification

Red tests before implementation:
- `go test ./internal/mcp -run TestHandleMemoryRecall_NilMemoryResultSurfacesDroppedHitsInDegradedField -count=1` failed before the dropped-hit warning existed.
- The temporal two-pass test required the new expectation that dropped hits accumulate from both passes.

Green tests after implementation:
- `go test ./internal/mcp -run 'TestHandleMemoryRecall_NilMemoryResultSurfacesDroppedHitsInDegradedField|TestHandleMemoryRecall_.*Embed.*Degraded' -count=1`
- `go test ./internal/search -run TestRecallTwoPassTemporal_AccumulatesDroppedHitsFromBothPasses -count=1`
- `go test ./internal/mcp ./internal/search -count=1`
- `pkgs=$(go list ./... | grep -Ev '/(cmd/longmemeval|internal/longmemeval|internal/wp05retrofit|cmd/wp05-retrofit-runner)(/|$)') && go test $pkgs -count=1`
- `git diff --check`
- checkin-lint via commit hook

## Manifest First

No container, pod, service unit, manifest, or runtime deployment behavior was changed by this PR.
