### PR TITLE
fix(longmemeval): authenticate scorer preflight

### DIFF
--- a/cmd/longmemeval/score_efficient.go
+++ b/cmd/longmemeval/score_efficient.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -18,21 +19,81 @@ import (
 // Context deadlines in the callers tighten this further per-request.
 var scorerHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
-// ollaHealthCheck returns true if the OAI /models endpoint responds with HTTP 200.
-func ollaHealthCheck(baseURL string) bool {
+type scorerPreflightErrorKind string
+
+const (
+	scorerPreflightAuth        scorerPreflightErrorKind = "auth"
+	scorerPreflightUnavailable scorerPreflightErrorKind = "unavailable"
+)
+
+type scorerPreflightError struct {
+	kind       scorerPreflightErrorKind
+	url        string
+	statusCode int
+	cause      error
+}
+
+func (e *scorerPreflightError) Error() string {
+	switch e.kind {
+	case scorerPreflightAuth:
+		if e.statusCode > 0 {
+			return fmt.Sprintf("scorer authentication failed during /models preflight at %s: HTTP %d", e.url, e.statusCode)
+		}
+		return fmt.Sprintf("scorer authentication failed during /models preflight at %s", e.url)
+	case scorerPreflightUnavailable:
+		if e.cause != nil {
+			return fmt.Sprintf("scorer endpoint unavailable during /models preflight at %s: %v", e.url, e.cause)
+		}
+		if e.statusCode > 0 {
+			return fmt.Sprintf("scorer endpoint unavailable during /models preflight at %s: HTTP %d", e.url, e.statusCode)
+		}
+	}
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	return "scorer preflight failed"
+}
+
+// ollaHealthCheck verifies that the OAI /models endpoint responds with HTTP 200.
+func ollaHealthCheck(baseURL, apiKey string) error {
 	url := strings.TrimRight(baseURL, "/") + "/models"
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return false
+		return &scorerPreflightError{
+			kind:  scorerPreflightUnavailable,
+			url:   url,
+			cause: err,
+		}
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 	resp, err := scorerHTTPClient.Do(req)
 	if err != nil {
-		return false
+		return &scorerPreflightError{
+			kind:  scorerPreflightUnavailable,
+			url:   url,
+			cause: err,
+		}
 	}
 	_ = resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return &scorerPreflightError{
+			kind:       scorerPreflightAuth,
+			url:        url,
+			statusCode: resp.StatusCode,
+		}
+	}
+	return &scorerPreflightError{
+		kind:       scorerPreflightUnavailable,
+		url:        url,
+		statusCode: resp.StatusCode,
+	}
 }
 
 // buildPreserveSkipSet splits scored labels into skip (CORRECT, preserve) and
@@ -86,13 +147,15 @@ func runScoreEfficient(cfg *Config) int {
 
 	// Decide backend: configured OAI scorer only. Switching judges on health
 	// failure makes score comparisons ambiguous, so fail closed instead.
-	useOAI := cfg.ScorerURL != "" && ollaHealthCheck(cfg.ScorerURL)
-	if useOAI {
-		log.Printf("score-efficient: backend=olla url=%s model=%s", cfg.ScorerURL, cfg.ScorerModel)
-	} else {
-		log.Printf("ERROR score-efficient: scorer unavailable or not configured; set --scorer-url/--scorer-model and verify /models")
+	if cfg.ScorerURL == "" || cfg.ScorerModel == "" {
+		log.Printf("ERROR score-efficient: scorer not configured; set --scorer-url/--scorer-model")
 		return 1
 	}
+	if err := ollaHealthCheck(cfg.ScorerURL, cfg.ScorerAPIKey); err != nil {
+		log.Printf("ERROR score-efficient: %v", err)
+		return 1
+	}
+	log.Printf("score-efficient: backend=olla url=%s model=%s", cfg.ScorerURL, cfg.ScorerModel)
 
 	work := make(chan longmemeval.RunEntry, len(runEntries))
 	var skipped, queued int

--- a/cmd/longmemeval/score_efficient_test.go
+++ b/cmd/longmemeval/score_efficient_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,8 +16,80 @@ import (
 )
 
 func TestOllaHealthCheck_unreachable(t *testing.T) {
-	if ollaHealthCheck("http://127.0.0.1:19999/v1") {
-		t.Error("unreachable endpoint must return false")
+	err := ollaHealthCheck("http://127.0.0.1:19999/v1", "")
+	if err == nil {
+		t.Fatal("unreachable endpoint must return an error")
+	}
+	var preflightErr *scorerPreflightError
+	if !errors.As(err, &preflightErr) {
+		t.Fatalf("error = %T, want *scorerPreflightError", err)
+	}
+	if preflightErr.kind != scorerPreflightUnavailable {
+		t.Fatalf("preflight error kind = %q, want %q", preflightErr.kind, scorerPreflightUnavailable)
+	}
+}
+
+func TestOllaHealthCheck_UsesBearerWhenAPIKeySet(t *testing.T) {
+	scorer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			http.Error(w, "missing bearer token", http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprint(w, `{"data":[{"id":"test-model"}]}`)
+	}))
+	defer scorer.Close()
+
+	if err := ollaHealthCheck(scorer.URL, ""); err == nil {
+		t.Fatal("health check without api key must fail")
+	} else {
+		var preflightErr *scorerPreflightError
+		if !errors.As(err, &preflightErr) {
+			t.Fatalf("error = %T, want *scorerPreflightError", err)
+		}
+		if preflightErr.kind != scorerPreflightAuth {
+			t.Fatalf("preflight error kind = %q, want %q", preflightErr.kind, scorerPreflightAuth)
+		}
+	}
+
+	if err := ollaHealthCheck(scorer.URL, "test-key"); err != nil {
+		t.Fatalf("health check with api key: %v", err)
+	}
+}
+
+func TestOllaHealthCheck_AuthFailureDiffersFromEndpointUnavailability(t *testing.T) {
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer authServer.Close()
+
+	authErr := ollaHealthCheck(authServer.URL, "")
+	if authErr == nil {
+		t.Fatal("expected auth error")
+	}
+
+	unavailableErr := ollaHealthCheck("http://127.0.0.1:19999/v1", "")
+	if unavailableErr == nil {
+		t.Fatal("expected unavailable error")
+	}
+
+	var authPreflightErr *scorerPreflightError
+	if !errors.As(authErr, &authPreflightErr) {
+		t.Fatalf("auth error = %T, want *scorerPreflightError", authErr)
+	}
+	if authPreflightErr.kind != scorerPreflightAuth {
+		t.Fatalf("auth error kind = %q, want %q", authPreflightErr.kind, scorerPreflightAuth)
+	}
+
+	var unavailablePreflightErr *scorerPreflightError
+	if !errors.As(unavailableErr, &unavailablePreflightErr) {
+		t.Fatalf("unavailable error = %T, want *scorerPreflightError", unavailableErr)
+	}
+	if unavailablePreflightErr.kind != scorerPreflightUnavailable {
+		t.Fatalf("unavailable error kind = %q, want %q", unavailablePreflightErr.kind, scorerPreflightUnavailable)
 	}
 }
 


### PR DESCRIPTION
Codex work for #1330 via fleet-dispatch. Draft — needs review/CI. Closes #1330