### PR TITLE
fix: validity-window NaN guard, healthcheck sed/exit-0 fix, gitShortSHA fallback

### DIFF
--- a/cmd/wp05-retrofit-runner/main.go
+++ b/cmd/wp05-retrofit-runner/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -19,25 +20,26 @@ import (
 
 func main() {
 	var (
-		dataPath      = flag.String("data", "/tmp/lme_s_multisession_133.json", "path to the LME-S multi-session fixture JSON")
-		serverURL     = flag.String("url", "", "Engram server URL (env: ENGRAM_URL)")
-		apiKey        = flag.String("api-key", "", "Engram API key (env: ENGRAM_API_KEY)")
-		projectPrefix = flag.String("project-prefix", "wp05-retrofit", "project namespace prefix; each fixture item gets its own <prefix>-<question_id> project")
+		dataPath              = flag.String("data", "/tmp/lme_s_multisession_133.json", "path to the LME-S multi-session fixture JSON")
+		serverURL             = flag.String("url", "", "Engram server URL (env: ENGRAM_URL)")
+		apiKey                = flag.String("api-key", "", "Engram API key (env: ENGRAM_API_KEY)")
+		projectPrefix         = flag.String("project-prefix", "wp05-retrofit", "project namespace prefix; each fixture item gets its own <prefix>-<question_id> project")
 		limit                 = flag.Int("limit", 200, "recall limit; must exceed the max haystack session count per item")
 		exhaustiveAggregation = flag.Bool("exhaustive-aggregation", false, "H8: for aggregation questions, union topK=500 primary+anchor recall with a project-wide memory_list sweep and build Layer B client-side")
 		skipIngest            = flag.Bool("skip-ingest", false, "recall/score only — assumes memories already ingested under project-prefix")
 		outPath               = flag.String("out", "results/wp05-retrofit/retrofit-bundle.json", "output path for the retrofit bundle JSON")
+		harnessSHAFlag        = flag.String("harness-sha", "", "override the harness SHA recorded in provenance; skips git rev-parse and the build-info fallback (useful outside a git checkout, e.g. a shallow clone or extracted tarball)")
 	)
 	flag.Parse()
 	applySharedDefaults(flag.CommandLine, serverURL, apiKey)
 
-	if err := run(*dataPath, *serverURL, *apiKey, *projectPrefix, *limit, *exhaustiveAggregation, *skipIngest, *outPath); err != nil {
+	if err := run(*dataPath, *serverURL, *apiKey, *projectPrefix, *limit, *exhaustiveAggregation, *skipIngest, *outPath, *harnessSHAFlag); err != nil {
 		fmt.Fprintf(os.Stderr, "wp05-retrofit-runner: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiveAggregation, skipIngest bool, outPath string) error {
+func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiveAggregation, skipIngest bool, outPath, harnessSHAOverride string) error {
 	items, err := wp05retrofit.LoadFixture(dataPath)
 	if err != nil {
 		return fmt.Errorf("load fixture: %w", err)
@@ -52,10 +54,7 @@ func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiv
 	}
 	defer func() { _ = client.Close() }()
 
-	harnessSHA, err := gitShortSHA(ctx)
-	if err != nil {
-		return fmt.Errorf("resolve harness SHA: %w", err)
-	}
+	harnessSHA := resolveHarnessSHA(ctx, harnessSHAOverride, gitShortSHA, debug.ReadBuildInfo)
 	runID := "wp05-retrofit-" + time.Now().UTC().Format("20060102T150405Z")
 	itemSet := fmt.Sprintf("%s-develop-n%d", strings.TrimSuffix(filepath.Base(dataPath), filepath.Ext(dataPath)), len(items))
 	featureFlags := []string{"layer_b_retrofit"}
@@ -168,6 +167,53 @@ func mcpDefaults() (url, token string) {
 		return url, token
 	}
 	return url, token
+}
+
+// harnessSHAUnknown is recorded when no SHA can be resolved by any means
+// (no git checkout, no VCS build-info stamp, and no --harness-sha override).
+// The eval tool must degrade gracefully rather than abort the whole run for
+// a provenance field that is informational, not load-bearing (#1320).
+const harnessSHAUnknown = "unknown"
+
+// resolveHarnessSHA determines the harness SHA to record in provenance,
+// trying each source in order and falling back to the next on failure:
+//  1. an explicit --harness-sha override, if provided
+//  2. `git rev-parse --short HEAD` (runGit), when run inside a git checkout
+//  3. the VCS revision embedded in the binary's build info (readBuildInfo),
+//     available when the binary was built via `go build`/`go install` from
+//     within a git checkout even if one isn't present at run time
+//  4. harnessSHAUnknown, if none of the above resolve
+//
+// runGit and readBuildInfo are parameters (rather than direct calls to
+// gitShortSHA/debug.ReadBuildInfo) so tests can exercise the fallback chain
+// without depending on the actual git/build-info state of the test runner.
+func resolveHarnessSHA(ctx context.Context, override string, runGit func(context.Context) (string, error), readBuildInfo func() (*debug.BuildInfo, bool)) string {
+	if override != "" {
+		return override
+	}
+	if sha, err := runGit(ctx); err == nil {
+		if sha = strings.TrimSpace(sha); sha != "" {
+			return sha
+		}
+	}
+	if readBuildInfo != nil {
+		if info, ok := readBuildInfo(); ok && info != nil {
+			for _, setting := range info.Settings {
+				if setting.Key != "vcs.revision" {
+					continue
+				}
+				rev := strings.TrimSpace(setting.Value)
+				if rev == "" {
+					continue
+				}
+				if len(rev) > 12 {
+					rev = rev[:12]
+				}
+				return rev
+			}
+		}
+	}
+	return harnessSHAUnknown
 }
 
 func gitShortSHA(ctx context.Context) (string, error) {

--- a/cmd/wp05-retrofit-runner/main_test.go
+++ b/cmd/wp05-retrofit-runner/main_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"runtime/debug"
+	"testing"
+)
+
+// TestResolveHarnessSHA_Override verifies that an explicit --harness-sha
+// value always wins, without even attempting git or build-info lookups.
+func TestResolveHarnessSHA_Override(t *testing.T) {
+	calledGit := false
+	calledBuildInfo := false
+	runGit := func(context.Context) (string, error) {
+		calledGit = true
+		return "deadbeef", nil
+	}
+	readBuildInfo := func() (*debug.BuildInfo, bool) {
+		calledBuildInfo = true
+		return nil, false
+	}
+
+	got := resolveHarnessSHA(context.Background(), "override-sha", runGit, readBuildInfo)
+
+	if got != "override-sha" {
+		t.Fatalf("resolveHarnessSHA() = %q, want %q", got, "override-sha")
+	}
+	if calledGit {
+		t.Error("resolveHarnessSHA() called runGit despite an explicit override being provided")
+	}
+	if calledBuildInfo {
+		t.Error("resolveHarnessSHA() called readBuildInfo despite an explicit override being provided")
+	}
+}
+
+// TestResolveHarnessSHA_GitSucceeds is the happy path: no override, git
+// resolves successfully — the git SHA must be used and build info must not
+// be consulted.
+func TestResolveHarnessSHA_GitSucceeds(t *testing.T) {
+	calledBuildInfo := false
+	runGit := func(context.Context) (string, error) {
+		return "abc1234", nil
+	}
+	readBuildInfo := func() (*debug.BuildInfo, bool) {
+		calledBuildInfo = true
+		return nil, false
+	}
+
+	got := resolveHarnessSHA(context.Background(), "", runGit, readBuildInfo)
+
+	if got != "abc1234" {
+		t.Fatalf("resolveHarnessSHA() = %q, want %q", got, "abc1234")
+	}
+	if calledBuildInfo {
+		t.Error("resolveHarnessSHA() called readBuildInfo despite git succeeding")
+	}
+}
+
+// TestResolveHarnessSHA_GitFailsFallsBackToBuildInfo covers the issue's core
+// scenario: no git checkout available (shallow clone, extracted tarball,
+// detached HEAD without refs). The function must not abort the run — it
+// must fall back to the VCS revision recorded in the binary's build info.
+func TestResolveHarnessSHA_GitFailsFallsBackToBuildInfo(t *testing.T) {
+	runGit := func(context.Context) (string, error) {
+		return "", errors.New("fatal: not a git repository")
+	}
+	readBuildInfo := func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs", Value: "git"},
+				{Key: "vcs.revision", Value: "0123456789abcdef0123456789abcdef01234567"},
+				{Key: "vcs.modified", Value: "false"},
+			},
+		}, true
+	}
+
+	got := resolveHarnessSHA(context.Background(), "", runGit, readBuildInfo)
+
+	want := "0123456789ab" // truncated to 12 chars
+	if got != want {
+		t.Fatalf("resolveHarnessSHA() = %q, want %q", got, want)
+	}
+}
+
+// TestResolveHarnessSHA_GitFailsShortRevisionNotTruncated verifies short
+// vcs.revision values (fewer than 12 chars) are returned as-is rather than
+// panicking on a slice-out-of-range.
+func TestResolveHarnessSHA_GitFailsShortRevisionNotTruncated(t *testing.T) {
+	runGit := func(context.Context) (string, error) {
+		return "", errors.New("no git binary")
+	}
+	readBuildInfo := func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc123"},
+			},
+		}, true
+	}
+
+	got := resolveHarnessSHA(context.Background(), "", runGit, readBuildInfo)
+
+	if got != "abc123" {
+		t.Fatalf("resolveHarnessSHA() = %q, want %q", got, "abc123")
+	}
+}
+
+// TestResolveHarnessSHA_AllSourcesFail is the boundary/degradation case: no
+// override, no git, no usable build info. resolveHarnessSHA must degrade
+// gracefully to a sentinel value rather than the caller aborting the whole
+// eval run (the original bug: gitShortSHA's error propagated up and killed
+// the run outside a git checkout).
+func TestResolveHarnessSHA_AllSourcesFail(t *testing.T) {
+	tests := []struct {
+		name          string
+		runGit        func(context.Context) (string, error)
+		readBuildInfo func() (*debug.BuildInfo, bool)
+	}{
+		{
+			name: "git fails, no build info available",
+			runGit: func(context.Context) (string, error) {
+				return "", errors.New("not a git repository")
+			},
+			readBuildInfo: func() (*debug.BuildInfo, bool) {
+				return nil, false
+			},
+		},
+		{
+			name: "git fails, build info present but no vcs.revision setting",
+			runGit: func(context.Context) (string, error) {
+				return "", errors.New("not a git repository")
+			},
+			readBuildInfo: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{
+					Settings: []debug.BuildSetting{
+						{Key: "GOOS", Value: "linux"},
+					},
+				}, true
+			},
+		},
+		{
+			name: "git succeeds but returns empty output, build info has empty revision",
+			runGit: func(context.Context) (string, error) {
+				return "   ", nil
+			},
+			readBuildInfo: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{
+					Settings: []debug.BuildSetting{
+						{Key: "vcs.revision", Value: ""},
+					},
+				}, true
+			},
+		},
+		{
+			name:   "readBuildInfo is nil",
+			runGit: func(context.Context) (string, error) { return "", errors.New("no git") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveHarnessSHA(context.Background(), "", tt.runGit, tt.readBuildInfo)
+			if got != harnessSHAUnknown {
+				t.Fatalf("resolveHarnessSHA() = %q, want %q", got, harnessSHAUnknown)
+			}
+		})
+	}
+}
+
+// TestGitShortSHA_RealGit is a light integration check that the real
+// gitShortSHA implementation (used as resolveHarnessSHA's runGit argument in
+// production) still returns a non-empty short SHA when actually run inside
+// this repo's git checkout.
+func TestGitShortSHA_RealGit(t *testing.T) {
+	sha, err := gitShortSHA(context.Background())
+	if err != nil {
+		t.Skipf("gitShortSHA() error (expected outside a git checkout): %v", err)
+	}
+	if sha == "" {
+		t.Error("gitShortSHA() returned an empty string with no error")
+	}
+}

