### PR TITLE
L2: anti-hedge per-type prompt for ss-preference (M0.5 Phase 4)

### DIFF
--- a/cmd/longmemeval/anti_hedge_test.go
+++ b/cmd/longmemeval/anti_hedge_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+// TestAntiHedgePrompts_SSPreferenceHappyPath verifies that with
+// --anti-hedge-prompts on, a single-session-preference question's generation
+// prompt (as actually sent to the LLM through the runOne pipeline) contains
+// the anti-hedge addendum. Uses the h8h12Capture fake MCP/LLM server pattern
+// (runOneWithCapture, cmd/longmemeval/h8h12_test.go) so this exercises real
+// wiring through run.go, not just the pure prompt builder.
+func TestAntiHedgePrompts_SSPreferenceHappyPath(t *testing.T) {
+	item := longmemeval.Item{
+		QuestionID:   "q-anti-hedge-happy",
+		Question:     "What kind of restaurant would I like?",
+		QuestionType: "single-session-preference",
+		QuestionDate: "2024-06-01",
+	}
+	capture := runOneWithCapture(t, &Config{
+		RecallTopK:       100,
+		AntiHedgePrompts: true,
+	}, item)
+	got := capture.lastPrompt(t)
+	if !strings.Contains(strings.ToLower(got), "anti-hedge rule") {
+		t.Fatalf("prompt sent to LLM missing anti-hedge addendum for ss-preference question:\n%s", got)
+	}
+}
+
+// TestAntiHedgePrompts_FlagOffIsBaseline verifies that with the flag off, the
+// prompt actually sent to the LLM for a single-session-preference question is
+// byte-identical to the standard baseline prompt (no addendum leaks in).
+func TestAntiHedgePrompts_FlagOffIsBaseline(t *testing.T) {
+	item := longmemeval.Item{
+		QuestionID:   "q-anti-hedge-off",
+		Question:     "What kind of restaurant would I like?",
+		QuestionType: "single-session-preference",
+		QuestionDate: "2024-06-01",
+	}
+	capture := runOneWithCapture(t, &Config{RecallTopK: 100}, item)
+	got := capture.lastPrompt(t)
+	want := longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, []string{
+		"Session date: 2024-05-10\nCalled my sister.",
+	})
+	if got != want {
+		t.Fatalf("anti-hedge flag off should preserve the baseline ss-preference prompt\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+// TestAntiHedgePrompts_NonPreferenceTypeUnaffected verifies the flag is a
+// no-op end-to-end for a question type that is neither
+// single-session-preference nor inferred-preference-shaped, even when on.
+func TestAntiHedgePrompts_NonPreferenceTypeUnaffected(t *testing.T) {
+	item := longmemeval.Item{
+		QuestionID:   "q-anti-hedge-nonpref",
+		Question:     "How many times did I call my sister?",
+		QuestionType: "multi-session",
+		QuestionDate: "2024-06-01",
+	}
+	capture := runOneWithCapture(t, &Config{
+		RecallTopK:       100,
+		AntiHedgePrompts: true,
+	}, item)
+	got := capture.lastPrompt(t)
+	if strings.Contains(strings.ToLower(got), "anti-hedge rule") {
+		t.Fatalf("anti-hedge addendum leaked into a non-preference question type prompt:\n%s", got)
+	}
+	want := longmemeval.GenerationPromptForType(item.Question, item.QuestionType, item.QuestionDate, []string{
+		"Session date: 2024-05-10\nCalled my sister.",
+	})
+	if got != want {
+		t.Fatalf("non-preference type prompt should be unaffected by --anti-hedge-prompts\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+// TestAntiHedgePrompts_FeatureFlagPersisted verifies buildFeatureFlags records
+// anti_hedge_prompts=true in run provenance when the flag is set, so registry
+// rows can attribute results to this lever (mirrors sibling flags like
+// dual_preference_recall/topic_anchor_boost in cmd/longmemeval/provenance.go).
+func TestAntiHedgePrompts_FeatureFlagPersisted(t *testing.T) {
+	flags := buildFeatureFlags(&Config{AntiHedgePrompts: true})
+	v, ok := flags["anti_hedge_prompts"]
+	if !ok || v != true {
+		t.Fatalf("buildFeatureFlags missing anti_hedge_prompts=true, got: %#v", flags)
+	}
+}
+
+// TestAntiHedgePrompts_FeatureFlagAbsentWhenOff verifies the flag key is
+// omitted entirely (not just false) when --anti-hedge-prompts is not set —
+// matching the sparse feature_flags convention every sibling flag follows.
+func TestAntiHedgePrompts_FeatureFlagAbsentWhenOff(t *testing.T) {
+	flags := buildFeatureFlags(&Config{})
+	if _, ok := flags["anti_hedge_prompts"]; ok {
+		t.Fatalf("buildFeatureFlags should omit anti_hedge_prompts when off, got: %#v", flags)
+	}
+}
+
+// TestAntiHedgePrompts_InferredPreferenceBoundary verifies the addendum fires
+// end-to-end for a "recommend"-phrased question even when the dataset's own
+// question_type label is not single-session-preference — the boundary case
+// covered by IsInferredPreferenceQuestion (the same gate --dual-preference-recall
+// already uses).
+func TestAntiHedgePrompts_InferredPreferenceBoundary(t *testing.T) {
+	item := longmemeval.Item{
+		QuestionID:   "q-anti-hedge-inferred",
+		Question:     "Can you recommend a hotel for my trip to Miami?",
+		QuestionType: "single-session-user",
+		QuestionDate: "2024-06-01",
+	}
+	if !longmemeval.IsInferredPreferenceQuestion(item.Question) {
+		t.Fatalf("test setup: question must be recognised as inferred-preference")
+	}
+	capture := runOneWithCapture(t, &Config{
+		RecallTopK:       100,
+		AntiHedgePrompts: true,
+	}, item)
+	got := capture.lastPrompt(t)
+	if !strings.Contains(strings.ToLower(got), "anti-hedge rule") {
+		t.Fatalf("inferred-preference question missing anti-hedge addendum end-to-end:\n%s", got)
+	}
+}

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -124,6 +124,9 @@ type Config struct {
 
 	// H-KUR: knowledge-update recency generation prompt (issue #1178).
 	KURecencyPrompt bool // instruct the model to answer with the most-recent-session value when multiple values for the same attribute appear across sessions (default off)
+
+	// L2 (M0.5 Phase 4 closeout): anti-hedge per-type generation prompt.
+	AntiHedgePrompts bool // append an anti-hedge addendum to single-session-preference and inferred-preference prompts instructing the model to commit to the stated preference rather than hedge with "it depends"/"I don't have enough information" when the context contains an answer (default off)
 	// Retrieval-fusion flags for issue #938.
 	RetrievalFusion     bool // union multiple query variants (primary/raw/identifier queries)
 	ExactSignalBoost    bool // re-rank candidate IDs by exact identifier/entity overlap
@@ -326,6 +329,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&cfg.PreferenceGround, "preference-ground", false, "H-PG: for single-session-preference answers, forbid specific brands/titles/cuisines/ingredients/genres unless they appear explicitly in retrieved context; prefer a short grounded answer over padded specifics (default off)")
 	// H-KUR: knowledge-update recency generation prompt (issue #1178)
 	fs.BoolVar(&cfg.KURecencyPrompt, "ku-recency-prompt", false, "H-KUR: for knowledge-update answers, instruct the model to answer with the value from the most recent session (latest date) when multiple values for the same attribute appear across sessions in context (default off)")
+	// L2 (M0.5 Phase 4 closeout): anti-hedge per-type generation prompt
+	fs.BoolVar(&cfg.AntiHedgePrompts, "anti-hedge-prompts", false, "L2: for single-session-preference and inferred-preference answers, append an addendum instructing the model to commit to the preference stated or implied in context rather than hedge with \"it depends\"/\"I don't have enough information\" when context contains an answer (default off)")
 	fs.BoolVar(&cfg.RetrievalFusion, "retrieval-fusion", false, "issue #938: fuse retrieval candidates from primary/raw/identifier query variants")
 	fs.BoolVar(&cfg.ExactSignalBoost, "exact-signal-boost", false, "issue #938: boost candidates that contain exact identifiers/entities from the question")
 	fs.BoolVar(&cfg.EvidenceFirstPacked, "evidence-first-pack", false, "issue #938: pack context in evidence-first order using exact overlap signals")

--- a/cmd/longmemeval/provenance.go
+++ b/cmd/longmemeval/provenance.go
@@ -241,6 +241,9 @@ func buildFeatureFlags(cfg *Config) map[string]any {
 	if cfg.AtomOracle {
 		flags["atom_oracle"] = true
 	}
+	if cfg.AntiHedgePrompts {
+		flags["anti_hedge_prompts"] = true
+	}
 	return flags
 }
 

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -830,6 +830,9 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// single-session-preference questions and is independent of the other flags.
 	// H-KUR (--ku-recency-prompt) is likewise orthogonal — it only fires for
 	// knowledge-update questions and is independent of the other flags.
+	// L2 (--anti-hedge-prompts) is likewise orthogonal — it only fires for
+	// single-session-preference and inferred-preference questions and is a
+	// pure prompt-addendum lever independent of the other flags.
 	var prompt string
 	switch {
 	case cfg.TemporalPromptAug:
@@ -840,6 +843,8 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 		prompt = longmemeval.GenerationPromptForTypePreferenceEnumerate(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.PreferenceGround:
 		prompt = longmemeval.GenerationPromptForTypePreferenceGround(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
+	case cfg.AntiHedgePrompts:
+		prompt = longmemeval.GenerationPromptForTypeAntiHedge(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	case cfg.KURecencyPrompt:
 		prompt = longmemeval.GenerationPromptForTypeKURecency(item.Question, item.QuestionType, item.QuestionDate, contextBlocks, true)
 	default:

--- a/internal/longmemeval/claude.go
+++ b/internal/longmemeval/claude.go
@@ -564,6 +564,54 @@ GROUNDING RULE:
 - Prefer a short grounded answer over a padded one.`, questionDate, ctx, questionDate, question)
 }
 
+// antiHedgeAddendum (L2, M0.5 Phase 4 closeout) is the anti-hedge instruction
+// appended to preference-type generation prompts when --anti-hedge-prompts is
+// enabled. Targets the ss-preference hedging failure mode where the model
+// answers "it depends" / "I don't have enough information" / "it's unclear"
+// even though the retrieved context states or clearly implies a preference —
+// a refusal-shaped non-answer the judge scores as wrong even when the
+// underlying evidence was retrieved correctly. This is a pure prompt lever:
+// it does not change retrieval, matching, schema, or scoring.
+const antiHedgeAddendum = `ANTI-HEDGE RULE: If the context above states or clearly implies a preference relevant to this question, you MUST commit to that preference as your answer. Do not hedge with phrases like "it depends", "I don't have enough information", "it's unclear", "I cannot determine", "without more context", or any similar non-answer when the context contains an answer. Only say the preference is unknown if the context truly contains no relevant information about it.`
+
+// appendPromptAddendum appends addendum to prompt separated by a blank line,
+// trimming surrounding whitespace from each so repeated application stays
+// idempotent-shaped. Mirrors prependPromptPrefix's empty-string handling.
+func appendPromptAddendum(prompt, addendum string) string {
+	prompt = strings.TrimSpace(prompt)
+	addendum = strings.TrimSpace(addendum)
+	switch {
+	case addendum == "":
+		return prompt
+	case prompt == "":
+		return addendum
+	default:
+		return prompt + "\n\n" + addendum
+	}
+}
+
+// GenerationPromptForTypeAntiHedge (L2, M0.5 Phase 4 closeout) is like
+// GenerationPromptForType but, when antiHedgePrompts is true, appends the
+// antiHedgeAddendum to the generation prompt for single-session-preference
+// questions AND for questions IsInferredPreferenceQuestion identifies as
+// preference-shaped by their raw text (e.g. "What restaurant would I like?")
+// even when the dataset's own question_type label is something else — the
+// same inferred-preference gate --dual-preference-recall (H15) already uses.
+// For all other question types, or when the flag is false, the standard
+// GenerationPromptForType output is returned unchanged. Pure prompt lever: no
+// retrieval, matcher, schema, or scorer change.
+// Activated by --anti-hedge-prompts (Config.AntiHedgePrompts). Off by default.
+func GenerationPromptForTypeAntiHedge(question, questionType, questionDate string, contextBlocks []string, antiHedgePrompts bool) string {
+	base := GenerationPromptForType(question, questionType, questionDate, contextBlocks)
+	if !antiHedgePrompts {
+		return base
+	}
+	if questionType != "single-session-preference" && !IsInferredPreferenceQuestion(question) {
+		return base
+	}
+	return appendPromptAddendum(base, antiHedgeAddendum)
+}
+
 // GenerationPromptForTypeKURecency (H-KUR, issue #1178) is like
 // GenerationPromptForType but, when kuRecencyPrompt is true for
 // "knowledge-update" questions, routes to GenerationPromptKnowledgeUpdate — a

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -569,6 +569,83 @@ func TestGenerationPrompt_KURecency_NonKUTypeUnaffected(t *testing.T) {
 	}
 }
 
+// TestGenerationPrompt_AntiHedge_SSPreferenceHappyPath verifies the L2
+// anti-hedge addendum is appended to the standard single-session-preference
+// prompt when --anti-hedge-prompts is on, instructing the model to commit to
+// a stated preference rather than hedge.
+func TestGenerationPrompt_AntiHedge_SSPreferenceHappyPath(t *testing.T) {
+	question := "What kind of restaurant would I like?"
+	questionDate := "2024-03-15"
+	context := []string{"Session date: 2024-03-10\nUser said they love quiet ramen spots."}
+	prompt := longmemeval.GenerationPromptForTypeAntiHedge(question, "single-session-preference", questionDate, context, true)
+
+	base := longmemeval.GenerationPromptForType(question, "single-session-preference", questionDate, context)
+	if !strings.Contains(prompt, base) {
+		t.Errorf("anti-hedge prompt must still contain the standard preference prompt\nwant substring:\n%s\n\ngot:\n%s", base, prompt)
+	}
+	lower := strings.ToLower(prompt)
+	for _, want := range []string{
+		"anti-hedge rule",
+		"it depends",
+		"i don't have enough information",
+		"commit",
+	} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("anti-hedge prompt must contain %q, got:\n%s", want, prompt)
+		}
+	}
+}
+
+// TestGenerationPrompt_AntiHedge_FlagOffIsBaseline verifies the flag is a
+// true no-op (byte-identical to GenerationPromptForType) for a
+// single-session-preference question when antiHedgePrompts is false.
+func TestGenerationPrompt_AntiHedge_FlagOffIsBaseline(t *testing.T) {
+	question := "What kind of restaurant would I like?"
+	questionDate := "2024-03-15"
+	context := []string{"Session date: 2024-03-10\nUser said they love quiet ramen spots."}
+	got := longmemeval.GenerationPromptForTypeAntiHedge(question, "single-session-preference", questionDate, context, false)
+	want := longmemeval.GenerationPromptForType(question, "single-session-preference", questionDate, context)
+	if got != want {
+		t.Errorf("anti-hedge flag off should preserve standard preference prompt\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+// TestGenerationPrompt_AntiHedge_NonPreferenceTypeUnaffected verifies the
+// addendum is absent for a question type that is neither
+// single-session-preference nor recognised by IsInferredPreferenceQuestion,
+// even when the flag is on — the lever must not leak into other types.
+func TestGenerationPrompt_AntiHedge_NonPreferenceTypeUnaffected(t *testing.T) {
+	question := "When did the user buy their camera?"
+	questionDate := "2024-03-15"
+	context := []string{"Session date: 2024-01-05\nUser mentioned they bought a Sony A7IV last week."}
+	got := longmemeval.GenerationPromptForTypeAntiHedge(question, "single-session-user", questionDate, context, true)
+	want := longmemeval.GenerationPromptForType(question, "single-session-user", questionDate, context)
+	if got != want {
+		t.Errorf("anti-hedge flag must not affect non-preference question types\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+// TestGenerationPrompt_AntiHedge_InferredPreferenceBoundary verifies the
+// addendum also fires for a question whose raw text is preference-shaped
+// (matched by IsInferredPreferenceQuestion, e.g. a "recommend" phrasing) even
+// when its dataset question_type label is something other than
+// single-session-preference — mirroring the same inferred-preference gate
+// --dual-preference-recall (H15) already uses.
+func TestGenerationPrompt_AntiHedge_InferredPreferenceBoundary(t *testing.T) {
+	question := "Can you recommend a hotel for my trip to Miami?"
+	if !longmemeval.IsInferredPreferenceQuestion(question) {
+		t.Fatalf("test setup: question %q must be recognised as inferred-preference", question)
+	}
+	questionDate := "2024-03-15"
+	context := []string{"Session date: 2024-03-10\nUser said they prefer boutique hotels near the beach."}
+	prompt := longmemeval.GenerationPromptForTypeAntiHedge(question, "single-session-user", questionDate, context, true)
+
+	lower := strings.ToLower(prompt)
+	if !strings.Contains(lower, "anti-hedge rule") {
+		t.Errorf("inferred-preference question must receive the anti-hedge addendum even with a non-preference type label, got:\n%s", prompt)
+	}
+}
+
 // TestGenerationPromptKnowledgeUpdate_ContainsRecencyInstructionAndContext
 // verifies the underlying prompt builder (named per issue #1178's acceptance
 // criteria: GenerationPromptKnowledgeUpdate) embeds both the recency rule and


### PR DESCRIPTION
## Summary

Implements Phase 4 L2 of the M0.5 closeout plan (`docs/campaign/PLAN-M05-CLOSEOUT-LEVERS.md` / `docs/campaign/START-HERE-NEXT.md`, 02:35 AM EDT 2026-07-08 entry): an opt-in anti-hedge generation-prompt lever for `single-session-preference` questions, targeting the judge failure mode where the model answers "it depends" / "I don't have enough information" / "it's unclear" even though the retrieved context already states or implies the preference.

- New flag: **`--anti-hedge-prompts`** (`Config.AntiHedgePrompts`, default off).
- New function `longmemeval.GenerationPromptForTypeAntiHedge` (mirrors the existing `GenerationPromptForTypePreferenceGround`/`...PreferenceEnumerate` per-type prompt levers): when the flag is on, appends a fixed `antiHedgeAddendum` to the standard prompt for:
  - `question_type == "single-session-preference"`, **and**
  - any question `IsInferredPreferenceQuestion` recognizes as preference-shaped by raw text (e.g. a "recommend"/"favorite" phrasing) regardless of its dataset type label — the same inferred-preference gate `--dual-preference-recall` (H15) already uses.
- Wired into `run.go`'s per-type prompt-selection switch, alongside `PreferenceEnumerate`/`PreferenceGround`/`KURecencyPrompt` (mutually exclusive with those, same as the existing siblings).
- Persisted as `anti_hedge_prompts: true` in `buildFeatureFlags` (`provenance.go`) so `results/benchmark-registry.jsonl` rows can attribute future measurement runs to this lever.

**Pure prompt lever, implementation only** — no schema, matcher, retrieval, or scorer changes. The scorer lock is untouched. Measurement (a real run vs. baseline on the pinned generator, `Qwen3-Next-80B-A3B-Instruct-FP8` at `oblivion.petersimmons.com:8000`) is an explicit follow-up, not part of this PR — mind the campaign's documented ±7-8pp noise floor; a delta inside that band is a null result and should be recorded as such, not treated as a win or a loss.

## Files touched
- `internal/longmemeval/claude.go` — `antiHedgeAddendum` const, `appendPromptAddendum`, `GenerationPromptForTypeAntiHedge`
- `cmd/longmemeval/main.go` — `Config.AntiHedgePrompts` field + `--anti-hedge-prompts` flag registration
- `cmd/longmemeval/run.go` — switch-case wiring in the per-type prompt selection
- `cmd/longmemeval/provenance.go` — `buildFeatureFlags` persistence
- `internal/longmemeval/claude_test.go` — pure prompt-builder tests
- `cmd/longmemeval/anti_hedge_test.go` (new) — end-to-end wiring tests via the `h8h12Capture` fake MCP/LLM harness (`runOneWithCapture`), plus feature-flag persistence tests

## Test plan
- [x] Happy path: flag on + `single-session-preference` question → addendum present (pure-builder and end-to-end via `runOneWithCapture`)
- [x] Zero/empty: flag off → byte-identical to baseline; flag on + non-preference type → byte-identical to baseline (no leak)
- [x] Boundary: inferred-preference question shape (`IsInferredPreferenceQuestion`) with a non-`single-session-preference` type label → addendum still fires
- [x] Feature-flag provenance: `anti_hedge_prompts=true` present when on, key omitted entirely when off
- [x] `go test ./cmd/longmemeval/... -count=1 -race` — green
- [x] `go test ./internal/longmemeval/... -count=1 -race` — green
- [x] `gofmt -l` clean on every touched/new file (pre-existing `gofmt` drift on unrelated lines of `claude_test.go` predates this change and is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01AYYMBEy3EJkuPtKiV3795j