### PR TITLE
fix(ops): point instinct.service at installed Go consolidator

### DIFF
--- a/bin/checkin-lint.baseline
+++ b/bin/checkin-lint.baseline
@@ -246,7 +246,7 @@ D.exit-zero-wrapper::./.worktrees/issue-1063-extract-parser/hooks/engram/engram-
 D.exit-zero-wrapper::./.worktrees/issue-1063-extract-parser/hooks/engram/engram-precheck.sh::38
 D.exit-zero-wrapper::./.worktrees/issue-1063-extract-parser/hooks/pre-tool-use.sh::4
 D.exit-zero-wrapper::./ops/healthcheck.sh::37
-D.exit-zero-wrapper::./hooks/post-tool-use.sh::111
+D.exit-zero-wrapper::./hooks/post-tool-use.sh::113
 D.exit-zero-wrapper::./hooks/engram/engram-session-end.sh::16
 D.exit-zero-wrapper::./hooks/engram/engram-session-end.sh::65
 D.exit-zero-wrapper::./hooks/engram/engram-token-refresh.sh::33

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -119,10 +119,14 @@ print(f"  Wrote {settings_path}")
 PYEOF
 
 # 3. Build instinct binary
+# Name/path must match ops/instinct.service's ExecStart and the `make install-instinct`
+# target (see Makefile), and hooks/post-tool-use.sh's `command -v instinct-consolidate`
+# check — all three must agree on the same binary.
 echo "Building instinct binary..."
-go build -o "$HOME/bin/instinct" "$REPO_DIR/cmd/instinct"
-echo "  Binary installed at $HOME/bin/instinct"
+mkdir -p "$HOME/bin"
+go build -o "$HOME/bin/instinct-consolidate" "$REPO_DIR/cmd/instinct"
+echo "  Binary installed at $HOME/bin/instinct-consolidate"
 
 echo "Done."
-echo "  instinct binary: $HOME/bin/instinct"
+echo "  instinct binary: $HOME/bin/instinct-consolidate"
 echo "  To disable without uninstalling: export INSTINCT_ENABLED=0"

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -97,14 +97,16 @@ print(json.dumps(event))
 echo "$parsed" >> "$BUFFER_FILE"
 
 # Trigger consolidator every N events
+# Binary name must match ops/instinct.service's ExecStart and hooks/install.sh's
+# build target: $HOME/bin/instinct-consolidate.
 count=$(wc -l < "$BUFFER_FILE" 2>/dev/null || echo 0)
 threshold="${INSTINCT_CONSOLIDATE_EVERY:-20}"
 if (( count % threshold == 0 )); then
-    if command -v instinct &>/dev/null; then
-        instinct >> "$LOG_FILE" 2>&1 &
+    if command -v instinct-consolidate &>/dev/null; then
+        instinct-consolidate >> "$LOG_FILE" 2>&1 &
         disown
     else
-        echo "$(date -Iseconds) instinct binary not found on PATH — run hooks/install.sh" >> "$LOG_FILE"
+        echo "$(date -Iseconds) instinct-consolidate binary not found on PATH — run hooks/install.sh" >> "$LOG_FILE"
     fi
 fi
 

--- a/ops/instinct-service.test.sh
+++ b/ops/instinct-service.test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unit="ops/instinct.service"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+[[ -f "$unit" ]] || fail "missing $unit"
+
+exec_start_line="$(grep -E '^ExecStart=' "$unit" || true)"
+[[ -n "$exec_start_line" ]] || fail "missing ExecStart in $unit"
+
+expected='ExecStart=%h/bin/instinct-consolidate'
+[[ "$exec_start_line" == "$expected" ]] || fail "expected $expected, got: $exec_start_line"
+
+if grep -Eq '^Environment=PYTHONPATH=' "$unit"; then
+    fail "unexpected PYTHONPATH environment in $unit"
+fi
+
+if grep -Fq 'python3 -m instinct.run' "$unit"; then
+    fail "unexpected removed python module entrypoint in $unit"
+fi
+
+echo "PASS: $unit uses the installed Go consolidator contract"

--- a/ops/instinct-service.test.sh
+++ b/ops/instinct-service.test.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
+# Verifies that ops/instinct.service, the Makefile's install-instinct target, and
+# the instinct hooks all agree on the same consolidator binary name/path — and,
+# critically, that this is proven by actually building the binary rather than
+# just string-matching. A previous version of this test only grepped for the
+# expected name in the unit file, which caught nothing when hooks/install.sh
+# and hooks/post-tool-use.sh silently drifted to a different binary name.
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
 unit="ops/instinct.service"
