### PR TITLE
fix(mcp): triage remaining lenient getInt/getFloat/getBool call sites

### DIFF
--- a/internal/mcp/explore_handler_test.go
+++ b/internal/mcp/explore_handler_test.go
@@ -370,6 +370,100 @@ func TestHandleMemoryExplore_HappyPath(t *testing.T) {
 	require.NotEmpty(t, answer, "answer must be non-empty")
 }
 
+// ── TestHandleMemoryExplore_MaxIterationsWrongType_LoudError ────────────────
+
+// TestHandleMemoryExplore_MaxIterationsWrongType_LoudError covers #1282: a
+// present-but-uncoercible "max_iterations" must be a loud tool error, not a
+// silent fallback to cfg.ExploreMaxIters — max_iterations bounds the Claude
+// call loop the same way memory_sleep's llm_max_calls does, so masking a
+// caller's mistyped cost bound is the exact failure mode #1282 targets.
+func TestHandleMemoryExplore_MaxIterationsWrongType_LoudError(t *testing.T) {
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":        "test",
+		"question":       "what is the answer?",
+		"max_iterations": []any{1, 2},
+	}
+
+	result, err := handleMemoryExplore(context.Background(), pool, req, Config{claudeClient: c})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "expected tool error for wrong-typed max_iterations")
+	tc, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	require.Contains(t, tc.Text, "max_iterations")
+}
+
+// TestHandleMemoryExplore_TokenBudgetWrongType_LoudError covers #1282: a
+// present-but-uncoercible "token_budget" must be a loud tool error, not a
+// silent fallback to cfg.ExploreTokenBudget — token_budget caps LLM spend
+// the same way memory_sleep's llm_max_calls does.
+func TestHandleMemoryExplore_TokenBudgetWrongType_LoudError(t *testing.T) {
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":      "test",
+		"question":     "what is the answer?",
+		"token_budget": map[string]any{"a": 1},
+	}
+
+	result, err := handleMemoryExplore(context.Background(), pool, req, Config{claudeClient: c})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "expected tool error for wrong-typed token_budget")
+	tc, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	require.Contains(t, tc.Text, "token_budget")
+}
+
+// TestHandleMemoryExplore_MaxIterationsAndTokenBudget_HappyPath verifies that
+// valid caller-supplied max_iterations/token_budget values are honored (not
+// clamped away) and the loop still completes successfully.
+func TestHandleMemoryExplore_MaxIterationsAndTokenBudget_HappyPath(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"content": []map[string]string{{"type": "text", "text": `{"confidence":0.9,"gaps":[],"refined_query":null,"stop":true}`}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"content": []map[string]string{{"type": "text", "text": "The answer is 42."}},
+				"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, err := claude.New("test-key")
+	require.NoError(t, err)
+	c.BaseURL = srv.URL
+
+	pool := newTestNoopPool(t)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"project":        "test",
+		"question":       "what is the answer?",
+		"max_iterations": 3,
+		"token_budget":   5000,
+	}
+
+	result, err := handleMemoryExplore(context.Background(), pool, req, Config{claudeClient: c})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "unexpected tool error: %+v", result.Content)
+}
+
 // ── TestParseExploreScope_PopulatedScope ─────────────────────────────────────
 
 // TestParseExploreScope_PopulatedScope verifies that all scope fields are

--- a/internal/mcp/ingest_document.go
+++ b/internal/mcp/ingest_document.go
@@ -413,6 +413,11 @@ func handleMemoryIngestDocumentStream(ctx context.Context, s *Server, pool *Engi
 		if uploadID == "" {
 			return nil, fmt.Errorf("upload_id is required for append")
 		}
+		// #1282: lenient — the -1 sentinel default already guards against
+		// masking a wrongly-typed value: an uncoercible "part" falls through to
+		// the part_index fallback, and if that is also absent/uncoercible the
+		// explicit "part is required" error below fires. Unlike the other
+		// lenient sites, a bad value here cannot silently look like success.
 		part := getInt(args, "part", -1)
 		if part < 0 {
 			// Legacy callers may use part_index.

--- a/internal/mcp/relationship_strength_test.go
+++ b/internal/mcp/relationship_strength_test.go
@@ -180,6 +180,47 @@ func TestMemoryRelationshipHandlers_RejectNonFiniteStringStrength(t *testing.T) 
 	}
 }
 
