### PR TITLE
refactor(cmd): extract duplicated MCP default-discovery into internal/longmemeval

### DIFF
--- a/cmd/longmemeval/atom_build.go
+++ b/cmd/longmemeval/atom_build.go
@@ -195,11 +195,11 @@ func runAtomBuild(cfg *AtomBuildConfig, stdout, stderr io.Writer) int {
 	} else {
 		serverURL := cfg.ServerURL
 		if serverURL == "" {
-			serverURL = defaultServerURL()
+			serverURL = longmemeval.DefaultServerURL()
 		}
 		apiKey := cfg.APIKey
 		if apiKey == "" {
-			apiKey = defaultAPIKey()
+			apiKey = longmemeval.DefaultAPIKey()
 		}
 		storeAtom = makeRESTStoreFunc(serverURL, apiKey)
 		log.Printf("atom-build: using REST storage path at %s", serverURL)

--- a/cmd/longmemeval/main.go
+++ b/cmd/longmemeval/main.go
@@ -9,10 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-
-	neturl "net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -271,8 +268,8 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.ServerURL, "url", "", "Engram server URL")
 	// Default stays empty so `--help` never prints a resolved secret
 	// (TestHelp_RunSubcommandDoesNotLeakResolvedAPIKey). The ENGRAM_API_KEY env
-	// fallback is applied post-parse by applySharedDefaults → defaultAPIKey()
-	// (envOr("ENGRAM_API_KEY", …)), letting the secret be supplied via the
+	// fallback is applied post-parse by applySharedDefaults → longmemeval.DefaultAPIKey()
+	// (EnvOr("ENGRAM_API_KEY", …)), letting the secret be supplied via the
 	// environment without ever reaching argv / `ps` (security rule: no secret on argv).
 	fs.StringVar(&cfg.APIKey, "api-key", "", "Engram API key (env: ENGRAM_API_KEY)")
 	// #751: cleanup-policy enum replaces the old boolean --no-cleanup flag.
@@ -434,7 +431,7 @@ func dispatch(args []string, stdout, stderr io.Writer) int {
 			return exit
 		}
 		applyScoreEfficientDefaults(cfg, sefs)
-		if flagWasProvided(sefs, "scorer-api-key") {
+		if longmemeval.FlagWasProvided(sefs, "scorer-api-key") {
 			_, _ = fmt.Fprintln(stderr, "WARN: --scorer-api-key is deprecated; prefer LME_SCORER_API_KEY or OPENAI_API_KEY to avoid secrets on argv")
 		}
 		cfg.scorerThinkingSet = flagPassed(sefs, "scorer-thinking")
@@ -783,87 +780,23 @@ func applyRepairPreset(cfg *Config) error {
 	}
 }
 
-func defaultAPIKey() string {
-	_, token := mcpDefaults()
-	return envOr("ENGRAM_API_KEY", token)
-}
-
-func defaultServerURL() string {
-	url, _ := mcpDefaults()
-	return envOr("ENGRAM_URL", url)
-}
-
 func defaultScorerAPIKey() string {
 	return envOr("LME_SCORER_API_KEY", envOr("OPENAI_API_KEY", ""))
 }
 
 func applySharedDefaults(cfg *Config, fs *flag.FlagSet) {
-	if !flagWasProvided(fs, "api-key") {
-		cfg.APIKey = defaultAPIKey()
+	if !longmemeval.FlagWasProvided(fs, "api-key") {
+		cfg.APIKey = longmemeval.DefaultAPIKey()
 	}
-	if !flagWasProvided(fs, "url") {
-		cfg.ServerURL = defaultServerURL()
+	if !longmemeval.FlagWasProvided(fs, "url") {
+		cfg.ServerURL = longmemeval.DefaultServerURL()
 	}
 }
 
 func applyScoreEfficientDefaults(cfg *Config, fs *flag.FlagSet) {
-	if !flagWasProvided(fs, "scorer-api-key") {
+	if !longmemeval.FlagWasProvided(fs, "scorer-api-key") {
 		cfg.ScorerAPIKey = defaultScorerAPIKey()
 	}
-}
-
-func flagWasProvided(fs *flag.FlagSet, name string) bool {
-	provided := false
-	fs.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			provided = true
-		}
-	})
-	return provided
-}
-
-// mcpDefaults reads the engram URL and Bearer token from ~/.claude/mcp_servers.json,
-// which is kept current by the session-start hook. Falls back to localhost defaults.
-func mcpDefaults() (url, token string) {
-	url = "http://localhost:8788"
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return url, ""
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "mcp_servers.json"))
-	if err != nil {
-		return url, ""
-	}
-	var cfg struct {
-		McpServers map[string]struct {
-			URL     string            `json:"url"`
-			Headers map[string]string `json:"headers"`
-		} `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return url, ""
-	}
-	for name, srv := range cfg.McpServers {
-		if name != "engram" {
-			continue
-		}
-		// Strip /sse path component — the benchmark appends it in Connect().
-		// Parse properly so query params don't break the suffix check.
-		srvURL := srv.URL
-		if u, err := neturl.Parse(srvURL); err == nil {
-			u.Path = strings.TrimSuffix(u.Path, "/sse")
-			u.RawQuery = ""
-			srvURL = u.String()
-		}
-		if srvURL != "" {
-			url = srvURL
-		}
-		if auth := srv.Headers["Authorization"]; len(auth) > 7 {
-			token = auth[7:] // strip "Bearer "
-		}
-		return url, token
-	}
-	return url, token
 }
 
 func projectName(runID, questionID string) string {

--- a/cmd/longmemeval/prune.go
+++ b/cmd/longmemeval/prune.go
@@ -321,12 +321,12 @@ func dispatchPrune(args []string, stdout, stderr io.Writer) int {
 		}
 		return 2
 	}
-	cfg.ExplicitAPIKey = flagWasProvided(fs, "api-key")
+	cfg.ExplicitAPIKey = longmemeval.FlagWasProvided(fs, "api-key")
 	if !cfg.ExplicitAPIKey && cfg.UseDefaultToken {
-		cfg.APIKey = defaultAPIKey()
+		cfg.APIKey = longmemeval.DefaultAPIKey()
 	}
-	if !flagWasProvided(fs, "url") {
-		cfg.ServerURL = defaultServerURL()
+	if !longmemeval.FlagWasProvided(fs, "url") {
+		cfg.ServerURL = longmemeval.DefaultServerURL()
 	}
 
 	return runPrune(cfg, stdout, stderr)

--- a/cmd/wp05-retrofit-runner/main.go
+++ b/cmd/wp05-retrofit-runner/main.go
@@ -114,11 +114,16 @@ func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiv
 }
 
 func applySharedDefaults(fs *flag.FlagSet, serverURL, apiKey *string) {
+	// Use EnvOrTrimmed (not DefaultServerURL/DefaultAPIKey) to preserve this
+	// binary's historical whitespace-trimming env fallback from before the
+	// shared-package extract. Default* helpers keep cmd/longmemeval's
+	// non-trimming EnvOr semantics.
+	url, token := longmemeval.MCPDefaults()
 	if !longmemeval.FlagWasProvided(fs, "url") {
-		*serverURL = longmemeval.DefaultServerURL()
+		*serverURL = longmemeval.EnvOrTrimmed("ENGRAM_URL", url)
 	}
 	if !longmemeval.FlagWasProvided(fs, "api-key") {
-		*apiKey = longmemeval.DefaultAPIKey()
+		*apiKey = longmemeval.EnvOrTrimmed("ENGRAM_API_KEY", token)
 	}
 }
 

--- a/cmd/wp05-retrofit-runner/main.go
+++ b/cmd/wp05-retrofit-runner/main.go
@@ -16,7 +16,7 @@
 //
 // -url and -api-key default to the local Engram MCP server config
 // (~/.claude/mcp_servers.json) when not provided, mirroring cmd/longmemeval's
-// discovery behavior (see mcpDefaults). Provenance.HarnessSHA is resolved in
+// discovery behavior (see longmemeval.MCPDefaults). Provenance.HarnessSHA is resolved in
 // priority order: -harness-sha override, `git rev-parse --short HEAD`, the
 // binary's embedded VCS build-info revision, else "unknown" — see
 // resolveHarnessSHA; per issue #1320, a missing SHA is informational and
@@ -25,11 +25,9 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
-	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -116,80 +114,12 @@ func run(dataPath, serverURL, apiKey, projectPrefix string, limit int, exhaustiv
 }
 
 func applySharedDefaults(fs *flag.FlagSet, serverURL, apiKey *string) {
-	if !flagWasProvided(fs, "url") {
-		*serverURL = defaultServerURL()
+	if !longmemeval.FlagWasProvided(fs, "url") {
+		*serverURL = longmemeval.DefaultServerURL()
 	}
-	if !flagWasProvided(fs, "api-key") {
-		*apiKey = defaultAPIKey()
+	if !longmemeval.FlagWasProvided(fs, "api-key") {
+		*apiKey = longmemeval.DefaultAPIKey()
 	}
-}
-
-func flagWasProvided(fs *flag.FlagSet, name string) bool {
-	provided := false
-	fs.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			provided = true
-		}
-	})
-	return provided
-}
-
-func defaultAPIKey() string {
-	_, token := mcpDefaults()
-	return envOr("ENGRAM_API_KEY", token)
-}
-
-func defaultServerURL() string {
-	url, _ := mcpDefaults()
-	return envOr("ENGRAM_URL", url)
-}
-
-func envOr(name, fallback string) string {
-	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
-		return value
-	}
-	return fallback
-}
-
-// mcpDefaults mirrors cmd/longmemeval's MCP default discovery.
-func mcpDefaults() (url, token string) {
-	url = "http://localhost:8788"
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return url, ""
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "mcp_servers.json"))
-	if err != nil {
-		return url, ""
-	}
-	var cfg struct {
-		McpServers map[string]struct {
-			URL     string            `json:"url"`
-			Headers map[string]string `json:"headers"`
-		} `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return url, ""
-	}
-	for name, srv := range cfg.McpServers {
-		if name != "engram" {
-			continue
-		}
-		srvURL := srv.URL
-		if u, err := neturl.Parse(srvURL); err == nil {
-			u.Path = strings.TrimSuffix(u.Path, "/sse")
-			u.RawQuery = ""
-			srvURL = u.String()
-		}
-		if srvURL != "" {
-			url = srvURL
-		}
-		if auth := srv.Headers["Authorization"]; len(auth) > 7 {
-			token = auth[7:]
-		}
-		return url, token
-	}
-	return url, token
 }
 
 // harnessSHAUnknown is recorded when no SHA can be resolved by any means

