### PR TITLE
fix(local): CPU-portable compose default with ROCm overlay (#1336)

### DIFF
--- a/bin/checkin-lint.baseline
+++ b/bin/checkin-lint.baseline
@@ -261,7 +261,7 @@ D.exit-zero-wrapper::./hooks/engram/engram-precheck.sh::24
 D.exit-zero-wrapper::./hooks/engram/engram-precheck.sh::38
 D.exit-zero-wrapper::./hooks/pre-tool-use.sh::4
 G.latest-image::./docker-compose.yml::33
-G.latest-image::./docker-compose.local.yml::29
+G.latest-image::./docker-compose.local.yml::32
 G.latest-image::./docker-compose.yml::51
 G.latest-image::./docker-compose.yml::119
 G.latest-image::./docker-compose.local.yml::85

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,8 +9,11 @@
 #   engram-go       — MCP server (port 8788)
 #   engram-reembed  — background embedding worker
 #
-# Start with:
+# Start on CPU (portable default):
 #   docker compose -f docker-compose.local.yml up -d
+#
+# Start with AMD ROCm acceleration:
+#   docker compose -f docker-compose.local.yml -f docker-compose.rocm.yml up -d
 #
 # First time setup:
 #   docker volume create engram_pgdata
@@ -56,14 +59,11 @@ services:
 
   ollama:
     container_name: engram-ollama
-    image: ollama/ollama:rocm
+    image: ollama/ollama
     ports:
       - "127.0.0.1:11434:11434"
     volumes:
       - ollama_storage:/root/.ollama
-    devices:
-      - /dev/kfd:/dev/kfd
-      - /dev/dri:/dev/dri
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
       # KV-cache tuning (2026-05-07): cut jina VRAM ~8.9 GB → ~4 GB on 7900 XT

--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -1,0 +1,11 @@
+# AMD ROCm acceleration override for the local-only profile.
+#
+# Usage:
+#   docker compose -f docker-compose.local.yml -f docker-compose.rocm.yml up -d
+
+services:
+  ollama:
+    image: ollama/ollama:rocm
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,8 +86,17 @@ docker compose -f docker-compose.local.yml up -d
 ```
 
 For a predictable fresh-clone first run, use the local-only profile above.
+It uses the CPU-portable Ollama image by default, so it works without GPU
+device access on CPU-only Linux, macOS, NVIDIA, and other non-ROCm hosts.
 `make up` is the hybrid profile and assumes an external embed/LLM backend
 already exists at `ENGRAM_ROUTER_URL` (or legacy `LITELLM_URL`).
+
+On a Linux host configured for AMD ROCm, add the explicit acceleration
+override:
+
+```bash
+docker compose -f docker-compose.local.yml -f docker-compose.rocm.yml up -d
+```
 
 This local-only profile starts:
 
@@ -343,7 +352,15 @@ Remove the `#` characters. Then ensure you have the [NVIDIA Container Toolkit](h
 
 ### AMD (ROCm)
 
-Change the Ollama image to `ollama/ollama:rocm` and uncomment the `devices` block in `docker-compose.yml`. Your user must be in the `render` and `video` groups:
+The default local-only command uses CPU and does not require AMD device nodes.
+To use ROCm acceleration, apply the provided override, which selects the ROCm
+Ollama image and passes `/dev/kfd` and `/dev/dri` into the container:
+
+```bash
+docker compose -f docker-compose.local.yml -f docker-compose.rocm.yml up -d
+```
+
+Your user must be in the `render` and `video` groups:
 
 ```bash
 sudo usermod -aG render,video $USER


### PR DESCRIPTION
dispatch night-1336 (codex, effort low) — agent's change was correct but tripped the line-keyed lint baseline; coordinator resolved inline per night protocol. Closes #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01AYYMBEy3EJkuPtKiV3795j