### PR TITLE
docs: keep local-only compose commands on local profile

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,13 +145,17 @@ This is the moment it clicks. Run these checks and watch the pieces confirm each
 Check that the containers for your chosen profile are running and healthy:
 
 ```bash
-docker compose ps
+docker compose -f docker-compose.local.yml ps
 ```
 
-In hybrid mode, `engram-postgres` and `engram-go-app` should show `Up (healthy)`.
-In local-only mode, `engram-ollama` should also be present and healthy. If any
-service shows `Up (health: starting)`, wait 30 seconds and check again — the
-health checks run on a short interval.
+For the local-only profile, `engram-postgres`, `engram-ollama`, and
+`engram-go-app` should all show `Up (healthy)`. If any service shows
+`Up (health: starting)`, wait 30 seconds and check again — the health checks
+run on a short interval.
+
+If you started the hybrid profile with `make up`, rerun the same `ps` check
+against the default compose file. That profile should show `engram-postgres`
+and `engram-go-app` as `Up (healthy)`.
 
 Confirm the MCP endpoint is reachable:
 
@@ -356,13 +360,13 @@ And comment out the `ollama` service in `docker-compose.yml` so Docker does not 
 ## Common Problems
 
 **Port 8788 is already in use.**
-Something else claimed that port before Engram did. Set `ENGRAM_PORT=8789` (or any free port) in `.env`, restart with `docker compose up -d`, and update the port in your IDE config.
+Something else claimed that port before Engram did. Set `ENGRAM_PORT=8789` (or any free port) in `.env`, restart the same profile you started, and update the port in your IDE config. For local-only, use `docker compose -f docker-compose.local.yml up -d`. For hybrid, re-run `make up`.
 
 **Embedding model not found / connection errors on first start.**
 Ollama is still downloading the model — it can look like a crash when it is really just slow. Watch it finish:
 
 ```bash
-docker compose logs ollama -f
+docker compose -f docker-compose.local.yml logs ollama -f
 ```
 
 Wait for a line like `llm server listening`. Then the `engram-go-app` container will become healthy.
@@ -371,13 +375,13 @@ Wait for a line like `llm server listening`. Then the `engram-go-app` container 
 Either a container is not up yet, or `engram-go-app` is waiting on its dependencies. Confirm the state:
 
 ```bash
-docker compose ps
+docker compose -f docker-compose.local.yml ps
 ```
 
 If `engram-go-app` shows `Up (health: starting)`, it is waiting for Postgres or Ollama. Give it 30 seconds. If it shows `Exit`, the process crashed — check the logs to see why:
 
 ```bash
-docker compose logs engram-go-app
+docker compose -f docker-compose.local.yml logs engram-go-app
 ```
 
 The most common causes are a missing `POSTGRES_PASSWORD` or `ENGRAM_API_KEY`. Run `make init` to generate both.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -170,17 +170,17 @@ For the live Engram deployment in this environment, Kubernetes is the operationa
 make status-k8s
 ```
 
-It summarizes deployment readiness, image identity, pod restarts, previous container termination reasons, recent warning events, `/health`, `/ready`, and authenticated metrics when `ENGRAM_API_KEY` is available. Use the Docker commands below only for a confirmed local Docker/Compose stack.
+It summarizes deployment readiness, image identity, pod restarts, previous container termination reasons, recent warning events, `/health`, `/ready`, and authenticated metrics when `ENGRAM_API_KEY` is available. Use the Docker commands below only for a confirmed local Docker/Compose stack. If you started the local-only profile with `docker-compose.local.yml`, keep that same file override on every command below.
 
 ```bash
 # Local Docker only: check container state
-docker compose ps
+docker compose -f docker-compose.local.yml ps
 
 # Local Docker only: application logs - last 50 lines
-docker compose logs engram-go-app --tail=50
+docker compose -f docker-compose.local.yml logs engram-go-app --tail=50
 
 # Local Docker only: PostgreSQL logs
-docker compose logs engram-postgres --tail=20
+docker compose -f docker-compose.local.yml logs engram-postgres --tail=20
 
 # Local Docker only: memory count - quick health check
 docker exec engram-postgres psql -U engram -d engram -c "SELECT COUNT(*) FROM memories;"
@@ -195,7 +195,7 @@ curl -s http://localhost:8788/sse
 > `scripts/psql-exec.sh <file.sql>` which uses `docker cp` + `psql -f`
 > (unambiguous, no stdin). See issue #646.
 
-If the SSE endpoint returns nothing or hangs in live Kubernetes, run `make status-k8s` first and inspect the restart/crash/event rows before restarting anything. If the affected runtime is local Docker, check whether the Go container started correctly (`docker compose ps`) and whether PostgreSQL is accepting connections (`docker compose logs engram-postgres`). Most local startup failures are PostgreSQL not finishing its initialization before the Go process tries to connect - restart with `docker compose restart engram-go-app` once PostgreSQL is ready.
+If the SSE endpoint returns nothing or hangs in live Kubernetes, run `make status-k8s` first and inspect the restart/crash/event rows before restarting anything. If the affected runtime is local Docker, check whether the Go container started correctly (`docker compose -f docker-compose.local.yml ps`) and whether PostgreSQL is accepting connections (`docker compose -f docker-compose.local.yml logs engram-postgres`). Most local startup failures are PostgreSQL not finishing its initialization before the Go process tries to connect; once PostgreSQL is ready, restart the same local-only profile with `docker compose -f docker-compose.local.yml restart engram-go-app`.
 
 ---
 


### PR DESCRIPTION
Codex work for #1339 via fleet-dispatch. Draft — needs review/CI. Closes #1339