--- a/internal/search/validity_window_test.go
+++ b/internal/search/validity_window_test.go
@@ -14,6 +14,7 @@ package search_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -149,6 +150,19 @@ func TestValidityWindowFilter_SupersededFactDeranked(t *testing.T) {
 
 	require.True(t, foundOld, "outdated memory must be in recall results")
 	require.True(t, foundNew, "current memory must be in recall results")
+
+	// Guard against non-finite composite scores (NaN/Inf) *before* handing them
+	// to assert.Greater. testify's numeric comparator falls through to a bare
+	// "Can not compare type \"float64\"" failure when every ordering check on a
+	// NaN operand evaluates false — that error gives no indication a NaN was
+	// involved, which is what made this test flaky/confusing in CI (#1353).
+	// Failing loudly here with the actual values makes the underlying scoring
+	// issue (if any) visible instead of masquerading as a testify type error.
+	require.False(t, math.IsNaN(scoreOld) || math.IsNaN(scoreNew),
+		"composite scores must be finite, not NaN: scoreOld=%v scoreNew=%v", scoreOld, scoreNew)
+	require.False(t, math.IsInf(scoreOld, 0) || math.IsInf(scoreNew, 0),
+		"composite scores must be finite, not +/-Inf: scoreOld=%v scoreNew=%v", scoreOld, scoreNew)
+
 	assert.Greater(t, scoreNew, scoreOld,
 		"current fact (valid_from=2024) must outscore outdated fact (valid_from=2020) when validity window filter is ON")
 }

