### PR TITLE
dispatch: eg-1293-provenance-rollup (codex)

### DIFF
--- a/cmd/longmemeval/score.go
+++ b/cmd/longmemeval/score.go
@@ -456,8 +456,9 @@ func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEnt
 		byQType[qtype] = &scoreReportCounts{}
 	}
 	errorItems := make([]map[string]any, 0)
+	questionIDs := sortedScoreQuestionIDs(deduped)
 
-	for _, questionID := range sortedScoreQuestionIDs(deduped) {
+	for _, questionID := range questionIDs {
 		s := deduped[questionID]
 		if s.Status != "done" {
 			errorItems = append(errorItems, map[string]any{
@@ -509,6 +510,18 @@ func writeScoreReportWithCompleteness(cfg *Config, scores []longmemeval.ScoreEnt
 	scorerURL := redactURL(cfg.ScorerURL)
 	scorerMaxTokens := effectiveScorerMaxTokens(cfg)
 	provenance := scoreProvenanceForConfig(cfg)
+	// Persisted score rows are authoritative for report provenance. Keep the
+	// config-derived value as a fallback for legacy rows without provenance.
+	for _, questionID := range questionIDs {
+		rowProvenance := deduped[questionID].Provenance
+		if rowProvenance.GoldVersion != "" || rowProvenance.ScorerVersion != "" ||
+			len(rowProvenance.FeatureFlags) > 0 || rowProvenance.System != "" ||
+			rowProvenance.ItemSet != "" || rowProvenance.RunID != "" ||
+			rowProvenance.HarnessSHA != "" || rowProvenance.GenerationContext != "" {
+			provenance = rowProvenance
+			break
+		}
+	}
 
 	report := map[string]any{
 		"overall":               overall,

--- a/cmd/longmemeval/score_test.go
+++ b/cmd/longmemeval/score_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"syscall"
 	"testing"
 	"time"
@@ -138,6 +139,50 @@ func TestWriteScoreReport_DeduplicatesByQuestionID(t *testing.T) {
 	}
 	if gotCorrect != 2 {
 		t.Errorf("overall.correct = %d, want 2 (last-write-wins for q1)", gotCorrect)
+	}
+}
+
+func TestWriteScoreReport_RollsUpRowLevelProvenance(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{
+		OutDir:      dir,
+		RunID:       "config-run",
+		GoldVersion: "config-gold",
+	}
+	want := longmemeval.ScoreProvenance{
+		GoldVersion:       "row-gold",
+		ScorerVersion:     "row-scorer",
+		FeatureFlags:      map[string]any{"preserve_correct": true},
+		System:            "row-system",
+		ItemSet:           "row-items",
+		RunID:             "row-run",
+		HarnessSHA:        "row-sha",
+		GenerationContext: "full_timeline_context",
+	}
+	scores := []longmemeval.ScoreEntry{
+		{
+			QuestionID:   "q1",
+			QuestionType: "single-session-user",
+			ScoreLabel:   "CORRECT",
+			Status:       "done",
+			Provenance:   want,
+		},
+	}
+
+	writeScoreReport(cfg, scores)
+
+	data, err := os.ReadFile(filepath.Join(dir, "score_report.json"))
+	if err != nil {
+		t.Fatalf("read score_report.json: %v", err)
+	}
+	var report struct {
+		Provenance longmemeval.ScoreProvenance `json:"provenance"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse score_report.json: %v", err)
+	}
+	if !reflect.DeepEqual(report.Provenance, want) {
+		t.Fatalf("report provenance = %#v, want row provenance %#v", report.Provenance, want)
 	}
 }
 


### PR DESCRIPTION
Rolls row-level provenance up to the score_report top level (fixes #1293). The top-level value now derives from an actual row's persisted provenance instead of current config, so the two can no longer disagree. Schema unchanged; existing key's value only.