### PR TITLE
dispatch: layerc-b1-event-time (codex)

### DIFF
--- a/cmd/longmemeval/atom_build.go
+++ b/cmd/longmemeval/atom_build.go
@@ -318,7 +318,7 @@ func atomBuildWorker(
 			// 5-minute cap per session. Each session is small (well under the
 			// extractor's 6000-char window), so this is generous.
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			sa, err := extractor.Extract(ctx, st.text)
+			sa, err := extractor.Extract(ctx, st.text, st.date)
 			cancel()
 			if err != nil {
 				// Record the first error but keep going — one bad session must not
@@ -385,6 +385,7 @@ func atomBuildWorker(
 type sessionText struct {
 	sessionID string
 	text      string
+	date      time.Time
 }
 
 // buildSessionTexts formats each haystack session independently so the extractor
@@ -409,7 +410,11 @@ func buildSessionTexts(item longmemeval.Item, maxSessions int) []sessionText {
 		if i < len(item.HaystackSessionIDs) {
 			sid = item.HaystackSessionIDs[i]
 		}
-		all = append(all, sessionText{sessionID: sid, text: format(session)})
+		var sessionDate time.Time
+		if i < len(item.HaystackDates) {
+			sessionDate, _ = parseLongMemEvalQuestionDate(item.HaystackDates[i])
+		}
+		all = append(all, sessionText{sessionID: sid, text: format(session), date: sessionDate})
 	}
 
 	if maxSessions <= 0 || len(all) <= maxSessions {

--- a/cmd/longmemeval/atom_build_test.go
+++ b/cmd/longmemeval/atom_build_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/petersimmons1972/engram/internal/longmemeval"
+)
+
+type recordingAtomExtractor struct {
+	mu    sync.Mutex
+	dates []time.Time
+}
+
+func (r *recordingAtomExtractor) Extract(_ context.Context, _ string, dates ...time.Time) ([]atom.Atom, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.dates = append(r.dates, dates...)
+	return nil, nil
+}
+
+func TestAtomBuildWorkerThreadsSessionDateToExtractor(t *testing.T) {
+	extractor := &recordingAtomExtractor{}
+	workCh := make(chan atomBuildWorkItem, 1)
+	ckptCh := make(chan atomBuildEntry, 1)
+	workCh <- atomBuildWorkItem{
+		entry: longmemeval.IngestEntry{QuestionID: "q1", Project: "proj"},
+		item: longmemeval.Item{
+			QuestionID:         "q1",
+			HaystackSessionIDs: []string{"s1"},
+			HaystackDates:      []string{"2023/05/09 (Tue) 23:30"},
+			HaystackSessions: [][]longmemeval.Turn{{
+				{Role: "user", Content: "I attended a meetup."},
+			}},
+		},
+	}
+	close(workCh)
+
+	atomBuildWorker(extractor, nil, nil, "", 0, workCh, ckptCh)
+
+	require.Equal(t, []time.Time{time.Date(2023, 5, 9, 0, 0, 0, 0, time.UTC)}, extractor.dates)
+}

--- a/internal/atom/dedup.go
+++ b/internal/atom/dedup.go
@@ -78,6 +78,10 @@ func Deduplicate(existing []Atom, candidates []Atom, now time.Time) Deduplicatio
 
 		// Same subject+predicate.
 		if strings.EqualFold(strings.TrimSpace(existing.Value), strings.TrimSpace(c.Value)) {
+			if isDistinctDatedOccurrence(existing, c) {
+				result.Fresh = append(result.Fresh, c)
+				continue
+			}
 			// Identical value — reinforce (no action needed; existing stays active).
 			continue
 		}
@@ -98,4 +102,16 @@ func Deduplicate(existing []Atom, candidates []Atom, now time.Time) Deduplicatio
 	}
 
 	return result
+}
+
+func isDistinctDatedOccurrence(existing, candidate Atom) bool {
+	isEvent := candidate.Type == TypeEvent || candidate.Type == TypeStatusChange
+	if !isEvent || existing.ValidFrom == nil || candidate.ValidFrom == nil {
+		return false
+	}
+	return !eventOccurrenceDate(*existing.ValidFrom).Equal(eventOccurrenceDate(*candidate.ValidFrom))
+}
+
+func eventOccurrenceDate(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
 }

--- a/internal/atom/dedup.go
+++ b/internal/atom/dedup.go
@@ -1,6 +1,7 @@
 package atom
 
 import (
+	"log/slog"
 	"strings"
 	"time"
 )
@@ -65,6 +66,7 @@ func Deduplicate(existing []Atom, candidates []Atom, now time.Time) Deduplicatio
 
 		if seen[k] {
 			// Duplicate within the candidate batch — skip.
+			slog.Debug("atom deduplication: dropped duplicate candidate within batch", "key", k)
 			continue
 		}
 		seen[k] = true
@@ -105,8 +107,7 @@ func Deduplicate(existing []Atom, candidates []Atom, now time.Time) Deduplicatio
 }
 
 func isDistinctDatedOccurrence(existing, candidate Atom) bool {
-	isEvent := candidate.Type == TypeEvent || candidate.Type == TypeStatusChange
-	if !isEvent || existing.ValidFrom == nil || candidate.ValidFrom == nil {
+	if candidate.Type != TypeEvent || existing.ValidFrom == nil || candidate.ValidFrom == nil {
 		return false
 	}
 	return !eventOccurrenceDate(*existing.ValidFrom).Equal(eventOccurrenceDate(*candidate.ValidFrom))

--- a/internal/atom/dedup.go
+++ b/internal/atom/dedup.go
@@ -14,6 +14,12 @@ type SupersessionKey struct {
 	Predicate string
 }
 
+type batchDeduplicationKey struct {
+	SupersessionKey
+	Value     string
+	EventDate time.Time
+}
+
 // supersessionKey returns the dedup key for a.
 func supersessionKey(a *Atom) SupersessionKey {
 	return SupersessionKey{
@@ -21,6 +27,17 @@ func supersessionKey(a *Atom) SupersessionKey {
 		Subject:   strings.ToLower(strings.TrimSpace(a.Subject)),
 		Predicate: strings.ToLower(strings.TrimSpace(a.Predicate)),
 	}
+}
+
+func candidateBatchKey(a *Atom) batchDeduplicationKey {
+	key := batchDeduplicationKey{
+		SupersessionKey: supersessionKey(a),
+		Value:           strings.ToLower(strings.TrimSpace(a.Value)),
+	}
+	if a.Type == TypeEvent && a.ValidFrom != nil {
+		key.EventDate = eventOccurrenceDate(*a.ValidFrom)
+	}
+	return key
 }
 
 // DeduplicationResult is the output of Deduplicate.
@@ -58,18 +75,23 @@ func Deduplicate(existing []Atom, candidates []Atom, now time.Time) Deduplicatio
 	}
 
 	var result DeduplicationResult
-	seen := make(map[SupersessionKey]bool) // dedup within candidates
+	seen := make(map[batchDeduplicationKey]bool) // dedup exact candidates within the batch
 
 	for i := range candidates {
 		c := candidates[i]
 		k := supersessionKey(&c)
+		batchKey := candidateBatchKey(&c)
 
-		if seen[k] {
+		if seen[batchKey] {
 			// Duplicate within the candidate batch — skip.
-			slog.Debug("atom deduplication: dropped duplicate candidate within batch", "key", k)
+			slog.Debug(
+				"atom deduplication: dropped duplicate candidate within batch",
+				"key", k,
+				"value", c.Value,
+			)
 			continue
 		}
-		seen[k] = true
+		seen[batchKey] = true
 
 		existing, exists := index[k]
 		if !exists {

--- a/internal/atom/dedup_test.go
+++ b/internal/atom/dedup_test.go
@@ -164,16 +164,40 @@ func TestDeduplicate_DifferentPredicateBothFresh(t *testing.T) {
 }
 
 func TestDeduplicate_DuplicateCandidateWithinBatch(t *testing.T) {
-	// Two candidates with the same (subject, predicate) in the same batch.
+	// Two candidates with the same normalized key and value in the same batch.
 	candidates := []atom.Atom{
 		makeAtom("", "proj", "the user", "prefers", "coffee"),
-		makeAtom("", "proj", "the user", "prefers", "tea"),
+		makeAtom("", "proj", "the user", "prefers", " COFFEE "),
 	}
 
 	result := atom.Deduplicate(nil, candidates, testNow)
-	// First one wins; second is dropped as intra-batch duplicate.
+	// First one wins; second is dropped as an exact intra-batch duplicate.
 	assert.Len(t, result.Fresh, 1)
 	assert.Equal(t, "coffee", result.Fresh[0].Value)
+}
+
+func TestDeduplicate_SameValueEventsOnDifferentDatesWithinBatchAreFresh(t *testing.T) {
+	first := makeAtom("", "proj", "Alice", "attended", "Go meetup")
+	first.Type = atom.TypeEvent
+	first.ValidFrom = timePointer(time.Date(2026, 7, 4, 18, 0, 0, 0, time.FixedZone("EDT", -4*60*60)))
+	second := makeAtom("", "proj", "Alice", "attended", "go MEETUP")
+	second.Type = atom.TypeEvent
+	second.ValidFrom = timePointer(time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC))
+
+	result := atom.Deduplicate(nil, []atom.Atom{first, second}, testNow)
+
+	assert.Len(t, result.Fresh, 2)
+	assert.Empty(t, result.Superseded)
+}
+
+func TestDeduplicate_DifferentValuesWithinBatchAreFresh(t *testing.T) {
+	first := makeAtom("", "proj", "Alice", "employment", "Acme")
+	second := makeAtom("", "proj", "Alice", "employment", "Globex")
+
+	result := atom.Deduplicate(nil, []atom.Atom{first, second}, testNow)
+
+	assert.Len(t, result.Fresh, 2)
+	assert.Empty(t, result.Superseded)
 }
 
 func TestDeduplicate_EmptyInputs(t *testing.T) {

--- a/internal/atom/dedup_test.go
+++ b/internal/atom/dedup_test.go
@@ -14,14 +14,14 @@ var testNow = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 
 func makeAtom(id, project, subject, predicate, value string) atom.Atom {
 	return atom.Atom{
-		ID:        id,
-		Project:   project,
-		Type:      atom.TypePreference,
-		Subject:   subject,
-		Predicate: predicate,
-		Value:     value,
-		Statement: subject + " " + predicate + " " + value + ".",
-		Scope:     atom.ScopeGlobal,
+		ID:         id,
+		Project:    project,
+		Type:       atom.TypePreference,
+		Subject:    subject,
+		Predicate:  predicate,
+		Value:      value,
+		Statement:  subject + " " + predicate + " " + value + ".",
+		Scope:      atom.ScopeGlobal,
 		Confidence: 0.9,
 	}
 }
@@ -48,6 +48,37 @@ func TestDeduplicate_IdenticalValueReinforced(t *testing.T) {
 
 	result := atom.Deduplicate(existing, candidates, testNow)
 	// Same value → reinforce only, no new insert.
+	assert.Empty(t, result.Fresh)
+	assert.Empty(t, result.Superseded)
+}
+
+func TestB1CorruptionProbeSameValueDifferentDateEventsAreFresh(t *testing.T) {
+	existing := makeAtom("old-1", "proj", "the user", "attended", "Go meetup")
+	existing.Type = atom.TypeEvent
+	existingDate := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+	existing.ValidFrom = &existingDate
+	candidate := makeAtom("", "proj", "the user", "attended", "Go meetup")
+	candidate.Type = atom.TypeEvent
+	candidateDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	candidate.ValidFrom = &candidateDate
+
+	result := atom.Deduplicate([]atom.Atom{existing}, []atom.Atom{candidate}, testNow)
+
+	require.Len(t, result.Fresh, 1, "a recurring event on a different date must be inserted")
+	assert.Empty(t, result.Superseded, "a recurring event must not retire the earlier occurrence")
+}
+
+func TestDeduplicateSameValueSameDateEventIsReinforced(t *testing.T) {
+	eventDate := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+	existing := makeAtom("old-1", "proj", "the user", "attended", "Go meetup")
+	existing.Type = atom.TypeEvent
+	existing.ValidFrom = timePointer(eventDate)
+	candidate := makeAtom("", "proj", "the user", "attended", "Go meetup")
+	candidate.Type = atom.TypeEvent
+	candidate.ValidFrom = timePointer(eventDate)
+
+	result := atom.Deduplicate([]atom.Atom{existing}, []atom.Atom{candidate}, testNow)
+
 	assert.Empty(t, result.Fresh)
 	assert.Empty(t, result.Superseded)
 }

--- a/internal/atom/dedup_test.go
+++ b/internal/atom/dedup_test.go
@@ -83,6 +83,22 @@ func TestDeduplicateSameValueSameDateEventIsReinforced(t *testing.T) {
 	assert.Empty(t, result.Superseded)
 }
 
+func TestDeduplicateSameValueStatusChangeWithoutExplicitEventDateIsReinforced(t *testing.T) {
+	existingDate := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+	existing := makeAtom("old-1", "proj", "the user", "employment status", "employed")
+	existing.Type = atom.TypeStatusChange
+	existing.ValidFrom = timePointer(existingDate)
+	candidateDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	candidate := makeAtom("", "proj", "the user", "employment status", "employed")
+	candidate.Type = atom.TypeStatusChange
+	candidate.ValidFrom = timePointer(candidateDate)
+
+	result := atom.Deduplicate([]atom.Atom{existing}, []atom.Atom{candidate}, testNow)
+
+	assert.Empty(t, result.Fresh, "a restated status change must not create another active row")
+	assert.Empty(t, result.Superseded, "a restated status change is reinforcement, not supersession")
+}
+
 func TestDeduplicate_SupersessionOnValueChange(t *testing.T) {
 	existing := []atom.Atom{
 		makeAtom("old-1", "proj", "the user", "prefers", "dark chocolate"),

--- a/internal/atom/extract.go
+++ b/internal/atom/extract.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
+
+	"github.com/petersimmons1972/engram/internal/metrics"
 )
 
 // ClaudeCompleter is the narrow interface satisfied by *claude.Client.
@@ -17,7 +21,7 @@ type ClaudeCompleter interface {
 
 // Extractor extracts atoms from session text.
 type Extractor interface {
-	Extract(ctx context.Context, sessionText string) ([]Atom, error)
+	Extract(ctx context.Context, sessionText string, sessionDate ...time.Time) ([]Atom, error)
 }
 
 // ClaudeExtractor uses a Claude language model to extract typed atoms from
@@ -32,8 +36,7 @@ func NewClaudeExtractor(client ClaudeCompleter) *ClaudeExtractor {
 	return &ClaudeExtractor{client: client}
 }
 
-// maxSessionChars truncates session text before sending to the model.
-// Keeps atom prompts within the token budget; mirrors entity.maxContentChars.
+// maxSessionChars is the maximum size of each model extraction window.
 const maxSessionChars = 6000
 
 // extractionSystem is the system prompt for preference-focused atom extraction.
@@ -66,7 +69,8 @@ Return ONLY a JSON array of atom objects — no prose, no markdown fences — in
     "statement": "<canonical NL sentence, e.g. 'Alice prefers dark chocolate over milk chocolate.'>",
     "scope":     "<global | session:<id> | entity:<id>>",
     "confidence": <0.0–1.0>,
-    "source_span": "<optional verbatim quote or char range>"
+    "source_span": "<optional verbatim quote or char range>",
+    "event_date": "<optional event date, ISO YYYY-MM-DD>"
   }
 ]
 
@@ -82,6 +86,8 @@ Rules:
 - When a one-off user event or plan is useful, use atom_type event and retain its time anchor in the statement
   (for example, "On <date>, the user did X once") and session scope when available. If its timing or subject is
   ambiguous, skip it. Conservative extraction is better than an unsupported habitual claim.
+- For event and status_change atoms, set event_date to YYYY-MM-DD only when the source states or clearly implies
+  the event's own date. Keep that same date anchor in statement. Omit event_date rather than guessing.
 - subject should be the first-person actor ("the user") or a named entity.
 - Normalise subject to "the user" for first-person statements.
 - statement must be a complete, standalone sentence (no pronouns requiring external context).
@@ -100,16 +106,39 @@ type atomResponse struct {
 	Scope      string  `json:"scope"`
 	Confidence float64 `json:"confidence"`
 	SourceSpan string  `json:"source_span"`
+	EventDate  string  `json:"event_date"`
 }
 
-// Extract calls Claude and parses the JSON result into Atom slices.
-// Session text is silently truncated to maxSessionChars before sending.
+// Extract calls Claude once per message-aligned window and unions the results.
+// sessionDate is the authoritative assertion time supplied by the ingest path.
 // No real LLM call is made in tests — inject a mock via ClaudeCompleter.
-func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string) ([]Atom, error) {
-	if len([]rune(sessionText)) > maxSessionChars {
-		sessionText = string([]rune(sessionText)[:maxSessionChars])
+func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string, sessionDates ...time.Time) ([]Atom, error) {
+	var sessionDate time.Time
+	if len(sessionDates) > 0 {
+		sessionDate = sessionDates[0].UTC()
 	}
 
+	windows := sessionWindows(sessionText, maxSessionChars)
+	atoms := make([]Atom, 0)
+	seen := make(map[exactAtomKey]struct{})
+	for i, window := range windows {
+		windowAtoms, err := e.extractWindow(ctx, window, sessionDate)
+		if err != nil {
+			return nil, fmt.Errorf("atom extraction: window %d of %d: %w", i+1, len(windows), err)
+		}
+		for _, candidate := range windowAtoms {
+			key := exactKey(candidate)
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			atoms = append(atoms, candidate)
+		}
+	}
+	return atoms, nil
+}
+
+func (e *ClaudeExtractor) extractWindow(ctx context.Context, sessionText string, sessionDate time.Time) ([]Atom, error) {
 	prompt := "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n" + sessionText
 
 	raw, err := e.client.Complete(ctx, extractionSystem, prompt,
@@ -149,9 +178,117 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string) ([]At
 		if !a.IsValid() {
 			continue // skip malformed atoms silently
 		}
+		applyEventTime(&a, r.EventDate, sessionDate)
 		atoms = append(atoms, a)
 	}
 	return atoms, nil
+}
+
+type exactAtomKey struct {
+	typeName  string
+	subject   string
+	predicate string
+	value     string
+	statement string
+}
+
+func exactKey(a Atom) exactAtomKey {
+	return exactAtomKey{
+		typeName:  a.Type,
+		subject:   a.Subject,
+		predicate: a.Predicate,
+		value:     a.Value,
+		statement: a.Statement,
+	}
+}
+
+func sessionWindows(text string, maxRunes int) []string {
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return []string{text}
+	}
+
+	windows := make([]string, 0, (len(runes)+maxRunes-1)/maxRunes)
+	for len(runes) > maxRunes {
+		end := maxRunes
+		if boundaryEnd := lastMessageBoundary(runes[:maxRunes]); boundaryEnd >= maxRunes/2 {
+			end = boundaryEnd
+		}
+		windows = append(windows, string(runes[:end]))
+		runes = runes[end:]
+	}
+	windows = append(windows, string(runes))
+	return windows
+}
+
+func lastMessageBoundary(runes []rune) int {
+	for i := len(runes) - 1; i >= 0; i-- {
+		if runes[i] != '\n' || i+1 == len(runes) {
+			continue
+		}
+		nextLine := strings.ToLower(string(runes[i+1:]))
+		for _, prefix := range []string{
+			"user:", "human:", "assistant:", "system:", "tool:",
+			"[user]", "[human]", "[assistant]", "[system]", "[tool]",
+		} {
+			if strings.HasPrefix(nextLine, prefix) {
+				return i + 1
+			}
+		}
+	}
+	return 0
+}
+
+func applyEventTime(a *Atom, rawEventDate string, sessionDate time.Time) {
+	if !sessionDate.IsZero() {
+		observedAt := sessionDate
+		a.ObservedAt = &observedAt
+	}
+	if a.Type != TypeEvent && a.Type != TypeStatusChange {
+		return
+	}
+	if rawEventDate == "" {
+		if !sessionDate.IsZero() {
+			validFrom := dateOnly(sessionDate)
+			a.ValidFrom = &validFrom
+		}
+		return
+	}
+
+	eventDate, reason := parseEventDate(rawEventDate, sessionDate)
+	if reason != "" {
+		metrics.AtomEventDateRejections.WithLabelValues(reason).Inc()
+		slog.Warn("atom extraction: rejected event_date", "event_date", rawEventDate, "reason", reason)
+		return
+	}
+	a.ValidFrom = &eventDate
+}
+
+func parseEventDate(raw string, observedAt time.Time) (time.Time, string) {
+	if len(raw) != len(time.DateOnly) || (raw[4] != '-' && raw[4] != '/') || raw[7] != raw[4] {
+		return time.Time{}, "invalid_format"
+	}
+	normalized := strings.ReplaceAll(raw, "/", "-")
+	parsed, err := time.Parse(time.DateOnly, normalized)
+	if err != nil {
+		return time.Time{}, "invalid_format"
+	}
+	parsed = dateOnly(parsed)
+	if parsed.Before(time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+		return time.Time{}, "before_1990"
+	}
+	if !observedAt.IsZero() && parsed.After(observedAt.AddDate(1, 0, 0)) {
+		return time.Time{}, "more_than_one_year_future"
+	}
+	return parsed, ""
+}
+
+func dateOnly(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	value = value.UTC()
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
 }
 
 func extractAtomJSON(raw string) (string, error) {

--- a/internal/atom/extract.go
+++ b/internal/atom/extract.go
@@ -115,7 +115,7 @@ type atomResponse struct {
 func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string, sessionDates ...time.Time) ([]Atom, error) {
 	var sessionDate time.Time
 	if len(sessionDates) > 0 {
-		sessionDate = sessionDates[0].UTC()
+		sessionDate = sessionDates[0]
 	}
 
 	windows := sessionWindows(sessionText, maxSessionChars)
@@ -123,6 +123,9 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string, sessi
 	seen := make(map[exactAtomKey]struct{})
 	for i, window := range windows {
 		windowAtoms, err := e.extractWindow(ctx, window, sessionDate)
+		if err != nil {
+			windowAtoms, err = e.extractWindow(ctx, window, sessionDate)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("atom extraction: window %d of %d: %w", i+1, len(windows), err)
 		}
@@ -190,6 +193,7 @@ type exactAtomKey struct {
 	predicate string
 	value     string
 	statement string
+	scope     string
 }
 
 func exactKey(a Atom) exactAtomKey {
@@ -199,6 +203,7 @@ func exactKey(a Atom) exactAtomKey {
 		predicate: a.Predicate,
 		value:     a.Value,
 		statement: a.Statement,
+		scope:     a.Scope,
 	}
 }
 
@@ -241,7 +246,7 @@ func lastMessageBoundary(runes []rune) int {
 
 func applyEventTime(a *Atom, rawEventDate string, sessionDate time.Time) {
 	if !sessionDate.IsZero() {
-		observedAt := sessionDate
+		observedAt := dateOnly(sessionDate)
 		a.ObservedAt = &observedAt
 	}
 	if a.Type != TypeEvent && a.Type != TypeStatusChange {
@@ -287,7 +292,6 @@ func dateOnly(value time.Time) time.Time {
 	if value.IsZero() {
 		return time.Time{}
 	}
-	value = value.UTC()
 	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
 }
 

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,16 +20,138 @@ import (
 
 // stubCompleter implements atom.ClaudeCompleter for tests — no real LLM calls.
 type stubCompleter struct {
-	response string
-	err      error
-	system   string
-	prompt   string
+	response  string
+	responses []string
+	err       error
+	system    string
+	prompt    string
+	prompts   []string
 }
 
 func (s *stubCompleter) Complete(_ context.Context, system, prompt, _, _ string, _, _ int) (string, error) {
 	s.system = system
 	s.prompt = prompt
+	s.prompts = append(s.prompts, prompt)
+	if len(s.responses) > 0 {
+		response := s.responses[0]
+		s.responses = s.responses[1:]
+		return response, s.err
+	}
 	return s.response, s.err
+}
+
+func TestClaudeExtractorAssignsEventTimeFromSessionDate(t *testing.T) {
+	sessionDate := time.Date(2026, 7, 11, 18, 30, 0, 0, time.FixedZone("EDT", -4*60*60))
+	stub := &stubCompleter{response: `[
+{"atom_type":"event","subject":"the user","predicate":"attended","value":"Go meetup","statement":"On 2026-07-04, the user attended a Go meetup.","scope":"global","confidence":0.9,"event_date":"2026/07/04"},
+{"atom_type":"status_change","subject":"the user","predicate":"employment","value":"joined Acme","statement":"The user joined Acme.","scope":"global","confidence":0.9},
+{"atom_type":"fact","subject":"Acme","predicate":"location","value":"Boston","statement":"Acme is in Boston.","scope":"global","confidence":0.9,"event_date":"2020-01-01"}
+]`}
+
+	atoms, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), "dated session", sessionDate)
+	require.NoError(t, err)
+	require.Len(t, atoms, 3)
+
+	assert.Equal(t, "2026-07-04", atoms[0].ValidFrom.Format(time.DateOnly))
+	assert.Equal(t, "2026-07-11", atoms[0].ObservedAt.Format(time.DateOnly))
+	assert.Equal(t, "2026-07-11", atoms[1].ValidFrom.Format(time.DateOnly))
+	assert.Equal(t, "2026-07-11", atoms[1].ObservedAt.Format(time.DateOnly))
+	assert.Nil(t, atoms[2].ValidFrom, "event_date must not set valid_from for non-event atoms")
+	assert.Equal(t, "2026-07-11", atoms[2].ObservedAt.Format(time.DateOnly))
+	assert.Contains(t, stub.system, `"event_date"`)
+	assert.Contains(t, atoms[0].Statement, "2026-07-04", "statement must retain its date anchor")
+}
+
+func TestB1CorruptionProbeRejectsAdversarialEventDates(t *testing.T) {
+	sessionDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		eventDate string
+	}{
+		{name: "garbage", eventDate: "last Tuesday"},
+		{name: "mixed separators", eventDate: "2026/07-04"},
+		{name: "far future", eventDate: "2028-07-12"},
+		{name: "pre 1990", eventDate: "1989-12-31"},
+		{name: "swapped range", eventDate: "2026-07-12/2026-07-10"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := fmt.Sprintf(`[{"atom_type":"event","subject":"the user","predicate":"visited","value":"Rome","statement":"The user visited Rome.","scope":"global","confidence":0.9,"event_date":%q}]`, tt.eventDate)
+			atoms, err := atom.NewClaudeExtractor(&stubCompleter{response: response}).Extract(context.Background(), "session", sessionDate)
+			require.NoError(t, err)
+			require.Len(t, atoms, 1)
+			assert.Nil(t, atoms[0].ValidFrom)
+			assert.NotNil(t, atoms[0].ObservedAt)
+		})
+	}
+}
+
+func TestB1CorruptionProbeChunkingSupersetAndExactDedup(t *testing.T) {
+	sessionDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	first := `[{"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"Alpha exists.","scope":"global","confidence":0.9}]`
+	second := `[
+{"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"Alpha exists.","scope":"global","confidence":0.9},
+{"atom_type":"fact","subject":"Beyond6000","predicate":"exists","value":"yes","statement":"Beyond6000 exists.","scope":"global","confidence":0.9}
+]`
+	stub := &stubCompleter{responses: []string{first, second, `[]`}}
+	session := strings.Repeat("a", 6000) + "\n[user]\nBeyond6000 appears here.\n" + strings.Repeat("b", 9000)
+	truncatedAtoms, err := atom.NewClaudeExtractor(&stubCompleter{response: first}).Extract(
+		context.Background(),
+		string([]rune(session)[:6000]),
+		sessionDate,
+	)
+	require.NoError(t, err)
+
+	atoms, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), session, sessionDate)
+	require.NoError(t, err)
+	require.Greater(t, len(atoms), len(truncatedAtoms), "chunked extraction must be a strict superset")
+	assert.Len(t, stub.prompts, 3)
+	assert.Equal(t, "Alpha", atoms[0].Subject)
+	assert.Equal(t, "Beyond6000", atoms[1].Subject)
+	assert.Contains(t, stub.prompts[1], "Beyond6000")
+	for _, truncated := range truncatedAtoms {
+		assert.Contains(t, atoms, truncated, "every atom from the old truncated path must survive windowing")
+	}
+	for _, prompt := range stub.prompts {
+		window := strings.TrimPrefix(prompt, "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n")
+		assert.LessOrEqual(t, len([]rune(window)), 6000)
+	}
+}
+
+func TestClaudeExtractorStopsWhenAnyWindowFails(t *testing.T) {
+	sessionDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	stub := &stubCompleter{responses: []string{`[]`, `not json`}}
+	session := strings.Repeat("a", 6000) + "\n" + strings.Repeat("b", 100)
+
+	_, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), session, sessionDate)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "window 2")
+}
+
+func TestClaudeExtractorIgnoresPathologicallyEarlyBoundary(t *testing.T) {
+	stub := &stubCompleter{response: `[]`}
+	session := "user: " + strings.Repeat("a", 5494) + "\n" + strings.Repeat("continued", 800)
+
+	_, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), session, time.Now())
+	require.NoError(t, err)
+	require.Len(t, stub.prompts, 3)
+	firstWindow := strings.TrimPrefix(stub.prompts[0], "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n")
+	assert.Len(t, []rune(firstWindow), 6000, "an early newline must not create a tiny extraction window")
+}
+
+func TestClaudeExtractorPrefersRecognizedMessageBoundary(t *testing.T) {
+	stub := &stubCompleter{response: `[]`}
+	firstMessage := "user: " + strings.Repeat("a", 5494) + "\n"
+	session := firstMessage + "assistant: " + strings.Repeat("b", 1000)
+
+	_, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), session, time.Now())
+	require.NoError(t, err)
+	require.Len(t, stub.prompts, 2)
+	firstWindow := strings.TrimPrefix(stub.prompts[0], "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n")
+	secondWindow := strings.TrimPrefix(stub.prompts[1], "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n")
+	assert.Equal(t, firstMessage, firstWindow)
+	assert.True(t, strings.HasPrefix(secondWindow, "assistant: "))
 }
 
 type extractionFidelityFixture struct {

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -72,7 +72,7 @@ func TestB1CorruptionProbeRejectsAdversarialEventDates(t *testing.T) {
 		{name: "mixed separators", eventDate: "2026/07-04"},
 		{name: "far future", eventDate: "2028-07-12"},
 		{name: "pre 1990", eventDate: "1989-12-31"},
-		{name: "swapped range", eventDate: "2026-07-12/2026-07-10"},
+		{name: "date range is not a single ISO date", eventDate: "2026-07-12/2026-07-10"},
 	}
 
 	for _, tt := range tests {
@@ -119,14 +119,84 @@ func TestB1CorruptionProbeChunkingSupersetAndExactDedup(t *testing.T) {
 	}
 }
 
-func TestClaudeExtractorStopsWhenAnyWindowFails(t *testing.T) {
+func TestClaudeExtractorRetriesFailedWindowOnceThenFailsClosed(t *testing.T) {
 	sessionDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
-	stub := &stubCompleter{responses: []string{`[]`, `not json`}}
+	stub := &stubCompleter{responses: []string{`[]`, `not json`, `still not json`}}
 	session := strings.Repeat("a", 6000) + "\n" + strings.Repeat("b", 100)
 
 	_, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), session, sessionDate)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "window 2")
