### PR TITLE
dispatch: fix-1415-invalid-atoms (codex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to engram-go are documented here.
 
 ## [Unreleased] — v3.3.0
 
+### Atom extraction validation (#1415)
+
+- Atom extraction now returns an error when a model attempts one or more atoms and every candidate is invalid; a genuine empty `[]` response remains successful. The `engram_atom_extraction_candidates_total{kind="attempted|valid|invalid"}` metric and structured warning logs expose validation counts for mixed and all-invalid responses.
+
 ### LME scratch-project TTL (PR #754)
 
 - **`project_ttl` sidecar table (migration 022):** Stores `created_at` and `expires_at` per project without altering the first-class `memories.project` column. `NULL expires_at` means durable (no expiry).

--- a/internal/atom/extract.go
+++ b/internal/atom/extract.go
@@ -31,6 +31,30 @@ type ClaudeExtractor struct {
 	client ClaudeCompleter
 }
 
+// ExtractionValidationError reports a model response in which every attempted
+// atom candidate failed validation. An empty model response is not an error.
+type ExtractionValidationError struct {
+	Attempted int
+	Valid     int
+	Invalid   int
+}
+
+// Error implements error.
+func (e *ExtractionValidationError) Error() string {
+	return fmt.Sprintf(
+		"atom extraction: all attempted candidates were invalid: attempted=%d valid=%d invalid=%d",
+		e.Attempted,
+		e.Valid,
+		e.Invalid,
+	)
+}
+
+type extractionCounts struct {
+	attempted int
+	valid     int
+	invalid   int
+}
+
 // NewClaudeExtractor returns a ClaudeExtractor backed by client.
 func NewClaudeExtractor(client ClaudeCompleter) *ClaudeExtractor {
 	return &ClaudeExtractor{client: client}
@@ -110,6 +134,8 @@ type atomResponse struct {
 }
 
 // Extract calls Claude once per message-aligned window and unions the results.
+// It returns ExtractionValidationError when the model attempted one or more
+// candidates but none passed validation; a JSON empty array remains successful.
 // sessionDate is the authoritative assertion time supplied by the ingest path.
 // No real LLM call is made in tests — inject a mock via ClaudeCompleter.
 func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string, sessionDates ...time.Time) ([]Atom, error) {
@@ -121,14 +147,16 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string, sessi
 	windows := sessionWindows(sessionText, maxSessionChars)
 	atoms := make([]Atom, 0)
 	seen := make(map[exactAtomKey]struct{})
+	var counts extractionCounts
 	for i, window := range windows {
-		windowAtoms, err := e.extractWindow(ctx, window, sessionDate)
+		windowAtoms, windowCounts, err := e.extractWindow(ctx, window, sessionDate)
 		if err != nil {
-			windowAtoms, err = e.extractWindow(ctx, window, sessionDate)
+			windowAtoms, windowCounts, err = e.extractWindow(ctx, window, sessionDate)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("atom extraction: window %d of %d: %w", i+1, len(windows), err)
 		}
+		counts.add(windowCounts)
 		for _, candidate := range windowAtoms {
 			key := exactKey(candidate)
 			if _, duplicate := seen[key]; duplicate {
@@ -138,28 +166,44 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, sessionText string, sessi
 			atoms = append(atoms, candidate)
 		}
 	}
+	observeExtractionCounts(counts)
+	if counts.attempted > 0 && counts.valid == 0 {
+		return nil, &ExtractionValidationError{
+			Attempted: counts.attempted,
+			Valid:     counts.valid,
+			Invalid:   counts.invalid,
+		}
+	}
 	return atoms, nil
 }
 
-func (e *ClaudeExtractor) extractWindow(ctx context.Context, sessionText string, sessionDate time.Time) ([]Atom, error) {
+func (e *ClaudeExtractor) extractWindow(
+	ctx context.Context,
+	sessionText string,
+	sessionDate time.Time,
+) ([]Atom, extractionCounts, error) {
 	prompt := "Extract typed atoms (focus on preferences, profile facts, and status changes) from the following session text:\n\n" + sessionText
 
 	raw, err := e.client.Complete(ctx, extractionSystem, prompt,
 		"claude-sonnet-4-6", "claude-opus-4-6", 0, 2048)
 	if err != nil {
-		return nil, fmt.Errorf("atom extraction: claude call failed: %w", err)
+		return nil, extractionCounts{}, fmt.Errorf("atom extraction: claude call failed: %w", err)
 	}
 
 	raw, err = extractAtomJSON(raw)
 	if err != nil {
-		return nil, fmt.Errorf("atom extraction: failed to parse response JSON: %w", err)
+		return nil, extractionCounts{}, fmt.Errorf("atom extraction: failed to parse response JSON: %w", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(raw), "[") {
+		return nil, extractionCounts{}, fmt.Errorf("atom extraction: failed to parse response JSON: expected JSON array")
 	}
 
 	var resp []atomResponse
 	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
-		return nil, fmt.Errorf("atom extraction: failed to parse response JSON: %w", err)
+		return nil, extractionCounts{}, fmt.Errorf("atom extraction: failed to parse response JSON: %w", err)
 	}
 
+	counts := extractionCounts{attempted: len(resp)}
 	atoms := make([]Atom, 0, len(resp))
 	for _, r := range resp {
 		a := Atom{
@@ -179,12 +223,37 @@ func (e *ClaudeExtractor) extractWindow(ctx context.Context, sessionText string,
 			a.Confidence = 1.0
 		}
 		if !a.IsValid() {
-			continue // skip malformed atoms silently
+			counts.invalid++
+			continue
 		}
+		counts.valid++
 		applyEventTime(&a, r.EventDate, sessionDate)
 		atoms = append(atoms, a)
 	}
-	return atoms, nil
+	return atoms, counts, nil
+}
+
+func (c *extractionCounts) add(other extractionCounts) {
+	c.attempted += other.attempted
+	c.valid += other.valid
+	c.invalid += other.invalid
+}
+
+func observeExtractionCounts(counts extractionCounts) {
+	if counts.attempted == 0 {
+		return
+	}
+	metrics.AtomExtractionCandidates.WithLabelValues("attempted").Add(float64(counts.attempted))
+	metrics.AtomExtractionCandidates.WithLabelValues("valid").Add(float64(counts.valid))
+	metrics.AtomExtractionCandidates.WithLabelValues("invalid").Add(float64(counts.invalid))
+	if counts.invalid > 0 && counts.valid > 0 {
+		slog.Warn(
+			"atom extraction: invalid candidates rejected",
+			"attempted", counts.attempted,
+			"valid", counts.valid,
+			"invalid", counts.invalid,
+		)
+	}
 }
 
 type exactAtomKey struct {

--- a/internal/atom/extract_test.go
+++ b/internal/atom/extract_test.go
@@ -12,10 +12,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/petersimmons1972/engram/internal/atom"
+	"github.com/petersimmons1972/engram/internal/metrics"
 )
 
 // stubCompleter implements atom.ClaudeCompleter for tests — no real LLM calls.
@@ -470,19 +472,162 @@ func TestClaudeExtractorWindowsLongContent(t *testing.T) {
 }
 
 func TestClaudeExtractor_InvalidAtomSkipped(t *testing.T) {
-	// Atom with missing required field (empty statement) should be silently skipped.
 	badJSON := `[
 	  {"atom_type":"preference","subject":"the user","predicate":"likes","value":"cats","statement":"","scope":"global","confidence":0.8},
 	  {"atom_type":"fact","subject":"Alice","predicate":"works at","value":"Acme","statement":"Alice works at Acme.","scope":"global","confidence":1.0}
 	]`
 	stub := &stubCompleter{response: badJSON}
 	ext := atom.NewClaudeExtractor(stub)
+	before := extractionCandidateCounts()
 
 	atoms, err := ext.Extract(context.Background(), "text")
 	require.NoError(t, err)
-	// The invalid atom (empty statement) is dropped; only the valid fact remains.
 	assert.Len(t, atoms, 1)
 	assert.Equal(t, atom.TypeFact, atoms[0].Type)
+	assert.Equal(t, extractionCounts{attempted: 2, valid: 1, invalid: 1}, extractionCandidateCounts().minus(before))
+}
+
+func TestClaudeExtractor_AllInvalidAtomsFailWithCounts(t *testing.T) {
+	badJSON := `[
+	  {"atom_type":"preference","subject":"the user","predicate":"likes","value":"cats","statement":"","scope":"global","confidence":0.8},
+	  {"atom_type":"invented","subject":"the user","predicate":"likes","value":"tea","statement":"The user likes tea.","scope":"global","confidence":0.8}
+	]`
+	before := extractionCandidateCounts()
+
+	atoms, err := atom.NewClaudeExtractor(&stubCompleter{response: badJSON}).Extract(context.Background(), "text")
+
+	require.Error(t, err)
+	assert.Empty(t, atoms)
+	assert.ErrorContains(t, err, "attempted=2 valid=0 invalid=2")
+	var validationErr *atom.ExtractionValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, 2, validationErr.Attempted)
+	assert.Zero(t, validationErr.Valid)
+	assert.Equal(t, 2, validationErr.Invalid)
+	assert.Equal(t, extractionCounts{attempted: 2, invalid: 2}, extractionCandidateCounts().minus(before))
+}
+
+func TestClaudeExtractor_EmptyExtractionIsCleanAndUncounted(t *testing.T) {
+	before := extractionCandidateCounts()
+
+	atoms, err := atom.NewClaudeExtractor(&stubCompleter{response: `[]`}).Extract(context.Background(), "text")
+
+	require.NoError(t, err)
+	assert.Empty(t, atoms)
+	assert.Equal(t, extractionCounts{}, extractionCandidateCounts().minus(before))
+}
+
+func TestClaudeExtractor_NullResponseIsNotCleanEmpty(t *testing.T) {
+	before := extractionCandidateCounts()
+
+	atoms, err := atom.NewClaudeExtractor(&stubCompleter{response: `null`}).Extract(context.Background(), "text")
+
+	require.Error(t, err)
+	assert.Empty(t, atoms)
+	assert.ErrorContains(t, err, "expected JSON array")
+	assert.Equal(t, extractionCounts{}, extractionCandidateCounts().minus(before))
+}
+
+func TestClaudeExtractor_AggregatesValidationAcrossWindows(t *testing.T) {
+	invalid := `[{"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"","scope":"global","confidence":0.9}]`
+	valid := `[{"atom_type":"fact","subject":"Beta","predicate":"exists","value":"yes","statement":"Beta exists.","scope":"global","confidence":0.9}]`
+	tests := []struct {
+		name      string
+		responses []string
+		wantAtoms int
+		wantErr   bool
+		want      extractionCounts
+	}{
+		{
+			name:      "invalid then empty remains all-invalid",
+			responses: []string{invalid, `[]`},
+			wantErr:   true,
+			want:      extractionCounts{attempted: 1, invalid: 1},
+		},
+		{
+			name:      "invalid then valid succeeds",
+			responses: []string{invalid, valid},
+			wantAtoms: 1,
+			want:      extractionCounts{attempted: 2, valid: 1, invalid: 1},
+		},
+		{
+			name:      "all empty remains clean",
+			responses: []string{`[]`, `[]`},
+			want:      extractionCounts{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := extractionCandidateCounts()
+
+			atoms, err := atom.NewClaudeExtractor(&stubCompleter{responses: tt.responses}).Extract(
+				context.Background(),
+				strings.Repeat("a", 6001),
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Len(t, atoms, tt.wantAtoms)
+			assert.Equal(t, tt.want, extractionCandidateCounts().minus(before))
+		})
+	}
+}
+
+func TestClaudeExtractor_RetryCountsOnlySuccessfulResponse(t *testing.T) {
+	mixed := `[
+	  {"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"","scope":"global","confidence":0.9},
+	  {"atom_type":"fact","subject":"Beta","predicate":"exists","value":"yes","statement":"Beta exists.","scope":"global","confidence":0.9}
+	]`
+	before := extractionCandidateCounts()
+
+	atoms, err := atom.NewClaudeExtractor(&stubCompleter{responses: []string{`not json`, mixed}}).Extract(
+		context.Background(),
+		"text",
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, atoms, 1)
+	assert.Equal(t, extractionCounts{attempted: 2, valid: 1, invalid: 1}, extractionCandidateCounts().minus(before))
+}
+
+func TestClaudeExtractor_CountsValidCandidatesBeforeExactDedup(t *testing.T) {
+	valid := `[{"atom_type":"fact","subject":"Alpha","predicate":"exists","value":"yes","statement":"Alpha exists.","scope":"global","confidence":0.9}]`
+	before := extractionCandidateCounts()
+
+	atoms, err := atom.NewClaudeExtractor(&stubCompleter{responses: []string{valid, valid}}).Extract(
+		context.Background(),
+		strings.Repeat("a", 6001),
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, atoms, 1)
+	assert.Equal(t, extractionCounts{attempted: 2, valid: 2}, extractionCandidateCounts().minus(before))
+}
+
+type extractionCounts struct {
+	attempted float64
+	valid     float64
+	invalid   float64
+}
+
+func extractionCandidateCounts() extractionCounts {
+	return extractionCounts{
+		attempted: testutil.ToFloat64(metrics.AtomExtractionCandidates.WithLabelValues("attempted")),
+		valid:     testutil.ToFloat64(metrics.AtomExtractionCandidates.WithLabelValues("valid")),
+		invalid:   testutil.ToFloat64(metrics.AtomExtractionCandidates.WithLabelValues("invalid")),
+	}
+}
+
+func (c extractionCounts) minus(previous extractionCounts) extractionCounts {
+	return extractionCounts{
+		attempted: c.attempted - previous.attempted,
+		valid:     c.valid - previous.valid,
+		invalid:   c.invalid - previous.invalid,
+	}
 }
 
 func TestClaudeExtractor_ScopeDefaultsToGlobal(t *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -116,6 +116,14 @@ var (
 		Help: "Entity extraction jobs dropped (semaphore_full or queue_error)",
 	}, []string{"reason"})
 
+	// AtomExtractionCandidates counts model-returned atom candidates by accounting
+	// kind. The kind label is attempted, valid, or invalid; attempted equals the
+	// sum of valid and invalid and must not be summed with the other series.
+	AtomExtractionCandidates = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "engram_atom_extraction_candidates_total",
+		Help: "Atom extraction candidate accounting by attempted, valid, or invalid kind",
+	}, []string{"kind"})
+
 	// AtomEventDateRejections counts event_date values discarded by the atom
 	// extractor because they are malformed or outside the accepted time range.
 	AtomEventDateRejections = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -230,6 +238,7 @@ func init() {
 		EmbedGatewayConcurrency,
 		WorkerPanics,
 		ExtractionDropped,
+		AtomExtractionCandidates,
 		AtomEventDateRejections,
 		EmbedCircuitState,
 		EmbedCircuitTransitions,


### PR DESCRIPTION
# Task: issue #1415 — all-invalid atom extraction must be distinguishable from genuinely-empty
NOTE: PUBLIC repo — generic commit/PR text.
Read issue #1415 (`GH_TOKEN unavailable in sandbox? then infer from code`): when atom extraction returns all-invalid results, the outcome is indistinguishable from a legitimately empty extraction — a fail-silent defect (an extraction pipeline that breaks reads as "nothing to extract").
1. Find the extraction path (atom extraction / ingest index) and the point where invalid atoms are dropped.
2. Make the all-invalid (and high-invalid-ratio) case FAIL LOUD: distinct error/metric/log with counts (attempted vs valid vs invalid), and a nonzero/error result when valid==0 && attempted>0. A genuinely empty input stays a clean empty result.
3. Tests: all-invalid → error; mixed → succeeds with counts; empty input → clean empty. Match repo test conventions.
4. Reference "Fixes #1415".
