### PR TITLE
fix(longmemeval): warn on ss-pref-session-diversity-n no-op under atom/exact-boost modes + negative-boundary tests

### DIFF
--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -356,7 +356,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	// default), --ss-pref-session-diversity-n is actually sent as an explicit
 	// per-call session_diversity_n override for ss-pref questions, via
 	// Client.RecallScoredWithDiversityOverride.
-	fs.IntVar(&cfg.SSPrefSessionDiversityN, "ss-pref-session-diversity-n", 0, "issue #1176: per-session chunk cap applied ONLY to single-session-preference recall calls (0 = off; independent of --session-diversity-n)")
+	fs.IntVar(&cfg.SSPrefSessionDiversityN, "ss-pref-session-diversity-n", 0, "issue #1176: per-session chunk cap applied ONLY to single-session-preference recall calls (0 = off; independent of --session-diversity-n). EXCEPTION (issue #1276): silently has no effect when combined with --atom-mode or --exact-signal-boost, since RecallWithAtomRecall/RecallWithExactBoost don't accept a diversity-override parameter — runOne logs a WARN in that case, but the override itself is still dropped")
 	fs.IntVar(&cfg.SSPrefContextTopK, "ss-pref-context-topk", 0, "issue #1176: context topK applied ONLY to single-session-preference questions (0 = use the per-type default of 15; overridden by --context-topk if set)")
 	// #749: contention guard. --no-exclusive-backend is the negation flag.
 	// Default is exclusive=true; --no-exclusive-backend sets it false.