+	assert.Len(t, stub.prompts, 3, "the failed window must be attempted exactly twice")
+}
+
+func TestClaudeExtractorRetriesFailedWindowOnceThenSucceeds(t *testing.T) {
+	stub := &stubCompleter{responses: []string{`not json`, `[]`}}
+
+	atoms, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), "session", time.Now())
+
+	require.NoError(t, err)
+	assert.Empty(t, atoms)
+	assert.Len(t, stub.prompts, 2)
+}
+
+func TestSessionWindowsPreserveEveryRune(t *testing.T) {
+	original := strings.Repeat("a", 5900) + "\nassistant: " + strings.Repeat("界", 6200)
+	stub := &stubCompleter{response: `[]`}
+
+	_, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), original)
+
+	require.NoError(t, err)
+	windows := make([]string, 0, len(stub.prompts))
+	for _, prompt := range stub.prompts {
+		windows = append(windows, strings.TrimPrefix(prompt, "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n"))
+	}
+	assert.Equal(t, original, strings.Join(windows, ""))
+}
+
+func TestClaudeExtractorWindowBoundaries(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantWindows int
+	}{
+		{name: "empty", content: "", wantWindows: 1},
+		{name: "exactly 6000", content: strings.Repeat("a", 6000), wantWindows: 1},
+		{name: "6001", content: strings.Repeat("a", 6001), wantWindows: 2},
+		{name: "multibyte at hard cut", content: strings.Repeat("a", 5999) + "界b", wantWindows: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &stubCompleter{response: `[]`}
+			_, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), tt.content)
+			require.NoError(t, err)
+			assert.Len(t, stub.prompts, tt.wantWindows)
+		})
+	}
+}
+
+func TestClaudeExtractorExactDedupIncludesScope(t *testing.T) {
+	response := `[{"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"Alpha exists.","scope":"global","confidence":0.9}]`
+	sessionResponse := `[{"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"Alpha exists.","scope":"session:s1","confidence":0.9}]`
+	stub := &stubCompleter{responses: []string{response, sessionResponse}}
+
+	atoms, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), strings.Repeat("a", 6001))
+
+	require.NoError(t, err)
+	assert.Len(t, atoms, 2)
+}
+
+func TestClaudeExtractorSessionDateKeepsLocalCalendarDay(t *testing.T) {
+	sessionDate := time.Date(2026, 7, 11, 23, 30, 0, 0, time.FixedZone("EDT", -4*60*60))
+	stub := &stubCompleter{response: `[{"atom_type":"event","subject":"the user","predicate":"visited","value":"Rome","statement":"The user visited Rome.","scope":"global","confidence":0.9}]`}
+
+	atoms, err := atom.NewClaudeExtractor(stub).Extract(context.Background(), "session", sessionDate)
+
+	require.NoError(t, err)
+	require.Len(t, atoms, 1)
+	want := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, want, *atoms[0].ObservedAt)
+	assert.Equal(t, want, *atoms[0].ValidFrom)
 }
 
 func TestClaudeExtractorIgnoresPathologicallyEarlyBoundary(t *testing.T) {
@@ -369,13 +439,14 @@ func TestExtract_NonJSONErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse response JSON")
 }
 
