### PR TITLE
refactor: share summary truncation fallback

### DIFF
--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -232,17 +232,34 @@ func ToHandles(results []types.SearchResult) []types.Handle {
 // async summarizer worker (internal/summarize/worker.go, ~30s poll interval)
 // has not yet processed — it falls back to a truncated content excerpt so
 // handle-mode triage still has something useful to look at instead of an
-// empty string (#1260). Mirrors the existing detail="summary" fallback used
-// for full recall results (see the "summary" case above).
+// empty string (#1260). Kept as a compatibility wrapper for handle-mode tests
+// and call sites; summaryContentFallback owns the shared truncation behavior.
 func handleSummaryFallback(m *types.Memory) string {
+	return summaryContentFallback(m)
+}
+
+func summaryContentFallback(m *types.Memory) string {
+	if m == nil {
+		return ""
+	}
 	if m.Summary != nil {
 		return *m.Summary
 	}
-	content := m.Content
-	if len(content) > 500 {
-		content = content[:500] + "…"
+	return truncatedContentFallback(m.Content)
+}
+
+func truncatedContentFallback(content string) string {
+	if len(content) <= 500 {
+		return content
 	}
-	return content
+	end := 0
+	for i := range content {
+		if i > 500 {
+			break
+		}
+		end = i
+	}
+	return content[:end] + "…"
 }
 
 // MergeCandidate is a pair of memories with their similarity score.
@@ -1239,15 +1256,7 @@ func (e *SearchEngine) RecallWithOpts(ctx context.Context, query string, topK in
 			// (Content, PatternConfidence, Tags, etc.) are stripped by design.
 			result.Memory = &types.Memory{ID: m.ID}
 		case "summary":
-			if m.Summary != nil {
-				result.Memory.Content = *m.Summary
-			} else {
-				content := m.Content
-				if len(content) > 500 {
-					content = content[:500] + "…"
-				}
-				result.Memory.Content = content
-			}
+			result.Memory.Content = summaryContentFallback(m)
 		}
 		results = append(results, result)
 	}
@@ -1733,11 +1742,7 @@ func rerankTextForMemory(m *types.Memory) string {
 	if m.Summary != nil {
 		return *m.Summary
 	}
-	summary := m.Content
-	if len(summary) > 500 {
-		summary = summary[:500]
-	}
-	return summary
+	return truncatedContentFallback(m.Content)
 }
 
 // mergeSearchResults unions two result slices, preserving the order of a first and

--- a/internal/search/engine_pure_test.go
+++ b/internal/search/engine_pure_test.go
@@ -6,8 +6,10 @@ package search
 import (
 	"context"
 	"math"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/petersimmons1972/engram/internal/types"
 )
@@ -150,6 +152,44 @@ func TestSortResults_TiedScores(t *testing.T) {
 	}
 }
 
+func TestSummaryContentFallback_UsesSummaryWhenPresent(t *testing.T) {
+	summary := "prepared summary"
+	got := summaryContentFallback(&types.Memory{
+		Summary: &summary,
+		Content: strings.Repeat("x", 600),
+	})
+	if got != summary {
+		t.Fatalf("summaryContentFallback() = %q, want %q", got, summary)
+	}
+}
+
+func TestSummaryContentFallback_TruncatesContentWithEllipsis(t *testing.T) {
+	content := strings.Repeat("a", 501)
+	want := strings.Repeat("a", 500) + "…"
+	got := summaryContentFallback(&types.Memory{Content: content})
+	if got != want {
+		t.Fatalf("summaryContentFallback() length/content mismatch: got len=%d want len=%d", len(got), len(want))
+	}
+	if handleGot := handleSummaryFallback(&types.Memory{Content: content}); handleGot != want {
+		t.Fatalf("handleSummaryFallback() = %q, want shared fallback %q", handleGot, want)
+	}
+	if rerankGot := rerankTextForMemory(&types.Memory{Content: content}); rerankGot != want {
+		t.Fatalf("rerankTextForMemory() = %q, want shared fallback %q", rerankGot, want)
+	}
+}
+
+func TestSummaryContentFallback_DoesNotSplitUTF8Rune(t *testing.T) {
+	content := strings.Repeat("é", 249) + "€tail"
+	got := summaryContentFallback(&types.Memory{Content: content})
+	if !utf8.ValidString(got) {
+		t.Fatalf("summaryContentFallback() returned invalid UTF-8: %q", got)
+	}
+	want := strings.Repeat("é", 249) + "…"
+	if got != want {
+		t.Fatalf("summaryContentFallback() = %q, want %q", got, want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // toConnectedMemories
 // ---------------------------------------------------------------------------
@@ -253,7 +293,6 @@ func TestToConnectedMemories_MixedDirections(t *testing.T) {
 		t.Errorf("in-source direction = %q, want 'incoming'", dirs["in-source"])
 	}
 }
-
 
 // ---------------------------------------------------------------------------
 // maybeRerank


### PR DESCRIPTION
## Summary

Closes #1273.

This PR extracts one shared summary fallback for search results:
- `detail=summary` fallback content.
- handle-mode summaries via `ToHandles` / `handleSummaryFallback`.
- reranker candidate text via `rerankTextForMemory`.

The shared behavior is:
- Prefer `Memory.Summary` when present.
- Otherwise use content truncated at a UTF-8-safe <=500-byte boundary plus ellipsis when truncated.

This resolves the prior ellipsis inconsistency and avoids splitting a multibyte UTF-8 rune at the byte boundary.

## Verification

Red test before implementation:
- `go test ./internal/search -run 'TestSummaryContentFallback|TestHandleSummaryFallback' -count=1` failed because the shared helper did not exist.

Green tests after implementation:
- `go test ./internal/search -run 'TestSummaryContentFallback|TestHandleSummaryFallback|TestMaybeRerank' -count=1`
- `go test ./internal/search -count=1`
- `pkgs=$(go list ./... | grep -Ev '/(cmd/longmemeval|internal/longmemeval|internal/wp05retrofit|cmd/wp05-retrofit-runner)(/|$)') && go test $pkgs -count=1`
- `git diff --check`
- checkin-lint via commit hook

## Manifest First

No container, pod, service unit, manifest, or runtime deployment behavior was changed by this PR.