--- a/internal/longmemeval/mcp_defaults.go
+++ b/internal/longmemeval/mcp_defaults.go
@@ -65,24 +65,38 @@ func FlagWasProvided(fs *flag.FlagSet, name string) bool {
 	return provided
 }
 
-// EnvOr returns the trimmed value of the named environment variable, or
-// fallback when the variable is unset or blank after trimming.
+// EnvOr returns the value of the named environment variable, or fallback when
+// the variable is unset or empty. It does not trim whitespace: a value of
+// "   " is returned as-is. This matches historical cmd/longmemeval semantics
+// (and is what DefaultAPIKey / DefaultServerURL use).
 func EnvOr(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// EnvOrTrimmed returns the trimmed value of the named environment variable, or
+// fallback when the variable is unset or blank after trimming. This matches
+// historical cmd/wp05-retrofit-runner semantics for ENGRAM_API_KEY / ENGRAM_URL.
+func EnvOrTrimmed(name, fallback string) string {
 	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
 		return value
 	}
 	return fallback
 }
 
-// DefaultAPIKey returns ENGRAM_API_KEY if set, otherwise the Bearer token from
-// MCPDefaults (empty when neither is available).
+// DefaultAPIKey returns ENGRAM_API_KEY if set (non-empty, not trimmed), otherwise
+// the Bearer token from MCPDefaults (empty when neither is available).
+// Non-trimming matches historical cmd/longmemeval behavior.
 func DefaultAPIKey() string {
 	_, token := MCPDefaults()
 	return EnvOr("ENGRAM_API_KEY", token)
 }
 