-func TestClaudeExtractor_TruncatesLongContent(t *testing.T) {
+func TestClaudeExtractorWindowsLongContent(t *testing.T) {
 	bigContent := strings.Repeat("a", 20000)
 	stub := &stubCompleter{response: `[]`}
 	ext := atom.NewClaudeExtractor(stub)
 
 	_, err := ext.Extract(context.Background(), bigContent)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	assert.Len(t, stub.prompts, 4)
 }
 
 func TestClaudeExtractor_InvalidAtomSkipped(t *testing.T) {

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -119,6 +119,26 @@ func TestB1CorruptionProbeChunkingSupersetAndExactDedup(t *testing.T) {
 	}
 }
 
+func TestExtractThenDeduplicateStoresDistinctDatedEventsFromSeparateWindows(t *testing.T) {
+	first := `[{"atom_type":"event","subject":"the user","predicate":"attended","value":"weekly meetup","statement":"On 2026-07-04, the user attended the weekly meetup.","scope":"global","confidence":0.9,"event_date":"2026-07-04"}]`
+	second := `[{"atom_type":"event","subject":"the user","predicate":"attended","value":"weekly meetup","statement":"On 2026-07-11, the user attended the weekly meetup.","scope":"global","confidence":0.9,"event_date":"2026-07-11"}]`
+	stub := &stubCompleter{responses: []string{first, second}}
+	session := strings.Repeat("a", 6000) + "\n[user]\nOn 2026-07-11, I attended the weekly meetup."
+
+	candidates, err := atom.NewClaudeExtractor(stub).Extract(
+		context.Background(),
+		session,
+		time.Date(2026, 7, 12, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.Len(t, candidates, 2)
+
+	result := atom.Deduplicate(nil, candidates, time.Date(2026, 7, 12, 0, 0, 0, 0, time.UTC))
+
+	assert.Len(t, result.Fresh, 2)
+	assert.Empty(t, result.Superseded)
+}
+
 func TestClaudeExtractorRetriesFailedWindowOnceThenFailsClosed(t *testing.T) {
 	sessionDate := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
 	stub := &stubCompleter{responses: []string{`[]`, `not json`, `still not json`}}

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -72,7 +72,7 @@ func TestB1CorruptionProbeRejectsAdversarialEventDates(t *testing.T) {
 		{name: "mixed separators", eventDate: "2026/07-04"},
 		{name: "far future", eventDate: "2028-07-12"},
 		{name: "pre 1990", eventDate: "1989-12-31"},
-		{name: "date range is not a single ISO date", eventDate: "2026-07-12/2026-07-10"},
+		{name: "range string rejected by length guard", eventDate: "2026-07-12/2026-07-10"},
 	}
 
 	for _, tt := range tests {

--- a/internal/atom/worker.go
+++ b/internal/atom/worker.go
@@ -123,7 +123,11 @@ func (w *Worker) processJob(ctx context.Context, job ExtractionJob) {
 		return
 	}
 
-	candidates, err := w.ext.Extract(ctx, mem.Content, mem.CreatedAt)
+	sessionDate := mem.CreatedAt
+	if mem.ValidFrom != nil {
+		sessionDate = *mem.ValidFrom
+	}
+	candidates, err := w.ext.Extract(ctx, mem.Content, sessionDate)
 	if err != nil {
 		slog.Warn("atom worker: extraction failed", "job", job.ID, "err", err)
 		if cerr := w.db.CompleteAtomExtractionJob(ctx, job.ID, err); cerr != nil {
@@ -135,10 +139,6 @@ func (w *Worker) processJob(ctx context.Context, job ExtractionJob) {
 	for i := range candidates {
 		candidates[i].Project = job.Project
 		candidates[i].ProvenanceMemoryID = job.MemoryID
-		if !mem.CreatedAt.IsZero() {
-			observedAt := mem.CreatedAt
-			candidates[i].ObservedAt = &observedAt
-		}
 	}
 
 	// Load all active atoms for the project to drive deduplication.

--- a/internal/atom/worker.go
+++ b/internal/atom/worker.go
@@ -123,7 +123,7 @@ func (w *Worker) processJob(ctx context.Context, job ExtractionJob) {
 		return
 	}
 
-	candidates, err := w.ext.Extract(ctx, mem.Content)
+	candidates, err := w.ext.Extract(ctx, mem.Content, mem.CreatedAt)
 	if err != nil {
 		slog.Warn("atom worker: extraction failed", "job", job.ID, "err", err)
 		if cerr := w.db.CompleteAtomExtractionJob(ctx, job.ID, err); cerr != nil {

--- a/internal/atom/worker_test.go
+++ b/internal/atom/worker_test.go
@@ -2,6 +2,7 @@ package atom_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -59,22 +60,30 @@ func (s *stubBackend) GetActiveAtoms(_ context.Context, _ string, _ string) ([]a
 
 func (s *stubBackend) InsertAtom(_ context.Context, a *atom.Atom) error {
 	s.inserted = append(s.inserted, *a)
+	s.existing = append(s.existing, *a)
 	return nil
 }
 
-func (s *stubBackend) RetireAtom(_ context.Context, atomID string, _ time.Time) error {
+func (s *stubBackend) RetireAtom(_ context.Context, atomID string, validTo time.Time) error {
 	s.retired = append(s.retired, atomID)
+	for i := range s.existing {
+		if s.existing[i].ID == atomID {
+			s.existing[i].ValidTo = timePointer(validTo)
+		}
+	}
 	return nil
 }
 
 // ── stub extractor ────────────────────────────────────────────────────────────
 
 type stubExtractor struct {
-	atoms []atom.Atom
-	err   error
+	atoms        []atom.Atom
+	err          error
+	sessionDates []time.Time
 }
 
-func (s *stubExtractor) Extract(_ context.Context, _ string) ([]atom.Atom, error) {
+func (s *stubExtractor) Extract(_ context.Context, _ string, sessionDates ...time.Time) ([]atom.Atom, error) {
+	s.sessionDates = append(s.sessionDates, sessionDates...)
 	return s.atoms, s.err
 }
 
@@ -201,6 +210,63 @@ func TestWorkerSetsObservedAt(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	require.NotEmpty(t, backend.inserted)
+	require.Equal(t, []time.Time{createdAt}, ext.sessionDates)
 	require.NotNil(t, backend.inserted[0].ObservedAt)
 	assert.True(t, backend.inserted[0].ObservedAt.Equal(createdAt))
+}
+
+func TestB1CorruptionProbeRepeatedIngestPreservesExistingRows(t *testing.T) {
+	backend := newStubBackend()
+	createdAt := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	preExisting := atom.Atom{
+		ID: "existing-1", Project: "proj", Type: atom.TypeEvent,
+		Subject: "the user", Predicate: "attended", Value: "Go meetup",
+		Statement: "On 2026-07-04, the user attended a Go meetup.",
+		Scope:     atom.ScopeGlobal, Confidence: 0.9,
+		ValidFrom:  timePointer(time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)),
+		ObservedAt: timePointer(createdAt),
+	}
+	backend.existing = []atom.Atom{preExisting}
+	backend.jobs = []atom.ExtractionJob{
+		{ID: "first-pass", MemoryID: "fixture", Project: "proj"},
+		{ID: "second-pass", MemoryID: "fixture", Project: "proj"},
+	}
+	backend.memories["fixture"] = &types.Memory{
+		ID: "fixture", Content: "On 2026-07-04, I attended a Go meetup.", CreatedAt: createdAt,
+	}
+	ext := &stubExtractor{atoms: []atom.Atom{{
+		Type: atom.TypeEvent, Subject: "the user", Predicate: "attended", Value: "Go meetup",
+		Statement: "On 2026-07-04, the user attended a Go meetup.", Scope: atom.ScopeGlobal,
+		Confidence: 0.9, ValidFrom: timePointer(time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)),
+	}}}
+	before, err := json.Marshal(backend.existing)
+	require.NoError(t, err)
+	mutationProbe := newStubBackend()
+	mutationProbe.existing = append(mutationProbe.existing, preExisting)
+	require.NoError(t, mutationProbe.RetireAtom(context.Background(), preExisting.ID, createdAt.Add(time.Hour)))
+	mutated, err := json.Marshal(mutationProbe.existing)
+	require.NoError(t, err)
+	require.NotEqual(t, before, mutated, "probe backend must expose persisted row mutations")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	worker := atom.NewWorker(backend, ext, atom.WorkerConfig{
+		PollInterval: time.Millisecond,
+		Projects:     []string{"proj"},
+	})
+	go worker.Run(ctx)
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond)
+
+	after, err := json.Marshal(backend.existing)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "pre-existing atom rows must remain byte-identical")
+	assert.Empty(t, backend.retired, "repeat ingestion must not retire pre-existing atoms")
+	assert.Empty(t, backend.inserted, "exact duplicates must not create replacement rows")
+	assert.Contains(t, backend.completedJobs, "first-pass")
+	assert.Contains(t, backend.completedJobs, "second-pass")
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
 }

--- a/internal/atom/worker_test.go
+++ b/internal/atom/worker_test.go
@@ -183,7 +183,7 @@ func TestWorker_MarkJobCompleteOnSuccess(t *testing.T) {
 	assert.NoError(t, jobErr)
 }
 
-func TestWorkerSetsObservedAt(t *testing.T) {
+func TestWorkerThreadsCreatedAtWhenValidFromIsNil(t *testing.T) {
 	backend := newStubBackend()
 	createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
 	backend.jobs = []atom.ExtractionJob{{ID: "job-observed", MemoryID: "mem-observed", Project: "proj"}}
@@ -211,8 +211,30 @@ func TestWorkerSetsObservedAt(t *testing.T) {
 
 	require.NotEmpty(t, backend.inserted)
 	require.Equal(t, []time.Time{createdAt}, ext.sessionDates)
-	require.NotNil(t, backend.inserted[0].ObservedAt)
-	assert.True(t, backend.inserted[0].ObservedAt.Equal(createdAt))
+}
+
+func TestWorkerPrefersMemoryValidFromAsSessionDate(t *testing.T) {
+	backend := newStubBackend()
+	createdAt := time.Date(2026, 7, 11, 3, 30, 0, 0, time.UTC)
+	validFrom := time.Date(2023, 5, 9, 0, 0, 0, 0, time.UTC)
+	backend.jobs = []atom.ExtractionJob{{ID: "job-valid-from", MemoryID: "mem-valid-from", Project: "proj"}}
+	backend.memories["mem-valid-from"] = &types.Memory{
+		ID: "mem-valid-from", Content: "I attended a meetup.", CreatedAt: createdAt, ValidFrom: &validFrom,
+	}
+	ext := &stubExtractor{atoms: []atom.Atom{{
+		Type: atom.TypeEvent, Subject: "the user", Predicate: "attended", Value: "meetup",
+		Statement: "The user attended a meetup.", Scope: atom.ScopeGlobal, Confidence: 0.9,
+	}}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	go atom.NewWorker(backend, ext, atom.WorkerConfig{
+		PollInterval: time.Millisecond,
+		Projects:     []string{"proj"},
+	}).Run(ctx)
+	<-ctx.Done()
+
+	require.Equal(t, []time.Time{validFrom}, ext.sessionDates)
 }
 
 func TestB1CorruptionProbeRepeatedIngestPreservesExistingRows(t *testing.T) {
@@ -265,6 +287,41 @@ func TestB1CorruptionProbeRepeatedIngestPreservesExistingRows(t *testing.T) {
 	assert.Empty(t, backend.inserted, "exact duplicates must not create replacement rows")
 	assert.Contains(t, backend.completedJobs, "first-pass")
 	assert.Contains(t, backend.completedJobs, "second-pass")
+}
+
+func TestB1CorruptionProbeSameValueDifferentDateEventsBothStored(t *testing.T) {
+	backend := newStubBackend()
+	firstDate := time.Date(2023, 5, 9, 0, 0, 0, 0, time.UTC)
+	secondDate := time.Date(2023, 5, 16, 0, 0, 0, 0, time.UTC)
+	backend.existing = []atom.Atom{{
+		ID: "first-event", Project: "proj", Type: atom.TypeEvent,
+		Subject: "the user", Predicate: "attended", Value: "weekly meetup",
+		Statement: "On 2023-05-09, the user attended the weekly meetup.",
+		Scope:     atom.ScopeGlobal, Confidence: 0.9, ValidFrom: &firstDate,
+	}}
+	backend.jobs = []atom.ExtractionJob{{ID: "second-event-job", MemoryID: "second-event-memory", Project: "proj"}}
+	backend.memories["second-event-memory"] = &types.Memory{
+		ID: "second-event-memory", Content: "On 2023-05-16, I attended the weekly meetup.",
+		CreatedAt: time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC), ValidFrom: &secondDate,
+	}
+	ext := &stubExtractor{atoms: []atom.Atom{{
+		Type: atom.TypeEvent, Subject: "the user", Predicate: "attended", Value: "weekly meetup",
+		Statement: "On 2023-05-16, the user attended the weekly meetup.",
+		Scope:     atom.ScopeGlobal, Confidence: 0.9, ValidFrom: &secondDate,
+	}}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	go atom.NewWorker(backend, ext, atom.WorkerConfig{
+		PollInterval: time.Millisecond,
+		Projects:     []string{"proj"},
+	}).Run(ctx)
+	<-ctx.Done()
+
+	require.Len(t, backend.existing, 2, "both dated event occurrences must be stored")
+	assert.Equal(t, firstDate, *backend.existing[0].ValidFrom)
+	assert.Equal(t, secondDate, *backend.existing[1].ValidFrom)
+	assert.Empty(t, backend.retired, "storing a recurrence must not mutate the earlier event")
 }
 
 func timePointer(value time.Time) *time.Time {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -116,6 +116,13 @@ var (
 		Help: "Entity extraction jobs dropped (semaphore_full or queue_error)",
 	}, []string{"reason"})
 
+	// AtomEventDateRejections counts event_date values discarded by the atom
+	// extractor because they are malformed or outside the accepted time range.
+	AtomEventDateRejections = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "engram_atom_event_date_rejections_total",
+		Help: "Atom event dates rejected before storage by rejection class",
+	}, []string{"reason"})
+
 	// EmbedCircuitState records the current state of the embed circuit breaker.
 	// Labels: state=open|closed|half_open.
 	EmbedCircuitState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -223,6 +230,7 @@ func init() {
 		EmbedGatewayConcurrency,
 		WorkerPanics,
 		ExtractionDropped,
+		AtomEventDateRejections,
 		EmbedCircuitState,
 		EmbedCircuitTransitions,
 		StoreEmbedAsyncTotal,


### PR DESCRIPTION
## Summary

- add structured `event_date` extraction for event and status-change atoms, with strict ISO date parsing, sanity clamps, rejection metrics, and session-date fallback
- preserve the source session's calendar date through both the production worker and LongMemEval atom-build paths
- replace 6,000-character truncation with lossless message-aware windows, exact-result deduplication, and one retry per failed window while keeping writes fail-closed
- preserve recurring event/status-change occurrences by inserting same-value atoms when their date-only `valid_from` differs, without updating or retiring the earlier atom

## Insert-only and corruption probes

The committed regression artifacts include:

- `TestB1CorruptionProbeRepeatedIngestPreservesExistingRows` — ingests the same fixture twice and proves pre-existing atom rows remain byte-identical
- `TestB1CorruptionProbeRejectsAdversarialEventDates` — proves malformed, out-of-range, and non-single-date inputs leave `valid_from` NULL
- `TestB1CorruptionProbeChunkingSupersetAndExactDedup` — proves long-session windowing retains the truncated prefix's atoms and finds atoms beyond character 6,000
- `TestB1CorruptionProbeSameValueDifferentDateEventsBothStored` — proves recurring same-value events on different dates are both stored without retiring the earlier occurrence

No migration is added. No UPDATE path was added for `valid_from`, `valid_to`, `supersedes`, or other fields on existing atom rows.

## Verification

- `go test -race ./internal/atom`
- `go test -race ./cmd/longmemeval -run 'Test(AtomBuildWorkerThreadsSessionDateToExtractor|ClaudeExtractor|SessionWindows|B1CorruptionProbe|Deduplicate|Worker)'`

schema-class carve-out: founder merge required, not merge-on-green

Closes #1403

## Round 2 fixes

- Restrict distinct dated occurrences to event atoms: events are per-occurrence, so the same event value on a different date remains fresh; status changes represent a single transition and same-value restatements reinforce the active row instead of creating another occurrence.
- Log intra-batch supersession-key drops at debug level and clarify the adversarial range test name.

## Round 3 fixes + known limitations

- Extend intra-batch deduplication to include the case-folded value and, for event atoms, the date-only `valid_from`. Exact sibling duplicates are still dropped, while different values and same-value events on different dates each reach existing-row evaluation.
- In-batch status-chain supersession remains deferred to B2. Different status values extracted in one batch may both insert as fresh; this change intentionally does not chain sibling candidates.
- Pre-existing atom rows have NULL `valid_from`; there is no migration or backfill in B1. Distinct-dated-occurrence detection therefore applies only between post-B1 rows. A same-value event candidate evaluated against a NULL-`valid_from` row is treated as reinforcement.