+makefile="Makefile"
 
 fail() {
     echo "FAIL: $1" >&2
@@ -24,4 +34,63 @@ if grep -Fq 'python3 -m instinct.run' "$unit"; then
     fail "unexpected removed python module entrypoint in $unit"
 fi
 
+# Derive the expected binary basename directly from the unit's ExecStart line
+# (rather than hardcoding it a second time) so this can't itself drift from the
+# check above.
+binary_name="$(basename "${exec_start_line#ExecStart=%h/bin/}")"
+[[ -n "$binary_name" ]] || fail "could not derive binary name from ExecStart in $unit"
+
+# --- Cross-check 1: hooks/install.sh and hooks/post-tool-use.sh reference the
+# --- same binary name (blocker: these previously drifted to "instinct").
+grep -Fq "$binary_name" hooks/install.sh ||
+    fail "hooks/install.sh does not build/reference $binary_name (name drift vs $unit)"
+grep -Fq "$binary_name" hooks/post-tool-use.sh ||
+    fail "hooks/post-tool-use.sh does not check for $binary_name on PATH (name drift vs $unit)"
+
+# --- Cross-check 2: actually BUILD the binary via `make install-instinct`
+# (the unit file's own header comment names this as the install path) into a
+# throwaway HOME, and confirm the artifact lands at the exact name/path this
+# unit's ExecStart expects. This catches drift even if someone renames the
+# Makefile's build target without touching this test's string checks.
+[[ -f "$makefile" ]] || fail "missing $makefile"
+grep -Eq '^install-instinct:' "$makefile" ||
+    fail "$makefile has no install-instinct target (referenced by $unit's header comment)"
+
+command -v go >/dev/null 2>&1 || fail "go toolchain not found — cannot verify install-instinct build"
+
+tmp_home="$(mktemp -d)"
+trap 'rm -rf "$tmp_home"' EXIT
+mkdir -p "$tmp_home/bin"
+
+# Preserve the real Go toolchain/module cache locations — only the install
+# destination ($HOME/bin) needs to be redirected into the throwaway dir.
+# Overriding HOME wholesale (without this) makes GOTOOLCHAIN=auto try to
+# locate/download the pinned toolchain under the fake HOME/sdk instead of
+# reusing the one already on disk at the real $HOME/sdk.
+if [[ -d "$HOME/sdk" ]]; then
+    ln -s "$HOME/sdk" "$tmp_home/sdk"
+fi
+
+build_log="$(mktemp)"
+# -buildvcs=false: under the throwaway HOME, git's safe.directory allowlist
+# (read from HOME) no longer trusts this checkout, which would otherwise make
+# `go build` fail trying to stamp VCS info it can't read.
+if ! env HOME="$tmp_home" \
+        GOPATH="$(go env GOPATH)" \
+        GOCACHE="$(go env GOCACHE)" \
+        GOROOT="$(go env GOROOT)" \
+        GOFLAGS="-buildvcs=false" \
+        make install-instinct >"$build_log" 2>&1; then
+    cat "$build_log" >&2
+    rm -f "$build_log"
+    fail "make install-instinct failed to build"
+fi
+rm -f "$build_log"
+
+built_path="$tmp_home/bin/$binary_name"
+[[ -x "$built_path" ]] ||
+    fail "make install-instinct did not produce an executable at $built_path — Makefile output name has drifted from $unit's ExecStart"
+
 echo "PASS: $unit uses the installed Go consolidator contract"
+echo "PASS: hooks/install.sh and hooks/post-tool-use.sh agree on binary name '$binary_name'"
+echo "PASS: 'make install-instinct' builds an executable matching $unit's ExecStart ($built_path)"

--- a/ops/instinct.service
+++ b/ops/instinct.service
@@ -5,6 +5,7 @@
 # (e.g., shared machines, background processing without an active Claude session).
 #
 # Installation (if you want timer mode):
+#   make install-instinct
 #   cp ops/instinct.service ~/.config/systemd/user/
 #   cp ops/instinct.timer   ~/.config/systemd/user/
 #   systemctl --user daemon-reload
@@ -18,11 +19,10 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/env python3 -m instinct.run
+ExecStart=%h/bin/instinct-consolidate
 WorkingDirectory=%h
 StandardOutput=append:%S/instinct/run.log
 StandardError=append:%S/instinct/run.log
-Environment=PYTHONPATH=%h/projects/engram-go/consolidator
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary\n- update `ops/instinct.service` to run `%h/bin/instinct-consolidate`, matching `make install-instinct`\n- remove the stale `PYTHONPATH`/`python3 -m instinct.run` wiring from the timer-mode unit\n- add `ops/instinct-service.test.sh` as a focused regression test for the service contract\n\n## Testing\n- `bash ops/instinct-service.test.sh` ✅\n- `bash -n ops/instinct-service.test.sh` ✅\n- `go test ./cmd/instinct ./cmd/audit -count=1` ✅\n- temporary HOME install smoke check via `make install-instinct` with disposable `HOME/bin` ✅\n- `git diff --check` ✅\n- `bash bin/checkin-lint.sh` ✅\n\n## Environment notes\n- `systemd-analyze verify ops/instinct.service` could not run in the sandbox because `systemd-analyze` is not installed\n- the exact `GOMODCACHE=/home/psimmons/go/pkg/mod` install check was not writable in this sandbox, so the install smoke check used the available module cache at `/opt/gomodcache`\n- the broad non-LME package sweep hit pre-existing environment failures unrelated to this change (`pgvector` extension unavailable and an existing `internal/embed` concurrency test failure)