-// DefaultServerURL returns ENGRAM_URL if set, otherwise the URL from
-// MCPDefaults (localhost:8788 when neither is available).
+// DefaultServerURL returns ENGRAM_URL if set (non-empty, not trimmed), otherwise
+// the URL from MCPDefaults (localhost:8788 when neither is available).
+// Non-trimming matches historical cmd/longmemeval behavior.
 func DefaultServerURL() string {
 	url, _ := MCPDefaults()
 	return EnvOr("ENGRAM_URL", url)

--- a/internal/longmemeval/mcp_defaults.go
+++ b/internal/longmemeval/mcp_defaults.go
@@ -1,0 +1,89 @@
+package longmemeval
+
+import (
+	"encoding/json"
+	"flag"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MCPDefaults reads the engram URL and Bearer token from ~/.claude/mcp_servers.json,
+// which is kept current by the session-start hook. Falls back to localhost defaults.
+func MCPDefaults() (url, token string) {
+	url = "http://localhost:8788"
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return url, ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "mcp_servers.json"))
+	if err != nil {
+		return url, ""
+	}
+	var cfg struct {
+		McpServers map[string]struct {
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return url, ""
+	}
+	for name, srv := range cfg.McpServers {
+		if name != "engram" {
+			continue
+		}
+		// Strip /sse path component — the benchmark appends it in Connect().
+		// Parse properly so query params don't break the suffix check.
+		srvURL := srv.URL
+		if u, err := neturl.Parse(srvURL); err == nil {
+			u.Path = strings.TrimSuffix(u.Path, "/sse")
+			u.RawQuery = ""
+			srvURL = u.String()
+		}
+		if srvURL != "" {
+			url = srvURL
+		}
+		if auth := srv.Headers["Authorization"]; len(auth) > 7 {
+			token = auth[7:] // strip "Bearer "
+		}
+		return url, token
+	}
+	return url, token
+}
+
+// FlagWasProvided reports whether the named flag was set on the FlagSet
+// (including an explicit empty value).
+func FlagWasProvided(fs *flag.FlagSet, name string) bool {
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			provided = true
+		}
+	})
+	return provided
+}
+
+// EnvOr returns the trimmed value of the named environment variable, or
+// fallback when the variable is unset or blank after trimming.
+func EnvOr(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// DefaultAPIKey returns ENGRAM_API_KEY if set, otherwise the Bearer token from
+// MCPDefaults (empty when neither is available).
+func DefaultAPIKey() string {
+	_, token := MCPDefaults()
+	return EnvOr("ENGRAM_API_KEY", token)
+}
+
+// DefaultServerURL returns ENGRAM_URL if set, otherwise the URL from
+// MCPDefaults (localhost:8788 when neither is available).
+func DefaultServerURL() string {
+	url, _ := MCPDefaults()
+	return EnvOr("ENGRAM_URL", url)
+}

--- a/internal/longmemeval/mcp_defaults_test.go
+++ b/internal/longmemeval/mcp_defaults_test.go
@@ -2,6 +2,8 @@ package longmemeval
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -18,7 +20,70 @@ func TestMCPDefaults_FallbackWhenNoConfig(t *testing.T) {
 	}
 }
 
