### PR TITLE
fix(scripts): resolve LongMemEval wrappers from the checked-out repo

### DIFF
--- a/scripts/longmemeval-pipeline.sh
+++ b/scripts/longmemeval-pipeline.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 # Maintained LongMemEval pipeline wrapper.
 # This script replaces ad-hoc result-local wrappers in ignored results trees.
 
-REPO=${REPO:-/home/psimmons/projects/engram-go}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+REPO=${REPO:-$DEFAULT_REPO}
 BIN=${BIN:-$REPO/longmemeval}
 DATA=${DATA:-$REPO/testdata/longmemeval/longmemeval_m_cleaned.json}
 OUT=${OUT:-$REPO/results/longmemeval}

--- a/scripts/longmemeval-resume.sh
+++ b/scripts/longmemeval-resume.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 # Maintained resume wrapper for run/score stages.
 # Optional RUN_PID waits for a running "longmemeval run" process before scoring.
 
-REPO=${REPO:-/home/psimmons/projects/engram-go}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+REPO=${REPO:-$DEFAULT_REPO}
 BIN=${BIN:-$REPO/longmemeval}
 DATA=${DATA:-$REPO/testdata/longmemeval/longmemeval_m_cleaned.json}
 OUT=${OUT:-$REPO/results/longmemeval}
@@ -15,6 +18,13 @@ RUN_INGEST=${RUN_INGEST:-0}
 SKIP_SCORE=${SKIP_SCORE:-0}
 RUN_PID=${RUN_PID:-}
 ROUTE_DISCOVER=${ROUTE_DISCOVER:-0}
+
+log() { echo "$(date '+%Y/%m/%d %H:%M:%S') $*"; }
+
+if [[ ! -x "$BIN" ]]; then
+  log "ERROR: binary not found or not executable: $BIN"
+  exit 1
+fi
 
 if [[ "$ROUTE_DISCOVER" == "1" ]]; then
   route_path="$OUT/route-discover.json"
@@ -45,18 +55,16 @@ fi
   --cleanup-policy never \
   2>&1 | tee -a "$OUT/run.log"
 
-if [[ "$SKIP_SCORE" == "1" ]]; then
-  exit 0
+if [[ "$SKIP_SCORE" != "1" ]]; then
+  while [[ -n "$RUN_PID" ]] && kill -0 "$RUN_PID" 2>/dev/null; do
+    sleep 30
+  done
+
+  "$BIN" score \
+    --data "$DATA" \
+    --out "$OUT" \
+    --llm-url "$LLM_URL" \
+    --llm-model "$LLM_MODEL" \
+    --workers "$WORKERS" \
+    2>&1 | tee "$OUT/score.log"
 fi
-
-while [[ -n "$RUN_PID" ]] && kill -0 "$RUN_PID" 2>/dev/null; do
-  sleep 30
-done
-
-"$BIN" score \
-  --data "$DATA" \
-  --out "$OUT" \
-  --llm-url "$LLM_URL" \
-  --llm-model "$LLM_MODEL" \
-  --workers "$WORKERS" \
-  2>&1 | tee "$OUT/score.log"