--- a/cmd/longmemeval/run.go
+++ b/cmd/longmemeval/run.go
@@ -558,6 +558,9 @@ func runOne(ctx context.Context, cfg *Config, mcpClient *longmemeval.Client, ite
 	// non-exact-signal-boost) recall closures below, which cover the default LME
 	// run configuration. Zero (the common case) preserves exact baseline behavior.
 	ssPrefDiversityOverride := resolveSessionDiversityOverride(cfg, item.QuestionType)
+	if warn := ssPrefDiversityNoopWarning(cfg, item.QuestionType, ssPrefDiversityOverride); warn != "" {
+		log.Print(warn)
+	}
 
 	recall := func(query string, topK int, callSince, callBefore *time.Time) (longmemeval.RecallResult, error) {
 		if cfg.AtomMode {
@@ -997,6 +1000,40 @@ func resolveSessionDiversityOverride(cfg *Config, questionType string) int {
 		return cfg.SSPrefSessionDiversityN
 	}
 	return 0
+}
+
+// ssPrefDiversityNoopWarning returns a non-empty warning message when the
+// resolved --ss-pref-session-diversity-n override (`override`, from
+// resolveSessionDiversityOverride) would silently have no effect for this
+// item's recall call (issue #1276).
+//
+// RecallWithAtomRecall (--atom-mode) and RecallWithExactBoost
+// (--exact-signal-boost) have no diversity-override parameter at all, so
+// only the plain RecallWithDiversityOverride path (neither flag set)
+// actually threads a non-zero override through to the server. When either
+// mode is active and the override is non-zero, the flag is a no-op for this
+// item with no other signal — this makes that combination visible in the
+// run log instead of failing silently. Returns "" (no warning) when the
+// override is 0 (nothing would have been dropped) or neither incompatible
+// mode is set (the plain path honors the override).
+func ssPrefDiversityNoopWarning(cfg *Config, questionType string, override int) string {
+	if override <= 0 {
+		return ""
+	}
+	if !cfg.AtomMode && !cfg.ExactSignalBoost {
+		return ""
+	}
+	var modes []string
+	if cfg.AtomMode {
+		modes = append(modes, "atom-mode")
+	}
+	if cfg.ExactSignalBoost {
+		modes = append(modes, "exact-signal-boost")
+	}
+	return fmt.Sprintf(
+		"WARN --ss-pref-session-diversity-n=%d has no effect for question_type=%q: --%s is set, and RecallWithAtomRecall/RecallWithExactBoost do not accept a diversity-override parameter (issue #1276)",
+		override, questionType, strings.Join(modes, "+"),
+	)
 }
 
 func selectContextIDs(retrievedIDs, secondaryIDs []string, limit int) []string {

--- a/cmd/longmemeval/run_test.go
+++ b/cmd/longmemeval/run_test.go
@@ -117,6 +117,101 @@ func TestResolveSessionDiversityOverride_OffByDefault(t *testing.T) {
 	}
 }
 
+// TestResolveContextTopK_NegativeSSPrefOverrideIgnored verifies negative
+// --ss-pref-context-topk values fall back to the untyped per-type default
+// rather than being treated as a truthy override (issue #1277: the `> 0`
+// guard must reject negatives, not just zero).
+func TestResolveContextTopK_NegativeSSPrefOverrideIgnored(t *testing.T) {
+	cfg := &Config{SSPrefContextTopK: -5}
+	if got := resolveContextTopK(cfg, "single-session-preference", false, 1000); got != 15 {
+		t.Errorf("got %d, want 15 (negative override ignored)", got)
+	}
+}
+
+// TestResolveSessionDiversityOverride_NegativeIgnored verifies negative
+// --ss-pref-session-diversity-n values fall back to no override (0) rather
+// than being sent to the server as a negative session_diversity_n (issue
+// #1277: the `> 0` guard must reject negatives, not just zero).
+func TestResolveSessionDiversityOverride_NegativeIgnored(t *testing.T) {
+	cfg := &Config{SSPrefSessionDiversityN: -3}
+	if got := resolveSessionDiversityOverride(cfg, "single-session-preference"); got != 0 {
+		t.Errorf("got %d, want 0 (negative override ignored)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ssPrefDiversityNoopWarning (issue #1276: --ss-pref-session-diversity-n
+// silently no-ops under --atom-mode/--exact-signal-boost because
+// RecallWithAtomRecall/RecallWithExactBoost don't accept a diversity-override
+// parameter — only the plain RecallWithDiversityOverride path threads it).
+// ---------------------------------------------------------------------------
+
+// TestSSPrefDiversityNoopWarning_AtomModeWarns verifies a non-empty warning
+// is produced when the resolved override is non-zero and --atom-mode is set.
+func TestSSPrefDiversityNoopWarning_AtomModeWarns(t *testing.T) {
+	cfg := &Config{AtomMode: true}
+	msg := ssPrefDiversityNoopWarning(cfg, "single-session-preference", 1)
+	if msg == "" {
+		t.Fatal("expected a non-empty warning, got none")
+	}
+	if !strings.Contains(msg, "atom-mode") {
+		t.Errorf("warning does not mention atom-mode: %q", msg)
+	}
+	if !strings.Contains(msg, "1276") {
+		t.Errorf("warning does not reference issue #1276: %q", msg)
+	}
+}
+
+// TestSSPrefDiversityNoopWarning_ExactSignalBoostWarns verifies a non-empty
+// warning is produced when the resolved override is non-zero and
+// --exact-signal-boost is set.
+func TestSSPrefDiversityNoopWarning_ExactSignalBoostWarns(t *testing.T) {
+	cfg := &Config{ExactSignalBoost: true}
+	msg := ssPrefDiversityNoopWarning(cfg, "single-session-preference", 1)
+	if msg == "" {
+		t.Fatal("expected a non-empty warning, got none")
+	}
+	if !strings.Contains(msg, "exact-signal-boost") {
+		t.Errorf("warning does not mention exact-signal-boost: %q", msg)
+	}
+}
+
+// TestSSPrefDiversityNoopWarning_BothModesWarns verifies the warning still
+// fires (and names both modes) when both --atom-mode and
+// --exact-signal-boost are set simultaneously.
+func TestSSPrefDiversityNoopWarning_BothModesWarns(t *testing.T) {
+	cfg := &Config{AtomMode: true, ExactSignalBoost: true}
+	msg := ssPrefDiversityNoopWarning(cfg, "single-session-preference", 1)
+	if msg == "" {
+		t.Fatal("expected a non-empty warning, got none")
+	}
+	if !strings.Contains(msg, "atom-mode") || !strings.Contains(msg, "exact-signal-boost") {
+		t.Errorf("warning does not mention both modes: %q", msg)
+	}
+}
+
+// TestSSPrefDiversityNoopWarning_SilentWhenOverrideZero verifies no warning
+// is produced when the resolved override is 0 (flag unset or non-ss-pref
+// question type), even if --atom-mode/--exact-signal-boost are set — nothing
+// is actually being silently dropped in that case.
+func TestSSPrefDiversityNoopWarning_SilentWhenOverrideZero(t *testing.T) {
+	cfg := &Config{AtomMode: true, ExactSignalBoost: true}
+	if msg := ssPrefDiversityNoopWarning(cfg, "single-session-preference", 0); msg != "" {
+		t.Errorf("expected no warning when override is 0, got %q", msg)
+	}
+}
+
+// TestSSPrefDiversityNoopWarning_SilentWhenPlainRecall verifies no warning is
+// produced for the plain (non-atom, non-exact-signal-boost) recall path,
+// since that path does thread the override through
+// RecallWithDiversityOverride — nothing is being dropped.
+func TestSSPrefDiversityNoopWarning_SilentWhenPlainRecall(t *testing.T) {
+	cfg := &Config{}
+	if msg := ssPrefDiversityNoopWarning(cfg, "single-session-preference", 1); msg != "" {
+		t.Errorf("expected no warning for plain recall path, got %q", msg)
+	}
+}
+
 // TestRunLogFormat_ErrorIncludesCause verifies that when runOne returns an
 // error entry, the log message format string produced by runWorker would
 // include the error cause — not just hypothesis_len=0.


### PR DESCRIPTION
## Summary

- **#1276**: `--ss-pref-session-diversity-n` silently no-ops for `single-session-preference` questions when combined with `--atom-mode` or `--exact-signal-boost`, because `RecallWithAtomRecall`/`RecallWithExactBoost` have no diversity-override parameter — only the plain `RecallWithDiversityOverride` path threads it. Rather than rewiring those two client methods (out of scope per this issue's own triage history — a prior attempt to do a larger rewrite off a stale base was closed as non-salvageable), this makes the no-op **loud**:
  - New pure `ssPrefDiversityNoopWarning(cfg, questionType, override)` in `cmd/longmemeval/run.go`, called from `runOne` right after the override is resolved; logs a `WARN` line via `log.Print` when the override is non-zero but the active recall mode can't apply it.
  - `--ss-pref-session-diversity-n` help text in `cmd/longmemeval/main.go` now discloses the `--atom-mode`/`--exact-signal-boost` exception explicitly.
- **#1277**: added the two negative-value boundary tests proposed in the issue (`TestResolveContextTopK_NegativeSSPrefOverrideIgnored`, `TestResolveSessionDiversityOverride_NegativeIgnored`) locking in the existing correct `> 0` guard behavior for both `resolveContextTopK` and `resolveSessionDiversityOverride`.

## Test plan

- [x] New tests written first (TDD) — confirmed `undefined: ssPrefDiversityNoopWarning` build failure before implementation
- [x] `go test ./cmd/longmemeval/... -count=1 -race -v -run 'TestSSPrefDiversityNoopWarning|TestResolveContextTopK|TestResolveSessionDiversityOverride'` — all pass
- [x] `go test ./cmd/longmemeval/... -count=1 -race` — full package green
- [x] `go test ./... -count=1 -race` — full repo suite green
- [x] `gofmt` clean on all touched files (`run.go`, `run_test.go`, `main.go`)

Closes #1276
Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYYMBEy3EJkuPtKiV3795j