+func TestMCPDefaults_HappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := `{
+  "mcpServers": {
+    "engram": {
+      "url": "http://engram.example:8788",
+      "headers": {
+        "Authorization": "Bearer sometoken"
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "mcp_servers.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	url, token := MCPDefaults()
+	if url != "http://engram.example:8788" {
+		t.Errorf("MCPDefaults() url = %q, want http://engram.example:8788", url)
+	}
+	if token != "sometoken" {
+		t.Errorf("MCPDefaults() token = %q, want sometoken", token)
+	}
+}
+
+func TestMCPDefaults_StripSSEPathAndQuery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := `{
+  "mcpServers": {
+    "engram": {
+      "url": "http://host:8788/sse?foo=bar",
+      "headers": {
+        "Authorization": "Bearer tok"
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "mcp_servers.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	url, token := MCPDefaults()
+	if url != "http://host:8788" {
+		t.Errorf("MCPDefaults() url = %q, want http://host:8788 (/sse stripped, query dropped)", url)
+	}
+	if token != "tok" {
+		t.Errorf("MCPDefaults() token = %q, want tok", token)
+	}
+}
+
 func TestEnvOr(t *testing.T) {
+	// Non-trimming: historical cmd/longmemeval semantics.
 	t.Run("returns fallback when unset", func(t *testing.T) {
 		got := EnvOr("__LONGMEMEVAL_ENVOR_UNSET_XYZ__", "fallback")
 		if got != "fallback" {
@@ -32,11 +97,143 @@ func TestEnvOr(t *testing.T) {
 			t.Errorf("EnvOr() = %q, want fromenv", got)
 		}
 	})
-	t.Run("trims whitespace and falls back when blank", func(t *testing.T) {
+	t.Run("returns empty string when env is empty", func(t *testing.T) {
+		t.Setenv("__LONGMEMEVAL_ENVOR_EMPTY_XYZ__", "")
+		got := EnvOr("__LONGMEMEVAL_ENVOR_EMPTY_XYZ__", "fallback")
+		if got != "fallback" {
+			t.Errorf("EnvOr() = %q, want fallback for empty value", got)
+		}
+	})
+	t.Run("preserves whitespace-only value without trimming", func(t *testing.T) {
+		// Regression for Finding 1: longmemeval historically did not trim.
 		t.Setenv("__LONGMEMEVAL_ENVOR_BLANK_XYZ__", "   ")
 		got := EnvOr("__LONGMEMEVAL_ENVOR_BLANK_XYZ__", "fallback")
+		if got != "   " {
+			t.Errorf("EnvOr() = %q, want %q (non-trimming longmemeval semantics)", got, "   ")
+		}
+	})
+}
+
+func TestEnvOrTrimmed(t *testing.T) {
+	// Trimming: historical cmd/wp05-retrofit-runner semantics.
+	t.Run("returns fallback when unset", func(t *testing.T) {
+		got := EnvOrTrimmed("__LONGMEMEVAL_ENVORTRIM_UNSET_XYZ__", "fallback")
 		if got != "fallback" {
-			t.Errorf("EnvOr() = %q, want fallback for whitespace-only value", got)
+			t.Errorf("EnvOrTrimmed() = %q, want fallback", got)
+		}
+	})
+	t.Run("returns env value when set", func(t *testing.T) {
+		t.Setenv("__LONGMEMEVAL_ENVORTRIM_SET_XYZ__", "fromenv")
+		got := EnvOrTrimmed("__LONGMEMEVAL_ENVORTRIM_SET_XYZ__", "fallback")
+		if got != "fromenv" {
+			t.Errorf("EnvOrTrimmed() = %q, want fromenv", got)
+		}
+	})
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Setenv("__LONGMEMEVAL_ENVORTRIM_PAD_XYZ__", "  padded  ")
+		got := EnvOrTrimmed("__LONGMEMEVAL_ENVORTRIM_PAD_XYZ__", "fallback")
+		if got != "padded" {
+			t.Errorf("EnvOrTrimmed() = %q, want padded", got)
+		}
+	})
+	t.Run("falls back when whitespace-only", func(t *testing.T) {
+		// Regression for Finding 1: wp05 historically trimmed then treated blank as unset.
+		t.Setenv("__LONGMEMEVAL_ENVORTRIM_BLANK_XYZ__", "   ")
+		got := EnvOrTrimmed("__LONGMEMEVAL_ENVORTRIM_BLANK_XYZ__", "fallback")
+		if got != "fallback" {
+			t.Errorf("EnvOrTrimmed() = %q, want fallback for whitespace-only value", got)
+		}
+	})
+}
+
+func TestDefaultAPIKey(t *testing.T) {
+	// Isolate MCP config so token fallback is deterministic.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := `{
+  "mcpServers": {
+    "engram": {
+      "url": "http://mcp-host:8788",
+      "headers": {
+        "Authorization": "Bearer mcp-token"
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "mcp_servers.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	t.Run("returns MCP token when env unset", func(t *testing.T) {
+		t.Setenv("ENGRAM_API_KEY", "")
+		// Unset is cleaner than empty for "not set" — but empty also falls through EnvOr.
+		// Clear any ambient value: Setenv("") still sets the var empty, which EnvOr treats as unset.
+		got := DefaultAPIKey()
+		if got != "mcp-token" {
+			t.Errorf("DefaultAPIKey() = %q, want mcp-token", got)
+		}
+	})
+	t.Run("returns ENGRAM_API_KEY when set", func(t *testing.T) {
+		t.Setenv("ENGRAM_API_KEY", "env-key")
+		got := DefaultAPIKey()
+		if got != "env-key" {
+			t.Errorf("DefaultAPIKey() = %q, want env-key", got)
+		}
+	})
+	t.Run("whitespace-only env is preserved not fallen back", func(t *testing.T) {
+		// longmemeval non-trimming path: "   " is non-empty so it wins over MCP token.
+		t.Setenv("ENGRAM_API_KEY", "   ")
+		got := DefaultAPIKey()
+		if got != "   " {
+			t.Errorf("DefaultAPIKey() = %q, want %q (non-trimming)", got, "   ")
+		}
+	})
+}
+
+func TestDefaultServerURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := `{
+  "mcpServers": {
+    "engram": {
+      "url": "http://mcp-host:8788",
+      "headers": {
+        "Authorization": "Bearer mcp-token"
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "mcp_servers.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	t.Run("returns MCP URL when env unset", func(t *testing.T) {
+		t.Setenv("ENGRAM_URL", "")
+		got := DefaultServerURL()
+		if got != "http://mcp-host:8788" {
+			t.Errorf("DefaultServerURL() = %q, want http://mcp-host:8788", got)
+		}
+	})
+	t.Run("returns ENGRAM_URL when set", func(t *testing.T) {
+		t.Setenv("ENGRAM_URL", "http://from-env:9999")
+		got := DefaultServerURL()
+		if got != "http://from-env:9999" {
+			t.Errorf("DefaultServerURL() = %q, want http://from-env:9999", got)
+		}
+	})
+	t.Run("whitespace-only env is preserved not fallen back", func(t *testing.T) {
+		t.Setenv("ENGRAM_URL", "   ")
+		got := DefaultServerURL()
+		if got != "   " {
+			t.Errorf("DefaultServerURL() = %q, want %q (non-trimming)", got, "   ")
 		}
 	})
 }

--- a/internal/longmemeval/mcp_defaults_test.go
+++ b/internal/longmemeval/mcp_defaults_test.go
@@ -1,0 +1,67 @@
+package longmemeval
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestMCPDefaults_FallbackWhenNoConfig(t *testing.T) {
+	// Isolate from the developer's real ~/.claude/mcp_servers.json.
+	t.Setenv("HOME", t.TempDir())
+
+	url, token := MCPDefaults()
+	if url != "http://localhost:8788" {
+		t.Errorf("MCPDefaults() url = %q, want http://localhost:8788", url)
+	}
+	if token != "" {
+		t.Errorf("MCPDefaults() token = %q, want empty", token)
+	}
+}
+
+func TestEnvOr(t *testing.T) {
+	t.Run("returns fallback when unset", func(t *testing.T) {
+		got := EnvOr("__LONGMEMEVAL_ENVOR_UNSET_XYZ__", "fallback")
+		if got != "fallback" {
+			t.Errorf("EnvOr() = %q, want fallback", got)
+		}
+	})
+	t.Run("returns env value when set", func(t *testing.T) {
+		t.Setenv("__LONGMEMEVAL_ENVOR_SET_XYZ__", "fromenv")
+		got := EnvOr("__LONGMEMEVAL_ENVOR_SET_XYZ__", "fallback")
+		if got != "fromenv" {
+			t.Errorf("EnvOr() = %q, want fromenv", got)
+		}
+	})
+	t.Run("trims whitespace and falls back when blank", func(t *testing.T) {
+		t.Setenv("__LONGMEMEVAL_ENVOR_BLANK_XYZ__", "   ")
+		got := EnvOr("__LONGMEMEVAL_ENVOR_BLANK_XYZ__", "fallback")
+		if got != "fallback" {
+			t.Errorf("EnvOr() = %q, want fallback for whitespace-only value", got)
+		}
+	})
+}
+
+func TestFlagWasProvided(t *testing.T) {
+	t.Run("false when flag omitted", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var v string
+		fs.StringVar(&v, "api-key", "", "key")
+		if err := fs.Parse(nil); err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if FlagWasProvided(fs, "api-key") {
+			t.Error("FlagWasProvided(api-key) = true, want false when omitted")
+		}
+	})
+	t.Run("true when flag provided", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var v string
+		fs.StringVar(&v, "api-key", "", "key")
+		if err := fs.Parse([]string{"--api-key=secret"}); err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if !FlagWasProvided(fs, "api-key") {
+			t.Error("FlagWasProvided(api-key) = false, want true when provided")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `cmd/wp05-retrofit-runner/main.go` duplicated ~60 lines of MCP default discovery (`mcpDefaults`, `applySharedDefaults`, flag introspection, `~/.claude/mcp_servers.json` parsing) that mirrored `cmd/longmemeval/main.go` (PR #1315 round-3 structural review, fleet item b01f2ea6, severity/nice-to-have).
- Extracted into `internal/longmemeval/mcp_defaults.go` as exported `MCPDefaults`, `FlagWasProvided`, `EnvOr`, `DefaultAPIKey`, `DefaultServerURL`.
- Both binaries now call the shared package. Also fixed two additional call sites in `cmd/longmemeval/prune.go` and `cmd/longmemeval/atom_build.go` that referenced the now-removed local helpers (found during the extract, not mentioned in the original issue text).
- `cmd/longmemeval`'s local `envOr` is kept (still used for `LME_SCORER_API_KEY`/`OPENAI_API_KEY`) — out of scope for this issue.

**AI-generated**: authored by the grok CLI (xAI grok-4.5) driven by a Claude Code supervisor in a tight local inner loop (issue text + file contents → grok edits → `go build`/`go test` → converged first try). Per repo policy this PR needs three rounds of adversarial review (correctness / coverage / structural) before merge.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/longmemeval/... ./cmd/longmemeval/... ./cmd/wp05-retrofit-runner/... -count=1 -race` — all pass
- [x] `gofmt -l` clean on touched files
- [x] New test `internal/longmemeval/mcp_defaults_test.go` covers `MCPDefaults` fallback (temp `$HOME`), `EnvOr` (unset/set/blank), `FlagWasProvided` (omitted/provided)
- [x] Existing tests referencing the old signatures (`cmd/longmemeval/dispatch_test.go` `applySharedDefaults(cfg, fs)`, `cmd/longmemeval/score_test.go` `envOr`) pass unmodified

Closes #1317