--- a/scripts/longmemeval-wrapper.test.sh
+++ b/scripts/longmemeval-wrapper.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Test suite for maintained LongMemEval wrapper scripts.
+# Usage: bash scripts/longmemeval-wrapper.test.sh
+#
+# These checks validate repo-root discovery and binary preflight behavior using
+# a temp local clone and a fake longmemeval binary. No network or real model
+# endpoints are required.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PIPELINE_REL="scripts/longmemeval-pipeline.sh"
+RESUME_REL="scripts/longmemeval-resume.sh"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" -eq "$actual" ]; then
+        echo "✓ PASS: $desc (exit=$actual)"
+        PASS=$((PASS+1))
+    else
+        echo "✗ FAIL: $desc (expected exit=$expected, got=$actual)"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF -- "$needle"; then
+        echo "✓ PASS: $desc"
+        PASS=$((PASS+1))
+    else
+        echo "✗ FAIL: $desc (missing '$needle')"
+        echo "    output: $haystack"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+make_clone() {
+    local clone_dir
+    clone_dir="$(mktemp -d)"
+    git clone -q -- "$REPO_ROOT" "$clone_dir"
+    cp "$REPO_ROOT/$PIPELINE_REL" "$clone_dir/$PIPELINE_REL"
+    cp "$REPO_ROOT/$RESUME_REL" "$clone_dir/$RESUME_REL"
+    echo "$clone_dir"
+}
+
+install_fake_binary() {
+    local clone_dir="$1"
+    cat >"$clone_dir/longmemeval" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+
+cmd="$1"
+shift
+
+case "$cmd" in
+    ingest|run|score|score-efficient)
+        while [ "$#" -gt 0 ]; do
+            if [ "$1" = "--out" ]; then
+                out_dir="$2"
+                mkdir -p "$out_dir"
+                case "$cmd" in
+                    ingest) : >"$out_dir/checkpoint-ingest.jsonl" ;;
+                    run) : >"$out_dir/run.log" ;;
+                    score|score-efficient) : >"$out_dir/score.log" ;;
+                esac
+                break
+            fi
+            shift
+        done
+        ;;
+esac
+EOF
+    chmod +x "$clone_dir/longmemeval"
+}
+
+clone_dir="$(make_clone)"
+
+out=$(
+    cd "$clone_dir" &&
+        env -i HOME="${HOME:-$clone_dir}" PATH="$PATH" bash "$PIPELINE_REL" 2>&1
+)
+rc=$?
+assert_exit "pipeline without binary fails cleanly" 1 "$rc"
+assert_contains "pipeline missing binary points at clone root" "$clone_dir/longmemeval" "$out"
+
+out=$(
+    cd "$clone_dir" &&
+        env -i HOME="${HOME:-$clone_dir}" PATH="$PATH" \
+            LLM_URL="http://127.0.0.1:8000/v1" \
+            LLM_MODEL="smoke-model" \
+            bash "$RESUME_REL" 2>&1
+)
+rc=$?
+assert_exit "resume without binary fails cleanly" 1 "$rc"
+assert_contains "resume missing binary points at clone root" "$clone_dir/longmemeval" "$out"
+
+install_fake_binary "$clone_dir"
+
+out=$(
+    cd "$clone_dir" &&
+        env -i HOME="${HOME:-$clone_dir}" PATH="$PATH" bash "$PIPELINE_REL" 2>&1
+)
+rc=$?
+assert_exit "pipeline with clone-local binary reaches config validation" 1 "$rc"
+assert_contains "pipeline empty env fails on missing generation config after binary check" "GEN_URL and GEN_MODEL are required" "$out"
+
+out=$(
+    cd "$clone_dir" &&
+        env -i HOME="${HOME:-$clone_dir}" PATH="$PATH" \
+            LLM_URL="http://127.0.0.1:8000/v1" \
+            LLM_MODEL="smoke-model" \
+            bash "$RESUME_REL" 2>&1
+)
+rc=$?
+assert_exit "resume with clone-local binary runs end-to-end" 0 "$rc"
+
+rm -rf "$clone_dir"
+
+echo
+echo "─── ${PASS} passed, ${FAIL} failed ───"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary\n- derive the default `REPO` for `scripts/longmemeval-pipeline.sh` and `scripts/longmemeval-resume.sh` from the script location instead of `/home/psimmons/...`\n- add the missing early binary existence check to `longmemeval-resume.sh` so both wrappers fail consistently before touching output paths\n- add `scripts/longmemeval-wrapper.test.sh`, a temp-clone `env -i` smoke suite that proves both wrappers resolve paths inside the active clone by default\n\n## Testing\n- `bash scripts/longmemeval-wrapper.test.sh`\n- `bash scripts/lme-judge.test.sh`\n- `bash bin/checkin-lint.sh`\n- `env -i HOME=\"$HOME\" PATH=\"/usr/local/go/bin:$PATH\" bash scripts/longmemeval-pipeline.sh`\n- `env -i HOME=\"$HOME\" PATH=\"/usr/local/go/bin:$PATH\" LLM_URL=http://127.0.0.1:8000/v1 LLM_MODEL=x bash scripts/longmemeval-resume.sh`\n- `PATH=\"/usr/local/go/bin:$PATH\" go test ./... -count=1 -race` (environment failure in existing DB/search suites: local Postgres lacks pgvector `vector` extension)