### PR TITLE
docs(lme,wp05retrofit): benchmark-registry.jsonl convention + WP-0.5c godoc

### DIFF
--- a/cmd/wp05-retrofit-runner/main.go
+++ b/cmd/wp05-retrofit-runner/main.go
@@ -1,3 +1,26 @@
+// Command wp05-retrofit-runner drives the internal/wp05retrofit harness
+// end-to-end against a live Engram server: load a LongMemEval-shaped
+// fixture, ingest+recall+score each item (see wp05retrofit.Run), and write
+// the resulting Bundle as JSON.
+//
+// This is WP-0.5c, the "retrofit" arm of the WP-0.5 retrofit-vs-greenfield
+// bake-off (see the internal/wp05retrofit package doc for full campaign
+// context and the duramind JSON-compatibility contract the output must
+// hold). It is bake-off scaffolding: expected to be retired once WP-0.5
+// concludes, not permanent CLI surface.
+//
+// Usage:
+//
+//	wp05-retrofit-runner -data <fixture.json> -url <engram-url> -api-key <key> \
+//	    -project-prefix wp05-retrofit -limit 200 -out results/wp05-retrofit/retrofit-bundle.json
+//
+// -url and -api-key default to the local Engram MCP server config
+// (~/.claude/mcp_servers.json) when not provided, mirroring cmd/longmemeval's
+// discovery behavior (see mcpDefaults). Provenance.HarnessSHA is resolved in
+// priority order: -harness-sha override, `git rev-parse --short HEAD`, the
+// binary's embedded VCS build-info revision, else "unknown" — see
+// resolveHarnessSHA; per issue #1320, a missing SHA is informational and
+// must never abort the run.
 package main
 
 import (

--- a/docs/lme-campaign/RUNBOOK.md
+++ b/docs/lme-campaign/RUNBOOK.md
@@ -108,6 +108,63 @@ c,p,i=tot; n=sum(tot); print(f'{"OVERALL":28} strict={c/n*100:5.1f}% lenient={(c
 PY
 ```
 
+### 7. Register the result in `results/benchmark-registry.jsonl`
+
+`results/benchmark-registry.jsonl` is the durable, git-tracked, one-line-per-run summary of
+every campaign measurement — curated headline numbers, not raw per-item dumps. `results/` is
+gitignored precisely to keep full raw run directories out of the repo; this file is the
+deliberate exception, force-added because it stays small (one JSON object per line) and gives
+anyone reading `main` a searchable history of every run's topline result without needing the
+raw artifacts to exist on disk.
+
+**Every LME run in this campaign — regardless of sub-effort, variant, or which arm of a
+bake-off it belongs to — appends one entry here after scoring**, whether or not the full raw
+`results/<name>/` dump is also committed (it usually isn't).
+
+Append with `git add -f results/benchmark-registry.jsonl` (the `-f` is required — the file
+lives inside the gitignored `results/` tree) and commit the new line alongside whatever else
+the run PR contains.
+
+**Schema** — one JSON object per line:
+
+Required fields:
+- `ts` — ISO-8601 UTC timestamp of when the entry was registered (not necessarily when the run
+  started).
+- `run_id` — the harness run identifier (matches `checkpoint-run.jsonl` / `RUN_STATUS.json`
+  provenance for the underlying run).
+- `label` — short human-readable slug for this measurement, unique enough to grep for
+  (e.g. `WP-0.2-oblivion-qwen3next-solo`).
+- `phase` — which campaign phase/work-package this measurement belongs to
+  (e.g. `Duramind-M0-WP0.2`).
+- `suite` — the dataset/suite identifier (e.g. `lme-s-500q`).
+- `strict_accuracy`, `lenient_accuracy` — the two headline scores (0–1 floats), per the
+  CORRECT / PARTIALLY_CORRECT / INCORRECT rubric in this doc's step 5–6.
+- `correct`, `total` — raw counts backing `strict_accuracy` (correct/total; lenient uses
+  correct+partially_correct, tracked in `by_question_type`, not duplicated at the top level).
+- `run_errors` — count of items that errored out of scoring entirely (0 for a clean run).
+- `config` — object capturing what varied this run: at minimum `generator`
+  (model/endpoint), `scorer_lock` (see `docs/lme-judging.md`), `gold_version`, and `workers`.
+  Add other knobs (flags, ingest source, generator_endpoint) as relevant to that run.
+- `by_question_type` — per-`question_type` breakdown, each with `strict`, `correct`, `total`
+  (mirrors the step-6 per-type table).
+
+Optional but strongly encouraged:
+- `notes` — free-text provenance: what this run is being compared against, any caveats
+  (invalid-attempt history, non-comparable generator/judge combos, divergence explanations),
+  and cross-references to `docs/lme-campaign/FINDINGS.md` or prior `run_id`s. Every row's
+  provenance (`gold_version`, `scorer_version`, `feature_flags`, `system`, `item_set`,
+  `run_id`, `harness_sha` — the full field list from `docs/lme-judging.md`) should be
+  reconstructable from `notes` plus `config` even if the raw `score_report.json` is gone.
+
+**Worked example** (WP-0.2 baseline, PR #1294 — abbreviated):
+
+```json
+{"ts": "2026-07-03T17:54:41Z", "run_id": "76a3ec13afadbc4c", "label": "WP-0.2-oblivion-qwen3next-solo", "phase": "Duramind-M0-WP0.2", "suite": "lme-s-500q", "strict_accuracy": 0.62, "lenient_accuracy": 0.674, "correct": 310, "total": 500, "run_errors": 0, "config": {"generator": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8", "generator_endpoint": "oblivion (DGX Spark, solo, gpu_memory_utilization=0.85)", "scorer_lock": "tier1-qwen3-2026-06-22", "gold_version": "gold-lme-s-2026-07-03", "workers": 1}, "by_question_type": {"knowledge-update": {"strict": 0.6538, "correct": 51, "total": 78}}, "notes": "Duramind WP-0.2 honest baseline vs locked non-thinking Qwen3-32B judge. Reference points: honest_plateau=67.87% strict (run 20260629, same scorer discipline); inflated_headline=81.4% (thinking-scorer + Sonnet generator, not comparable)."}
+```
+
+(History: this file/convention existed only on the `worktree-lme-preference-constraint` side
+branch before landing on `main` via PR #1294; see issue #1295.)
+
 ## Monitoring & gotchas (learned the hard way)
 - **Use `ps -eo cmd | grep '[p]attern'`, NOT `pgrep`/`pkill`** — those return exit 1 in this
   sandbox and abort multi-line scripts. Kill by explicit PID from `ps`.

--- a/internal/longmemeval/claude_test.go
+++ b/internal/longmemeval/claude_test.go
@@ -874,8 +874,9 @@ func TestGenerationPromptForTypeEnumerate_IgnoresEnumerateFirstForNonAggregation
 // its own enumeration instructions and the hardExclusionRule.
 //
 // This test verifies two things:
-//  (a) the enumerate-first prefix is NOT injected (guard fires correctly)
-//  (b) the HARD EXCLUSION RULE keywords ARE present (base preference prompt returned)
+//
+//	(a) the enumerate-first prefix is NOT injected (guard fires correctly)
+//	(b) the HARD EXCLUSION RULE keywords ARE present (base preference prompt returned)
 func TestGenerationPromptForTypeEnumerate_PreferenceType_SkipsEnumerateFirst(t *testing.T) {
 	question := "What headphone brand does the user prefer?"
 	contextBlocks := []string{

--- a/internal/wp05retrofit/runner.go
+++ b/internal/wp05retrofit/runner.go
@@ -1,3 +1,31 @@
+// Package wp05retrofit measures engram-go's existing recall path augmented
+// with Layer B (aggregation-summary) plumbing against the LongMemEval
+// fixture format, for the WP-0.5 retrofit-vs-greenfield bake-off.
+//
+// Campaign context: WP-0.5 compares two ways of getting aggregation-question
+// scoring onto engram-go — "retrofit" (this package: bolt Layer B onto the
+// existing ingest/recall path with minimal structural change) versus
+// "greenfield" (a from-scratch aggregation-aware substrate, measured
+// elsewhere). This package is the retrofit arm (WP-0.5c): it drives
+// ingest+recall through the existing engram-go client seam, optionally
+// builds Layer B client-side over a merged, exhaustive candidate set for
+// aggregation-shaped questions (see RecallItem / recallItemExhaustive in
+// recall_exhaustive.go), and scores/serializes the result.
+//
+// Duramind compatibility target: Bundle, ItemResult, and Provenance are
+// hand-kept byte-for-byte JSON-compatible with duramind's
+// internal/wp05c.{Bundle,ItemResult,Provenance} (see field-level comments
+// below) so the two arms' output can be diffed and compared by duramind's
+// bake-off tooling without a translation layer. Any change to these types'
+// JSON shape must be mirrored in duramind or the comparison breaks silently.
+//
+// Lifetime: this package is bake-off scaffolding, not permanent
+// architecture. It is expected to be retired once WP-0.5 concludes and one
+// arm is chosen — either promoted to production code under its own name, or
+// deleted along with the rest of the losing arm. Treat it as experimental:
+// do not build unrelated functionality on top of it. See PR #1315 (origin)
+// and issue #1316 (this doc pass, flagged in PR #1315 round-3 review) for
+// history.
 package wp05retrofit
 
 import (
@@ -17,10 +45,24 @@ import (
 )
 
 const (
-	SystemName          = "engram-go-retrofit"
-	SubstrateName       = "retrofit"
+	// SystemName identifies this harness in Bundle.System and
+	// Provenance.System; it distinguishes retrofit-arm output from the
+	// greenfield arm's output in duramind's bake-off comparison.
+	SystemName = "engram-go-retrofit"
+	// SubstrateName identifies the WP-0.5 arm ("retrofit" vs "greenfield")
+	// in Bundle.Substrate.
+	SubstrateName = "retrofit"
+	// SubstrateAssessment is the (currently unfilled) verdict slot in
+	// Bundle.SubstrateAssessment; it is always "unknown" from this harness
+	// and is expected to be filled in by a separate analysis/judging pass,
+	// not by the runner itself.
 	SubstrateAssessment = "unknown"
-	MeasuredPathLayerB  = "layer_b_only"
+	// MeasuredPathLayerB is the fixed value recorded in
+	// ItemResult.MeasuredPath. Layer B is built additively alongside the
+	// base recall results (see tools_recall.go note referenced in
+	// ScoreItem), so every item scored by this harness took the same
+	// "layer_b_only" measured path; there is currently no alternate path.
+	MeasuredPathLayerB = "layer_b_only"
 )
 
 const constituentMetricsNote = "constituent_recall and constituent_precision are unmeasured at this stage " +
@@ -79,11 +121,25 @@ type Client interface {
 
 // Config controls one retrofit runner execution.
 type Config struct {
-	ProjectPrefix         string
-	Limit                 int
+	// ProjectPrefix namespaces each fixture item into its own project
+	// (<ProjectPrefix>-<question_id>) so items never share recall scope.
+	ProjectPrefix string
+	// Limit is the recall topK passed to the client. It must exceed the
+	// largest haystack session count of any fixture item or recall will
+	// silently truncate evidence.
+	Limit int
+	// ExhaustiveAggregation enables H8: for aggregation-shaped questions,
+	// union a deep primary+anchor recall with a full project memory_list
+	// sweep and build Layer B client-side over the merged set, instead of
+	// relying on the server's single-call Layer B. See RecallItem.
 	ExhaustiveAggregation bool
-	SkipIngest            bool
-	ProvenanceTemplate    Provenance
+	// SkipIngest assumes memories are already ingested under
+	// ProjectPrefix and runs recall/score only.
+	SkipIngest bool
+	// ProvenanceTemplate is copied into every ItemResult.Provenance
+	// produced by this run (see ScoreItem); it is filled in once per run,
+	// not per item.
+	ProvenanceTemplate Provenance
 }
 
 // Logf is the minimal logging seam shared by the runner and CLI.


### PR DESCRIPTION
## Summary
- Documents the `results/benchmark-registry.jsonl` convention (landed via PR #1294, previously undocumented) as RUNBOOK.md step 7: schema, required/optional fields citing `docs/lme-judging.md`'s provenance field list, and a worked example.
- Adds package-level godoc to `internal/wp05retrofit` (campaign context, duramind JSON-compatibility contract, lifetime/deprecation note) and `cmd/wp05-retrofit-runner` (usage, harness-SHA resolution order), plus godoc on the previously-undocumented `Config` fields and the `SystemName`/`SubstrateName`/`SubstrateAssessment`/`MeasuredPathLayerB` const block. Comments only — zero behavior change.
- Fixes the residual `internal/longmemeval/claude_test.go` gofmt drift from #1278.

## #1278 verdict
**Not clean — one file still needed the fix, now applied.**
Re-verified against `origin/main` @ `aaffd6d` before touching anything:
- `cmd/longmemeval/run.go` — **already gofmt-clean** (an intervening merge fixed it; `gofmt -l` empty, `gofmt` diff empty).
- `internal/longmemeval/claude_test.go` — **still drifted** (tab-vs-space doc-comment indentation at the `TestGenerationPromptForTypeEnumerate_PreferenceType_SkipsEnumerateFirst` doc comment, ~line 877). Fixed with `gofmt -w`; diff is whitespace-only (verified via `git diff`).

## Incidental finding (not fixed here, filed separately)
While re-checking gofmt cleanliness I found 4 more files with EOF-newline drift in `internal/wp05retrofit` and 3 files with possibly-gofmt-version-dependent struct-tag alignment drift elsewhere. Out of scope for this doc/formatting-fix PR — filed as #1379.

## Test plan
- [x] `gofmt -l` clean on all touched Go files
- [x] `go build ./...`
- [x] `go test ./internal/wp05retrofit/... ./cmd/wp05-retrofit-runner/... ./internal/longmemeval/... -count=1` — all green

Closes #1295
Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYYMBEy3EJkuPtKiV3795j