+// TestMemoryRelationshipHandlers_RejectUncoercibleNonStringStrength covers
+// #1282: a present-but-uncoercible non-string "strength" (bool, array,
+// object) must be a loud tool error, not a silent fallback to the default
+// 1.0 — before this fix, relationshipStrength routed non-string values
+// through getFloat, which discarded the caller's bad value and stored 1.0
+// as if the caller had asked for it.
+func TestMemoryRelationshipHandlers_RejectUncoercibleNonStringStrength(t *testing.T) {
+	handlers := []struct {
+		name    string
+		handler func(context.Context, *EnginePool, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "memory_adopt", handler: handleMemoryAdopt},
+		{name: "memory_connect", handler: handleMemoryConnect},
+	}
+
+	badStrengths := []struct {
+		name string
+		val  any
+	}{
+		{name: "bool", val: true},
+		{name: "array", val: []any{1, 2}},
+		{name: "object", val: map[string]any{"a": 1}},
+	}
+
+	for _, handlerTC := range handlers {
+		t.Run(handlerTC.name, func(t *testing.T) {
+			for _, strength := range badStrengths {
+				t.Run(strength.name, func(t *testing.T) {
+					backend := &relationshipCaptureBackend{}
+					pool := newRelationshipCapturePool(t, backend)
+
+					_, err := handlerTC.handler(context.Background(), pool, relationshipRequest(strength.val))
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "strength must be numeric")
+					require.Empty(t, backend.relationships, "a bad strength must not silently default to 1.0 and persist")
+				})
+			}
+		})
+	}
+}
+
 func relationshipRequest(strength any) mcpgo.CallToolRequest {
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{

--- a/internal/mcp/safety.go
+++ b/internal/mcp/safety.go
@@ -82,6 +82,44 @@ type verificationResult struct {
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
 // handleGetConstraints lists constraint memories matching an optional query.
+// constraintLookupParams extracts and range-clamps the limit/stale_after_days
+// params shared by handleGetConstraints, handleCheckConstraints, and
+// handleVerifyBeforeActing.
+//
+// #1282: loud — these gate which constraints the safety pipeline surfaces and
+// whether a constraint is treated as stale (i.e. no longer authoritative). A
+// caller who deliberately widens limit or disables staleness via
+// stale_after_days must not have that intent silently discarded by a
+// mistyped value falling back to the (narrower) default — the same
+// masked-intent failure mode as memory_audit_compare's limit (#1282). A
+// resultErr is returned pre-formatted as a tool error for the caller to
+// return directly.
+func constraintLookupParams(args map[string]any) (limit, staleAfterDays int, resultErr *mcpgo.CallToolResult) {
+	limit, limitPresent, limitErr := requireOptionalInt(args, "limit")
+	if limitErr != nil {
+		return 0, 0, mcpgo.NewToolResultError(limitErr.Error())
+	}
+	if !limitPresent {
+		limit = defaultConstraintLimit
+	}
+	if limit < 1 || limit > 50 {
+		limit = defaultConstraintLimit
+	}
+
+	staleAfterDays, staleAfterDaysPresent, staleAfterDaysErr := requireOptionalInt(args, "stale_after_days")
+	if staleAfterDaysErr != nil {
+		return 0, 0, mcpgo.NewToolResultError(staleAfterDaysErr.Error())
+	}
+	if !staleAfterDaysPresent {
+		staleAfterDays = defaultStaleAfterDays
+	}
+	if staleAfterDays < 1 || staleAfterDays > 3650 {
+		staleAfterDays = defaultStaleAfterDays
+	}
+
+	return limit, staleAfterDays, nil
+}
+
 func handleGetConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	args := req.GetArguments()
 	project, err := getProject(args, "default")
@@ -89,13 +127,9 @@ func handleGetConstraints(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 		return nil, err
 	}
 	query := getString(args, "query", "")
-	limit := getInt(args, "limit", defaultConstraintLimit)
-	if limit < 1 || limit > 50 {
-		limit = defaultConstraintLimit
-	}
-	staleAfterDays := getInt(args, "stale_after_days", defaultStaleAfterDays)
-	if staleAfterDays < 1 || staleAfterDays > 3650 {
-		staleAfterDays = defaultStaleAfterDays
+	limit, staleAfterDays, errResult := constraintLookupParams(args)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	h, err := pool.Get(ctx, project)
@@ -128,13 +162,9 @@ func handleCheckConstraints(ctx context.Context, pool *EnginePool, req mcpgo.Cal
 	if proposedAction == "" {
 		return mcpgo.NewToolResultError("proposed_action is required"), nil
 	}
-	limit := getInt(args, "limit", defaultConstraintLimit)
-	if limit < 1 || limit > 50 {
-		limit = defaultConstraintLimit
-	}
-	staleAfterDays := getInt(args, "stale_after_days", defaultStaleAfterDays)
-	if staleAfterDays < 1 || staleAfterDays > 3650 {
-		staleAfterDays = defaultStaleAfterDays
+	limit, staleAfterDays, errResult := constraintLookupParams(args)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	h, err := pool.Get(ctx, project)
@@ -165,13 +195,9 @@ func handleVerifyBeforeActing(ctx context.Context, pool *EnginePool, req mcpgo.C
 	if proposedAction == "" {
 		return mcpgo.NewToolResultError("proposed_action is required"), nil
 	}
-	limit := getInt(args, "limit", defaultConstraintLimit)
-	if limit < 1 || limit > 50 {
-		limit = defaultConstraintLimit
-	}
-	staleAfterDays := getInt(args, "stale_after_days", defaultStaleAfterDays)
-	if staleAfterDays < 1 || staleAfterDays > 3650 {
-		staleAfterDays = defaultStaleAfterDays
+	limit, staleAfterDays, errResult := constraintLookupParams(args)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	h, err := pool.Get(ctx, project)

--- a/internal/mcp/safety_constraint_lookup_test.go
+++ b/internal/mcp/safety_constraint_lookup_test.go
@@ -1,0 +1,124 @@
+package mcp
+
+// Handler-level tests for the shared constraintLookupParams helper (#1282),
+// exercised through handleGetConstraints, handleCheckConstraints, and
+// handleVerifyBeforeActing. These three tools gate which constraints the
+// safety pipeline surfaces and whether one is treated as stale (i.e. no
+// longer authoritative) — a caller who deliberately widens limit or disables
+// staleness via stale_after_days must not have that intent silently
+// discarded by a mistyped value falling back to the (narrower) default.
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+type constraintLookupHandler struct {
+	name           string
+	requiresAction bool
+	handler        func(context.Context, *EnginePool, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+}
+
+func constraintLookupHandlers() []constraintLookupHandler {
+	return []constraintLookupHandler{
+		{name: "get_constraints", requiresAction: false, handler: handleGetConstraints},
+		{name: "check_constraints", requiresAction: true, handler: handleCheckConstraints},
+		{name: "verify_before_acting", requiresAction: true, handler: handleVerifyBeforeActing},
+	}
+}
+
+func constraintLookupRequest(tc constraintLookupHandler, extras map[string]any) mcpgo.CallToolRequest {
+	args := map[string]any{"project": "test"}
+	if tc.requiresAction {
+		args["proposed_action"] = "select 1"
+	} else {
+		args["query"] = "select 1"
+	}
+	for k, v := range extras {
+		args[k] = v
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = args
+	return req
+}
+
+// TestConstraintLookupHandlers_LimitWrongType_LoudError covers #1282: a
+// present-but-uncoercible "limit" must be a loud tool error, not a silent
+// fallback to defaultConstraintLimit — an analogous case to
+// memory_audit_compare's limit, which #1281/#1282 explicitly called out as
+// load-bearing.
+func TestConstraintLookupHandlers_LimitWrongType_LoudError(t *testing.T) {
+	for _, tc := range constraintLookupHandlers() {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newTestNoopPool(t)
+			result, err := tc.handler(context.Background(), pool, constraintLookupRequest(tc, map[string]any{
+				"limit": []any{1, 2},
+			}))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.True(t, result.IsError, "expected tool error for wrong-typed limit")
+			text, ok := result.Content[0].(mcpgo.TextContent)
+			require.True(t, ok)
+			require.Contains(t, text.Text, "limit")
+		})
+	}
+}
+
+// TestConstraintLookupHandlers_StaleAfterDaysWrongType_LoudError covers
+// #1282: a present-but-uncoercible "stale_after_days" must be a loud tool
+// error, not a silent fallback to defaultStaleAfterDays — silently defaulting
+// here could mask a caller's deliberate attempt to widen or narrow the
+// staleness window on a constraint-verification call.
+func TestConstraintLookupHandlers_StaleAfterDaysWrongType_LoudError(t *testing.T) {
+	for _, tc := range constraintLookupHandlers() {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newTestNoopPool(t)
+			result, err := tc.handler(context.Background(), pool, constraintLookupRequest(tc, map[string]any{
+				"stale_after_days": map[string]any{"a": 1},
+			}))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.True(t, result.IsError, "expected tool error for wrong-typed stale_after_days")
+			text, ok := result.Content[0].(mcpgo.TextContent)
+			require.True(t, ok)
+			require.Contains(t, text.Text, "stale_after_days")
+		})
+	}
+}
+
+// TestConstraintLookupHandlers_EmptyArgs_HappyPath verifies the zero-value
+// case: no limit/stale_after_days supplied at all applies the defaults and
+// returns a non-error result (empty constraint set, since noopBackend has no
+// stored memories).
+func TestConstraintLookupHandlers_EmptyArgs_HappyPath(t *testing.T) {
+	for _, tc := range constraintLookupHandlers() {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newTestNoopPool(t)
+			result, err := tc.handler(context.Background(), pool, constraintLookupRequest(tc, nil))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.False(t, result.IsError, "unexpected tool error: %+v", result.Content)
+		})
+	}
+}
+
+// TestConstraintLookupHandlers_ValidLimitAndStaleAfterDays_Honored covers the
+// boundary case: valid caller-supplied limit/stale_after_days values within
+// range are accepted and produce a non-error result.
+func TestConstraintLookupHandlers_ValidLimitAndStaleAfterDays_Honored(t *testing.T) {
+	for _, tc := range constraintLookupHandlers() {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newTestNoopPool(t)
+			result, err := tc.handler(context.Background(), pool, constraintLookupRequest(tc, map[string]any{
+				"limit":            5,
+				"stale_after_days": 30,
+			}))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.False(t, result.IsError, "unexpected tool error: %+v", result.Content)
+		})
+	}
+}

--- a/internal/mcp/tools_admin.go
+++ b/internal/mcp/tools_admin.go
@@ -61,7 +61,14 @@ func relationshipStrength(args map[string]any) (float64, error) {
 		}
 		return f, nil
 	}
-	strength := getFloat(args, "strength", 1.0)
+	// #1282: a present-but-uncoercible non-string value (bool, array, object)
+	// must be a loud tool error, not a silent fallback to the default 1.0 —
+	// strength is persisted relationship data, the same load-bearing category
+	// as memory_store's importance param fixed in #1281.
+	strength, ok := coerceToFloat(raw)
+	if !ok {
+		return 0, fmt.Errorf("strength must be numeric, got %T", raw)
+	}
 	if err := validateRelationshipStrength(strength); err != nil {
 		return 0, err
 	}
@@ -223,6 +230,10 @@ func handleMemoryAggregate(ctx context.Context, pool *EnginePool, req mcpgo.Call
 		return nil, fmt.Errorf("by: required (tag, type, or failure_class)")
 	}
 	filter := getString(args, "filter", "")
+	// #1282: lenient — result-count knob already range-clamped below, so a
+	// present-but-uncoercible value degrading to the default 20 is harmless
+	// (this is the "memory_aggregate rows returned" bucket, not a data-loss
+	// or approval-bypass concern like memory_audit_compare's limit).
 	limit := getInt(args, "limit", 20)
 	if limit < 1 || limit > 1000 {
 		limit = 20
@@ -263,6 +274,9 @@ func handleMemoryDiagnose(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 		return nil, err
 	}
 	question := getString(args, "question", "")
+	// #1282: lenient — read-only diagnostic recall-count tuning knob; a bad
+	// value silently degrading to the default 10 changes result breadth, not
+	// correctness or safety.
 	topK := getInt(args, "top_k", 10)
 	detail := getString(args, "detail", "full")
 	if question == "" {

--- a/internal/mcp/tools_episode.go
+++ b/internal/mcp/tools_episode.go
@@ -54,6 +54,8 @@ func handleMemoryEpisodeList(ctx context.Context, pool *EnginePool, req mcpgo.Ca
 	if err != nil {
 		return nil, err
 	}
+	// #1282: lenient — read-only episode-list page size; a bad value silently
+	// degrading to the default 20 changes result breadth, not correctness.
 	limit := getInt(args, "limit", 20)
 	h, err := pool.Get(ctx, project)
 	if err != nil {

--- a/internal/mcp/tools_reason.go
+++ b/internal/mcp/tools_reason.go
@@ -51,6 +51,8 @@ func handleMemoryReason(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 		return nil, err
 	}
 	question := getString(args, "question", "")
+	// #1282: lenient — result-count knob already range-clamped below, so a
+	// bad value silently degrading to the default 10 is harmless.
 	topK := getInt(args, "top_k", 10)
 	if topK < 1 {
 		topK = 1
@@ -213,13 +215,26 @@ func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 		return mcpgo.NewToolResultError("memory_explore requires ANTHROPIC_API_KEY to be set"), nil
 	}
 
-	maxIter := getInt(args, "max_iterations", cfg.ExploreMaxIters)
+	// #1282: loud — max_iterations bounds the Claude call loop the same way
+	// memory_sleep's llm_max_calls does; a caller who explicitly bounds cost
+	// with a low value must not have that intent silently discarded by a
+	// mistyped param falling back to cfg.ExploreMaxIters.
+	maxIter, maxIterPresent, maxIterErr := requireOptionalInt(args, "max_iterations")
+	if maxIterErr != nil {
+		return mcpgo.NewToolResultError(maxIterErr.Error()), nil
+	}
+	if !maxIterPresent {
+		maxIter = cfg.ExploreMaxIters
+	}
 	if maxIter < 1 {
 		maxIter = 1
 	}
 	if maxIter > 10 {
 		maxIter = 10
 	}
+	// #1282: lenient — accuracy-tuning knob; a bad value silently degrading to
+	// the default 0.75 changes when the loop stops early, not correctness or
+	// cost bounds.
 	threshold := getFloat(args, "confidence_threshold", 0.75)
 	if threshold < 0 {
 		threshold = 0
@@ -227,10 +242,21 @@ func handleMemoryExplore(ctx context.Context, pool *EnginePool, req mcpgo.CallTo
 	if threshold > 1 {
 		threshold = 1
 	}
-	budget := getInt(args, "token_budget", cfg.ExploreTokenBudget)
+	// #1282: loud — same cost-bound rationale as max_iterations above: a
+	// caller-supplied token_budget caps LLM spend, so a mistyped value must
+	// not silently fall back to a possibly-larger default.
+	budget, budgetPresent, budgetErr := requireOptionalInt(args, "token_budget")
+	if budgetErr != nil {
+		return mcpgo.NewToolResultError(budgetErr.Error()), nil
+	}
+	if !budgetPresent {
+		budget = cfg.ExploreTokenBudget
+	}
 	if budget <= 0 {
 		budget = 20000
 	}
+	// #1282: lenient — debug-only trace-inclusion toggle; a bad value
+	// silently degrading to the default false only omits trace detail.
 	includeTrace := getBool(args, "include_trace", false)
 	scope := parseExploreScope(args)
 
@@ -292,6 +318,8 @@ func handleMemoryAsk(ctx context.Context, pool *EnginePool, req mcpgo.CallToolRe
 		return mcpgo.NewToolResultError("memory_ask requires Claude (set ENGRAM_CLAUDE_KEY)"), nil
 	}
 
+	// #1282: lenient — result-count knob already range-checked below, so a bad
+	// value silently degrading to the default 0 is harmless.
 	topK := getInt(args, "top_k", 0)
 	if topK < 0 {
 		return mcpgo.NewToolResultError("top_k: must be >= 0"), nil

--- a/internal/mcp/tools_recall.go
+++ b/internal/mcp/tools_recall.go
@@ -335,10 +335,14 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 			args["top_k"] = limit
 		}
 	}
-	topK := clampTopK(getInt(args, "top_k", defaultTopK), recallMaxTopK())
+	// #1282: lenient below — handleMemoryRecall's option flags/knobs are either
+	// already range-clamped (topK) or default-off ranking/behavior toggles
+	// where a bad value silently degrading to the default changes result
+	// quality/shape, not correctness or a caller's cost/safety intent.
+	topK := clampTopK(getInt(args, "top_k", defaultTopK), recallMaxTopK()) // #1282: lenient, clamped below
 	detail := getString(args, "detail", "summary")
-	includeConflicts := getBool(args, "include_conflicts", false)
-	recordEvent := getBool(args, "record_event", false)
+	includeConflicts := getBool(args, "include_conflicts", false) // #1282: lenient, opt-in enrichment toggle
+	recordEvent := getBool(args, "record_event", false)           // #1282: lenient, opt-in event-recording toggle
 	rawMode := getString(args, "mode", cfg.RecallDefaultMode)
 	mode, err := normalizeRecallMode(rawMode)
 	if err != nil {
@@ -354,14 +358,14 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	// default off). When enabled, the engine parses temporal anchors from
 	// question_text (falling back to query) against question_date and runs a
 	// second, date-filtered pass unioned with the first.
-	temporalWindowRecall := getBool(args, "temporal_window_recall", false)
+	temporalWindowRecall := getBool(args, "temporal_window_recall", false) // #1282: lenient, default-off experiment flag
 	questionText := getString(args, "question_text", "")
 	questionDate := getString(args, "question_date", "")
 	atomRecallAsOf, err := parseRecallTimeArg(args, "atom_recall_as_of")
 	if err != nil {
 		return nil, err
 	}
-	opts.AtomRecallEnabled = getBool(args, "atom_recall", false)
+	opts.AtomRecallEnabled = getBool(args, "atom_recall", false) // #1282: lenient, default-off experiment flag
 	opts.AtomRecallAsOf = atomRecallAsOf
 
 	// Federated path: "projects" overrides the single-project recall.
@@ -473,13 +477,13 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if err != nil {
 		return nil, err
 	}
-	rerank := getBool(args, "rerank", false)
-	exactFactBoost := getBool(args, "exact_fact_boost", false)
+	rerank := getBool(args, "rerank", false)                   // #1282: lenient, opt-in reranker toggle
+	exactFactBoost := getBool(args, "exact_fact_boost", false) // #1282: lenient, default-off experiment flag
 	opts.DateSince = since
 	opts.DateBefore = before
 	// H-TAB (LME exp #3): topic-anchor boost for preference queries.
-	opts.TopicAnchorBoost = getBool(args, "topic_anchor_boost", false)
-	opts.SessionDiversityN = getInt(args, "session_diversity_n", cfg.SessionDiversityN)
+	opts.TopicAnchorBoost = getBool(args, "topic_anchor_boost", false)                  // #1282: lenient, default-off experiment flag
+	opts.SessionDiversityN = getInt(args, "session_diversity_n", cfg.SessionDiversityN) // #1282: lenient, ranking-tuning knob
 	opts.TemporalWindowRecall = temporalWindowRecall
 	opts.QuestionText = questionText
 	opts.QuestionDate = questionDate
@@ -514,12 +518,14 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	// or per-call by passing paraphrase_union=true in the MCP args.
 	{
 		v := strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_PARAPHRASE_UNION")))
+		// #1282: lenient, default-off experiment flag.
 		opts.ParaphraseUnion = v == "true" || v == "1" || getBool(args, "paraphrase_union", false)
 	}
 	// RRF fusion (LME experiment #6, issue #938 improvement #1, default OFF).
 	// Enable server-wide via ENGRAM_RRF_FUSION=true|1 env var, or per-call via rrf_fusion=true.
 	{
 		v := strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_RRF_FUSION")))
+		// #1282: lenient, default-off experiment flag.
 		opts.Fusion = v == "true" || v == "1" || getBool(args, "rrf_fusion", false)
 	}
 
@@ -536,6 +542,7 @@ func handleMemoryRecall(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	// env var or per-request evidence_first_pack=true arg. Default OFF.
 	{
 		v := strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_EVIDENCE_FIRST_PACK")))
+		// #1282: lenient, default-off experiment flag.
 		opts.EvidenceFirstPack = v == "true" || v == "1" || getBool(args, "evidence_first_pack", false)
 	}
 
@@ -822,6 +829,8 @@ func handleMemoryTimeline(ctx context.Context, pool *EnginePool, req mcpgo.CallT
 	if err != nil {
 		return nil, fmt.Errorf("as_of must be RFC3339 (e.g. 2025-03-05T14:00:00Z): %w", err)
 	}
+	// #1282: lenient — read-only page size; a bad value silently degrading to
+	// the default 20 changes result breadth, not correctness.
 	limit := getInt(args, "limit", 20)
 	memories, err := h.Engine.MemoryAsOf(ctx, asOf, limit)
 	if err != nil {
@@ -870,6 +879,8 @@ func handleMemoryExpand(ctx context.Context, pool *EnginePool, req mcpgo.CallToo
 	if errResult != nil {
 		return errResult, nil
 	}
+	// #1282: lenient — graph-traversal depth already range-clamped below, so a
+	// bad value silently degrading to the default 2 is harmless.
 	requestedDepth := getInt(args, "depth", 2)
 	depth := requestedDepth
 	if depth < 1 || depth > 5 {


### PR DESCRIPTION
## Summary

Follow-up to #1281/#1365 (unit EG-4). Triages the ~32 remaining lenient `getInt`/`getFloat`/`getBool` call sites called out in #1282's suggested scope, across `tools_admin.go`, `tools_episode.go`, `tools_reason.go`, `tools_recall.go`, `safety.go`, and `ingest_document.go`.

- **9 sites upgraded to loud errors** (using the existing `requireOptionalInt`/`requireOptionalFloat` helpers — `requireOptionalBool` already exists from #1365):
  - `memory_adopt` / `memory_connect`'s relationship `strength` — persisted data, same load-bearing category as `importance` (#1281).
  - `memory_explore`'s `max_iterations` and `token_budget` — LLM loop/cost bounds, directly analogous to `memory_sleep`'s `llm_max_calls`.
  - `get_constraints` / `check_constraints` / `verify_before_acting`'s `limit` and `stale_after_days` (×3 handlers each, factored into a shared `constraintLookupParams` helper) — gate the safety-critical constraint pipeline, the same category as `memory_audit_compare`'s `limit`.
- **23 sites documented lenient in place** with a one-line `#1282: lenient` comment explaining why: already range-clamped result-count/page-size knobs (`limit`, `top_k`, `depth`), default-off ranking/experiment toggles (`rerank`, `exact_fact_boost`, `topic_anchor_boost`, `atom_recall`, `paraphrase_union`, `rrf_fusion`, `evidence_first_pack`, etc.), or — for `ingest_document.go`'s `part`/`part_index` — already guarded by a `-1` sentinel that can't silently look like success.

## Test plan

- [x] TDD: new tests added per upgraded site (happy path + wrong-type loud-error boundary), following the `tools_store_test.go`/`migrate_guards_test.go` pattern from #1281/#1365:
  - `internal/mcp/relationship_strength_test.go`: `TestMemoryRelationshipHandlers_RejectUncoercibleNonStringStrength`
  - `internal/mcp/explore_handler_test.go`: `TestHandleMemoryExplore_MaxIterationsWrongType_LoudError`, `TestHandleMemoryExplore_TokenBudgetWrongType_LoudError`, `TestHandleMemoryExplore_MaxIterationsAndTokenBudget_HappyPath`
  - `internal/mcp/safety_constraint_lookup_test.go` (new): loud-error + happy-path + valid-boundary tests across all 3 constraint-lookup handlers
- [x] `go test ./internal/mcp/... -count=1 -race` — green
- [x] `go test ./... -count=1` (full repo) — green
- [x] `gofmt -l` clean on all touched files
- [x] `go build ./...` — clean

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYYMBEy3EJkuPtKiV3795j