--- a/ops/healthcheck.sh
+++ b/ops/healthcheck.sh
@@ -15,7 +15,7 @@ fi
 
 # Extract the most recent ISO-8601 timestamp from log lines of the form:
 #   instinct: ... [2026-04-22T10:00:00Z]
-last_ts=$(sed -n 's/.*\[\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z\)\].*/\1/p' "$LOG" | tail -1 || :)
+last_ts=$(sed -n 's/.*\[\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z\)\].*/\1/p' "$LOG" 2>/dev/null | tail -1 || :)
 
 if [[ -z "$last_ts" ]]; then
     echo "WARN: no timestamped instinct runs found in $LOG"
@@ -34,3 +34,4 @@ fi
 
 echo "OK: instinct last ran ${gap}s ago"
 echo "Last: $last_ts"
+exit 0

--- a/ops/healthcheck.test.sh
+++ b/ops/healthcheck.test.sh
@@ -56,6 +56,96 @@ assert_exit "healthcheck works without grep -P" 0 "$rc"
 assert_contains "reports healthy status" "OK: instinct last ran" "$out"
 assert_contains "reports extracted timestamp" "Last: $now_ts" "$out"
 
+# --- Multi-line log: the newest (last) timestamp must be the one reported,
+# not the first bracketed match in the file (#1362 nice-to-have #1). ---
+older_ts="2020-01-01T00:00:00Z"
+printf 'instinct: ok [%s]\ninstinct: ok [%s]\n' "$older_ts" "$now_ts" >"$tmp/state/instinct/run.log"
+
+out=$(PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" INSTINCT_MAX_GAP=7200 bash "$SCRIPT" 2>&1)
+rc=$?
+assert_exit "healthcheck picks newest of multiple log lines" 0 "$rc"
+assert_contains "reports the newest timestamp, not the oldest" "Last: $now_ts" "$out"
+if echo "$out" | grep -qF -- "Last: $older_ts"; then
+  echo "FAIL: healthcheck reported the older timestamp instead of the newest"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: healthcheck did not report the older timestamp"
+  PASS=$((PASS + 1))
+fi
+
+# --- Missing log file: must WARN and exit non-zero, with no date/arithmetic
+# garbage (e.g. "date: invalid date" or unbound-variable errors) leaking into
+# output (#1362 blocker #1). ---
+rm -f "$tmp/state/instinct/run.log"
+out=$(PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" INSTINCT_MAX_GAP=7200 bash "$SCRIPT" 2>&1)
+rc=$?
+assert_exit "missing log file exits non-zero" 1 "$rc"
+assert_contains "missing log file reports a clear WARN" "WARN: instinct run.log not found" "$out"
+if echo "$out" | grep -qiE "invalid date|unbound variable|No such file or directory"; then
+  echo "FAIL: missing-log path leaked raw command error output"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: missing-log path produced no raw command error output"
+  PASS=$((PASS + 1))
+fi
+
+# --- Log exists but has no recognizable timestamp: must WARN and exit
+# non-zero without falling through to gap arithmetic on an empty last_ts. ---
+mkdir -p "$tmp/state/instinct"
+printf 'instinct: started, no timestamp yet\n' >"$tmp/state/instinct/run.log"
+out=$(PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" INSTINCT_MAX_GAP=7200 bash "$SCRIPT" 2>&1)
+rc=$?
+assert_exit "log with no timestamp exits non-zero" 1 "$rc"
+assert_contains "log with no timestamp reports a clear WARN" "WARN: no timestamped instinct runs found" "$out"
+if echo "$out" | grep -qiE "invalid date|unbound variable"; then
+  echo "FAIL: empty-last_ts path leaked date/arithmetic garbage"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: empty-last_ts path produced no date/arithmetic garbage"
+  PASS=$((PASS + 1))
+fi
+
+# --- Log exists but is unreadable (permission denied): the sed extraction
+# must not leak raw stderr, and the script must still fall through to the
+# empty-last_ts WARN path cleanly (#1362 blocker #1). ---
+if [ "$(id -u)" -ne 0 ]; then
+  printf 'instinct: ok [%s]\n' "$now_ts" >"$tmp/state/instinct/run.log"
+  chmod 000 "$tmp/state/instinct/run.log"
+  out=$(PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" INSTINCT_MAX_GAP=7200 bash "$SCRIPT" 2>&1)
+  rc=$?
+  chmod 644 "$tmp/state/instinct/run.log"
+  assert_exit "unreadable log exits non-zero" 1 "$rc"
+  if echo "$out" | grep -qiE "Permission denied|invalid date|unbound variable"; then
+    echo "FAIL: unreadable-log path leaked raw sed/date error output"
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS: unreadable-log path produced no raw sed/date error output"
+    PASS=$((PASS + 1))
+  fi
+else
+  echo "SKIP: unreadable-log test (running as root, chmod 000 has no effect)"
+fi
+
+# --- Stale run: gap exceeds INSTINCT_MAX_GAP, must FAIL / exit non-zero
+# (#1362 nice-to-have #3). ---
+old_ts="2020-01-01T00:00:00Z"
+printf 'instinct: ok [%s]\n' "$old_ts" >"$tmp/state/instinct/run.log"
+out=$(PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" INSTINCT_MAX_GAP=60 bash "$SCRIPT" 2>&1)
+rc=$?
+assert_exit "stale run exits non-zero" 1 "$rc"
+assert_contains "stale run reports WARN" "WARN: instinct last ran" "$out"
+
+# --- Success path must not depend on the last command's exit status: an
+# explicit `exit 0` must terminate the script (#1362 blocker #3). ---
+printf 'instinct: ok [%s]\n' "$now_ts" >"$tmp/state/instinct/run.log"
+if grep -qE '^exit 0$' "$SCRIPT"; then
+  echo "PASS: success path has an explicit exit 0"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: success path is missing an explicit exit 0"
+  FAIL=$((FAIL + 1))
+fi
+
 echo
 echo "--- ${PASS} passed, ${FAIL} failed ---"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Bundles three independent night-pass fixes; a fourth issue (#1312) was investigated and found already resolved.

- **#1353** — `TestValidityWindowFilter_SupersededFactDeranked` occasionally failed in CI with testify's opaque `Can not compare type "float64"` error. Root cause: testify's numeric `compare()` falls through to `isComparable=false` when every ordering check on a NaN operand evaluates false — so a NaN composite score (not an int/float64 type mismatch as originally guessed) produces that exact message. Added explicit `math.IsNaN`/`math.IsInf` guards with diagnostic messages ahead of the `assert.Greater` call so any future non-finite score fails loudly with actual values instead of a confusing testify internals error.
- **#1362** — post-merge review of `ops/healthcheck.sh` (#1352) found: (1) the sed timestamp extraction lost its `2>/dev/null` when it replaced `grep -P`, so an unreadable/raced log file leaks raw sed stderr instead of falling through cleanly to the existing empty-`last_ts` WARN path; (2) the explicit `exit 0` on the success path was dropped, making the healthy contract depend on the last `echo`'s exit status. Restored both. Added `ops/healthcheck.test.sh` cases for: multi-line logs (newest timestamp wins), missing log, empty-timestamp log, **unreadable (chmod 000) log** (reproduces blocker #1 — verified failing against the pre-fix script, passing after), stale run, and the explicit `exit 0` (verified failing against the pre-fix script).
- **#1320** — `gitShortSHA` in `cmd/wp05-retrofit-runner/main.go` aborted the whole eval run when run outside a git checkout (shallow clone, extracted tarball). Added `resolveHarnessSHA`, which tries, in order: an explicit `--harness-sha` flag, `git rev-parse --short HEAD`, the `vcs.revision` embedded in the binary's build info (`debug.ReadBuildInfo`), and only falls back to a literal `"unknown"` sentinel if none resolve. New `main_test.go` covers the override, git-succeeds, git-fails-with-buildinfo, short-revision, and all-sources-fail (multiple subcases) paths via injected `runGit`/`readBuildInfo` functions.
- **#1312** — investigated, not modified. Both nice-to-haves (misleading "embed unavailable" warning text when only `droppedHits>0`, and a dedicated two-pass drop-accumulation test) were already fixed by commit `bc8497c` (PR #1366, merged 2026-07-06): `addRecallWarnings` now gates the embed-warning text on `embedDegraded` specifically (`internal/mcp/tools_recall.go`), `fetch_recall_test.go:917` asserts the embed warning is absent on a dropped-hits-only path, and `internal/search/temporal_two_pass_test.go` adds `TestRecallTwoPassTemporal_AccumulatesDroppedHitsFromBothPasses`. Re-ran both tests against this branch to confirm — both pass.

## Test plan

- [x] `internal/search/validity_window_test.go`: `TestValidityWindowFilter_SupersededFactDeranked` passes (x3) against local Postgres (`TEST_DATABASE_URL`)
- [x] `ops/healthcheck.test.sh`: 17/17 assertions pass; new assertions verified to fail against the pre-fix script (`git stash`), pass after
- [x] `cmd/wp05-retrofit-runner`: new `main_test.go` — all cases pass; `go build ./...` succeeds
- [x] `go test ./cmd/wp05-retrofit-runner/... ./internal/search/... ./internal/mcp/... -count=1 -race` — all pass
- [x] `go test ./... -count=1` (full repo, with `TEST_DATABASE_URL` set) — one pre-existing failure in `internal/db` (`TestEnqueueChunkLeases_Batch`), in a package this PR does not touch — unrelated
- [x] `gofmt -l` clean on all touched Go files

Closes #1353
Closes #1362
Closes #1320

https://claude.ai/code/session_01AYYMBEy3EJkuPtKiV3795j